### PR TITLE
Stop leaking wf's raw tty into the zellij server (#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "dirs",
+ "libc",
  "nucleo-matcher",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ tokio = { version = "1", features = [
     "sync",
     "time",
 ] }
+
+[dev-dependencies]
+libc = "0.2.189"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ How `wf` hands over depends on where it is itself running, decided from its own
 - **inside another session** — zellij's session switcher gesture
   (`switch-session`) moves you over, and `wf` exits as it goes: the tab it was
   drawing in belongs to the session you just left, so nothing could reach it to
-  quit it. Run `wf` again in the session you land in to pick the next ticket.
+  quit it. It prints no parting line either, for the same reason — you are
+  already elsewhere, so the only pane it could print into is one you have left.
+  Run `wf` again in the session you land in to pick the next ticket.
 
 No new navigation keybindings: getting back is zellij's standard detach or
 tab/session switching. The project's session is created detached if it does not

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -36,6 +36,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
 use tokio::process::Command;
@@ -107,18 +108,19 @@ pub fn host_from_env(zellij: Option<&str>, session_name: Option<&str>) -> Host {
 /// Probed by *running* it rather than by searching `$PATH`, because the question
 /// that matters is whether this module's invocations will work — a `zellij` that
 /// is on PATH but cannot start is no more usable than an absent one. `--version`
-/// is the one invocation that touches no session, and the inherited zellij
-/// variables are scrubbed as everywhere else so a stale `ZELLIJ_SESSION_NAME`
-/// cannot make even this hang (#5 findings).
+/// is the one invocation that touches no session, and it goes through
+/// [`zellij_command`] like every other, so the inherited zellij variables are
+/// scrubbed — a stale `ZELLIJ_SESSION_NAME` cannot make even this hang (#5
+/// findings) — and `wf`'s raw tty stays out of its stdin (#30).
 pub async fn zellij_available() -> bool {
-    Command::new("zellij")
-        .arg("--version")
-        .env_remove("ZELLIJ")
-        .env_remove("ZELLIJ_SESSION_NAME")
-        .env_remove("ZELLIJ_PANE_ID")
-        .output()
-        .await
-        .is_ok_and(|output| output.status.success())
+    let argv = ["zellij".to_string(), "--version".to_string()];
+    match zellij_command(&argv, None) {
+        Ok(mut command) => command
+            .output()
+            .await
+            .is_ok_and(|output| output.status.success()),
+        Err(_) => false,
+    }
 }
 
 /// The answer to [`detect_host`], computed at most once per process.
@@ -769,22 +771,44 @@ impl Opened {
     }
 }
 
-/// Run a zellij invocation, scrubbing the inherited zellij variables so it
-/// cannot be silently retargeted at — or hang on — the session those name.
-/// The exit status is *not* trusted (`zellij action` returns 0 on failure);
-/// callers verify by re-reading state.
-async fn run(argv: &[String], cwd: Option<&Path>) -> Result<String> {
+/// Prepare a `zellij` invocation: scrub the inherited zellij variables so it
+/// cannot be silently retargeted at — or hang on — the session those name, and
+/// **detach it from `wf`'s terminal**.
+///
+/// The stdin part is not hygiene, it is the #30 fix. `wf` is a ratatui TUI, so
+/// its tty is in **raw** mode for as long as the picker is up. A zellij client
+/// reads the termios it gives new panes **from its own stdin**, and the server
+/// then stamps that state onto every pane it ever creates — permanently, for the
+/// server's whole lifetime. So a session `wf` created while holding a raw tty
+/// produced panes born `-echo -icanon -isig -opost`: the agent's keys did not
+/// echo, `Ctrl-c` was inert, and `\n` moved down without a carriage return, which
+/// is the "broken terminal after a cross-session launch" of #30.
+///
+/// `tokio`'s `Command::output()` is what let this through: unlike
+/// `std::process::Command::output()`, it sets **only** stdout and stderr to
+/// piped, leaving stdin *inherited*. Nulling stdin here is the whole fix, and it
+/// belongs on every invocation rather than just session creation — the leak is a
+/// property of the tty `wf` holds, not of which subcommand runs.
+fn zellij_command(argv: &[String], cwd: Option<&Path>) -> Result<Command> {
     let (program, args) = argv.split_first().context("empty zellij invocation")?;
     let mut command = Command::new(program);
     command
         .args(args)
         .env_remove("ZELLIJ")
         .env_remove("ZELLIJ_SESSION_NAME")
-        .env_remove("ZELLIJ_PANE_ID");
+        .env_remove("ZELLIJ_PANE_ID")
+        .stdin(Stdio::null());
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }
-    let output = command
+    Ok(command)
+}
+
+/// Run a zellij invocation via [`zellij_command`]. The exit status is *not*
+/// trusted (`zellij action` returns 0 on failure); callers verify by re-reading
+/// state.
+async fn run(argv: &[String], cwd: Option<&Path>) -> Result<String> {
+    let output = zellij_command(argv, cwd)?
         .output()
         .await
         .with_context(|| format!("running `{}`", argv.join(" ")))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,9 +156,7 @@ async fn main() -> Result<()> {
     }
     let result = run(&mut terminal, app, sessions, tx, updates, focus).await;
     ratatui::restore();
-    if let Ending::HandedOver(parting) = result? {
-        println!("wf: {parting}");
-    }
+    result?;
     Ok(())
 }
 
