### PR TITLE
Isolated containers per branch: a devcontainer for wayfinder

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,54 @@
+# The devcontainer image for working on `wf` — one container per branch, via
+# devpod/devlaunch (`dl blooop/wayfinder@<branch>`).
+#
+# Deliberately thin. A completely cold build of this crate — empty cargo
+# registry, empty target/ — measured **9 seconds** on this machine (release 12s,
+# incremental one-file 1s, `cargo test --no-run` 2s). So there is no cargo-chef
+# dep-prebake, no sccache, and no shared cache volume in here: every mechanism of
+# that sort would cost more in complexity and image size than the 9 seconds it
+# could save. If that number ever grows into the minutes, this is the file to
+# revisit — see blooop/wayfinder#39 for the measurements.
+#
+# What it *does* carry is the three binaries `wf` shells out to and discovers on
+# PATH — `gh`, `zellij`, and the agent CLI — because `cargo test` here is not
+# hermetic: tests/live_fetch.rs drives `gh` against the real tracker and
+# tests/live_zellij_launch.rs starts real zellij sessions.
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+# Pinned rather than "latest" so an image rebuild is a deliberate version bump
+# and not a silent one. Both are plain static binaries with no build step.
+ARG GH_VERSION=2.97.0
+ARG ZELLIJ_VERSION=0.44.3
+
+# One layer, and the tarballs are deleted in it: an unpacked tarball left behind
+# in an earlier layer stays in the image however thoroughly a later layer removes
+# it.
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) gh_arch=linux_amd64; zj_arch=x86_64-unknown-linux-musl ;; \
+      arm64) gh_arch=linux_arm64; zj_arch=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    tmp="$(mktemp -d)"; \
+    curl -fsSL -o "$tmp/gh.tar.gz" \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_${gh_arch}.tar.gz"; \
+    tar -xzf "$tmp/gh.tar.gz" -C "$tmp"; \
+    install -Dm755 "$tmp/gh_${GH_VERSION}_${gh_arch}/bin/gh" /usr/local/bin/gh; \
+    curl -fsSL -o "$tmp/zellij.tar.gz" \
+      "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-${zj_arch}.tar.gz"; \
+    tar -xzf "$tmp/zellij.tar.gz" -C "$tmp"; \
+    install -Dm755 "$tmp/zellij" /usr/local/bin/zellij; \
+    rm -rf "$tmp"; \
+    gh --version; zellij --version
+
+# The agent CLI installs per-user into ~/.local/bin, so it is installed as the
+# user that will run it. `~/.claude` is a bind mount from the host (see
+# devcontainer.json) and is deliberately *not* what this writes to — the binary
+# lives in the image, the credentials and settings come from the host at runtime.
+USER vscode
+RUN set -eux; \
+    curl -fsSL https://claude.ai/install.sh | bash; \
+    /home/vscode/.local/bin/claude --version
+ENV PATH=/home/vscode/.local/bin:$PATH
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,77 @@
+{
+  "name": "wayfinder",
+
+  // Built from this repo's own Dockerfile rather than a prebuilt image. A cold
+  // `cargo build` here is 9 seconds (see blooop/wayfinder#39), so the thing a
+  // prebuilt image would save is the *image* build, not the crate build —
+  // whether that is worth a registry and a publishing workflow is
+  // blooop/wayfinder#43, still open. Until then, local build.
+  // `context` is this directory, NOT the repo root. The Dockerfile copies nothing
+  // out of the context — it only downloads pinned binaries — so a repo-root
+  // context would buy nothing and costs a great deal: devpod hashes the build
+  // context and gives up past 5000 files, and `target/` alone is far beyond that
+  // ("failed to compute context hash: exceeded limit of 5000 files"). If a future
+  // change needs Cargo.toml/Cargo.lock in the image (e.g. baking compiled deps),
+  // widen this to ".." and add a .dockerignore excluding target/ in the same
+  // commit.
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+
+  // Note what is NOT here: `"runArgs": ["--network=host"]`. python_template sets
+  // it, and copying it would defeat one of the three reasons this container
+  // exists — several branches' test runs not colliding on ports and sockets.
+  // The default bridge network is what keeps them apart.
+
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
+  },
+
+  // These two mounts are what make the container useful and are also the holes
+  // in the containment that justified it, so they are the narrowest pair that
+  // works rather than python_template's full set:
+  //
+  //   - `gh` auth is not optional: tests/live_fetch.rs drives the real tracker.
+  //   - the agent's own credentials come from ~/.claude.
+  //
+  // `~/.ssh` is deliberately absent — devpod forwards git credentials and can
+  // forward an ssh agent, which lends the *use* of a key without handing over
+  // the key itself. Whether these mounts stay, narrow to read-only, or become
+  // injected tokens is blooop/wayfinder#41, which is still open; this is the
+  // working starting point, not the settled answer.
+  //
+  // KNOWN GAP, measured: mounting ~/.config/gh does **not** convey gh auth on
+  // this host. `gh` stores the token in the system keyring, so hosts.yml holds
+  // only `users: {blooop: {}}` and no `oauth_token` — inside the container
+  // `gh auth status` reports "The token in default is invalid". Git itself is
+  // fine (devpod forwards credentials); it is only the `gh` CLI that is
+  // unauthenticated, which means tests/live_fetch.rs cannot pass yet. Fixing it
+  // means choosing between injecting `GH_TOKEN` (a long-lived token in the
+  // container's environment) and a one-off `gh auth login` inside the container
+  // (which persists into this bind mount, because the container has no keyring).
+  // That choice is blooop/wayfinder#41 and it gates blooop/wayfinder#42.
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind",
+    "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind"
+  ],
+
+  // Runs on the *host* before the container is created. Bind-mounting a path
+  // that does not exist yet makes docker create it as a root-owned directory,
+  // which then fails confusingly inside the container; mkdir -p is idempotent
+  // and will not clobber an existing config.
+  "initializeCommand": "mkdir -p \"$HOME/.claude\" \"$HOME/.config/gh\"",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "mhutchie.git-graph",
+        "anthropic.claude-code"
+      ]
+    }
+  },
+
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
One container per branch, driven by devpod/devlaunch (`dl blooop/wayfinder@<branch>`), so several branches — and the agents working them — run at once without sharing a working tree, a port namespace, or the host.

