### PR TITLE
wf 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Multi-project wayfinder manager TUI: fuzzy-find picker and terminal starmap over agentic planning maps"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.1.1"
+  version: "0.2.0"
 
 package:
   name: wf


### PR DESCRIPTION
## Summary

Cuts 0.2.0. Nothing but the version, in the three places that must agree: `Cargo.toml`, `Cargo.lock` (the recipe builds `--locked`), and `recipe/recipe.yaml` (CI fails the build when it drifts).

What main has accumulated since v0.1.1:

- **Streaming startup** (af83494) — the screen goes up before any network or zellij call. Time to first frame ~4.0s → 0.05s.
- **The projects cache forgets** — `ProjectsCache::prune_missing` drops checkouts whose directory is gone. Registration was purely accretive, so a deleted checkout kept offering itself as a launch host (turning a single-checkout repo into a picker) and kept the surviving checkout stuck with a disambiguated session name — `projects` instead of `wayfinder`.

Minor rather than patch: the headline change is user-visible behaviour, not a fix. `wf` is a binary, so there is no library API to reserve minor bumps for.

## Test plan

- `cargo test` — 128 tests pass (115 lib + integration), including `pruning_forgets_deleted_checkouts_and_renames_the_survivor`, which builds two checkouts of one repo, deletes one, and asserts the survivor is both kept and renamed back.
- `cargo clippy --all-targets` clean.
- `cargo check --locked` passes, so the lockfile genuinely carries 0.2.0 — the recipe build would fail otherwise.
- CI's own version-drift guard, run locally with the same `sed`: `Cargo.toml=0.2.0 recipe=0.2.0`.
- The `package` job here rebuilds and install-tests the recipe, so the `v0.2.0` tag will be a rebuild of something already known good.

## Review notes

- `cargo fmt --check` reports 35 diffs across 10 files (`app.rs`, `model.rs`, `ui.rs`, `refresh.rs`, `fetch.rs`, `filter.rs`, `main.rs`, `projects.rs`, and two `tests/live_*.rs`). All of it predates this branch — nothing in CI runs `cargo fmt`, so the tree has simply never been rustfmt-clean. Deliberately not fixed here: it would bury a 3-line release bump under a whole-codebase reformat. Worth its own PR, ideally with a `fmt --check` step in `package.yml` so it stays fixed.
- The prune fix landed on main inside af83494, whose message is entirely about streaming startup and does not mention it. Noting it here so the release notes and `git log` have one place that connects the two.

## Summary by Sourcery

Build:
- Update Cargo.toml, Cargo.lock, and recipe/recipe.yaml to use version 0.2.0 for the wf package.