@@ -271,9 +269,9 @@ enum LaunchReport {
     /// `wf` is still up; this is its notice line.
     Notice(String),
     /// The zellij client left for another session, so this launch was `wf`'s
-    /// last act: the line is printed on the way out instead (see
-    /// [`launch::Handoff::Quit`]).
-    HandedOver(String),
+    /// last act — and its notice has nowhere to land (see
+    /// [`launch::Handoff::Quit`] and [`Ending::HandedOver`]).
+    HandedOver,
 }
 
 /// Perform one launch (#16): give the agent somewhere to run, then hand over as
@@ -308,10 +306,7 @@ async fn perform_launch(
             "{verb} {}",
             launch.describe()
         ))),
-        Handoff::Quit => Ok(LaunchReport::HandedOver(format!(
-            "{verb} {} — run `wf` in that session to pick another ticket",
-            launch.describe()
-        ))),
+        Handoff::Quit => Ok(LaunchReport::HandedOver),
         Handoff::Suspend { argv, cwd } => {
             let (program, args) = argv.split_first().expect("a handoff argv is non-empty");
             // What was handed over decides what "back" means: a whole session,
@@ -426,9 +421,13 @@ enum Ending {
     /// The user quit.
     Quit,
     /// A launch moved the zellij client to another session, so `wf` handed the
-    /// terminal over; this line is printed once the terminal is restored,
-    /// because by then there is no TUI left to show a notice in.
-    HandedOver(String),
+    /// terminal over.
+    ///
+    /// Carries **nothing** to say on the way out, because there is nobody left
+    /// to say it to (#30): the client is already in the other session, so the
+    /// pane `wf` would print into is an abandoned pty in the session it just
+    /// left. The line this used to carry was unreadable by construction.
+    HandedOver,
 }
 
 /// The event loop. It starts with **no data at all** (#27): the maps, which
@@ -563,9 +562,7 @@ async fn run(
                             LaunchReport::Notice(notice) => notice,
                             // Nothing after this can be seen from here: the
                             // client is in another session now.
-                            LaunchReport::HandedOver(parting) => {
-                                return Ok(Ending::HandedOver(parting))
-                            }
+                            LaunchReport::HandedOver => return Ok(Ending::HandedOver),
                         };
                         app.replace_map(merge_maps(&maps));
                         app.notice = Some(notice);

--- a/tests/live_zellij_termios.rs
+++ b/tests/live_zellij_termios.rs
@@ -1,0 +1,178 @@
+//! Regression test for #30: a session `wf` creates must have **cooked** panes,
+//! even though `wf` holds a raw-mode terminal the whole time it is up.
+//!
+//! The bug this guards is invisible from inside `wf` and silent at the boundary.
+//! `wf` is a ratatui TUI, so its tty is raw. A zellij client reads the termios it
+//! gives new panes **from its own stdin**, and the server then stamps that state
+//! onto every pane it ever creates, for its whole lifetime. Because
+//! `tokio::process::Command::output()` pipes only stdout and stderr — leaving
+//! stdin *inherited*, unlike `std::process::Command::output()` — every session
+//! `wf` created was born raw, and the agent in it ran on a tty with `-echo`
+//! (keys invisible), `-isig` (`Ctrl-c` inert) and `-opost` (`\n` with no carriage
+//! return, so output staircases). That is the "broken terminal after a
+//! cross-session launch" of #30.
+//!
+//! So this test does the one thing the unit tests cannot: it makes **this
+//! process's stdin a genuinely raw tty**, then goes through the real
+//! `ensure_session` / `create_or_focus_tab` path and asks the pane itself what
+//! termios it got. It lives in its own file because it mutates fd 0, which is
+//! process-wide; libtest gives each integration test file its own binary.
+//!
+//! Needs `zellij` on PATH.
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use wf::launch::{create_or_focus_tab, ensure_session, tab_label, TabOutcome};
+use wf::model::{classify, Ticket, TicketType};
+
+/// The flags that decide whether a terminal is usable at all. Each is asserted
+/// present *and* not negated, because `stty -a` writes the off state as `-flag`.
+const COOKED: [&str; 4] = ["echo", "icanon", "isig", "opost"];
+
+/// Kills and deletes the throwaway session on drop, panic or not.
+struct Throwaway(String);
+
+impl Throwaway {
+    fn zellij(&self, args: &[&str]) {
+        let _ = Command::new("zellij")
+            .args(args)
+            .env_remove("ZELLIJ")
+            .env_remove("ZELLIJ_SESSION_NAME")
+            .env_remove("ZELLIJ_PANE_ID")
+            .output();
+    }
+}
+
+impl Drop for Throwaway {
+    fn drop(&mut self) {
+        self.zellij(&["kill-session", &self.0]);
+        // A killed session stays serialized and would be resurrected stale by
+        // the next same-name create — the #5 findings' resurrection gotcha.
+        self.zellij(&["delete-session", &self.0]);
+    }
+}
+
+/// Put a **raw** pty on this process's stdin, standing in for `wf`'s own
+/// terminal while the picker is up.
+///
+/// The master fd is deliberately leaked: closing it would make every read on the
+/// slave fail with `EIO`, and this process only ever needs the slave to *be* a
+/// raw tty, never to carry traffic.
+fn raw_tty_on_stdin() {
+    unsafe {
+        let mut master = 0;
+        let mut slave = 0;
+        assert_eq!(
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ),
+            0,
+            "openpty failed"
+        );
+        assert!(libc::dup2(slave, libc::STDIN_FILENO) >= 0, "dup2 failed");
+        let mut settings: libc::termios = std::mem::zeroed();
+        assert_eq!(
+            libc::tcgetattr(libc::STDIN_FILENO, &mut settings),
+            0,
+            "tcgetattr failed"
+        );
+        libc::cfmakeraw(&mut settings);
+        assert_eq!(
+            libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &settings),
+            0,
+            "tcsetattr failed"
+        );
+        // Prove the premise rather than assume it: if stdin is not raw, a pass
+        // below would mean nothing.
+        let mut check: libc::termios = std::mem::zeroed();
+        libc::tcgetattr(libc::STDIN_FILENO, &mut check);
+        assert_eq!(
+            check.c_lflag & libc::ECHO,
+            0,
+            "stdin should be raw (no echo)"
+        );
+    }
+}
+
+/// Split `stty -a` output into flag tokens (`echo`, `-icanon`, …), dropping the
+/// `key = value` control-character assignments, which are not flags.
+fn flags(stty: &str) -> Vec<&str> {
+    stty.split([';', '\n'])
+        .map(str::trim)
+        .filter(|field| !field.contains('=') && !field.is_empty())
+        .flat_map(str::split_whitespace)
+        .collect()
+}
+
+#[tokio::test]
+async fn a_session_wf_creates_has_cooked_panes() {
+    raw_tty_on_stdin();
+
+    let session = format!("wf-it-termios-{}", std::process::id());
+    let guard = Throwaway(session.clone());
+    let cwd = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let report = std::env::temp_dir().join(format!("{session}-stty.txt"));
+    let _ = std::fs::remove_file(&report);
+
+    // The stand-in agent: no real claude, it just reports the tty it was handed.
+    // The `sleep` keeps the pane alive long enough to be observed as a live tab.
+    let command: Vec<String> = [
+        "bash".to_string(),
+        "-lc".to_string(),
+        format!("stty -a > {} 2>&1; sleep 5", report.display()),
+    ]
+    .to_vec();
+
+    // The real path: `wf` creates the session while holding the raw tty above —
+    // exactly what `Handoff::Quit` does, since a cross-session launch is
+    // precisely the case where the target session must be created.
+    ensure_session(&session, cwd)
+        .await
+        .expect("create the session");
+    let ticket = Ticket {
+        repo: "blooop/wayfinder".to_string(),
+        number: 30,
+        title: "cross-session handoff".to_string(),
+        status: classify(true, false, vec![]),
+        ticket_type: TicketType::Grilling,
+    };
+    let opened = create_or_focus_tab(&session, &tab_label(&ticket), cwd, &command)
+        .await
+        .expect("create the tab");
+    assert_eq!(opened.outcome(), TabOutcome::Created);
+
+    // The pane writes its termios once bash is up; poll rather than guess.
+    let mut stty = String::new();
+    for _ in 0..40 {
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        if let Ok(text) = std::fs::read_to_string(&report) {
+            if text.contains("speed") {
+                stty = text;
+                break;
+            }
+        }
+    }
+    drop(guard);
+    let _ = std::fs::remove_file(&report);
+    assert!(!stty.is_empty(), "the pane never reported its termios");
+
+    let flags = flags(&stty);
+    for flag in COOKED {
+        let off = format!("-{flag}");
+        assert!(
+            !flags.contains(&off.as_str()),
+            "#30: pane was born with `{off}` — wf leaked its raw tty into the \
+             zellij server again. Full stty:\n{stty}"
+        );
+        assert!(
+            flags.contains(&flag),
+            "expected `{flag}` in the pane's termios. Full stty:\n{stty}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #30 — the "broken terminal after a cross-session launch".

## What was wrong

`wf` is a ratatui TUI, so its tty is **raw** for as long as the picker is up. A zellij client reads the termios it gives new panes **from its own stdin**, and the server then stamps that state onto **every pane it ever creates**, for its whole lifetime.

`tokio::process::Command::output()` sets *only* stdout and stderr to piped (`tokio-1.53.1/src/process/mod.rs:1065`) — it never touches stdin, so stdin stays **inherited**. That is a silent divergence from `std::process::Command::output()`, which nulls it. Both of `launch.rs`'s spawn sites used `output()`, so every session `wf` created was born raw and the agent in it ran on a tty with:

- `-echo` — keys did not echo
- `-isig` — `Ctrl-c` inert
- `-opost` — `onlcr` not applied, so `\n` drops a line without a carriage return and output staircases

Which is exactly the reported symptom set, including the two states #30 called mutually exclusive. They were never in conflict: the pane was raw **from birth**, not left raw by a teardown.

Two hypotheses are ruled out by measurement, not argument. `wf`'s own `init`/`restore` symmetry was never at fault, and the **EXITED-pane post-mortem is not the cause** — zellij 0.44.3 renders *no* exit hint on a dead pane (no such string anywhere in the byte stream) and `Enter` there produces zero output, so `Enter` is not a live binding on a corpse and #5's no-`--close-on-exit` rule stands untouched.

## How it was localised

Identical `zellij attach --create-background`, varying only the creating process's fds:

| stdin | stdout/stderr | resulting pane termios |
| --- | --- | --- |
| raw pty | raw pty | **raw** |
| `/dev/null` (ctty *still* the raw pty) | `/dev/null` | cooked |
| **raw pty** | pipes | **raw** |

The last row is exactly `output()`'s shape; the middle row rules out the controlling terminal. It is the **fd**, not the ctty.

Then end to end on the real binary: `wf` driven under a pty through a genuine `Handoff::Quit`, and both sessions probed afterwards from an unrelated **cooked** shell — the session `wf` created reported `-opost -isig -icanon -echo`, the session it did not create reported none of them. Post-fix, both report `opost isig icanon echo`, and the agent's own tty comes up `icrnl opost isig icanon echo`.

## The change

`.stdin(Stdio::null())`, on a shared `zellij_command()` so both spawn sites get it and the reason is written down once. The leak is a property of the tty `wf` holds, not of which subcommand runs, so it belongs on **every** invocation rather than just session creation.

`Handoff::Suspend` still inherits the terminal deliberately — it calls `suspend(terminal)` first, restoring cooked mode, and the child there *is* the thing that needs the screen.

**Wider than #30 assumed:** any session `wf` creates was affected, so AFK agent tabs in new sessions had been running on raw `0×0` ptys too — not just the cross-session HITL path.

## Also, the unreachable parting line

#30 asked for this to be fixed or dropped. It was unreachable by construction: `println!`ed after the client had already moved to the other session, into an abandoned pty in the session just left. Dropped, and `Ending::HandedOver` / `LaunchReport::HandedOver` lose their `String` — the type no longer claims a message exists that nobody can read. The README already carried that guidance where it *can* be seen, and now says so explicitly.

## Verification

- New `tests/live_zellij_termios.rs` makes the test process's stdin a genuinely raw tty (`openpty` + `cfmakeraw`, asserting the premise), goes through the real `ensure_session` / `create_or_focus_tab`, and asks the pane itself what termios it got. **Verified to fail without the fix** (`#30: pane was born with -echo …`) **and pass with it**. Its own file, because it mutates fd 0.
- `cargo test`: 141 tests across 9 binaries green, including the existing live zellij, fetch, poll, discovery and streaming-startup suites.
- `cargo clippy --all-targets -- -D warnings` clean.
- `libc` added as a **dev**-dependency only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Detach zellij subprocesses from wf's raw TTY to prevent leaking raw terminal settings into created sessions, remove an unreachable handover notice path, and add an integration test ensuring sessions created by wf have cooked terminal settings.

Bug Fixes:
- Ensure zellij subprocess stdin is null so wf's raw TTY state is not propagated to new panes and sessions.

Enhancements:
- Refactor zellij process launching through a shared helper that centralizes environment scrubbing and stdin configuration.
- Remove the unreachable handover parting message and simplify related Ending/LaunchReport variants and behavior.

Build:
- Add libc as a dev-dependency for test-time TTY manipulation.

Documentation:
- Clarify README behavior when wf hands over from inside another zellij session and explicitly note that no parting line is printed.

Tests:
- Add an integration test that runs with a raw stdin TTY and verifies that sessions and panes created by wf have cooked terminal termios settings.