Resolves #40 on [the devpod map](https://github.com/blooop/wayfinder/issues/35), alongside #36, #37, #38, #39.

## Verified, not just written

| check | result |
| --- | --- |
| two branches → two containers, concurrently | `default-wf-7439e` + `default-wf-4a7ca` |
| both cold-build at once | 33 s each, independent 422 M `target/` apiece |
| `gh` / `zellij` / `claude` / `cargo` on PATH as `vscode` | yes |
| `devpod up` end-to-end | ~40 s including dotfiles |

## Deliberately thin

A fully cold `cargo build` here — empty registry, empty `target/` — measures **9 seconds** (#39). So there is no cargo-chef prebake, no sccache, no shared cache volume: each would cost more complexity than the seconds it saves. Two independent reasons, in fact — the in-container checkout lands at `/workspaces/<workspace-id>`, so branches get different paths and cargo's path-sensitive fingerprints could never be reused across them anyway.

The 2.1 GB `target/` and 566 MB registry that motivated the worry were both misleading: a fresh full build is 932 M, and this crate's own registry share is 73 M.

## What the image carries, and why

`gh`, `zellij` and the agent CLI, because the tests are not hermetic: `live_fetch.rs` drives `gh` against the real tracker and `live_zellij_launch.rs` starts real zellij sessions. Container isolation is what stops two concurrent runs of the latter colliding on session names — so this fixes an existing problem rather than only adding cost.

## Two things deliberately not copied from python_template

- **`--network=host`** — it would defeat the port isolation this exists for.
- **A repo-root build context** — it blows devpod's 5000-file context-hash limit because of `target/`. The Dockerfile copies nothing from context, so the context is `.devcontainer`.

## Known gap

Mounting `~/.config/gh` conveys **no credential**: the host keeps its token in a keyring, so `hosts.yml` has no `oauth_token` and `gh` inside the container is unauthenticated. Git is unaffected. This means `live_fetch.rs` cannot pass in-container yet. Choosing between an injected `GH_TOKEN` and a one-off in-container `gh auth login` is #41, which gates #42 — documented inline rather than settled here, since it is a security-posture call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a per-branch Rust devcontainer image and configuration for isolated development environments with required CLIs preinstalled.

Enhancements:
- Introduce a Rust-based devcontainer image that bundles gh, zellij, and the agent CLI for non-hermetic tests.
- Configure devcontainer settings to support isolated per-branch development using devpod/devlaunch without sharing host resources.

Build:
- Add Dockerfile-based devcontainer image definition for local development tooling.