### PR TITLE
Launch without zellij: enter runs the agent right here

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Multi-project wayfinder manager TUI: fuzzy-find picker and terminal starmap over agentic planning maps"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The package declares no run dependencies. `wf` finds `gh` (authenticated),
 `zellij` and the agent CLI on PATH and says so plainly when one is missing,
 rather than dragging second copies of them into its own environment.
 
+`zellij` is optional: without it `enter` runs the agent in `wf`'s own terminal
+instead of in a tab (see [Without zellij](#without-zellij)).
+
 `wf --version` and `wf --help` are the only arguments; everything else is keys
 in the TUI.
 
@@ -74,7 +77,7 @@ chosen yourself with `ctrl-f`/`ctrl-g`.
 
 ## Launching
 
-Picking a ticket creates or focuses a zellij tab in that project's session,
+With zellij, picking a ticket creates or focuses a zellij tab in that project's session,
 with the checkout as its cwd, running the `/wayfinder` skill on the ticket. The
 tab is the unit of work and the unit of supervision: it survives `wf` exiting,
 it is reachable by normal zellij navigation, and re-picking a ticket focuses its
@@ -91,8 +94,8 @@ both.
 
 | key | what it does |
 | --- | --- |
-| `enter` | HITL: create-or-focus the ticket's tab and take you into it (`claude --dangerously-skip-permissions "/wayfinder <map> <n>"`) |
-| `ctrl-a` | AFK: spawn the same tab headless (`claude --dangerously-skip-permissions -p "/wayfinder <map> <n>"`) — no attach, no focus steal |
+| `enter` | HITL: create-or-focus the ticket's tab and take you into it (`claude --dangerously-skip-permissions "/wayfinder <map> <n>"`) — with no zellij, run that agent right here |
+| `ctrl-a` | AFK: spawn the same tab headless (`claude --dangerously-skip-permissions -p "/wayfinder <map> <n>"`) — no attach, no focus steal; needs zellij |
 | `↑`/`↓`, `enter`, `esc` | in the which-checkout picker: pick which project hosts the tab, or cancel |
 
 Both modes pass `--dangerously-skip-permissions`. For AFK that is closer to a
@@ -102,10 +105,12 @@ would be a tab that never finishes — indistinguishable from slow work. HITL ge
 it too, so entering a tab is the same session whether you opened it or auto-start
 did.
 
-How `wf` hands over depends on where it is running, decided from its own
-`$ZELLIJ` — never from a `zellij action` exit code, which is `0` even on
-failure:
+How `wf` hands over depends on where it is running, decided from whether there is
+a `zellij` on PATH at all and then from its own `$ZELLIJ` — never from a
+`zellij action` exit code, which is `0` even on failure:
 
+- **no zellij installed** — the TUI suspends and the agent itself runs as a
+  *child* in the checkout (see [Without zellij](#without-zellij));
 - **outside zellij** — the TUI suspends, `zellij attach <session>` runs as a
   *child*, and detaching returns to `wf` (which refetches, since the tracker
   moved while you were away);
@@ -125,6 +130,32 @@ A finished or crashed agent's tab lingers with an EXITED banner — that is the
 post-mortem, and closing it is yours to do. The line above the match count
 counts the agent tabs zellij is holding, as of the last launch, `ctrl-r`, or
 auto-start; it stays empty when there are none.
+
+## Without zellij
+
+`zellij` is a nicety, not a requirement. When there is no `zellij` on PATH at all,
+`enter` skips the tab entirely: `wf` steps out of the terminal and runs the agent
+as its own child in the checkout, exactly the same
+`claude --dangerously-skip-permissions "/wayfinder <map> <n>"`. Quitting the
+agent returns to the picker, which refetches because the tracker moved while you
+were in there. One ticket at a time, no tab strip, nothing to detach from.
+
+That is a different state from "zellij is installed but this terminal is not in a
+session" — the latter still gets a tab, and `wf` runs `zellij attach` to reach it.
+
+Which of the two it is gets decided by one `zellij --version`, on the first
+launch or poll that needs the answer and cached for the rest of the process —
+never before the first frame, since every subprocess is kept off that path (#27)
+and a zellij call is exactly the boundary that can wedge (#21).
+
+What a tab was carrying is honestly absent rather than faked:
+
+- `ctrl-a` is refused (`no zellij — afk needs a tab; enter runs this ticket here
+  instead`). A headless agent is supervised by its tab; with no tab it would be a
+  process you cannot see, find or reap, so `wf` will not start one;
+- auto-start is off for the same reason — there is nothing to reconcile towards;
+- the agent-tab count line stays empty, and re-picking a ticket starts a fresh
+  agent on it, since there is no tab to find already running.
 
 ## Auto-start
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.2.1"
+  version: "0.2.2"
 
 package:
   name: wf
@@ -104,6 +104,7 @@ about:
     mapped repo's tickets are read live from GitHub Issues via `gh`, and picking
     a ticket creates or focuses a zellij tab named `<repo>#<n>` running an agent
     on it — `enter` to work it interactively, `ctrl-a` to spawn it headless.
+    zellij is optional: without it, `enter` runs the agent in wf's own terminal.
 
 extra:
   recipe-maintainers:

--- a/src/autostart.rs
+++ b/src/autostart.rs
@@ -33,13 +33,20 @@
 //!
 //! No off switch, no stagger, no fan-out cap: quitting `wf` is the switch, and
 //! the population is typically zero to two.
+//!
+//! On a machine with no zellij ([`crate::launch::Host::NoZellij`]) auto-start is
+//! off, and off by the same rule rather than by a special case: an AFK agent is
+//! supervised by its tab, so with no tab to put it in there is nothing to
+//! start. The driver skips the reconcile, and if it did not, "no session's tab
+//! state is known" already means [`reconcile`] plans nothing — the same
+//! conservative answer it gives for an unqueryable session.
 
 use std::collections::BTreeMap;
 
 use anyhow::{bail, Result};
 
 use crate::launch::{
-    execute, find_tab, plan, Handoff, Host, Launch, MapIssues, Mode, OpenTab, Targets,
+    execute, find_tab, plan, Handoff, Host, Launch, MapIssues, Mode, Opened, Targets,
 };
 use crate::model::{Status, Ticket};
 use crate::projects::Checkout;
@@ -199,18 +206,20 @@ pub fn reconcile(
 /// human's zellij client would already have been moved. [`reconcile`] only ever
 /// plans `Mode::Afk` and a test above pins that; this is the second lock, on the
 /// side that would do the damage.
-pub async fn start(launch: &Launch, host: &Host) -> Result<OpenTab> {
+pub async fn start(launch: &Launch, host: &Host) -> Result<Opened> {
     match launch.mode {
         Mode::Afk => {}
         Mode::Hitl => bail!("auto-start refuses a HITL launch: {}", launch.describe()),
     }
-    let (tab, handoff) = execute(launch, host).await?;
+    let (opened, handoff) = execute(launch, host).await?;
     match handoff {
-        Handoff::Stay => Ok(tab),
-        // Unreachable while `launch::handoff` maps every AFK launch to `Stay`.
-        // Matched rather than ignored so that changing it there has to come back
-        // through here and answer for it.
-        Handoff::Suspend(_) => bail!("auto-start will not suspend the TUI"),
+        Handoff::Stay => Ok(opened),
+        // Unreachable while `launch::handoff` maps every AFK launch *that has a
+        // tab* to `Stay`. Matched rather than ignored so that changing it there
+        // has to come back through here and answer for it — and it is the third
+        // lock on auto-start without zellij, where the handoff is a `Suspend`
+        // that would run a headless agent over the top of the TUI.
+        Handoff::Suspend { .. } => bail!("auto-start will not suspend the TUI"),
         Handoff::Quit => bail!("auto-start will not hand the terminal over"),
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,7 +1,13 @@
 //! The launch seam (Build 4, #16) — the daily-use line.
 //!
-//! One picked ticket becomes a zellij tab in that project's session, cwd set
-//! to the checkout, running the `/wayfinder` skill. The tab has two names and
+//! On a machine with zellij, one picked ticket becomes a zellij tab in that
+//! project's session, cwd set to the checkout, running the `/wayfinder` skill.
+//! On a machine **without** zellij ([`Host::NoZellij`]) there is no tab to make,
+//! so the same picked ticket runs the same agent as `wf`'s own child in `wf`'s
+//! own terminal: `enter` steps out of the TUI, the agent takes the screen, and
+//! quitting it comes back to the picker. Everything below that depends on a tab
+//! — dedupe, focus, the agent count, auto-start — simply has nothing to act on
+//! there, and says so rather than pretending. The tab has two names and
 //! the difference is load-bearing (#20): its **key** [`TabKey`] —
 //! `<short_repo>#<number>`, per the #7 naming amendment — is its identity, and
 //! its **label** [`TabLabel`] is the key plus a capped title, which is what a
@@ -33,6 +39,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use tokio::process::Command;
+use tokio::sync::OnceCell;
 
 use crate::model::Ticket;
 use crate::projects::Checkout;
@@ -59,10 +66,19 @@ impl Mode {
     }
 }
 
-/// Where `wf` itself is running. Read once from `wf`'s own environment —
-/// never from a `zellij action` exit code, which is 0 even on failure.
+/// Where `wf` itself is running. The zellij cases are read once from `wf`'s own
+/// environment — never from a `zellij action` exit code, which is 0 even on
+/// failure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Host {
+    /// There is no `zellij` on PATH at all, so no tab can host anything. `wf`
+    /// runs the agent as its own child in its own terminal instead.
+    ///
+    /// Distinct from [`Host::Outside`], which is "zellij exists, it just does
+    /// not own this terminal yet" — that one still gets a tab, and `wf` attaches
+    /// to reach it. Collapsing the two would make `wf` shell out to a binary
+    /// that is not there and read the failure as an empty session list.
+    NoZellij,
     /// No zellij session owns this terminal: `wf` must suspend itself and
     /// run `zellij attach` as a child to hand over.
     Outside,
@@ -74,7 +90,8 @@ pub enum Host {
     InsideUnnamed,
 }
 
-/// Classify the launch host from the two zellij variables.
+/// Classify the launch host from the two zellij variables, *given* that zellij
+/// is installed. [`detect_host`] answers the installed question first.
 pub fn host_from_env(zellij: Option<&str>, session_name: Option<&str>) -> Host {
     match zellij {
         None => Host::Outside,
@@ -85,11 +102,48 @@ pub fn host_from_env(zellij: Option<&str>, session_name: Option<&str>) -> Host {
     }
 }
 
-/// [`host_from_env`] against the live process environment.
-pub fn detect_host() -> Host {
-    let zellij = std::env::var("ZELLIJ").ok();
-    let name = std::env::var("ZELLIJ_SESSION_NAME").ok();
-    host_from_env(zellij.as_deref(), name.as_deref())
+/// Is there a `zellij` on PATH at all?
+///
+/// Probed by *running* it rather than by searching `$PATH`, because the question
+/// that matters is whether this module's invocations will work — a `zellij` that
+/// is on PATH but cannot start is no more usable than an absent one. `--version`
+/// is the one invocation that touches no session, and the inherited zellij
+/// variables are scrubbed as everywhere else so a stale `ZELLIJ_SESSION_NAME`
+/// cannot make even this hang (#5 findings).
+pub async fn zellij_available() -> bool {
+    Command::new("zellij")
+        .arg("--version")
+        .env_remove("ZELLIJ")
+        .env_remove("ZELLIJ_SESSION_NAME")
+        .env_remove("ZELLIJ_PANE_ID")
+        .output()
+        .await
+        .is_ok_and(|output| output.status.success())
+}
+
+/// The answer to [`detect_host`], computed at most once per process.
+///
+/// Both halves of that answer — whether zellij is installed, and which session
+/// owns this terminal — are fixed for `wf`'s lifetime, so this is a cache of a
+/// settled fact rather than state. Memoised rather than resolved at startup and
+/// threaded down, because the probe is a subprocess and #27 keeps every
+/// subprocess off the path to the first frame: the first caller to *need* the
+/// host pays for it, and that caller is always a keystroke or a poll.
+static HOST: OnceCell<Host> = OnceCell::const_new();
+
+/// The live launch host: [`Host::NoZellij`] when there is no zellij to talk to,
+/// otherwise [`host_from_env`] against the live process environment.
+pub async fn detect_host() -> Host {
+    HOST.get_or_init(|| async {
+        if !zellij_available().await {
+            return Host::NoZellij;
+        }
+        let zellij = std::env::var("ZELLIJ").ok();
+        let name = std::env::var("ZELLIJ_SESSION_NAME").ok();
+        host_from_env(zellij.as_deref(), name.as_deref())
+    })
+    .await
+    .clone()
 }
 
 /// A fully-resolved launch: which session hosts the tab, what the tab is
@@ -542,11 +596,17 @@ pub fn count_agent_tabs(names: &[String]) -> usize {
     names.iter().filter(|n| is_agent_tab(n)).count()
 }
 
-/// Whether `wf` itself must step aside after the tab exists.
+/// Whether `wf` itself must step aside once the agent has somewhere to run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Handoff {
-    /// Suspend the TUI, run this argv as a child, then restore and refresh.
-    Suspend(Vec<String>),
+    /// Suspend the TUI, run this argv as a child in `cwd`, then restore and
+    /// refresh.
+    ///
+    /// The child is either `zellij attach` (the tab is elsewhere and `wf` owns
+    /// the terminal it must be reached from) or, with no zellij, the agent
+    /// itself. `cwd` is always the checkout: `zellij attach` does not care, and
+    /// an agent run directly cares completely.
+    Suspend { argv: Vec<String>, cwd: PathBuf },
     /// Keep the TUI up: the tab runs on its own (AFK), or the zellij client
     /// was moved to it by native navigation while `wf` keeps running in its
     /// own tab — *in this same session*, so the user can navigate back to it.
@@ -556,9 +616,10 @@ pub enum Handoff {
     Quit,
 }
 
-/// Decide the handoff. AFK never attaches; inside zellij, `wf` is not the
-/// thing that owns the terminal, so the *client* moves rather than the TUI
-/// suspending.
+/// Decide the handoff. With no zellij `wf` always steps out, because the agent
+/// *is* its child and they cannot share the screen. Otherwise: AFK never
+/// attaches; inside zellij, `wf` is not the thing that owns the terminal, so the
+/// *client* moves rather than the TUI suspending.
 ///
 /// Whether `wf` survives that move is exactly whether it can be navigated back
 /// to. A same-session launch focuses a sibling tab, and `wf`'s own tab is still
@@ -569,10 +630,27 @@ pub enum Handoff {
 /// Every such launch used to leak one, and returning to that session later
 /// landed you on a pane that swallowed every key you typed (#22). So `wf`
 /// hands over and exits, restoring the terminal on the way out.
-pub fn handoff(mode: Mode, host: &Host, session: &str) -> Handoff {
-    match (mode, host) {
+///
+/// Takes the whole [`Launch`] rather than a mode and a session name because the
+/// no-zellij handoff runs the agent itself, and so needs the argv and the cwd
+/// too — and because a mode passed separately from the launch it describes is a
+/// second copy that can disagree with the first.
+pub fn handoff(host: &Host, launch: &Launch) -> Handoff {
+    let suspend = |argv: Vec<String>| Handoff::Suspend {
+        argv,
+        cwd: launch.cwd.clone(),
+    };
+    let session = launch.session.as_str();
+    match (launch.mode, host) {
+        // No multiplexer, so there is no third place for the agent to live: it
+        // runs here, in wf's terminal, and wf must get out of the way of it
+        // whether or not a human asked. An AFK launch never reaches this in
+        // practice — the driver refuses it and [`execute`] bails — and the
+        // `Suspend` it maps to is the third lock: `autostart::start` rejects a
+        // `Suspend` handoff outright.
+        (_, Host::NoZellij) => suspend(launch.agent_argv()),
         (Mode::Afk, _) => Handoff::Stay,
-        (Mode::Hitl, Host::Outside) => Handoff::Suspend(attach_argv(session)),
+        (Mode::Hitl, Host::Outside) => suspend(attach_argv(session)),
         (Mode::Hitl, Host::Inside(current)) if current != session => Handoff::Quit,
         // An unnamed host cannot be compared to the target, so it is treated as
         // the same session: staying is the recoverable guess (a live TUI in a
@@ -591,6 +669,9 @@ pub fn handoff(mode: Mode, host: &Host, session: &str) -> Handoff {
 /// tab was created would otherwise dedupe correctly and then fail to focus.
 pub fn focus_steps(host: &Host, launch: &Launch, tab: &OpenTab) -> Vec<Vec<String>> {
     match (launch.mode, host) {
+        // There is no client to move and no tab it could be moved to; the
+        // `Suspend` handoff runs the agent right here.
+        (_, Host::NoZellij) => Vec::new(),
         (Mode::Afk, _) => Vec::new(),
         (Mode::Hitl, Host::Outside) => Vec::new(),
         (Mode::Hitl, Host::InsideUnnamed) => vec![go_to_tab_argv(&launch.session, &tab.name)],
@@ -655,6 +736,36 @@ impl OpenTab {
     /// The name zellij will answer to for this tab.
     pub fn name(&self) -> &str {
         &self.name
+    }
+}
+
+/// Where a launch's agent ended up — the one thing that differs between a
+/// machine with zellij and one without.
+///
+/// A sum rather than an `Option<OpenTab>`: "no tab" here is not a missing value
+/// to be defaulted or unwrapped, it is a *different, complete* kind of launch,
+/// and the difference decides whether focusing, dedupe and counting mean
+/// anything at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Opened {
+    /// In a zellij tab — created just now, or already there and focused.
+    Tab(OpenTab),
+    /// In `wf`'s own terminal, as its child: no zellij on this machine, so
+    /// there is no tab to name, focus, dedupe against or count.
+    Direct,
+}
+
+impl Opened {
+    /// The word for what just happened, for the notice line. A direct launch is
+    /// always `started`: there was no tab to find already running.
+    pub fn verb(&self) -> &'static str {
+        match self {
+            Opened::Tab(tab) => match tab.outcome() {
+                TabOutcome::Created => "started",
+                TabOutcome::Existed => "focused",
+            },
+            Opened::Direct => "started",
+        }
     }
 }
 
@@ -753,10 +864,34 @@ pub async fn create_or_focus_tab(
     }
 }
 
-/// Perform a launch: ensure the session, create-or-focus the ticket's tab,
-/// move the zellij client if that is this host's handoff, and report what the
-/// caller must still do (suspend-and-attach, or nothing).
-pub async fn execute(launch: &Launch, host: &Host) -> Result<(OpenTab, Handoff)> {
+/// Perform a launch and report what the caller must still do.
+///
+/// With zellij: ensure the session, create-or-focus the ticket's tab, move the
+/// client if that is this host's handoff. Without: nothing to prepare at all —
+/// the agent is the child the caller is about to run, so the whole launch *is*
+/// its handoff.
+pub async fn execute(launch: &Launch, host: &Host) -> Result<(Opened, Handoff)> {
+    match host {
+        Host::NoZellij => {
+            // Second lock on the AFK refusal (the driver is the first): a
+            // headless agent with no tab is a process nobody can watch, find or
+            // reap, and #7 makes the tab the whole supervision story.
+            if launch.mode == Mode::Afk {
+                bail!("no zellij: an afk agent needs a tab to be supervised in");
+            }
+            Ok((Opened::Direct, handoff(host, launch)))
+        }
+        Host::Outside | Host::Inside(_) | Host::InsideUnnamed => {
+            let tab = execute_in_zellij(launch, host).await?;
+            let handoff = handoff(host, launch);
+            Ok((Opened::Tab(tab), handoff))
+        }
+    }
+}
+
+/// The zellij half of [`execute`]: session, tab, client. Never reached with
+/// [`Host::NoZellij`], so every `zellij` invocation below has a `zellij` to run.
+async fn execute_in_zellij(launch: &Launch, host: &Host) -> Result<OpenTab> {
     ensure_session(&launch.session, &launch.cwd).await?;
 
     // An AFK tab must not steal focus; remember where focus is so it can be
@@ -784,7 +919,7 @@ pub async fn execute(launch: &Launch, host: &Host) -> Result<(OpenTab, Handoff)>
         run(&go_to_tab_argv(&launch.session, &tab), None).await?;
     }
 
-    Ok((opened, handoff(launch.mode, host, &launch.session)))
+    Ok(opened)
 }
 
 /// Count the agent tabs across the projects' sessions — the AFK status line.
@@ -795,6 +930,11 @@ pub async fn execute(launch: &Launch, host: &Host) -> Result<(OpenTab, Handoff)>
 /// rather than looking any ticket up, and [`is_agent_tab`] recognises a key at
 /// the head of a name whatever follows it.
 pub async fn agent_tab_count(sessions: &[String]) -> usize {
+    // No zellij, so no tabs — a fact about the machine rather than a failed
+    // query, and answered without spawning anything.
+    if detect_host().await == Host::NoZellij {
+        return 0;
+    }
     let listing = match list_sessions().await {
         Ok(listing) => listing,
         Err(_) => return 0,
@@ -826,6 +966,13 @@ pub async fn agent_tab_count(sessions: &[String]) -> usize {
 /// poll reconciles nothing.
 pub async fn tabs_by_session(sessions: &[String]) -> crate::autostart::TabsBySession {
     let mut tabs = crate::autostart::TabsBySession::new();
+    // With no zellij every session's tab state is *unknown*, which is the empty
+    // map — and reconciliation reads that as "sit this poll out", the same
+    // conservative answer it gives an unqueryable session. Auto-start is
+    // therefore off without zellij by the existing rule, not a special case.
+    if detect_host().await == Host::NoZellij {
+        return tabs;
+    }
     let Ok(listing) = list_sessions().await else {
         return tabs;
     };
@@ -1164,12 +1311,15 @@ mod tests {
     fn outside_zellij_hitl_suspends_and_attaches_as_a_child() {
         let launch = launch_for(Mode::Hitl, "wayfinder");
         assert_eq!(
-            handoff(Mode::Hitl, &Host::Outside, "wayfinder"),
-            Handoff::Suspend(vec![
-                "zellij".to_string(),
-                "attach".to_string(),
-                "wayfinder".to_string()
-            ])
+            handoff(&Host::Outside, &launch),
+            Handoff::Suspend {
+                argv: vec![
+                    "zellij".to_string(),
+                    "attach".to_string(),
+                    "wayfinder".to_string()
+                ],
+                cwd: PathBuf::from("/data/proj/wayfinder"),
+            }
         );
         // Nothing else moves the client: the attach does it.
         let tab = opened(TabOutcome::Created, "wayfinder#16 launch seam");
@@ -1181,7 +1331,7 @@ mod tests {
         let launch = launch_for(Mode::Hitl, "wayfinder");
         let host = Host::Inside("wayfinder".to_string());
         let tab = opened(TabOutcome::Created, "wayfinder#16 launch seam");
-        assert_eq!(handoff(Mode::Hitl, &host, "wayfinder"), Handoff::Stay);
+        assert_eq!(handoff(&host, &launch), Handoff::Stay);
         assert_eq!(
             focus_steps(&host, &launch, &tab),
             vec![go_to_tab_argv("wayfinder", "wayfinder#16 launch seam")]
@@ -1211,7 +1361,7 @@ mod tests {
         let tab = opened(TabOutcome::Created, "wayfinder#16 launch seam");
         // The client leaves this session, so the tab wf is drawing in becomes
         // unreachable: it must not be left running there (#22).
-        assert_eq!(handoff(Mode::Hitl, &host, "k1"), Handoff::Quit);
+        assert_eq!(handoff(&host, &launch), Handoff::Quit);
         assert_eq!(
             focus_steps(&host, &launch, &tab),
             vec![
@@ -1225,13 +1375,16 @@ mod tests {
     fn wf_survives_only_a_handoff_it_can_be_navigated_back_from() {
         // Same session: wf's tab is still a tab-switch away, so it stays up.
         let same = Host::Inside("wayfinder".to_string());
-        assert_eq!(handoff(Mode::Hitl, &same, "wayfinder"), Handoff::Stay);
+        assert_eq!(
+            handoff(&same, &launch_for(Mode::Hitl, "wayfinder")),
+            Handoff::Stay
+        );
         // Another session: the client is gone from here, so staying would leak
         // a TUI holding a pane nobody can reach.
-        assert_eq!(handoff(Mode::Hitl, &same, "k1"), Handoff::Quit);
+        assert_eq!(handoff(&same, &launch_for(Mode::Hitl, "k1")), Handoff::Quit);
         // Unnamed: not comparable, so the recoverable guess wins.
         assert_eq!(
-            handoff(Mode::Hitl, &Host::InsideUnnamed, "k1"),
+            handoff(&Host::InsideUnnamed, &launch_for(Mode::Hitl, "k1")),
             Handoff::Stay
         );
     }
@@ -1246,7 +1399,7 @@ mod tests {
         ] {
             let launch = launch_for(Mode::Afk, "wayfinder");
             let tab = opened(TabOutcome::Created, "wayfinder#16 launch seam");
-            assert_eq!(handoff(Mode::Afk, &host, "wayfinder"), Handoff::Stay);
+            assert_eq!(handoff(&host, &launch), Handoff::Stay);
             assert!(
                 focus_steps(&host, &launch, &tab).is_empty(),
                 "host {host:?}"
@@ -1270,6 +1423,81 @@ mod tests {
             &Host::Inside("wayfinder".to_string()),
             &launch_for(Mode::Hitl, "wayfinder")
         ));
+    }
+
+    #[test]
+    fn with_no_zellij_hitl_runs_the_agent_itself_in_the_checkout() {
+        // The whole point of the no-zellij path: a machine with no multiplexer
+        // still launches. The child is `claude`, not `zellij attach`, and it runs in the
+        // checkout — the cwd zellij's `new-tab --cwd` would otherwise have set.
+        let launch = launch_for(Mode::Hitl, "wayfinder");
+        assert_eq!(
+            handoff(&Host::NoZellij, &launch),
+            Handoff::Suspend {
+                argv: vec![
+                    "claude".to_string(),
+                    SKIP_PERMISSIONS.to_string(),
+                    "/wayfinder 1 16".to_string(),
+                ],
+                cwd: PathBuf::from("/data/proj/wayfinder"),
+            }
+        );
+        // The same agent either way: what changes is where it runs, never what
+        // it is handed.
+        match handoff(&Host::NoZellij, &launch) {
+            Handoff::Suspend { argv, .. } => assert_eq!(argv, launch.agent_argv()),
+            other => panic!("expected a suspend, got {other:?}"),
+        }
+        // Nothing to focus and no client to move.
+        let tab = opened(TabOutcome::Created, "wayfinder#16 launch seam");
+        assert!(focus_steps(&Host::NoZellij, &launch, &tab).is_empty());
+        assert!(!afk_steals_focus(&Host::NoZellij, &launch));
+    }
+
+    #[test]
+    fn a_missing_zellij_is_not_the_same_host_as_an_unattached_one() {
+        // `Outside` still gets a tab and attaches to reach it; `NoZellij` has no
+        // tab at all. Collapsing them would attach to a binary that is not there.
+        let launch = launch_for(Mode::Hitl, "wayfinder");
+        let outside = handoff(&Host::Outside, &launch);
+        let none = handoff(&Host::NoZellij, &launch);
+        assert_ne!(outside, none);
+        assert!(matches!(outside, Handoff::Suspend { ref argv, .. } if argv[0] == "zellij"));
+        assert!(matches!(none, Handoff::Suspend { ref argv, .. } if argv[0] == "claude"));
+        // And the env-only classifier never invents it: whether zellij exists is
+        // a question about PATH, which `host_from_env` is not asked about.
+        for (zellij, name) in [(None, None), (Some("0"), Some("wayfinder")), (Some("0"), None)] {
+            assert_ne!(host_from_env(zellij, name), Host::NoZellij);
+        }
+    }
+
+    #[tokio::test]
+    async fn with_no_zellij_an_afk_launch_is_refused_before_anything_runs() {
+        // An AFK agent is supervised by its tab (#7). With no tab there is
+        // nothing to watch it in, so `execute` refuses rather than orphaning a
+        // headless `claude -p` — and refuses without touching the filesystem or
+        // spawning anything, which is why this test needs no zellij.
+        let err = execute(&launch_for(Mode::Afk, "wayfinder"), &Host::NoZellij)
+            .await
+            .expect_err("an afk launch with no zellij must be refused");
+        assert!(err.to_string().contains("afk"), "got {err}");
+        // Third lock: even if that guard were removed, the handoff it maps to is
+        // a `Suspend`, which `autostart::start` rejects outright.
+        assert!(matches!(
+            handoff(&Host::NoZellij, &launch_for(Mode::Afk, "wayfinder")),
+            Handoff::Suspend { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn with_no_zellij_hitl_execute_opens_nothing_and_hands_over() {
+        let launch = launch_for(Mode::Hitl, "wayfinder");
+        let (opened, handoff) = execute(&launch, &Host::NoZellij)
+            .await
+            .expect("a direct launch needs nothing to exist first");
+        assert_eq!(opened, Opened::Direct);
+        assert_eq!(opened.verb(), "started");
+        assert!(matches!(handoff, Handoff::Suspend { .. }));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@
 //!
 //! Build 4: the launch seam (see #16/#5/#7) — `enter` creates or focuses the
 //! `<repo>#<n>` zellij tab in the project's session and hands the terminal
-//! over to a HITL agent; `ctrl-a` spawns the same tab headless (AFK).
+//! over to a HITL agent; `ctrl-a` spawns the same tab headless (AFK). With no
+//! zellij on the machine at all, `enter` runs that same agent as `wf`'s own
+//! child in the checkout instead, and the tab-shaped features say so rather
+//! than pretending ([`launch::Host::NoZellij`]).
 //!
 //! Build 6: auto-start (see #19/#18) — after every healthy poll, `wf` reconciles
 //! the invariant "every frontier `research` ticket has a tab" and spawns the

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 use wf::app::{App, Outcome, Scope};
 use wf::autostart::{self, PollHealthByRepo};
-use wf::launch::{self, Handoff, Launch, MapIssues, TabOutcome};
+use wf::launch::{self, Handoff, Host, Launch, MapIssues, Mode, Opened};
 use wf::model::{merge_maps, Map};
 use wf::projects::{self, ProjectsCache};
 use wf::refresh::{Freshness, LoadEvent, Pollers, RefreshEvent, Startup};
@@ -275,25 +275,33 @@ enum LaunchReport {
     HandedOver(String),
 }
 
-/// Perform one launch (#16): create-or-focus the tab, then hand over as this
-/// host requires — suspending the TUI around `zellij attach` when `wf` owns
-/// the terminal, staying up when zellij's own navigation moves the client
-/// within this session, and quitting when it moves the client off it.
+/// Perform one launch (#16): give the agent somewhere to run, then hand over as
+/// this host requires — suspending the TUI around `zellij attach` when `wf` owns
+/// the terminal, staying up when zellij's own navigation moves the client within
+/// this session, quitting when it moves the client off it, and — with no zellij
+/// on the machine at all — suspending around the agent *itself*, which is then
+/// `wf`'s own child and comes back here when it exits.
 async fn perform_launch(
     terminal: &mut DefaultTerminal,
     launch: &Launch,
     maps: &mut BTreeMap<String, Map>,
     map_issues: &BTreeMap<String, u64>,
 ) -> Result<LaunchReport> {
-    let host = launch::detect_host();
-    let (tab, handoff) = match launch::execute(launch, &host).await {
+    let host = launch::detect_host().await;
+    // ctrl-a with no zellij. Refused here rather than in `App`, which decides
+    // *what* to launch and is deliberately blind to the environment; refused at
+    // all because #7 makes the tab the entire supervision story for a headless
+    // agent, and there is no tab here to hold one.
+    if launch.mode == Mode::Afk && host == Host::NoZellij {
+        return Ok(LaunchReport::Notice(
+            "no zellij — afk needs a tab; enter runs this ticket here instead".to_string(),
+        ));
+    }
+    let (opened, handoff) = match launch::execute(launch, &host).await {
         Ok(result) => result,
         Err(err) => return Ok(LaunchReport::Notice(format!("launch failed: {err}"))),
     };
-    let verb = match tab.outcome() {
-        TabOutcome::Created => "started",
-        TabOutcome::Existed => "focused",
-    };
+    let verb = opened.verb();
     match handoff {
         Handoff::Stay => Ok(LaunchReport::Notice(format!(
             "{verb} {}",
@@ -303,16 +311,27 @@ async fn perform_launch(
             "{verb} {} — run `wf` in that session to pick another ticket",
             launch.describe()
         ))),
-        Handoff::Suspend(argv) => {
-            let (program, args) = argv.split_first().expect("attach argv is non-empty");
+        Handoff::Suspend { argv, cwd } => {
+            let (program, args) = argv.split_first().expect("a handoff argv is non-empty");
+            // What was handed over decides what "back" means: a whole session,
+            // when the zellij client was free to roam its tabs, and this one
+            // ticket when the child *was* the agent.
+            let from = match &opened {
+                Opened::Tab(_) => launch.session.clone(),
+                Opened::Direct => launch.key().to_string(),
+            };
             suspend(terminal)?;
-            let status = tokio::process::Command::new(program).args(args).status().await;
+            let status = tokio::process::Command::new(program)
+                .args(args)
+                .current_dir(cwd)
+                .status()
+                .await;
             resume(terminal)?;
             // Away for a while: the tracker moved (a claim, maybe a close).
             refetch_all(maps, map_issues).await;
             Ok(LaunchReport::Notice(match status {
-                Ok(_) => format!("back from {}", launch.session),
-                Err(err) => format!("could not attach to {}: {err}", launch.session),
+                Ok(_) => format!("back from {from}"),
+                Err(err) => format!("could not run {from}: {err}"),
             }))
         }
     }
@@ -350,7 +369,7 @@ async fn reconcile_autostart(
         return None;
     }
 
-    let host = launch::detect_host();
+    let host = launch::detect_host().await;
     let mut started = Vec::new();
     let mut failed = 0usize;
     for launch in &launches {


### PR DESCRIPTION
zellij was a hard requirement. With none on PATH, `enter` shelled out to a binary that is not there and read every failure as an empty session list — so selecting a ticket did nothing at all. Now it just enters the session.

## What changed

A fourth host, `Host::NoZellij`, decided by probing `zellij --version`. It is deliberately **distinct** from `Outside`: "zellij exists, it just does not own this terminal" still gets a tab and attaches to reach it, while this one has no tab to get. Collapsing the two is what made `wf` attach to a missing binary.

On that host `enter` suspends the TUI and runs the same agent — `claude --dangerously-skip-permissions "/wayfinder <map> <n>"` — as `wf`'s own child in the checkout. Quitting the agent returns to the picker, which refetches, exactly as it does after a detach.

The probe is memoised in a `tokio::sync::OnceCell` rather than resolved at startup and threaded down. Both halves of the answer are fixed for the process's lifetime, but #27 keeps every subprocess off the path to the first frame and #21 is about that exact boundary wedging — so the first caller that *needs* the host pays for it, and that caller is always a keystroke or a poll.

## Modelling

- `execute` returns an `Opened` sum (`Tab(OpenTab)` | `Direct`) instead of an `OpenTab`. "No tab" is not a missing value to unwrap or default — it is a different, complete kind of launch, and the difference decides whether focusing, dedupe and counting mean anything.
- `Handoff::Suspend` carries the `cwd` it now needs (`zellij attach` does not care; an agent run directly cares completely).
- `handoff` takes the whole `Launch` rather than a mode and a session name passed separately from the launch they describe.

## What is honestly absent rather than faked

- `ctrl-a` is refused — `no zellij — afk needs a tab; enter runs this ticket here instead`. A headless agent is supervised by its tab (#7); with no tab it would be a process you cannot see, find or reap. Triple-locked: the driver refuses it, `execute` bails, and `autostart::start` rejects the `Suspend` handoff it maps to.
- Auto-start is off, and off by the **existing** rule rather than a new case: `tabs_by_session` reports every session's tabs as unknown, which `reconcile` already treats as "sit this poll out".
- `agent_tab_count` answers zero without spawning anything.

## Verification

`cargo test` (125 unit + 5 bin + live fetch/poll/discovery + the live zellij integration tests) and `cargo clippy --all-targets -D warnings` are green — the zellij paths are untouched and still proven against a real zellij.

End to end with zellij shimmed away and a fake `claude` on PATH, driving the real TUI under a pty:

- `enter` → `claude ran: pwd=/home/ags/projects/wayfinder args=--dangerously-skip-permissions /wayfinder 1 30`, and the TUI resumed afterwards;
- `ctrl-a` → nothing spawned.

Also bumps to 0.2.2 (`Cargo.toml`, `Cargo.lock`, `recipe/recipe.yaml`) and documents the path in the README under *Without zellij*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)