### PR TITLE
Build 8 — every open map renders as its own cluster (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ to open on all of them.
 
 The registry is a per-machine cache at `~/.cache/wf/projects.json`
 (`$XDG_CACHE_HOME` respected) holding `{path, repo}` per checkout, plus every
-open map the last search found. Deleting it is safe — projects re-accrete as
-you open them, and the maps are re-found on the next start.
+open map that the last search found. Deleting it is safe — projects re-accrete
+as you open them, and the maps are re-found on the next start.
 
 Only repos with an open `wayfinder:map`-labelled issue show tickets; other
 checkouts stay cached but hidden.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,17 @@ known project, `ctrl-f` re-focuses the row's project). Run outside a checkout
 to open on all of them.
 
 The registry is a per-machine cache at `~/.cache/wf/projects.json`
-(`$XDG_CACHE_HOME` respected) holding `{path, repo}` per checkout, plus the map
-issue number the last search found for each repo. Deleting it is safe — projects
-re-accrete as you open them, and the map numbers are re-found on the next start.
+(`$XDG_CACHE_HOME` respected) holding `{path, repo}` per checkout, plus every
+open map the last search found. Deleting it is safe — projects re-accrete as
+you open them, and the maps are re-found on the next start.
 
 Only repos with an open `wayfinder:map`-labelled issue show tickets; other
 checkouts stay cached but hidden.
+
+**Every open map renders as its own cluster** — a `▌ repo · map title` header
+carrying the per-status counts (`○` frontier `◐` claimed `⊘` blocked `●` done),
+with the map's tickets grouped beneath it. A repo can keep several maps open at
+once and each gets its own cluster; focusing a project shows all of them.
 
 ## Startup
 
@@ -88,7 +93,7 @@ then it *is* the process you started.
 | *type anything* | fuzzy-filter the list; group headers stay, showing `matched/total` |
 | `↑`/`↓`, `ctrl-j`/`ctrl-k` | move the cursor over ticket rows (headers are never a stop) |
 | `enter` | run the agent on the ticket under the cursor, here, and exit |
-| `ctrl-f` | focus the cursor row's project — drops the repo column |
+| `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |
 | `ctrl-g` | widen back to every project |
 | `ctrl-r` | refetch every map in place, keeping your query, scope and cursor |
 | `esc` | clear the query; on an empty query, quit |

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,14 +49,30 @@ pub enum Overlay {
     PickCheckout { launches: Vec<Launch>, cursor: usize },
 }
 
-/// One on-screen row: which map's cluster it is in, and the ticket's index
+/// One on-screen row: which map's cluster it is in, and the ticket's position
 /// within that cluster. The map half matters (#50): two maps of one repo may
 /// list the same ticket, and those are two distinct rows.
-pub type Row = (MapId, usize);
+///
+/// **Positional, and only valid against the clusters it was read from** — an
+/// index into a `Vec` that the next fetch replaces. [`RowKey`] is the durable
+/// half. They are separate named types rather than two same-shaped tuples
+/// because that is the distinction that matters and the one a `.0`/`.1` at a
+/// call site cannot show.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Row {
+    pub map: MapId,
+    /// Index into that cluster's `tickets`.
+    pub index: usize,
+}
 
-/// A row's stable identity across refreshes: the map and the ticket number —
-/// what the cursor anchors to when clusters are swapped underneath it.
-pub type RowKey = (MapId, u64);
+/// A row's stable identity across refreshes: the map and the ticket *number* —
+/// what the cursor anchors to when clusters are swapped underneath it. Unlike
+/// [`Row`] this survives a refetch, which is the whole reason both exist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RowKey {
+    pub map: MapId,
+    pub ticket: u64,
+}
 
 pub struct App {
     /// The clusters on screen: every open map that has arrived, in
@@ -150,7 +166,12 @@ impl App {
     pub fn scoped(&self) -> Vec<Row> {
         self.scoped_clusters()
             .into_iter()
-            .flat_map(|(id, map)| (0..map.tickets.len()).map(|i| (id.clone(), i)))
+            .flat_map(|(id, map)| {
+                (0..map.tickets.len()).map(|index| Row {
+                    map: id.clone(),
+                    index,
+                })
+            })
             .collect()
     }
 
@@ -168,7 +189,10 @@ impl App {
                         .iter()
                         .copied()
                         .filter(|&i| map.tickets[i].status.group() == group)
-                        .map(|i| (id.clone(), i)),
+                        .map(|index| Row {
+                            map: id.clone(),
+                            index,
+                        }),
                 );
             }
         }
@@ -177,7 +201,15 @@ impl App {
 
     /// The ticket a row names.
     pub fn ticket(&self, row: &Row) -> &Ticket {
-        &self.clusters[&row.0].tickets[row.1]
+        &self.clusters[&row.map].tickets[row.index]
+    }
+
+    /// A row's durable identity — the anchor a refetch preserves.
+    pub fn row_key(&self, row: &Row) -> RowKey {
+        RowKey {
+            map: row.map.clone(),
+            ticket: self.ticket(row).number,
+        }
     }
 
     /// Cursor position clamped into the visible list.
@@ -193,15 +225,14 @@ impl App {
     /// The ticket under the cursor, if any row is visible.
     pub fn cursor_ticket(&self) -> Option<&Ticket> {
         self.cursor_row().map(|row| {
-            let map: &Map = &self.clusters[&row.0];
-            &map.tickets[row.1]
+            let map: &Map = &self.clusters[&row.map];
+            &map.tickets[row.index]
         })
     }
 
     /// The cursor row's stable identity.
     fn cursor_key(&self) -> Option<RowKey> {
-        self.cursor_row()
-            .map(|row| (row.0.clone(), self.ticket(&row).number))
+        self.cursor_row().map(|row| self.row_key(&row))
     }
 
     /// Point the cursor at a specific row if it is visible.
@@ -209,7 +240,7 @@ impl App {
         let pos = self
             .visible()
             .iter()
-            .position(|row| row.0 == key.0 && self.ticket(row).number == key.1);
+            .position(|row| &self.row_key(row) == key);
         self.cursor = pos.unwrap_or(0);
     }
 
@@ -233,7 +264,7 @@ impl App {
         let new_order: Vec<RowKey> = self
             .visible()
             .iter()
-            .map(|row| (row.0.clone(), self.ticket(row).number))
+            .map(|row| self.row_key(row))
             .collect();
         self.cursor = crate::refresh::preserve_cursor(anchor.as_ref(), old_index, &new_order);
     }
@@ -249,7 +280,7 @@ impl App {
             return Outcome::Continue;
         };
         let ticket = self.ticket(&row).clone();
-        let map_issue = row.0.number;
+        let map_issue = row.map.number;
         match launch::plan(&self.checkouts, &ticket, map_issue) {
             Targets::Unregistered => {
                 self.notice = Some(format!(
@@ -334,7 +365,7 @@ impl App {
             }
             KeyCode::Char('f') if ctrl => {
                 if let Some(key) = self.cursor_key() {
-                    self.scope = Scope::Project(key.0.repo.clone());
+                    self.scope = Scope::Project(key.map.repo.clone());
                     self.point_at(&key);
                 }
                 Outcome::Continue
@@ -696,7 +727,7 @@ mod tests {
         assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
         let visible = app.visible();
         assert_eq!(visible.len(), 2, "both wayfinder maps stay on screen");
-        assert!(visible.iter().all(|(id, _)| id.repo == "blooop/wayfinder"));
+        assert!(visible.iter().all(|row| row.map.repo == "blooop/wayfinder"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,25 +1,24 @@
 //! Main-screen state and the keybindings (#14).
 //!
-//! [`App`] owns everything the screen needs between keypresses: the map, the
-//! fuzzy query, the cursor over *visible* rows, the project scope, and a
-//! one-shot notice line. Key handling returns an [`Outcome`] so the binary owns
-//! the side effects: the app decides *what* to launch and `main` is the only
-//! thing that may act on it, because acting on it means giving the terminal
-//! back and never coming here again (#34).
+//! [`App`] owns everything the screen needs between keypresses: the clusters
+//! (one per open map, #50), the fuzzy query, the cursor over *visible* rows,
+//! the project scope, and a one-shot notice line. Key handling returns an
+//! [`Outcome`] so the binary owns the side effects: the app decides *what* to
+//! launch and `main` is the only thing that may act on it, because acting on
+//! it means giving the terminal back and never coming here again (#34).
 
 use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::filter::matching_indices;
-use crate::launch::{self, Launch, MapIssues, Targets};
-use crate::model::{merge_maps, Map, Ticket, GROUP_LABELS};
+use crate::launch::{self, Launch, Targets};
+use crate::model::{Map, MapId, MapSet, Ticket, GROUP_LABELS};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
 
-/// Project scope: everything, or one repo focused via `ctrl-f`.
-/// With a single repo synced this is a near-no-op, but the state is wired
-/// so multi-project (Build 3) only has to feed more tickets in.
+/// Project scope: everything, or one repo focused via `ctrl-f`. A repo, not a
+/// map: focusing where you stand means seeing every open map of that repo.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Scope {
     All,
@@ -31,8 +30,8 @@ pub enum Scope {
 pub enum Outcome {
     Continue,
     Quit,
-    /// Force a refetch (`ctrl-r`). The loop performs it and puts the result
-    /// back via [`App::replace_map`].
+    /// Force a refetch (`ctrl-r`). The loop performs it and puts the results
+    /// back via [`App::replace_clusters`].
     Refresh,
     /// Run this ticket's agent. The last thing `wf` ever does: the loop
     /// returns, the terminal is restored, and the process becomes the agent.
@@ -50,8 +49,22 @@ pub enum Overlay {
     PickCheckout { launches: Vec<Launch>, cursor: usize },
 }
 
+/// One on-screen row: which map's cluster it is in, and the ticket's index
+/// within that cluster. The map half matters (#50): two maps of one repo may
+/// list the same ticket, and those are two distinct rows.
+pub type Row = (MapId, usize);
+
+/// A row's stable identity across refreshes: the map and the ticket number —
+/// what the cursor anchors to when clusters are swapped underneath it.
+pub type RowKey = (MapId, u64);
+
 pub struct App {
-    pub map: Map,
+    /// The clusters on screen: every open map that has arrived, in
+    /// (repo, number) order — which is also render order.
+    pub clusters: BTreeMap<MapId, Map>,
+    /// The maps believed open — the cached seed until the search answers, the
+    /// search's answer afterwards. This is what `ctrl-r` refetches.
+    pub open_maps: MapSet,
     pub query: String,
     pub scope: Scope,
     /// One-shot status message shown on the count line; cleared on the next
@@ -60,22 +73,20 @@ pub struct App {
     /// Launch input from the projects cache (#15 handoff): which checkouts
     /// exist on this machine.
     pub checkouts: Vec<Checkout>,
-    /// Each repo's map issue number — `/wayfinder`'s first argument.
-    pub map_issues: MapIssues,
-    /// Repos whose last map fetch failed — **state, not a message.**
+    /// Maps whose last fetch failed — **state, not a message.**
     ///
     /// A failure has to be drawn on every frame, and the one-shot `notice` is
     /// cleared by the very next keypress. Nothing polls any more either, so a
-    /// failed fetch is the final word on that repo until `ctrl-r`: with only a
+    /// failed fetch is the final word on that map until `ctrl-r`: with only a
     /// notice, one keystroke turns "GitHub is down" into a screen that says
     /// *no projects — run wf inside a checkout to register it*, which is the
     /// exact lie [`crate::refresh::Startup`] exists to prevent for the
     /// still-loading case.
     ///
-    /// A set of slugs rather than a flag, because the flag it replaces could
-    /// not say *which* repo, and a partial failure — four maps on screen, one
-    /// missing — is the case that hides best.
-    pub failed: BTreeSet<String>,
+    /// A set of [`MapId`]s rather than a flag, because the flag it replaces
+    /// could not say *which* map, and a partial failure — four clusters on
+    /// screen, one missing — is the case that hides best.
+    pub failed: BTreeSet<MapId>,
     /// How much of the initial load has landed (#27). The screen is drawn
     /// before any of it, so this is what stops an empty list from reading as
     /// "no tickets" while the fetch is still out.
@@ -85,15 +96,15 @@ pub struct App {
 }
 
 impl App {
-    /// An app over a map already in hand — so nothing is being waited on.
-    pub fn new(map: Map) -> Self {
+    /// An app over clusters already in hand — so nothing is being waited on.
+    pub fn new(clusters: BTreeMap<MapId, Map>) -> Self {
         Self {
-            map,
+            clusters,
+            open_maps: MapSet::new(),
             query: String::new(),
             scope: Scope::All,
             notice: None,
             checkouts: Vec::new(),
-            map_issues: MapIssues::new(),
             failed: BTreeSet::new(),
             startup: Startup::loaded(),
             overlay: Overlay::None,
@@ -108,45 +119,65 @@ impl App {
     pub fn empty() -> Self {
         Self {
             startup: Startup::default(),
-            ..Self::new(merge_maps(&BTreeMap::new()))
+            ..Self::new(BTreeMap::new())
         }
     }
 
-    /// Attach the launch inputs: the cached checkouts (the candidate trees an
-    /// agent could run in) and the per-repo map issue numbers.
-    pub fn with_projects(mut self, checkouts: Vec<Checkout>, map_issues: MapIssues) -> Self {
+    /// Attach the launch input: the cached checkouts (the candidate trees an
+    /// agent could run in). Which map a ticket belongs to is no longer a
+    /// lookup — every row sits in a cluster that *is* its map (#50).
+    pub fn with_checkouts(mut self, checkouts: Vec<Checkout>) -> Self {
         self.checkouts = checkouts;
-        self.map_issues = map_issues;
         self
     }
 
-    fn in_scope(&self, ticket: &Ticket) -> bool {
+    fn in_scope(&self, id: &MapId) -> bool {
         match &self.scope {
             Scope::All => true,
-            Scope::Project(repo) => &ticket.repo == repo,
+            Scope::Project(repo) => &id.repo == repo,
         }
     }
 
-    /// Ticket indices currently in scope (before the fuzzy query).
-    pub fn scoped(&self) -> Vec<usize> {
-        (0..self.map.tickets.len())
-            .filter(|&i| self.in_scope(&self.map.tickets[i]))
+    /// The clusters currently in scope, in render order.
+    pub fn scoped_clusters(&self) -> Vec<(&MapId, &Map)> {
+        self.clusters
+            .iter()
+            .filter(|(id, _)| self.in_scope(id))
             .collect()
     }
 
-    /// Ticket indices visible right now, in on-screen order: group-major
-    /// (frontier / claimed / blocked / done), map order within a group.
-    /// The cursor indexes this list — group headers are never cursor stops.
-    pub fn visible(&self) -> Vec<usize> {
-        let matched = matching_indices(&self.map.tickets, &self.query);
+    /// Rows currently in scope (before the fuzzy query), cluster-major.
+    pub fn scoped(&self) -> Vec<Row> {
+        self.scoped_clusters()
+            .into_iter()
+            .flat_map(|(id, map)| (0..map.tickets.len()).map(|i| (id.clone(), i)))
+            .collect()
+    }
+
+    /// Rows visible right now, in on-screen order: cluster-major (maps in
+    /// (repo, number) order), group-major within a cluster (frontier / claimed
+    /// / blocked / done), map order within a group. The cursor indexes this
+    /// list — cluster and group headers are never cursor stops.
+    pub fn visible(&self) -> Vec<Row> {
         let mut out = Vec::new();
-        for group in 0..GROUP_LABELS.len() {
-            out.extend(matched.iter().copied().filter(|&i| {
-                let t = &self.map.tickets[i];
-                t.status.group() == group && self.in_scope(t)
-            }));
+        for (id, map) in self.scoped_clusters() {
+            let matched = matching_indices(&map.tickets, &self.query);
+            for group in 0..GROUP_LABELS.len() {
+                out.extend(
+                    matched
+                        .iter()
+                        .copied()
+                        .filter(|&i| map.tickets[i].status.group() == group)
+                        .map(|i| (id.clone(), i)),
+                );
+            }
         }
         out
+    }
+
+    /// The ticket a row names.
+    pub fn ticket(&self, row: &Row) -> &Ticket {
+        &self.clusters[&row.0].tickets[row.1]
     }
 
     /// Cursor position clamped into the visible list.
@@ -154,23 +185,32 @@ impl App {
         self.cursor.min(self.visible().len().saturating_sub(1))
     }
 
-    /// The ticket under the cursor, if any row is visible.
-    pub fn cursor_ticket(&self) -> Option<&Ticket> {
-        self.visible()
-            .get(self.cursor_pos())
-            .map(|&i| &self.map.tickets[i])
+    /// The row under the cursor, if any is visible.
+    pub fn cursor_row(&self) -> Option<Row> {
+        self.visible().get(self.cursor_pos()).cloned()
     }
 
-    /// Point the cursor at a specific ticket if it is visible.
-    fn point_at(&mut self, repo: &str, number: u64) {
-        if let Some(pos) = self.visible().iter().position(|&i| {
-            let t = &self.map.tickets[i];
-            t.repo == repo && t.number == number
-        }) {
-            self.cursor = pos;
-        } else {
-            self.cursor = 0;
-        }
+    /// The ticket under the cursor, if any row is visible.
+    pub fn cursor_ticket(&self) -> Option<&Ticket> {
+        self.cursor_row().map(|row| {
+            let map: &Map = &self.clusters[&row.0];
+            &map.tickets[row.1]
+        })
+    }
+
+    /// The cursor row's stable identity.
+    fn cursor_key(&self) -> Option<RowKey> {
+        self.cursor_row()
+            .map(|row| (row.0.clone(), self.ticket(&row).number))
+    }
+
+    /// Point the cursor at a specific row if it is visible.
+    fn point_at(&mut self, key: &RowKey) {
+        let pos = self
+            .visible()
+            .iter()
+            .position(|row| row.0 == key.0 && self.ticket(row).number == key.1);
+        self.cursor = pos.unwrap_or(0);
     }
 
     fn move_cursor(&mut self, delta: isize) {
@@ -183,45 +223,38 @@ impl App {
         self.cursor = pos.clamp(0, len as isize - 1) as usize;
     }
 
-    /// Swap in freshly fetched data, keeping query/scope intact and the
-    /// cursor pinned to ticket identity (falling back to the same position,
-    /// clamped, if the ticket vanished — see `refresh::preserve_cursor`).
-    pub fn replace_map(&mut self, map: Map) {
-        let anchor = self.cursor_ticket().map(|t| (t.repo.clone(), t.number));
+    /// Swap in freshly fetched clusters, keeping query/scope intact and the
+    /// cursor pinned to row identity (falling back to the same position,
+    /// clamped, if the row vanished — see `refresh::preserve_cursor`).
+    pub fn replace_clusters(&mut self, clusters: BTreeMap<MapId, Map>) {
+        let anchor = self.cursor_key();
         let old_index = self.cursor_pos();
-        self.map = map;
-        let visible = self.visible();
-        let new_order: Vec<(&str, u64)> = visible
+        self.clusters = clusters;
+        let new_order: Vec<RowKey> = self
+            .visible()
             .iter()
-            .map(|&i| {
-                let t = &self.map.tickets[i];
-                (t.repo.as_str(), t.number)
-            })
+            .map(|row| (row.0.clone(), self.ticket(row).number))
             .collect();
-        self.cursor = crate::refresh::preserve_cursor(
-            anchor.as_ref().map(|(repo, number)| (repo.as_str(), *number)),
-            old_index,
-            &new_order,
-        );
+        self.cursor = crate::refresh::preserve_cursor(anchor.as_ref(), old_index, &new_order);
     }
 
     /// Resolve a launch of the cursor's ticket: straight to the loop when
     /// there is one candidate checkout, through the picker when there are
-    /// several, and a notice when there is none to launch into.
+    /// several, and a notice when there is none to launch into. Which map the
+    /// ticket belongs to is the cluster it sits in — a row without a map is
+    /// unrepresentable, so the old "repo has no map" failure is gone with it.
     fn request_launch(&mut self) -> Outcome {
-        let Some(ticket) = self.cursor_ticket().cloned() else {
+        let Some(row) = self.cursor_row() else {
             self.notice = Some("nothing selected".to_string());
             return Outcome::Continue;
         };
-        let (repo, number) = (&ticket.repo, ticket.number);
-        let Some(&map_issue) = self.map_issues.get(repo) else {
-            self.notice = Some(format!("{repo} has no map — nothing to hand /wayfinder"));
-            return Outcome::Continue;
-        };
+        let ticket = self.ticket(&row).clone();
+        let map_issue = row.0.number;
         match launch::plan(&self.checkouts, &ticket, map_issue) {
             Targets::Unregistered => {
                 self.notice = Some(format!(
-                    "no registered checkout of {repo} on this machine — run wf inside one"
+                    "no registered checkout of {} on this machine — run wf inside one",
+                    ticket.repo
                 ));
                 Outcome::Continue
             }
@@ -230,7 +263,7 @@ impl App {
                 Outcome::Launch(launch)
             }
             Targets::Many(launches) => {
-                self.notice = Some(format!("{repo}#{number}: which checkout?"));
+                self.notice = Some(format!("{}#{}: which checkout?", ticket.repo, ticket.number));
                 self.overlay = Overlay::PickCheckout { launches, cursor: 0 };
                 Outcome::Continue
             }
@@ -300,18 +333,17 @@ impl App {
                 Outcome::Refresh
             }
             KeyCode::Char('f') if ctrl => {
-                if let Some(t) = self.cursor_ticket() {
-                    let (repo, number) = (t.repo.clone(), t.number);
-                    self.scope = Scope::Project(repo.clone());
-                    self.point_at(&repo, number);
+                if let Some(key) = self.cursor_key() {
+                    self.scope = Scope::Project(key.0.repo.clone());
+                    self.point_at(&key);
                 }
                 Outcome::Continue
             }
             KeyCode::Char('g') if ctrl => {
-                let anchor = self.cursor_ticket().map(|t| (t.repo.clone(), t.number));
+                let anchor = self.cursor_key();
                 self.scope = Scope::All;
-                if let Some((repo, number)) = anchor {
-                    self.point_at(&repo, number);
+                if let Some(key) = anchor {
+                    self.point_at(&key);
                 }
                 Outcome::Continue
             }
@@ -363,7 +395,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, Map, Ticket, TicketType};
+    use crate::model::{classify, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -373,27 +405,54 @@ mod tests {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
     }
 
+    fn ticket(
+        repo: &str,
+        number: u64,
+        title: &str,
+        open: bool,
+        assigned: bool,
+        needs: Vec<u64>,
+    ) -> Ticket {
+        Ticket {
+            repo: repo.to_string(),
+            number,
+            title: title.to_string(),
+            status: classify(open, assigned, needs.clone()),
+            ticket_type: TicketType::Task,
+            blocked_by: needs,
+        }
+    }
+
+    /// Two clusters: the wayfinder map and a dotfiles map.
     fn fixture_app() -> App {
-        let t = |repo: &str, number: u64, title: &str, open: bool, assigned: bool, needs: Vec<u64>| {
-            Ticket {
-                repo: repo.to_string(),
-                number,
-                title: title.to_string(),
-                status: classify(open, assigned, needs),
-                ticket_type: TicketType::Task,
-            }
-        };
-        App::new(Map {
-            repo: "blooop/wayfinder".to_string(),
-            title: "Map: wf".to_string(),
-            tickets: vec![
-                t("blooop/wayfinder", 2, "Choose the stack", false, true, vec![]),
-                t("blooop/wayfinder", 6, "Re-entry breadcrumbs", true, false, vec![]),
-                t("blooop/wayfinder", 7, "Supervising AFK agents", true, false, vec![6]),
-                t("blooop/wayfinder", 9, "Main screen design", true, true, vec![]),
-                t("blooop/dotfiles", 103, "Prune legacy bash aliases", true, false, vec![]),
-            ],
-        })
+        let mut clusters = BTreeMap::new();
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 1),
+            Map {
+                title: "Map: wf".to_string(),
+                tickets: vec![
+                    ticket("blooop/wayfinder", 2, "Choose the stack", false, true, vec![]),
+                    ticket("blooop/wayfinder", 6, "Re-entry breadcrumbs", true, false, vec![]),
+                    ticket("blooop/wayfinder", 7, "Supervising AFK agents", true, false, vec![6]),
+                    ticket("blooop/wayfinder", 9, "Main screen design", true, true, vec![]),
+                ],
+            },
+        );
+        clusters.insert(
+            MapId::new("blooop/dotfiles", 4),
+            Map {
+                title: "Map: dotfiles".to_string(),
+                tickets: vec![ticket(
+                    "blooop/dotfiles",
+                    103,
+                    "Prune legacy bash aliases",
+                    true,
+                    false,
+                    vec![],
+                )],
+            },
+        );
+        App::new(clusters)
     }
 
     fn type_str(app: &mut App, s: &str) {
@@ -415,12 +474,14 @@ mod tests {
     }
 
     #[test]
-    fn cursor_moves_over_ticket_rows_in_group_order_and_clamps() {
+    fn cursor_moves_cluster_major_then_group_major_and_clamps() {
         let mut app = fixture_app();
-        // On-screen order: frontier #6, #103 · claimed #9 · blocked #7 · done #2.
-        assert_eq!(app.cursor_ticket().unwrap().number, 6);
-        app.handle_key(key(KeyCode::Down));
+        // Clusters order by (repo, number): dotfiles#4 before wayfinder#1.
+        // On-screen: dotfiles frontier #103 · wayfinder frontier #6, claimed #9,
+        // blocked #7, done #2.
         assert_eq!(app.cursor_ticket().unwrap().number, 103);
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(app.cursor_ticket().unwrap().number, 6);
         app.handle_key(ctrl('j'));
         assert_eq!(app.cursor_ticket().unwrap().number, 9);
         for _ in 0..10 {
@@ -432,7 +493,7 @@ mod tests {
         for _ in 0..10 {
             app.handle_key(key(KeyCode::Up));
         }
-        assert_eq!(app.cursor_ticket().unwrap().number, 6); // clamped at first row
+        assert_eq!(app.cursor_ticket().unwrap().number, 103); // clamped at first row
     }
 
     #[test]
@@ -455,35 +516,31 @@ mod tests {
     }
 
     /// The fixture app plus launch inputs: one checkout of wayfinder, two of
-    /// a multi-checkout repo, and map issues for both.
+    /// dotfiles.
     fn launchable_app() -> App {
         let checkout = |path: &str, repo: &str| Checkout {
             path: std::path::PathBuf::from(path),
             repo: repo.to_string(),
         };
-        let mut map_issues = MapIssues::new();
-        map_issues.insert("blooop/wayfinder".to_string(), 1);
-        map_issues.insert("blooop/dotfiles".to_string(), 4);
-        fixture_app().with_projects(
-            vec![
-                checkout("/data/proj/wayfinder", "blooop/wayfinder"),
-                checkout("/data/k1/dotfiles", "blooop/dotfiles"),
-                checkout("/data/k2/dotfiles", "blooop/dotfiles"),
-            ],
-            map_issues,
-        )
+        fixture_app().with_checkouts(vec![
+            checkout("/data/proj/wayfinder", "blooop/wayfinder"),
+            checkout("/data/k1/dotfiles", "blooop/dotfiles"),
+            checkout("/data/k2/dotfiles", "blooop/dotfiles"),
+        ])
     }
 
     #[test]
-    fn enter_launches_the_cursors_ticket_without_prompting() {
+    fn enter_launches_the_cursors_ticket_with_its_clusters_map() {
         let mut app = launchable_app();
-        // Cursor starts on frontier wayfinder#6, whose repo has one checkout.
+        // Move to wayfinder#6, whose repo has one checkout.
+        app.handle_key(key(KeyCode::Down));
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(launch.key(), "wayfinder#6");
         assert_eq!(launch.cwd(), std::path::Path::new("/data/proj/wayfinder"));
+        // The map issue is the cluster's — not a per-repo lookup.
         assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 1 6");
         assert_eq!(app.overlay, Overlay::None, "one candidate must not prompt");
         assert!(app
@@ -491,6 +548,33 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("wayfinder#6 in /data/proj/wayfinder"));
+    }
+
+    #[test]
+    fn the_same_ticket_on_two_maps_launches_with_the_cluster_it_was_picked_in() {
+        // One repo, two open maps, both listing ticket #6: the row's cluster —
+        // not the repo — decides `/wayfinder`'s map argument.
+        let mut clusters = BTreeMap::new();
+        for map_number in [1u64, 47] {
+            clusters.insert(
+                MapId::new("blooop/wayfinder", map_number),
+                Map {
+                    title: format!("Map: {map_number}"),
+                    tickets: vec![ticket("blooop/wayfinder", 6, "Shared ticket", true, false, vec![])],
+                },
+            );
+        }
+        let mut app = App::new(clusters).with_checkouts(vec![Checkout {
+            path: std::path::PathBuf::from("/data/proj/wayfinder"),
+            repo: "blooop/wayfinder".to_string(),
+        }]);
+        // Row 0 is map #1's copy, row 1 is map #47's.
+        app.handle_key(key(KeyCode::Down));
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 47 6");
     }
 
     #[test]
@@ -506,7 +590,7 @@ mod tests {
     #[test]
     fn several_checkouts_open_the_picker_and_enter_launches_the_pick() {
         let mut app = launchable_app();
-        app.handle_key(key(KeyCode::Down)); // dotfiles#103 — two checkouts
+        // Cursor starts on dotfiles#103 — two checkouts.
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
             Overlay::PickCheckout { launches, cursor } => {
@@ -531,8 +615,7 @@ mod tests {
     #[test]
     fn the_picker_clamps_and_esc_cancels_it() {
         let mut app = launchable_app();
-        app.handle_key(key(KeyCode::Down));
-        app.handle_key(key(KeyCode::Enter));
+        app.handle_key(key(KeyCode::Enter)); // dotfiles#103 under the cursor
         for _ in 0..5 {
             app.handle_key(key(KeyCode::Down));
         }
@@ -548,17 +631,11 @@ mod tests {
     }
 
     #[test]
-    fn a_repo_with_no_checkout_or_no_map_says_so_instead_of_launching() {
-        // No launch inputs at all: every ticket is unlaunchable, and the
-        // reason is the missing map (nothing to hand /wayfinder).
+    fn a_repo_with_no_checkout_says_so_instead_of_launching() {
+        // No checkouts registered: every ticket is unlaunchable — and the one
+        // reason left is the missing checkout, because a row's map is its
+        // cluster and cannot be missing.
         let mut app = fixture_app();
-        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
-        assert!(app.notice.as_deref().unwrap().contains("has no map"));
-
-        // Map known, checkout gone from the cache: the other failure.
-        let mut map_issues = MapIssues::new();
-        map_issues.insert("blooop/wayfinder".to_string(), 1);
-        let mut app = fixture_app().with_projects(Vec::new(), map_issues);
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         let notice = app.notice.as_deref().unwrap();
         assert!(notice.contains("no registered checkout"), "notice: {notice}");
@@ -576,35 +653,73 @@ mod tests {
     #[test]
     fn ctrl_f_focuses_cursor_rows_project_and_ctrl_g_widens() {
         let mut app = fixture_app();
-        app.handle_key(key(KeyCode::Down)); // cursor on dotfiles #103
+        app.handle_key(key(KeyCode::Down)); // cursor on wayfinder #6
         app.handle_key(ctrl('f'));
-        assert_eq!(app.scope, Scope::Project("blooop/dotfiles".to_string()));
-        assert_eq!(app.visible().len(), 1);
-        assert_eq!(app.cursor_ticket().unwrap().number, 103);
+        assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
+        assert_eq!(app.visible().len(), 4);
+        assert_eq!(app.cursor_ticket().unwrap().number, 6);
         app.handle_key(ctrl('g'));
         assert_eq!(app.scope, Scope::All);
         assert_eq!(app.visible().len(), 5);
         // cursor stayed anchored on the same ticket
-        assert_eq!(app.cursor_ticket().unwrap().number, 103);
+        assert_eq!(app.cursor_ticket().unwrap().number, 6);
     }
 
     #[test]
-    fn ctrl_r_requests_refresh_and_replace_map_keeps_anchor() {
+    fn focus_keeps_every_open_map_of_the_repo() {
+        // Two maps on one repo: focusing the repo is not focusing one map.
+        let mut clusters = BTreeMap::new();
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 1),
+            Map {
+                title: "Map: wf".to_string(),
+                tickets: vec![ticket("blooop/wayfinder", 6, "t6", true, false, vec![])],
+            },
+        );
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 47),
+            Map {
+                title: "Map: selection view".to_string(),
+                tickets: vec![ticket("blooop/wayfinder", 50, "t50", true, false, vec![])],
+            },
+        );
+        clusters.insert(
+            MapId::new("blooop/dotfiles", 4),
+            Map {
+                title: "Map: dotfiles".to_string(),
+                tickets: vec![ticket("blooop/dotfiles", 103, "t103", true, false, vec![])],
+            },
+        );
+        let mut app = App::new(clusters);
+        app.handle_key(key(KeyCode::Down)); // cursor onto wayfinder#6 (map #1)
+        app.handle_key(ctrl('f'));
+        assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
+        let visible = app.visible();
+        assert_eq!(visible.len(), 2, "both wayfinder maps stay on screen");
+        assert!(visible.iter().all(|(id, _)| id.repo == "blooop/wayfinder"));
+    }
+
+    #[test]
+    fn ctrl_r_requests_refresh_and_replace_clusters_keeps_anchor() {
         let mut app = fixture_app();
         assert_eq!(app.handle_key(ctrl('r')), Outcome::Refresh);
-        app.handle_key(key(KeyCode::Down)); // cursor on #103
-        let same = app.map.clone();
-        app.replace_map(same);
-        assert_eq!(app.cursor_ticket().unwrap().number, 103);
+        app.handle_key(key(KeyCode::Down)); // cursor on wayfinder#6
+        let same = app.clusters.clone();
+        app.replace_clusters(same);
+        assert_eq!(app.cursor_ticket().unwrap().number, 6);
     }
 
     #[test]
-    fn replace_map_does_not_teleport_when_cursor_ticket_vanishes() {
+    fn replace_clusters_does_not_teleport_when_cursor_ticket_vanishes() {
         let mut app = fixture_app();
-        app.handle_key(key(KeyCode::Down)); // cursor on #103, position 1
-        let mut smaller = app.map.clone();
-        smaller.tickets.retain(|t| t.number != 103);
-        app.replace_map(smaller);
+        app.handle_key(key(KeyCode::Down)); // cursor on wayfinder#6, position 1
+        let mut smaller = app.clusters.clone();
+        smaller
+            .get_mut(&MapId::new("blooop/wayfinder", 1))
+            .unwrap()
+            .tickets
+            .retain(|t| t.number != 6);
+        app.replace_clusters(smaller);
         // Identity gone: cursor stays at the same position, clamped.
         assert_eq!(app.cursor_pos(), 1);
         assert_eq!(app.cursor_ticket().unwrap().number, 9);
@@ -614,18 +729,24 @@ mod tests {
     fn focus_separates_a_fork_from_its_upstream() {
         // Two repos sharing a short name: identity and scope are the slug,
         // so focusing one must not drag the other's rows in.
-        let t = |repo: &str, number: u64| Ticket {
-            repo: repo.to_string(),
-            number,
-            title: "Prune legacy bash aliases".to_string(),
-            status: classify(true, false, vec![]),
-            ticket_type: TicketType::Task,
-        };
-        let mut app = App::new(Map {
-            repo: "2 projects".to_string(),
-            title: "wf".to_string(),
-            tickets: vec![t("blooop/dotfiles", 5), t("upstream/dotfiles", 5)],
-        });
+        let mut clusters = BTreeMap::new();
+        for owner in ["blooop", "upstream"] {
+            clusters.insert(
+                MapId::new(format!("{owner}/dotfiles"), 1),
+                Map {
+                    title: "Map: dotfiles".to_string(),
+                    tickets: vec![ticket(
+                        &format!("{owner}/dotfiles"),
+                        5,
+                        "Prune legacy bash aliases",
+                        true,
+                        false,
+                        vec![],
+                    )],
+                },
+            );
+        }
+        let mut app = App::new(clusters);
         app.handle_key(key(KeyCode::Down)); // cursor on upstream/dotfiles#5
         assert_eq!(app.cursor_ticket().unwrap().repo, "upstream/dotfiles");
         app.handle_key(ctrl('f'));

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -9,6 +9,12 @@
 //! sub-issue's labels become a [`TicketType`] here and nothing inward re-sniffs
 //! them (parse, don't validate).
 //!
+//! The `blockedBy` selection already carries the *full* edge set — closed
+//! blockers included — and since #50 the parse keeps it: the open subset
+//! becomes [`Status::Blocked`]'s `needs`, the whole set becomes
+//! [`Ticket::blocked_by`] (the DAG), and neither is re-derived from the other
+//! afterwards.
+//!
 //! Both invocations are `stdin`-nulled and `kill_on_drop`. Neither is
 //! decoration. `tokio`'s `Command::output()` pipes only stdout and stderr and
 //! leaves **stdin inherited** — a silent divergence from `std`'s, which nulls
@@ -18,16 +24,15 @@
 //! zombie it will never reap: aborting the task drops the `Child`, and only
 //! `kill_on_drop` turns that into a signal.
 
-use std::collections::HashMap;
 use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tokio::process::Command;
 
-use crate::model::{classify, Map, Ticket, TicketType};
+use crate::model::{classify, Map, MapId, MapSet, Ticket, TicketType};
 
-/// The label that makes an issue a map. Both the search that *finds* a map and
+/// The label that makes an issue a map. Both the search that *finds* maps and
 /// the fetch that *reads* one test for this, so a cached number can never be
 /// believed on its own (#28).
 pub const MAP_LABEL: &str = "wayfinder:map";
@@ -119,9 +124,13 @@ fn is_open(state: &str) -> bool {
     state == "OPEN"
 }
 
-/// Fetch one repo's map live: the map issue `number` in `owner/name`, its
-/// sub-issues, and their blocking edges — one `gh api graphql` round trip.
-pub async fn fetch_map(owner: &str, name: &str, number: u64) -> Result<Map> {
+/// Fetch one map live: the map issue named by `id`, its sub-issues, and their
+/// blocking edges — one `gh api graphql` round trip.
+pub async fn fetch_map(id: &MapId) -> Result<Map> {
+    let (owner, name) = id
+        .repo
+        .split_once('/')
+        .with_context(|| format!("malformed repo slug {:?}", id.repo))?;
     let output = Command::new("gh")
         .args([
             "api",
@@ -131,7 +140,7 @@ pub async fn fetch_map(owner: &str, name: &str, number: u64) -> Result<Map> {
             "-F",
             &format!("name={name}"),
             "-F",
-            &format!("number={number}"),
+            &format!("number={}", id.number),
             "-f",
             &format!("query={MAP_QUERY}"),
         ])
@@ -148,14 +157,14 @@ pub async fn fetch_map(owner: &str, name: &str, number: u64) -> Result<Map> {
         );
     }
 
-    parse_map(&output.stdout, owner, name, number)
+    parse_map(&output.stdout, id)
 }
 
 /// Turn one `gh api graphql` response body into a [`Map`] — the whole parse
 /// boundary, kept apart from the process call so it is testable without the
 /// network. Every raw tracker string a ticket is derived from (state,
 /// assignees, blocker states, labels) is interpreted exactly here.
-fn parse_map(body: &[u8], owner: &str, name: &str, number: u64) -> Result<Map> {
+fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
     let resp: GraphQlResponse =
         serde_json::from_slice(body).context("unparseable GraphQL response from gh")?;
     if let Some(err) = resp.errors.first() {
@@ -165,7 +174,7 @@ fn parse_map(body: &[u8], owner: &str, name: &str, number: u64) -> Result<Map> {
         .data
         .and_then(|d| d.repository)
         .and_then(|r| r.issue)
-        .with_context(|| format!("map issue {owner}/{name}#{number} not found"))?;
+        .with_context(|| format!("map issue {}#{} not found", id.repo, id.number))?;
 
     // The number may have come from the cache (#28), so the issue it names has
     // to prove it is still a map rather than be taken at its word. A map that
@@ -174,7 +183,11 @@ fn parse_map(body: &[u8], owner: &str, name: &str, number: u64) -> Result<Map> {
     // sub-issues as its map. The unconditional search corrects the number
     // moments later.
     if !is_open(&issue.state) || !issue.labels.nodes.iter().any(|l| l.name == MAP_LABEL) {
-        bail!("{owner}/{name}#{number} is no longer an open `{MAP_LABEL}` issue");
+        bail!(
+            "{}#{} is no longer an open `{MAP_LABEL}` issue",
+            id.repo,
+            id.number
+        );
     }
 
     let mut tickets: Vec<Ticket> = issue
@@ -182,6 +195,8 @@ fn parse_map(body: &[u8], owner: &str, name: &str, number: u64) -> Result<Map> {
         .nodes
         .into_iter()
         .map(|sub| {
+            // One pass over the same edges yields both facts: the open subset
+            // is status, the whole set is structure (#50).
             let open_blockers: Vec<u64> = sub
                 .blocked_by
                 .nodes
@@ -189,8 +204,9 @@ fn parse_map(body: &[u8], owner: &str, name: &str, number: u64) -> Result<Map> {
                 .filter(|b| is_open(&b.state))
                 .map(|b| b.number)
                 .collect();
+            let blocked_by: Vec<u64> = sub.blocked_by.nodes.iter().map(|b| b.number).collect();
             Ticket {
-                repo: format!("{owner}/{name}"),
+                repo: id.repo.clone(),
                 number: sub.number,
                 title: sub.title,
                 status: classify(
@@ -201,13 +217,13 @@ fn parse_map(body: &[u8], owner: &str, name: &str, number: u64) -> Result<Map> {
                 ticket_type: TicketType::from_labels(
                     sub.labels.nodes.iter().map(|l| l.name.as_str()),
                 ),
+                blocked_by,
             }
         })
         .collect();
     tickets.sort_by_key(|t| t.number);
 
     Ok(Map {
-        repo: format!("{owner}/{name}"),
         title: issue.title,
         tickets,
     })
@@ -225,15 +241,15 @@ struct SearchResponse {
     items: Vec<SearchItem>,
 }
 
-/// Which of `repos` have a `wayfinder:map` issue — one label-scoped search
+/// Every open `wayfinder:map` issue across `repos` — one label-scoped search
 /// (per the #4 resolution: one query intersected with cached remotes, never
-/// N probes). Returns `repo slug → map issue number`; repos without maps
-/// are simply absent. Only open map issues count (a closed map is a
-/// finished map), and if a repo somehow has several, the lowest issue
-/// number wins — deterministic and almost always the original.
-pub async fn find_maps(repos: &[String]) -> Result<HashMap<String, u64>> {
+/// N probes). Returns the full [`MapSet`]: a repo with several open maps
+/// contributes several ids (#50 — the lowest-number-per-slug rule that used to
+/// hide all but one is gone), and repos without maps are simply absent. Only
+/// open map issues count — a closed map is a finished map.
+pub async fn find_maps(repos: &[String]) -> Result<MapSet> {
     if repos.is_empty() {
-        return Ok(HashMap::new());
+        return Ok(MapSet::new());
     }
     // Multiple `repo:` qualifiers OR together in GitHub issue search, so
     // the whole cached set is one query.
@@ -265,18 +281,17 @@ pub async fn find_maps(repos: &[String]) -> Result<HashMap<String, u64>> {
     parse_map_search(&output.stdout)
 }
 
-/// Parse a `search/issues` response into `repo slug → lowest map issue`.
-fn parse_map_search(body: &[u8]) -> Result<HashMap<String, u64>> {
+/// Parse a `search/issues` response into the set of open maps it names.
+fn parse_map_search(body: &[u8]) -> Result<MapSet> {
     let resp: SearchResponse =
         serde_json::from_slice(body).context("unparseable search response from gh")?;
-    let mut maps = HashMap::new();
+    let mut maps = MapSet::new();
     for item in resp.items {
         // repository_url is "https://api.github.com/repos/<owner>/<name>".
         let Some(slug) = item.repository_url.split("/repos/").nth(1) else {
             continue;
         };
-        let entry = maps.entry(slug.to_string()).or_insert(item.number);
-        *entry = (*entry).min(item.number);
+        maps.insert(MapId::new(slug, item.number));
     }
     Ok(maps)
 }
@@ -284,18 +299,27 @@ fn parse_map_search(body: &[u8]) -> Result<HashMap<String, u64>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::Status;
 
     #[test]
-    fn map_search_parses_slug_and_keeps_lowest_number_per_repo() {
+    fn map_search_keeps_every_open_map_including_several_on_one_repo() {
+        // The #50 change in one fixture: wayfinder has two open maps and both
+        // survive the parse — the old lowest-number rule would have kept only
+        // #1 and silently hidden #9.
         let body = r#"{"items": [
             {"number": 9, "repository_url": "https://api.github.com/repos/blooop/wayfinder"},
             {"number": 1, "repository_url": "https://api.github.com/repos/blooop/wayfinder"},
             {"number": 4, "repository_url": "https://api.github.com/repos/kinisi/kinisi_ros"}
         ]}"#;
         let maps = parse_map_search(body.as_bytes()).expect("parse");
-        assert_eq!(maps.len(), 2);
-        assert_eq!(maps["blooop/wayfinder"], 1);
-        assert_eq!(maps["kinisi/kinisi_ros"], 4);
+        let expected: MapSet = [
+            MapId::new("blooop/wayfinder", 1),
+            MapId::new("blooop/wayfinder", 9),
+            MapId::new("kinisi/kinisi_ros", 4),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(maps, expected);
     }
 
     /// A response shaped exactly like the live one, with the `labels` selection
@@ -316,14 +340,17 @@ mod tests {
             {"number": 21, "title": "Unlabelled fog", "state": "OPEN",
              "labels": {"nodes": []},
              "assignees": {"nodes": []},
-             "blockedBy": {"nodes": []}}
+             "blockedBy": {"nodes": [{"number": 18, "state": "CLOSED"}, {"number": 3, "state": "OPEN"}]}}
         ]}
     }}}}"#;
 
+    fn wf_map_id() -> MapId {
+        MapId::new("blooop/wayfinder", 1)
+    }
+
     #[test]
     fn the_map_parse_carries_each_sub_issues_type_through_from_its_labels() {
-        let map = parse_map(MAP_RESPONSE.as_bytes(), "blooop", "wayfinder", 1).expect("parse");
-        assert_eq!(map.repo, "blooop/wayfinder");
+        let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
         assert_eq!(map.title, "Map: wf");
         let types: Vec<(u64, TicketType)> =
             map.tickets.iter().map(|t| (t.number, t.ticket_type)).collect();
@@ -340,7 +367,25 @@ mod tests {
         // The type is a *separate* axis from derived status: #3 is frontier
         // *and* research, and neither fact is read off the other.
         let research = map.tickets.iter().find(|t| t.number == 3).expect("#3");
-        assert_eq!(research.status, crate::model::Status::Frontier);
+        assert_eq!(research.status, Status::Frontier);
+    }
+
+    #[test]
+    fn the_parse_keeps_closed_blocker_edges_as_structure_not_status() {
+        // #19 is blocked only by the closed #18: frontier for status, but the
+        // edge survives on `blocked_by` — the DAG the selection views draw.
+        let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+        let t19 = map.tickets.iter().find(|t| t.number == 19).expect("#19");
+        assert_eq!(t19.status, Status::Frontier, "a closed blocker doesn't block");
+        assert_eq!(t19.blocked_by, vec![18], "…but its edge is kept");
+        // #21 mixes one closed and one open blocker: status sees only the open
+        // one, structure sees both.
+        let t21 = map.tickets.iter().find(|t| t.number == 21).expect("#21");
+        assert_eq!(t21.status, Status::Blocked { needs: vec![3] });
+        assert_eq!(t21.blocked_by, vec![18, 3]);
+        // And the reverse edges fall out by inversion, closed blocker included.
+        assert_eq!(map.unblocks(18), vec![19, 21]);
+        assert_eq!(map.unblocks(3), vec![21]);
     }
 
     /// The same response with the map issue's own state/labels swapped out —
@@ -366,7 +411,7 @@ mod tests {
             ("OPEN", ""),
         ] {
             let body = map_response_with(state, labels);
-            let err = parse_map(body.as_bytes(), "blooop", "wayfinder", 1)
+            let err = parse_map(body.as_bytes(), &wf_map_id())
                 .expect_err("a non-map must not parse as a map");
             assert!(
                 err.to_string().contains("no longer an open"),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -51,6 +51,7 @@ mod tests {
             title: title.to_string(),
             status: Status::Frontier,
             ticket_type: TicketType::Task,
+            blocked_by: vec![],
         }
     }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -13,7 +13,6 @@
 //! its own initiative — it hands [`Launch`] to the binary, which restores and
 //! then calls [`Launch::exec`] as its last act.
 
-use std::collections::BTreeMap;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -199,9 +198,6 @@ pub fn plan(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets 
     }
 }
 
-/// Map issue numbers by repo slug — `/wayfinder`'s first argument.
-pub type MapIssues = BTreeMap<String, u64>;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,6 +210,7 @@ mod tests {
             title: "the ticket".to_string(),
             status: classify(true, false, vec![]),
             ticket_type: TicketType::Task,
+            blocked_by: vec![],
         }
     }
 
@@ -339,6 +336,7 @@ mod tests {
             title: "done".to_string(),
             status: Status::Done,
             ticket_type: TicketType::Task,
+            blocked_by: vec![],
         };
         match plan(&cache(), &done, 1) {
             Targets::One(launch) => assert_eq!(launch.key(), "wayfinder#2"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! * **Discovery** is accretive (#4/#15): running `wf` inside a checkout
 //!   registers it in a per-machine cache — no registry, no background scan.
 //! * **Data** is GitHub Issues via one `gh api graphql` query per map (#3),
-//!   merged into one grouped list behind a nucleo fuzzy query (#8/#9).
+//!   rendered as one cluster per open map (#50) behind a nucleo fuzzy query.
 //! * **Startup** streams (#27): the screen is drawn before any network call,
 //!   and the cached map numbers (#28) are already being fetched when it
 //!   appears. Nothing polls afterwards — a warm start costs ~0.6 s, so

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use tokio::task::JoinHandle;
 
 use wf::app::{App, Outcome, Scope};
 use wf::launch::Launch;
-use wf::model::{merge_maps, Map};
+use wf::model::{Map, MapId};
 use wf::projects::{self, ProjectsCache};
 use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup};
 
@@ -124,7 +124,8 @@ async fn main() -> Result<()> {
     // [`wf::refresh::spawn_discovery`]); this only decides what `wf` fetches
     // while waiting for it.
     let seed = cache.map_seed();
-    let mut app = App::empty().with_projects(cache.checkouts.clone(), seed.clone());
+    let mut app = App::empty().with_checkouts(cache.checkouts.clone());
+    app.open_maps = seed.clone();
     app.startup = Startup::seeded(&seed);
 
     // The screen goes up *before* any network call (#27). Everything that used
@@ -143,7 +144,10 @@ async fn main() -> Result<()> {
     // opens wide and jumps a couple of seconds later. `focus` is kept either
     // way: the search still gets to overrule a seed that has gone stale.
     let focus = here.map(|(_, slug)| slug);
-    if let Some(slug) = focus.as_ref().filter(|slug| seed.contains_key(*slug)) {
+    if let Some(slug) = focus
+        .as_ref()
+        .filter(|slug| seed.iter().any(|id| &id.repo == *slug))
+    {
         app.scope = Scope::Project(slug.clone());
     }
     let ending = run(&mut terminal, app, discovery, tx, updates, focus).await;
@@ -245,27 +249,27 @@ async fn run(
     mut updates: UnboundedReceiver<LoadEvent>,
     mut focus: Option<String>,
 ) -> Result<Ending> {
-    let mut maps: BTreeMap<String, Map> = BTreeMap::new();
+    let mut clusters: BTreeMap<MapId, Map> = BTreeMap::new();
     // The cached seed starts fetching immediately (#28); the search's answer
-    // reconciles this set rather than adding to it, so a number that moved is
-    // corrected in the task actually doing the fetching, not just in the state
-    // `enter` reads.
+    // reconciles this set rather than adding to it, so a map that closed or
+    // opened is corrected in the tasks actually doing the fetching, not just
+    // in the state the screen reads.
     let mut loaders = Loaders::new();
-    loaders.reconcile(&app.map_issues, &tx);
+    loaders.reconcile(&app.open_maps, &tx);
     loop {
-        // Drain everything that landed before drawing. A fetch swaps one repo's
-        // map in the merged view; App::replace_map keeps the cursor pinned to
-        // ticket identity, query and scope untouched.
+        // Drain everything that landed before drawing. A fetch swaps one map's
+        // cluster; App::replace_clusters keeps the cursor pinned to row
+        // identity, query and scope untouched.
         while let Ok(event) = updates.try_recv() {
             match event {
-                LoadEvent::Discovered(map_issues) => {
-                    // Reconciling the loaders *is* the load for every repo the
+                LoadEvent::Discovered(found) => {
+                    // Reconciling the loaders *is* the load for every map the
                     // seed did not already cover: those fetches are all in
                     // flight at once and each lands on screen as it arrives.
-                    loaders.reconcile(&map_issues, &tx);
-                    app.startup.searched(&map_issues);
+                    loaders.reconcile(&found, &tx);
+                    app.startup.searched(&found);
                     if let Some(slug) = focus.take() {
-                        if map_issues.contains_key(&slug) {
+                        if found.iter().any(|id| id.repo == slug) {
                             app.scope = Scope::Project(slug);
                         } else {
                             // The seed may have focused this repo a moment ago on
@@ -281,33 +285,33 @@ async fn run(
                     }
                     // Maps the search dropped must stop being rendered as well as
                     // stop being fetched — their rows are as stale as their load.
-                    // A repo that is no longer mapped also stops being a
-                    // *failure*: there is nothing left to have failed.
-                    maps.retain(|slug, _| map_issues.contains_key(slug));
-                    app.failed.retain(|slug| map_issues.contains_key(slug));
-                    app.map_issues = map_issues;
-                    app.replace_map(merge_maps(&maps));
+                    // A map that is no longer open also stops being a *failure*:
+                    // there is nothing left to have failed.
+                    clusters.retain(|id, _| found.contains(id));
+                    app.failed.retain(|id| found.contains(id));
+                    app.open_maps = found;
+                    app.replace_clusters(clusters.clone());
                 }
                 // Discovery retries, so this is a status report and not an end
                 // state: `wf` stays on screen and recovers when the search does.
                 LoadEvent::SearchFailed => {
                     app.notice = Some("map search failed — retrying".to_string());
                 }
-                LoadEvent::Fetched { repo, outcome } => {
-                    app.startup.record_arrival(&repo);
+                LoadEvent::Fetched { id, outcome } => {
+                    app.startup.record_arrival(&id);
                     match outcome {
                         MapFetch::Loaded(new_map) => {
-                            app.failed.remove(&repo);
-                            maps.insert(repo, new_map);
-                            app.replace_map(merge_maps(&maps));
+                            app.failed.remove(&id);
+                            clusters.insert(id, new_map);
+                            app.replace_clusters(clusters.clone());
                         }
                         // Nothing polls any more, so a failed load is not a blip
                         // the next cycle papers over — it is the final word on
-                        // that repo until someone asks again. Recorded as state
+                        // that map until someone asks again. Recorded as state
                         // rather than announced as a notice, because a notice
                         // is gone on the next keypress and this is not.
                         MapFetch::Failed => {
-                            app.failed.insert(repo);
+                            app.failed.insert(id);
                         }
                     }
                 }
@@ -336,7 +340,7 @@ async fn run(
                     // write wins. Results stream in as they land, so the last
                     // word on how it went is the count line, not this notice.
                     Outcome::Refresh => {
-                        loaders.restart(&app.map_issues, &tx);
+                        loaders.restart(&app.open_maps, &tx);
                         app.startup.reloading();
                         app.failed.clear();
                     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,47 @@
-//! The wayfinder ticket model: tickets and their derived status.
+//! The wayfinder ticket model: maps, tickets, and their derived status.
 //!
 //! Status is derived, never stored (per the wayfinder model):
 //! closed = done; open + assigned = claimed; open + unassigned with open
 //! blockers = blocked; otherwise frontier.
+
+use serde::{Deserialize, Serialize};
+
+/// The identity of one map: the repo it lives in and its map issue number.
+///
+/// A repo can hold several open maps at once (#50), so the slug alone stopped
+/// being an identity — every place that used to say "this repo's map" (the
+/// projects cache, the loaders, the failure set, the clusters on screen) now
+/// says *which* map, and a second map on one repo is an ordinary value instead
+/// of the one the lowest-number rule silently hid.
+///
+/// `Ord` is (repo, number), which is also the on-screen cluster order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct MapId {
+    /// Full repo slug (e.g. "blooop/wayfinder") — the full slug, never the
+    /// short name, because a fork and its upstream share a short name.
+    pub repo: String,
+    /// The map issue's number in that repo.
+    pub number: u64,
+}
+
+impl MapId {
+    pub fn new(repo: impl Into<String>, number: u64) -> Self {
+        Self {
+            repo: repo.into(),
+            number,
+        }
+    }
+
+    /// The short repo name shown in the cluster header (the slug's name half:
+    /// "blooop/wayfinder" → "wayfinder"). Display only — never an identity key.
+    pub fn short_repo(&self) -> &str {
+        self.repo.split('/').next_back().unwrap_or(&self.repo)
+    }
+}
+
+/// The set of maps believed open — what the search answers with, what the
+/// cache seeds, and what the loaders reconcile against.
+pub type MapSet = std::collections::BTreeSet<MapId>;
 
 /// Derived state of a ticket on a map. `Blocked` carries the open blockers
 /// (`needs`) so a blocked ticket without its blockers is unrepresentable.
@@ -25,7 +64,7 @@ impl Status {
         }
     }
 
-    /// Position of this status's group on the main screen
+    /// Position of this status's group within a cluster
     /// (frontier / claimed / blocked / done).
     pub fn group(&self) -> usize {
         match self {
@@ -120,7 +159,6 @@ impl TicketType {
             TicketType::Untyped => 4,
         }
     }
-
 }
 
 /// One ticket (sub-issue) on a map.
@@ -136,51 +174,65 @@ pub struct Ticket {
     pub status: Status,
     /// The `wayfinder:*` type, parsed from the issue's labels at fetch time.
     pub ticket_type: TicketType,
+    /// Every issue this ticket is blocked by — the full DAG edge set, closed
+    /// blockers included (#50). This is *structure*, where
+    /// [`Status::Blocked::needs`] is *status*: `needs` is the open subset at
+    /// fetch time, and both are parsed once from the same `gh` response rather
+    /// than one being re-derived from the other. Reverse (unblocks) edges are
+    /// derived locally by inversion ([`Map::unblocks`]); the numbers may name
+    /// issues outside the map, which inversion simply never visits.
+    pub blocked_by: Vec<u64>,
 }
 
 impl Ticket {
-    /// The short repo name shown in the row's repo column (the slug's name
-    /// half: "blooop/wayfinder" → "wayfinder"). Display only — never an
-    /// identity key.
+    /// The short repo name (the slug's name half: "blooop/wayfinder" →
+    /// "wayfinder"). Display and fuzzy-match only — never an identity key.
     pub fn short_repo(&self) -> &str {
         self.repo.split('/').next_back().unwrap_or(&self.repo)
     }
 }
 
-/// One project's map: the map issue plus its sub-issue tickets.
+/// One map's cluster: the map issue plus its sub-issue tickets.
+///
+/// Deliberately *without* its own [`MapId`]: a map is always held under its id
+/// (in the clusters the screen renders, in a load event), so carrying a second
+/// copy would let the two disagree.
 #[derive(Debug, Clone)]
 pub struct Map {
-    /// Full repo slug (e.g. "blooop/wayfinder"), shown in the header.
-    pub repo: String,
     /// Title of the map issue itself.
     pub title: String,
     pub tickets: Vec<Ticket>,
 }
 
-/// Merge the latest map per repo (keyed by slug) into the single [`Map`]
-/// the screen renders. Several checkouts of one repo share one entry here,
-/// so each repo's tickets appear exactly once. Tickets sort by
-/// (repo, number); the header names the one repo when there is one, or
-/// counts projects otherwise.
-pub fn merge_maps(maps: &std::collections::BTreeMap<String, Map>) -> Map {
-    let repo = match maps.len() {
-        0 => "no projects — run wf inside a checkout to register it".to_string(),
-        1 => maps.keys().next().expect("len checked").clone(),
-        n => format!("{n} projects"),
-    };
-    let mut tickets: Vec<Ticket> = maps.values().flat_map(|m| m.tickets.iter().cloned()).collect();
-    tickets.sort_by(|a, b| (&a.repo, a.number).cmp(&(&b.repo, b.number)));
-    Map {
-        repo,
-        title: "wf".to_string(),
-        tickets,
+impl Map {
+    /// The tickets this ticket unblocks — the reverse of [`Ticket::blocked_by`],
+    /// derived by inversion over the map's own tickets (#50). Direct dependents
+    /// only; edges pointing outside the map never show up here because the
+    /// tickets that would carry them are not on this map.
+    pub fn unblocks(&self, number: u64) -> Vec<u64> {
+        self.tickets
+            .iter()
+            .filter(|t| t.blocked_by.contains(&number))
+            .map(|t| t.number)
+            .collect()
+    }
+
+    /// Ticket counts by status group (frontier / claimed / blocked / done) —
+    /// the cluster header's `○n ◐n ⊘n ●n`.
+    pub fn counts(&self) -> [usize; 4] {
+        let mut counts = [0; 4];
+        for t in &self.tickets {
+            counts[t.status.group()] += 1;
+        }
+        counts
     }
 }
 
 /// Derive a ticket's status from its raw tracker state.
 ///
 /// `open_blockers` lists the numbers of *open* issues blocking this one;
-/// closed blockers don't block.
+/// closed blockers don't block (they are structure, kept on
+/// [`Ticket::blocked_by`], not status).
 pub fn classify(is_open: bool, is_assigned: bool, open_blockers: Vec<u64>) -> Status {
     if !is_open {
         Status::Done
@@ -220,23 +272,6 @@ mod tests {
     #[test]
     fn open_unassigned_unblocked_is_frontier() {
         assert_eq!(classify(true, false, vec![]), Status::Frontier);
-    }
-
-    fn map(slug: &str, numbers: &[u64]) -> Map {
-        Map {
-            repo: slug.to_string(),
-            title: format!("Map: {slug}"),
-            tickets: numbers
-                .iter()
-                .map(|&n| Ticket {
-                    repo: slug.to_string(),
-                    number: n,
-                    title: format!("t{n}"),
-                    status: Status::Frontier,
-                    ticket_type: TicketType::Task,
-                })
-                .collect(),
-        }
     }
 
     #[test]
@@ -306,41 +341,81 @@ mod tests {
     }
 
     #[test]
-    fn merge_flattens_repos_sorted_by_repo_then_number() {
-        let mut maps = std::collections::BTreeMap::new();
-        maps.insert("kinisi/zeta".to_string(), map("kinisi/zeta", &[2, 1]));
-        maps.insert("blooop/alpha".to_string(), map("blooop/alpha", &[9]));
-        let merged = merge_maps(&maps);
-        assert_eq!(merged.repo, "2 projects");
-        let keys: Vec<(&str, u64)> = merged
-            .tickets
-            .iter()
-            .map(|t| (t.repo.as_str(), t.number))
-            .collect();
+    fn short_repo_is_the_name_half_of_the_slug() {
+        assert_eq!(MapId::new("blooop/wayfinder", 1).short_repo(), "wayfinder");
+        let t = Ticket {
+            repo: "blooop/wayfinder".to_string(),
+            number: 1,
+            title: "t".to_string(),
+            status: Status::Frontier,
+            ticket_type: TicketType::Task,
+            blocked_by: vec![],
+        };
+        assert_eq!(t.short_repo(), "wayfinder");
+    }
+
+    #[test]
+    fn map_ids_order_by_repo_then_number_which_is_cluster_order() {
+        let mut ids = vec![
+            MapId::new("kinisi/zeta", 4),
+            MapId::new("blooop/wayfinder", 47),
+            MapId::new("blooop/wayfinder", 1),
+        ];
+        ids.sort();
         assert_eq!(
-            keys,
-            vec![("blooop/alpha", 9), ("kinisi/zeta", 1), ("kinisi/zeta", 2)]
+            ids,
+            vec![
+                MapId::new("blooop/wayfinder", 1),
+                MapId::new("blooop/wayfinder", 47),
+                MapId::new("kinisi/zeta", 4),
+            ]
         );
     }
 
-    #[test]
-    fn short_repo_is_the_name_half_of_the_slug() {
-        let t = &map("blooop/wayfinder", &[1]).tickets[0];
-        assert_eq!(t.short_repo(), "wayfinder");
-        assert_eq!(t.repo, "blooop/wayfinder");
+    fn ticket(number: u64, open: bool, blocked_by: Vec<u64>) -> Ticket {
+        Ticket {
+            repo: "blooop/wayfinder".to_string(),
+            number,
+            title: format!("t{number}"),
+            status: classify(open, false, vec![]),
+            ticket_type: TicketType::Task,
+            blocked_by,
+        }
     }
 
     #[test]
-    fn merge_of_one_repo_names_it_in_the_header() {
-        let mut maps = std::collections::BTreeMap::new();
-        maps.insert("blooop/alpha".to_string(), map("blooop/alpha", &[1]));
-        assert_eq!(merge_maps(&maps).repo, "blooop/alpha");
+    fn unblocks_is_the_local_inversion_of_the_full_edge_set() {
+        // #50 → #51 and #50 → #52, with #48 closed but its edge kept: the DAG
+        // survives the blocker closing, which is exactly why closed edges stay.
+        let map = Map {
+            title: "Map: selection view".to_string(),
+            tickets: vec![
+                ticket(48, false, vec![]),
+                ticket(50, true, vec![48]),
+                ticket(51, true, vec![50]),
+                ticket(52, true, vec![50]),
+            ],
+        };
+        assert_eq!(map.unblocks(50), vec![51, 52]);
+        assert_eq!(map.unblocks(48), vec![50], "closed blockers keep their edges");
+        assert_eq!(map.unblocks(52), Vec::<u64>::new());
+        // An edge pointing outside the map inverts to nothing rather than
+        // panicking or inventing a ticket.
+        assert_eq!(map.unblocks(999), Vec::<u64>::new());
     }
 
     #[test]
-    fn merge_of_nothing_says_so() {
-        let merged = merge_maps(&std::collections::BTreeMap::new());
-        assert!(merged.tickets.is_empty());
-        assert!(merged.repo.contains("no projects"), "header: {}", merged.repo);
+    fn counts_tally_the_four_status_groups() {
+        let mut done = ticket(2, false, vec![]);
+        done.status = Status::Done;
+        let mut claimed = ticket(9, true, vec![]);
+        claimed.status = Status::Claimed;
+        let mut blocked = ticket(7, true, vec![6]);
+        blocked.status = Status::Blocked { needs: vec![6] };
+        let map = Map {
+            title: "Map: wf".to_string(),
+            tickets: vec![ticket(6, true, vec![]), claimed, blocked, done],
+        };
+        assert_eq!(map.counts(), [1, 1, 1, 1]);
     }
 }

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
-use crate::launch::MapIssues;
+use crate::model::MapSet;
 
 /// One touched checkout: where it lives, and which repo its `origin` points at.
 ///
@@ -36,22 +36,27 @@ pub struct Checkout {
 /// The per-machine cache of touched checkouts, plus the last map search's
 /// findings (#28).
 ///
-/// The findings are keyed by **repo slug**, not held on a [`Checkout`]: which
-/// issue is a repo's map is a property of the repo, and two checkouts of one
-/// repo would otherwise each carry a copy that can disagree with the other.
+/// The findings are a set of [`MapId`]s, not held on a [`Checkout`]: which
+/// issues are a repo's maps is a property of the repo, and two checkouts of
+/// one repo would otherwise each carry a copy that can disagree with the
+/// other. A set of ids rather than a per-repo number because a repo can hold
+/// several open maps at once (#50) — the old `repo → one number` table could
+/// not even represent that.
 ///
 /// There is deliberately no third "not yet searched" state. The search is
 /// unconditional — the cache is a head start, never a skip (see
 /// [`crate::refresh::spawn_discovery`]) — so nothing ever branches on *why* a
-/// repo is absent from `maps`, only on the fact that it has no head start.
-/// A state nothing can observe is a state not worth modelling.
+/// repo is absent from `open_maps`, only on the fact that it has no head
+/// start. A state nothing can observe is a state not worth modelling.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProjectsCache {
     pub checkouts: Vec<Checkout>,
-    /// `repo slug → map issue number`, as of the last successful search.
-    /// Absent from an older cache file, which simply means no head start.
+    /// Every open map the last successful search found. A fresh field name
+    /// (not the pre-#50 `maps` table) on purpose: an older cache file's `maps`
+    /// is skipped as an unknown field, so its checkouts survive the upgrade
+    /// and only the head start is lost — once.
     #[serde(default)]
-    pub maps: MapIssues,
+    pub open_maps: MapSet,
 }
 
 impl ProjectsCache {
@@ -85,35 +90,30 @@ impl ProjectsCache {
         self.forget_unknown_maps();
     }
 
-    /// The head start (#28): every map issue number the last search found, for
-    /// repos still in the cache. Read before the first frame, so the pollers
-    /// start fetching at `t≈0` instead of after the ~2.5 s search.
-    pub fn map_seed(&self) -> MapIssues {
-        self.maps.clone()
+    /// The head start (#28): every open map the last search found, for repos
+    /// still in the cache. Read before the first frame, so the loaders start
+    /// fetching at `t≈0` instead of after the ~2.5 s search.
+    pub fn map_seed(&self) -> MapSet {
+        self.open_maps.clone()
     }
 
     /// Record what a search over `searched` found, so the next run has a head
-    /// start. Repos that were searched and have no map are simply dropped —
-    /// absence *is* "no head start", and that is all this table means.
-    pub fn record_search(&mut self, searched: &[String], found: &MapIssues) {
-        for repo in searched {
-            match found.get(repo) {
-                Some(&number) => {
-                    self.maps.insert(repo.clone(), number);
-                }
-                None => {
-                    self.maps.remove(repo);
-                }
-            }
-        }
+    /// start. A searched repo keeps exactly the maps the search named — a repo
+    /// whose maps all closed is simply dropped, because absence *is* "no head
+    /// start", and that is all this set means.
+    pub fn record_search(&mut self, searched: &[String], found: &MapSet) {
+        self.open_maps
+            .retain(|id| !searched.contains(&id.repo) || found.contains(id));
+        self.open_maps
+            .extend(found.iter().filter(|id| searched.contains(&id.repo)).cloned());
     }
 
     /// Drop findings for repos no checkout points at any more — the seed must
     /// not outlive the checkouts that justify fetching it.
     fn forget_unknown_maps(&mut self) {
         let repos = self.repos();
-        self.maps
-            .retain(|repo, _| repos.binary_search(repo).is_ok());
+        self.open_maps
+            .retain(|id| repos.binary_search(&id.repo).is_ok());
     }
 
     /// Drop checkouts whose directory no longer exists. A deleted checkout must
@@ -199,6 +199,7 @@ pub async fn discover_checkout(dir: &Path) -> Option<(PathBuf, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::MapId;
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
@@ -233,22 +234,25 @@ mod tests {
 
     #[test]
     fn an_older_cache_file_still_loads() {
-        // Two shape changes so far, and a cache is not truth: the seed shipped
-        // after the cache did (#28), so an older file simply has no head start;
-        // and the per-checkout session name went with the multiplexer (#34), so
-        // a file that still carries one is read straight past it.
+        // Three shape changes so far, and a cache is not truth: the seed
+        // shipped after the cache did (#28), so an older file simply has no
+        // head start; the per-checkout session name went with the multiplexer
+        // (#34); and the `repo → one map` table gave way to `open_maps` (#50).
+        // A file carrying any of the old shapes is read straight past them —
+        // the checkouts always survive.
         let dir = std::env::temp_dir().join(format!("wf-test-old-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("projects.json");
         std::fs::write(
             &file,
             br#"{"checkouts": [{"path": "/data/proj/wayfinder",
-                 "repo": "blooop/wayfinder", "session": "wayfinder"}]}"#,
+                 "repo": "blooop/wayfinder", "session": "wayfinder"}],
+                 "maps": {"blooop/wayfinder": 1}}"#,
         )
         .unwrap();
         let cache = ProjectsCache::load_or_default(&file);
         assert_eq!(cache.checkouts.len(), 1, "the checkouts must survive");
-        assert!(cache.map_seed().is_empty());
+        assert!(cache.map_seed().is_empty(), "the pre-#50 table is not a seed");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -259,23 +263,29 @@ mod tests {
         cache.register(p("/data/proj/dotfiles"), "blooop/dotfiles".to_string());
         let searched = cache.repos();
 
-        let found: MapIssues = [("blooop/wayfinder".to_string(), 1)].into_iter().collect();
+        // Two open maps on one repo both seed — the whole point of #50.
+        let found: MapSet = [
+            MapId::new("blooop/wayfinder", 1),
+            MapId::new("blooop/wayfinder", 47),
+        ]
+        .into_iter()
+        .collect();
         cache.record_search(&searched, &found);
         assert_eq!(cache.map_seed(), found, "an unmapped repo is simply absent");
 
-        // The map moved and the other repo gained one: the search is the
+        // One map closed, the other repo gained one: the search is the
         // authority, so the seed follows it rather than accumulating.
-        let found: MapIssues = [
-            ("blooop/wayfinder".to_string(), 42),
-            ("blooop/dotfiles".to_string(), 7),
+        let found: MapSet = [
+            MapId::new("blooop/wayfinder", 47),
+            MapId::new("blooop/dotfiles", 7),
         ]
         .into_iter()
         .collect();
         cache.record_search(&searched, &found);
         assert_eq!(cache.map_seed(), found);
 
-        // And a map that has gone stops being a head start.
-        cache.record_search(&searched, &MapIssues::new());
+        // And maps that have gone stop being a head start.
+        cache.record_search(&searched, &MapSet::new());
         assert!(cache.map_seed().is_empty());
     }
 
@@ -290,7 +300,7 @@ mod tests {
         cache.register(gone.clone(), "blooop/wayfinder".to_string());
         cache.record_search(
             &cache.repos(),
-            &[("blooop/wayfinder".to_string(), 1)].into_iter().collect(),
+            &[MapId::new("blooop/wayfinder", 1)].into_iter().collect(),
         );
         assert!(!cache.map_seed().is_empty());
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -380,11 +380,14 @@ mod tests {
     fn the_same_ticket_under_two_maps_is_two_distinct_rows() {
         // #50: identity carries the map, so the cursor stays on the cluster it
         // was in rather than jumping to the other map's copy of the ticket.
-        let on_map_1 = (MapId::new("blooop/wayfinder", 1), 6u64);
-        let on_map_47 = (MapId::new("blooop/wayfinder", 47), 6u64);
-        let order = [on_map_1.clone(), on_map_47.clone()];
-        assert_eq!(preserve_cursor(Some(&on_map_47), 0, &order), 1);
-        assert_eq!(preserve_cursor(Some(&on_map_1), 1, &order), 0);
+        // Against the real `RowKey`, since that is the K this is generic for.
+        let on = |map: u64| crate::app::RowKey {
+            map: MapId::new("blooop/wayfinder", map),
+            ticket: 6,
+        };
+        let order = [on(1), on(47)];
+        assert_eq!(preserve_cursor(Some(&on(47)), 0, &order), 1);
+        assert_eq!(preserve_cursor(Some(&on(1)), 1, &order), 0);
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -5,12 +5,16 @@
 //! nothing here to keep fresh — [Build 7](https://github.com/blooop/wayfinder/issues/34)
 //! deleted the two-tier ETag poll ([Build 5](https://github.com/blooop/wayfinder/issues/17))
 //! along with the event loop it served. What is left is a **one-shot load per
-//! repo**, streamed:
+//! map**, streamed:
 //!
-//! 1. The cached map numbers (#28) start their fetches before the first frame.
+//! 1. The cached map ids (#28) start their fetches before the first frame.
 //! 2. One `wayfinder:map` label search runs unconditionally alongside them and
 //!    reconciles that set — the cache is a head start, never a skip.
 //! 3. Each map lands on screen as it arrives; `ctrl-r` is how you ask again.
+//!
+//! Everything is keyed by [`MapId`] rather than repo slug (#50): a repo can
+//! hold several open maps, and each is its own load, its own arrival, and its
+//! own possible failure.
 //!
 //! Failures never surface as errors: every outcome is a [`MapFetch`], and a
 //! failed load leaves the picker up with a notice rather than taking it down.
@@ -23,8 +27,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::fetch;
-use crate::launch::MapIssues;
-use crate::model::Map;
+use crate::model::{Map, MapId, MapSet};
 use crate::projects::ProjectsCache;
 
 /// How long the map search waits before trying again. The only recurring timer
@@ -32,13 +35,13 @@ use crate::projects::ProjectsCache;
 /// permanently empty.
 pub const RETRY_INTERVAL: Duration = Duration::from_secs(4);
 
-/// One repo's map load. Two states, because with the conditional probe gone
+/// One map's load. Two states, because with the conditional probe gone
 /// there is no third: a fetch either produced a map or it did not.
 #[derive(Debug)]
 pub enum MapFetch {
     /// The map came back.
     Loaded(Map),
-    /// The fetch failed (network, auth, parse); nothing to show for this repo.
+    /// The fetch failed (network, auth, parse); nothing to show for this map.
     Failed,
 }
 
@@ -48,28 +51,28 @@ pub enum MapFetch {
 /// and every variant is "something arrived that the screen should reflect".
 #[derive(Debug)]
 pub enum LoadEvent {
-    /// The one `wayfinder:map` label search returned: these repos have maps.
+    /// The one `wayfinder:map` label search returned: these are the open maps.
     /// Empty is a real answer — none of the cached repos is mapped.
-    Discovered(MapIssues),
+    Discovered(MapSet),
     /// The label search failed. [`spawn_discovery`] keeps retrying, so this is
     /// only ever a status report.
     SearchFailed,
-    /// One repo's map load reported.
-    Fetched { repo: String, outcome: MapFetch },
+    /// One map's load reported.
+    Fetched { id: MapId, outcome: MapFetch },
 }
 
 /// Has the `wayfinder:map` label search answered yet?
 ///
 /// Its own axis since #28, because the cached seed makes maps arrive *before*
-/// the search does: "which repos are mapped" and "have their maps landed" stop
-/// happening in that order, so one cannot stand in for the other.
+/// the search does: "which maps exist" and "have they landed" stop happening
+/// in that order, so one cannot stand in for the other.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Search {
     /// Still out. A failed search waits here too, since discovery retries, so a
     /// network blip at startup simply looks like a slow start.
     #[default]
     Out,
-    /// Answered — the set of mapped repos is now authoritative.
+    /// Answered — the set of open maps is now authoritative.
     Answered,
 }
 
@@ -87,30 +90,30 @@ pub enum Search {
 /// finished before anything had confirmed the map set. Here `is_loaded` is
 /// *derived* from both facts, so it cannot disagree with either.
 ///
-/// `arrived` is a set of repo slugs rather than a count because the loads run
+/// `arrived` is a set of [`MapId`]s rather than a count because the loads run
 /// concurrently: naming who is still pending is the only thing that cannot be
-/// fooled by one repo reporting twice.
+/// fooled by one map reporting twice.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Startup {
     search: Search,
-    expected: BTreeSet<String>,
-    arrived: BTreeSet<String>,
+    expected: BTreeSet<MapId>,
+    arrived: BTreeSet<MapId>,
 }
 
 impl Startup {
     /// Start from the cached head start (#28): these maps are believed to exist
     /// and are already being fetched, but the search has yet to confirm them. An
     /// empty seed is the cold start, identical to the pre-cache behaviour.
-    pub fn seeded(map_issues: &MapIssues) -> Self {
+    pub fn seeded(maps: &MapSet) -> Self {
         Self {
             search: Search::Out,
-            expected: map_issues.keys().cloned().collect(),
+            expected: maps.clone(),
             arrived: BTreeSet::new(),
         }
     }
 
-    /// Nothing is being waited on — for an [`crate::app::App`] handed a map it
-    /// already has, and for tests.
+    /// Nothing is being waited on — for an [`crate::app::App`] handed its maps
+    /// already, and for tests.
     pub fn loaded() -> Self {
         Self {
             search: Search::Answered,
@@ -118,19 +121,19 @@ impl Startup {
         }
     }
 
-    /// The search answered: `map_issues` is now the authoritative set of mapped
-    /// repos. A seeded repo it omits stops being waited on; one it adds joins
-    /// the wait unless it has already reported.
-    pub fn searched(&mut self, map_issues: &MapIssues) {
+    /// The search answered: `maps` is now the authoritative set of open maps.
+    /// A seeded map it omits stops being waited on; one it adds joins the wait
+    /// unless it has already reported.
+    pub fn searched(&mut self, maps: &MapSet) {
         self.search = Search::Answered;
-        self.expected = map_issues.keys().cloned().collect();
+        self.expected = maps.clone();
     }
 
-    /// Record `repo`'s map reporting. A *failed* fetch counts as reported: the
+    /// Record `id`'s map reporting. A *failed* fetch counts as reported: the
     /// wait for that map is over either way, and its failure is carried by
     /// [`crate::app::App::failed`] rather than by looking unfinished forever.
-    pub fn record_arrival(&mut self, repo: &str) {
-        self.arrived.insert(repo.to_string());
+    pub fn record_arrival(&mut self, id: &MapId) {
+        self.arrived.insert(id.clone());
     }
 
     /// `ctrl-r`: every map is being fetched again, so nothing has arrived yet.
@@ -143,14 +146,14 @@ impl Startup {
         self.arrived.clear();
     }
 
-    /// Repos whose maps are still out.
-    fn pending(&self) -> impl Iterator<Item = &String> {
+    /// Maps still out.
+    fn pending(&self) -> impl Iterator<Item = &MapId> {
         self.expected.difference(&self.arrived)
     }
 
     /// Is there nothing left to wait for? Every expected map has reported *and*
     /// the search has answered — a seeded start satisfies the first long before
-    /// the second, and the search is what may still add a repo mapped since the
+    /// the second, and the search is what may still add a map opened since the
     /// last run, so both are required.
     pub fn is_loaded(&self) -> bool {
         self.pending().next().is_none() && self.search == Search::Answered
@@ -174,23 +177,19 @@ impl Startup {
     }
 }
 
-/// One in-flight (or finished) load, and the map number it was started for.
-struct Loading {
-    number: u64,
-    task: JoinHandle<()>,
-}
-
-/// The map loads: **at most one per repo, at the map number currently
-/// believed**. That invariant is the whole reason this owns the tasks (#28).
+/// The map loads: **at most one per map id**. That invariant is the whole
+/// reason this owns the tasks (#28).
 ///
-/// A seeded start can be *wrong* — the number came from the last run — and the
-/// correction arrives later, in the search's answer. A corrected number that
-/// only landed in `App::map_issues` would fix what `enter` launches while the
-/// task actually doing the fetching kept asking for the old issue; so the load
-/// set is reconciled against the truth instead.
+/// A seeded start can be *wrong* — the ids came from the last run — and the
+/// correction arrives later, in the search's answer. A corrected set that only
+/// landed in `App::open_maps` would fix what the screen believes while the
+/// tasks actually doing the fetching kept asking for stale issues; so the load
+/// set is reconciled against the truth instead. The id *is* the whole target
+/// — repo and number both — so "same repo, different map number" is simply a
+/// different key, not a number to compare.
 #[derive(Default)]
 pub struct Loaders {
-    running: BTreeMap<String, Loading>,
+    running: BTreeMap<MapId, JoinHandle<()>>,
 }
 
 impl Loaders {
@@ -198,34 +197,30 @@ impl Loaders {
         Self::default()
     }
 
-    /// Make the loads match `want`: drop any whose repo is no longer mapped or
-    /// whose map number changed, start one for every repo not already loaded at
-    /// the right number, and leave the rest untouched — a repo whose map has
-    /// already arrived at the right number has nothing to fetch again.
+    /// Make the loads match `want`: drop any map no longer in the set, start
+    /// one for every map not already loading, and leave the rest untouched — a
+    /// map that has already arrived has nothing to fetch again.
     ///
-    /// Every event is tagged with the loading repo's slug so the UI loop knows
-    /// which map to swap. This call **is** the load for the repos it starts: N
+    /// Every event is tagged with its [`MapId`] so the UI loop knows which
+    /// cluster to swap. This call **is** the load for the maps it starts: N
     /// maps are fetched concurrently, one round trip of wall clock rather than
     /// N, and each one streams into a UI already on screen.
-    pub fn reconcile(&mut self, want: &MapIssues, tx: &mpsc::UnboundedSender<LoadEvent>) {
-        self.running.retain(|slug, loading| {
-            let still_wanted = want.get(slug) == Some(&loading.number);
+    pub fn reconcile(&mut self, want: &MapSet, tx: &mpsc::UnboundedSender<LoadEvent>) {
+        self.running.retain(|id, task| {
+            let still_wanted = want.contains(id);
             if !still_wanted {
                 // A no-op for a load that already finished, and the point for
-                // one still in flight against a number that has since moved.
-                loading.task.abort();
+                // one still in flight against a map that has since closed.
+                task.abort();
             }
             still_wanted
         });
-        for (slug, &number) in want {
-            if self.running.contains_key(slug) {
+        for id in want {
+            if self.running.contains_key(id) {
                 continue;
             }
-            let Some((owner, name)) = split_slug(slug) else {
-                continue; // a malformed cache entry is skipped, never panicked on
-            };
-            let task = spawn_load(owner, name, number, slug.clone(), tx.clone());
-            self.running.insert(slug.clone(), Loading { number, task });
+            let task = spawn_load(id.clone(), tx.clone());
+            self.running.insert(id.clone(), task);
         }
     }
 
@@ -233,13 +228,13 @@ impl Loaders {
     ///
     /// The refetch has to go through *this* rather than fetching alongside it,
     /// and the reason is ordering. A load started at t₀ and a refetch started
-    /// at t₁ > t₀ both write the same repo's map, and the load can land second
-    /// — so a refetch racing the initial load used to be overwritten by an
-    /// older snapshot while the screen said `refreshed`. Nothing polls now, so
-    /// that stale map would be final. Restarting means every result reaches the
-    /// UI through one channel, in send order, and the newest write wins by
+    /// at t₁ > t₀ both write the same map's cluster, and the load can land
+    /// second — so a refetch racing the initial load used to be overwritten by
+    /// an older snapshot while the screen said `refreshed`. Nothing polls now,
+    /// so that stale map would be final. Restarting means every result reaches
+    /// the UI through one channel, in send order, and the newest write wins by
     /// construction.
-    pub fn restart(&mut self, want: &MapIssues, tx: &mpsc::UnboundedSender<LoadEvent>) {
+    pub fn restart(&mut self, want: &MapSet, tx: &mpsc::UnboundedSender<LoadEvent>) {
         self.abort_all();
         self.reconcile(want, tx);
     }
@@ -254,57 +249,43 @@ impl Loaders {
     /// the agent as a zombie holding its terminal.
     pub async fn shutdown(&mut self) {
         self.abort_all();
-        for (_, loading) in std::mem::take(&mut self.running) {
+        for (_, task) in std::mem::take(&mut self.running) {
             // A load that already finished joins immediately; an aborted one
             // resolves to a `JoinError::Cancelled`. Both mean "gone".
-            let _ = loading.task.await;
+            let _ = task.await;
         }
     }
 
     fn abort_all(&mut self) {
-        for loading in self.running.values() {
-            loading.task.abort();
+        for task in self.running.values() {
+            task.abort();
         }
         self.running.clear();
     }
 
-    /// The repos being loaded, and at which map issue — the reconciled truth,
-    /// for tests and for anything that needs to know what is actually live.
-    pub fn targets(&self) -> MapIssues {
-        self.running
-            .iter()
-            .map(|(slug, loading)| (slug.clone(), loading.number))
-            .collect()
+    /// The maps being loaded — the reconciled truth, for tests and for
+    /// anything that needs to know what is actually live.
+    pub fn targets(&self) -> MapSet {
+        self.running.keys().cloned().collect()
     }
 }
 
-/// Split an `owner/name` slug, rejecting anything that is not one.
-fn split_slug(slug: &str) -> Option<(&str, &str)> {
-    let (owner, name) = slug.split_once('/')?;
-    (!owner.is_empty() && !name.is_empty() && !name.contains('/')).then_some((owner, name))
-}
-
-/// Fetch one repo's map and report it. One shot: there is no loop, because
-/// there is nothing to stay fresh for (#26).
-fn spawn_load(
-    owner: &str,
-    name: &str,
-    number: u64,
-    slug: String,
-    tx: mpsc::UnboundedSender<LoadEvent>,
-) -> JoinHandle<()> {
-    let (owner, name) = (owner.to_string(), name.to_string());
+/// Fetch one map and report it. One shot: there is no loop, because there is
+/// nothing to stay fresh for (#26). A malformed cached id (a slug that is not
+/// `owner/name`) fails the fetch and reports as [`MapFetch::Failed`], which is
+/// visible on the count line rather than silently skipped.
+fn spawn_load(id: MapId, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let outcome = match fetch::fetch_map(&owner, &name, number).await {
+        let outcome = match fetch::fetch_map(&id).await {
             Ok(map) => MapFetch::Loaded(map),
             Err(_) => MapFetch::Failed,
         };
-        let _ = tx.send(LoadEvent::Fetched { repo: slug, outcome });
+        let _ = tx.send(LoadEvent::Fetched { id, outcome });
     })
 }
 
-/// Find which cached repos have a `wayfinder:map`, off the path to the first
-/// frame (#27).
+/// Find every open `wayfinder:map` across the cached repos, off the path to
+/// the first frame (#27).
 ///
 /// It **retries** on [`RETRY_INTERVAL`] rather than giving up. A single failed
 /// search would otherwise leave `wf` permanently empty with no way back:
@@ -312,11 +293,11 @@ fn spawn_load(
 /// knows about none.
 ///
 /// It runs **unconditionally**, warm cache or cold (#28). The cache is a head
-/// start, never a skip: this is the one thing that can add a repo mapped since
-/// the last run, drop one whose map was closed, and correct a number that moved
-/// — so the seed is never trusted for longer than one search round trip. On
-/// success it writes its findings back to `cache_path`, which is what makes the
-/// *next* run warm; a failed write costs only that head start.
+/// start, never a skip: this is the one thing that can add a map opened since
+/// the last run, drop one that was closed, and correct an id that moved — so
+/// the seed is never trusted for longer than one search round trip. On success
+/// it writes its findings back to `cache_path`, which is what makes the *next*
+/// run warm; a failed write costs only that head start.
 ///
 /// Returns its handle so the launch path can stop it and wait: it holds a `gh`
 /// child of its own, and the same reasoning as [`Loaders::shutdown`] applies.
@@ -329,12 +310,11 @@ pub fn spawn_discovery(
         loop {
             match fetch::find_maps(&repos).await {
                 Ok(found) => {
-                    let found: MapIssues = found.into_iter().collect();
                     let mut cache = ProjectsCache::load_or_default(&cache_path);
                     cache.record_search(&repos, &found);
                     let _ = cache.save(&cache_path);
                     let _ = tx.send(LoadEvent::Discovered(found));
-                    return; // the set of mapped repos is fixed for this run
+                    return; // the set of open maps is fixed for this run
                 }
                 Err(_) if tx.send(LoadEvent::SearchFailed).is_err() => return, // UI is gone
                 Err(_) => {}
@@ -346,18 +326,21 @@ pub fn spawn_discovery(
 
 /// Where the cursor lands after a load or a refresh swaps the ticket list.
 ///
-/// Identity wins over position: if the previously selected ticket (by
-/// `(repo, number)`) still exists anywhere in the new order, the cursor
-/// follows it. Only if it vanished does the cursor fall back to the same
-/// index, clamped to the new length. A map arriving must never teleport the
-/// selection just because rows moved between groups.
-pub fn preserve_cursor(
-    old_selected: Option<(&str, u64)>,
+/// Identity wins over position: if the previously selected row still exists
+/// anywhere in the new order, the cursor follows it. Only if it vanished does
+/// the cursor fall back to the same index, clamped to the new length. A map
+/// arriving must never teleport the selection just because rows moved.
+///
+/// Generic over the key so the caller decides what identity *is* — since #50
+/// that is `(MapId, ticket number)`: the same ticket listed on two maps of one
+/// repo is two rows, and the map half is what keeps the cursor on the right one.
+pub fn preserve_cursor<K: PartialEq>(
+    old_selected: Option<&K>,
     old_index: usize,
-    new_order: &[(&str, u64)],
+    new_order: &[K],
 ) -> usize {
     if let Some(sel) = old_selected {
-        if let Some(idx) = new_order.iter().position(|k| *k == sel) {
+        if let Some(idx) = new_order.iter().position(|k| k == sel) {
             return idx;
         }
     }
@@ -376,61 +359,56 @@ mod tests {
     #[test]
     fn cursor_follows_ticket_identity_when_rows_reorder() {
         // B was selected at index 1; a fresh map moves it to the top.
-        assert_eq!(preserve_cursor(Some(B), 1, &[B, A, C]), 0);
+        assert_eq!(preserve_cursor(Some(&B), 1, &[B, A, C]), 0);
         // …or to the bottom.
-        assert_eq!(preserve_cursor(Some(B), 1, &[A, C, B]), 2);
+        assert_eq!(preserve_cursor(Some(&B), 1, &[A, C, B]), 2);
     }
 
     #[test]
     fn cursor_stays_put_when_nothing_moved() {
-        assert_eq!(preserve_cursor(Some(B), 1, &[A, B, C]), 1);
+        assert_eq!(preserve_cursor(Some(&B), 1, &[A, B, C]), 1);
     }
 
     #[test]
     fn identity_is_repo_and_number_not_number_alone() {
         // A ("wayfinder"#6) selected; new list has "other"#6 earlier — must
         // not match it.
-        assert_eq!(preserve_cursor(Some(A), 2, &[D, B, A]), 2);
+        assert_eq!(preserve_cursor(Some(&A), 2, &[D, B, A]), 2);
+    }
+
+    #[test]
+    fn the_same_ticket_under_two_maps_is_two_distinct_rows() {
+        // #50: identity carries the map, so the cursor stays on the cluster it
+        // was in rather than jumping to the other map's copy of the ticket.
+        let on_map_1 = (MapId::new("blooop/wayfinder", 1), 6u64);
+        let on_map_47 = (MapId::new("blooop/wayfinder", 47), 6u64);
+        let order = [on_map_1.clone(), on_map_47.clone()];
+        assert_eq!(preserve_cursor(Some(&on_map_47), 0, &order), 1);
+        assert_eq!(preserve_cursor(Some(&on_map_1), 1, &order), 0);
     }
 
     #[test]
     fn vanished_ticket_falls_back_to_same_index_clamped() {
         // C vanished; cursor was at 2, new list has 2 rows → clamp to 1.
-        assert_eq!(preserve_cursor(Some(C), 2, &[A, B]), 1);
+        assert_eq!(preserve_cursor(Some(&C), 2, &[A, B]), 1);
         // Cursor was at 0 and that ticket vanished → stay at 0.
-        assert_eq!(preserve_cursor(Some(A), 0, &[B, C]), 0);
+        assert_eq!(preserve_cursor(Some(&A), 0, &[B, C]), 0);
     }
 
     #[test]
     fn empty_new_list_pins_cursor_to_zero() {
-        assert_eq!(preserve_cursor(Some(A), 2, &[]), 0);
+        assert_eq!(preserve_cursor(Some(&A), 2, &[]), 0);
     }
 
     #[test]
     fn no_prior_selection_clamps_index() {
-        assert_eq!(preserve_cursor(None, 5, &[A, B]), 1);
-        assert_eq!(preserve_cursor(None, 0, &[A, B]), 0);
+        assert_eq!(preserve_cursor::<(&str, u64)>(None, 5, &[A, B]), 1);
+        assert_eq!(preserve_cursor::<(&str, u64)>(None, 0, &[A, B]), 0);
     }
 
-    #[test]
-    fn a_slug_is_owner_slash_name_and_nothing_else() {
-        assert_eq!(split_slug("blooop/wayfinder"), Some(("blooop", "wayfinder")));
-        // A malformed cache entry must be skipped, not fetched and not panicked
-        // on — these are the shapes `Loaders::reconcile` silently drops.
-        assert_eq!(split_slug("wayfinder"), None);
-        assert_eq!(split_slug("/wayfinder"), None);
-        assert_eq!(split_slug("blooop/"), None);
-        assert_eq!(split_slug("a/b/c"), None);
-        assert_eq!(split_slug(""), None);
-    }
-
-    /// The `Discovered` payload for a set of repo slugs.
-    fn found(slugs: &[&str]) -> MapIssues {
-        slugs
-            .iter()
-            .enumerate()
-            .map(|(i, slug)| ((*slug).to_string(), i as u64 + 1))
-            .collect()
+    /// A `MapSet` from (slug, number) pairs.
+    fn found(maps: &[(&str, u64)]) -> MapSet {
+        maps.iter().map(|&(slug, n)| MapId::new(slug, n)).collect()
     }
 
     /// A cold start: no cached seed, search still out.
@@ -440,7 +418,7 @@ mod tests {
 
     #[test]
     fn a_search_that_found_no_maps_is_loaded_not_loading() {
-        // Zero mapped repos is an *answer*: there is nothing to wait for, so
+        // Zero open maps is an *answer*: there is nothing to wait for, so
         // the screen must stop claiming to be loading.
         let mut startup = cold();
         startup.searched(&found(&[]));
@@ -450,38 +428,43 @@ mod tests {
 
     #[test]
     fn loading_completes_when_every_discovered_map_has_reported() {
+        // Three maps, two of them on one repo — each is its own arrival (#50).
         let mut startup = cold();
-        startup.searched(&found(&["a/one", "a/two", "a/three"]));
+        startup.searched(&found(&[("a/one", 1), ("a/one", 9), ("b/two", 2)]));
         assert_eq!(startup.hint(), "· loading maps 0/3");
-        startup.record_arrival("a/one");
-        assert_eq!(startup.hint(), "· loading maps 1/3");
-        startup.record_arrival("a/two");
+        startup.record_arrival(&MapId::new("a/one", 1));
+        assert_eq!(
+            startup.hint(),
+            "· loading maps 1/3",
+            "the repo's other map is still out"
+        );
+        startup.record_arrival(&MapId::new("a/one", 9));
         assert_eq!(startup.hint(), "· loading maps 2/3");
-        startup.record_arrival("a/three");
+        startup.record_arrival(&MapId::new("b/two", 2));
         assert!(startup.is_loaded());
     }
 
     #[test]
-    fn one_repo_reporting_twice_does_not_complete_another_repos_load() {
-        // The loads are concurrent, and `ctrl-r` can make a repo report again
+    fn one_map_reporting_twice_does_not_complete_another_maps_load() {
+        // The loads are concurrent, and `ctrl-r` can make a map report again
         // while a slow one is still out. Counting arrivals would call that
         // done; naming who is still pending cannot.
         let mut startup = cold();
-        startup.searched(&found(&["fast/one", "slow/two"]));
-        startup.record_arrival("fast/one");
-        startup.record_arrival("fast/one");
+        startup.searched(&found(&[("fast/one", 1), ("slow/two", 2)]));
+        startup.record_arrival(&MapId::new("fast/one", 1));
+        startup.record_arrival(&MapId::new("fast/one", 1));
         assert_eq!(startup.hint(), "· loading maps 1/2", "slow/two is still out");
-        startup.record_arrival("slow/two");
+        startup.record_arrival(&MapId::new("slow/two", 2));
         assert!(startup.is_loaded());
     }
 
     #[test]
     fn arrivals_after_the_load_do_not_push_the_screen_back_into_loading() {
         let mut startup = cold();
-        startup.searched(&found(&["a/one"]));
-        startup.record_arrival("a/one");
-        startup.record_arrival("a/one");
-        startup.record_arrival("b/two"); // never expected; not a regression
+        startup.searched(&found(&[("a/one", 1)]));
+        startup.record_arrival(&MapId::new("a/one", 1));
+        startup.record_arrival(&MapId::new("a/one", 1));
+        startup.record_arrival(&MapId::new("b/two", 2)); // never expected; not a regression
         assert!(startup.is_loaded());
         assert_eq!(startup.hint(), "");
     }
@@ -491,7 +474,7 @@ mod tests {
         // Both draw an empty list; only the hint says why it is empty.
         assert_eq!(cold().hint(), "· searching for maps…");
         assert_eq!(
-            Startup::seeded(&found(&["a/one", "a/two"])).hint(),
+            Startup::seeded(&found(&[("a/one", 1), ("a/two", 2)])).hint(),
             "· loading maps 0/2"
         );
     }
@@ -501,16 +484,16 @@ mod tests {
         // The #28 head start: the cache already named these maps, so the screen
         // says what it is waiting for from the first frame rather than spending
         // the search's ~2.5s claiming to be looking for maps at all.
-        let mut startup = Startup::seeded(&found(&["a/one", "b/two"]));
+        let mut startup = Startup::seeded(&found(&[("a/one", 1), ("b/two", 2)]));
         assert_eq!(startup.hint(), "· loading maps 0/2");
-        startup.record_arrival("a/one");
-        startup.record_arrival("b/two");
+        startup.record_arrival(&MapId::new("a/one", 1));
+        startup.record_arrival(&MapId::new("b/two", 2));
         // Every *cached* map is in, but the search has yet to confirm the set —
-        // and confirming it is exactly what may add a repo mapped since the last
+        // and confirming it is exactly what may add a map opened since the last
         // run, so the load is not over until both are true.
         assert!(!startup.is_loaded(), "the search has not answered yet");
         assert_eq!(startup.hint(), "· searching for maps…");
-        startup.searched(&found(&["a/one", "b/two"]));
+        startup.searched(&found(&[("a/one", 1), ("b/two", 2)]));
         assert!(startup.is_loaded());
     }
 
@@ -519,18 +502,18 @@ mod tests {
         // A refresh refetches every map, so nothing has arrived until it does.
         // Without this the hint stays empty and `ctrl-r` is a silent pause.
         let mut startup = cold();
-        let maps = found(&["a/one", "b/two"]);
+        let maps = found(&[("a/one", 1), ("b/two", 2)]);
         startup.searched(&maps);
-        startup.record_arrival("a/one");
-        startup.record_arrival("b/two");
+        startup.record_arrival(&MapId::new("a/one", 1));
+        startup.record_arrival(&MapId::new("b/two", 2));
         assert!(startup.is_loaded());
 
         startup.reloading();
         assert!(!startup.is_loaded());
         assert_eq!(startup.hint(), "· loading maps 0/2");
-        startup.record_arrival("a/one");
+        startup.record_arrival(&MapId::new("a/one", 1));
         assert_eq!(startup.hint(), "· loading maps 1/2");
-        startup.record_arrival("b/two");
+        startup.record_arrival(&MapId::new("b/two", 2));
         assert!(startup.is_loaded(), "the search already answered; it stays answered");
         assert_eq!(startup.hint(), "");
     }
@@ -538,17 +521,29 @@ mod tests {
     #[test]
     fn the_search_overrules_a_seed_it_disagrees_with() {
         // Cached "b/two" lost its map and "c/three" gained one since last run.
-        let mut startup = Startup::seeded(&found(&["a/one", "b/two"]));
-        startup.record_arrival("a/one");
-        let mut authoritative = found(&["a/one"]);
-        authoritative.insert("c/three".to_string(), 9);
-        startup.searched(&authoritative);
+        let mut startup = Startup::seeded(&found(&[("a/one", 1), ("b/two", 2)]));
+        startup.record_arrival(&MapId::new("a/one", 1));
+        startup.searched(&found(&[("a/one", 1), ("c/three", 9)]));
         assert_eq!(
             startup.hint(),
             "· loading maps 1/2",
             "b/two is no longer waited on; c/three now is"
         );
-        startup.record_arrival("c/three");
+        startup.record_arrival(&MapId::new("c/three", 9));
+        assert!(startup.is_loaded());
+    }
+
+    #[test]
+    fn a_moved_map_number_is_a_different_map_to_wait_on() {
+        // The seed said #2; the search says the repo's map is #1. Same repo,
+        // different id — the arrival of the stale fetch must not satisfy the
+        // wait for the corrected one.
+        let mut startup = Startup::seeded(&found(&[("a/one", 2)]));
+        startup.record_arrival(&MapId::new("a/one", 2));
+        startup.searched(&found(&[("a/one", 1)]));
+        assert!(!startup.is_loaded(), "#1 has not arrived; #2 no longer counts");
+        assert_eq!(startup.hint(), "· loading maps 0/1");
+        startup.record_arrival(&MapId::new("a/one", 1));
         assert!(startup.is_loaded());
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -84,7 +84,7 @@ fn body_with_cursor(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
             }
             let members: Vec<&Row> = visible
                 .iter()
-                .filter(|(row_id, i)| row_id == id && map.tickets[*i].status.group() == group)
+                .filter(|row| &row.map == id && map.tickets[row.index].status.group() == group)
                 .collect();
             let header = if filtering {
                 format!("  {label} — {}/{}", members.len(), total)
@@ -96,7 +96,7 @@ fn body_with_cursor(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
                 Style::new().add_modifier(Modifier::BOLD),
             ));
             for row in members {
-                let ticket = &map.tickets[row.1];
+                let ticket = &map.tickets[row.index];
                 let under_cursor = cursor_row.as_ref() == Some(row);
                 if under_cursor {
                     cursor_line = Some(lines.len());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,10 @@
-//! The main screen: grouped flat list (frontier / claimed / blocked / done)
-//! with the minimal row — state glyph, repo, number, title, `— needs #N` on
-//! blocked rows — per the #8 and #9 resolutions. Build 2 adds the fuzzy
-//! query (2a: groups survive typing), the cursor, and the bottom prompt.
+//! The main screen: one cluster per open map (#50) — a `▌ repo · map title`
+//! header carrying the per-status counts, with the map's tickets grouped
+//! beneath it (frontier / claimed / blocked / done) in the minimal row —
+//! state glyph, number, title, `— needs #N` on blocked rows. The repo column
+//! is gone: every row sits under a header that names its repo. Build 2's
+//! fuzzy query (2a: groups survive typing), the cursor, and the bottom prompt
+//! are unchanged.
 
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -9,8 +12,8 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
-use crate::app::{App, Overlay, Scope};
-use crate::model::{Status, GROUP_LABELS};
+use crate::app::{App, Overlay, Row, Scope};
+use crate::model::{Map, MapId, Status, GROUP_LABELS};
 
 fn glyph_style(status: &Status) -> Style {
     match status {
@@ -21,74 +24,107 @@ fn glyph_style(status: &Status) -> Style {
     }
 }
 
-/// The grouped list body as styled lines (header + surviving rows per group,
-/// in fixed group order). Shared by the live draw and the TestBackend tests.
+/// The cluster header: `▌ <repo> · <map title>  ○n ◐n ⊘n ●n`. The counts are
+/// the whole map's, not the query's — they describe the cluster's shape, and
+/// the group headers already carry `matched/total` while a query is live.
+fn cluster_header(id: &MapId, map: &Map) -> Line<'static> {
+    let [frontier, claimed, blocked, done] = map.counts();
+    let count_style = [
+        Style::new().fg(Color::Green),
+        Style::new().fg(Color::Yellow),
+        Style::new().fg(Color::Red),
+        Style::new().add_modifier(Modifier::DIM),
+    ];
+    let glyphs = ['○', '◐', '⊘', '●'];
+    let mut spans = vec![Span::styled(
+        format!("▌ {} · {}", id.short_repo(), map.title),
+        Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+    )];
+    for (i, count) in [frontier, claimed, blocked, done].into_iter().enumerate() {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(format!("{}{count}", glyphs[i]), count_style[i]));
+    }
+    Line::from(spans)
+}
+
+/// The cluster body as styled lines: one header per in-scope map, its groups
+/// beneath it in fixed order. Shared by the live draw and the TestBackend
+/// tests.
 ///
-/// Filtering is 2a per the #9 resolution: non-matching rows drop, every
-/// group header stays (showing `matched/total` while a query is live), and
-/// group order never changes. Focus mode drops the repo column — the
-/// header already names the project.
+/// Filtering is 2a per the #9 resolution: non-matching rows drop, group
+/// headers stay (showing `matched/total` while a query is live), and group
+/// order never changes. A group the cluster has no tickets in at all is
+/// skipped — with several clusters on screen, empty headers would outnumber
+/// the rows.
 pub fn body_lines(app: &App) -> Vec<Line<'static>> {
+    body_with_cursor(app).0
+}
+
+/// [`body_lines`] plus which line the cursor row landed on — what the draw
+/// scrolls to. `None` when no row is visible. Needed since #50: several
+/// clusters can be taller than the screen, and a cursor the body cannot show
+/// is a picker that cannot pick.
+fn body_with_cursor(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
     let visible = app.visible();
-    let scoped = app.scoped();
-    let cursor_idx = visible.get(app.cursor_pos()).copied();
-    let show_repo = app.scope == Scope::All;
+    let cursor_row = visible.get(app.cursor_pos()).cloned();
+    let mut cursor_line = None;
     let filtering = !app.query.is_empty();
 
     let mut lines = vec![Line::default()];
-    for (group, label) in GROUP_LABELS.iter().enumerate() {
-        let total = scoped
-            .iter()
-            .filter(|&&i| app.map.tickets[i].status.group() == group)
-            .count();
-        let members: Vec<usize> = visible
-            .iter()
-            .copied()
-            .filter(|&i| app.map.tickets[i].status.group() == group)
-            .collect();
-        let header = if filtering {
-            format!("  {label} — {}/{}", members.len(), total)
-        } else {
-            format!("  {label} — {total}")
-        };
-        lines.push(Line::styled(
-            header,
-            Style::new().add_modifier(Modifier::BOLD),
-        ));
-        for idx in members {
-            let ticket = &app.map.tickets[idx];
-            let cursor = if cursor_idx == Some(idx) { '▶' } else { ' ' };
-            let mut spans = vec![
-                Span::raw(format!("  {cursor} ")),
-                Span::styled(ticket.status.glyph().to_string(), glyph_style(&ticket.status)),
-            ];
-            if show_repo {
-                spans.push(Span::raw(format!(
-                    " {:<10} #{:<4} {}",
-                    ticket.short_repo(),
-                    ticket.number,
-                    ticket.title
-                )));
+    for (id, map) in app.scoped_clusters() {
+        lines.push(cluster_header(id, map));
+        for (group, label) in GROUP_LABELS.iter().enumerate() {
+            let total = map
+                .tickets
+                .iter()
+                .filter(|t| t.status.group() == group)
+                .count();
+            if total == 0 {
+                continue;
+            }
+            let members: Vec<&Row> = visible
+                .iter()
+                .filter(|(row_id, i)| row_id == id && map.tickets[*i].status.group() == group)
+                .collect();
+            let header = if filtering {
+                format!("  {label} — {}/{}", members.len(), total)
             } else {
-                spans.push(Span::raw(format!(" #{:<4} {}", ticket.number, ticket.title)));
-            }
-            if let Status::Blocked { needs } = &ticket.status {
-                let needs: Vec<String> = needs.iter().map(|n| format!("#{n}")).collect();
-                spans.push(Span::styled(
-                    format!("  — needs {}", needs.join(", ")),
-                    Style::new().add_modifier(Modifier::DIM),
-                ));
-            }
-            let style = match ticket.status {
-                Status::Done => Style::new().add_modifier(Modifier::DIM),
-                _ => Style::new(),
+                format!("  {label} — {total}")
             };
-            lines.push(Line::from(spans).style(style));
+            lines.push(Line::styled(
+                header,
+                Style::new().add_modifier(Modifier::BOLD),
+            ));
+            for row in members {
+                let ticket = &map.tickets[row.1];
+                let under_cursor = cursor_row.as_ref() == Some(row);
+                if under_cursor {
+                    cursor_line = Some(lines.len());
+                }
+                let cursor = if under_cursor { '▶' } else { ' ' };
+                let mut spans = vec![
+                    Span::raw(format!("  {cursor} ")),
+                    Span::styled(ticket.status.glyph().to_string(), glyph_style(&ticket.status)),
+                    Span::raw(format!(" #{:<4} {}", ticket.number, ticket.title)),
+                ];
+                if let Status::Blocked { needs } = &ticket.status {
+                    let needs: Vec<String> = needs.iter().map(|n| format!("#{n}")).collect();
+                    spans.push(Span::styled(
+                        format!("  — needs {}", needs.join(", ")),
+                        Style::new().add_modifier(Modifier::DIM),
+                    ));
+                }
+                let style = match ticket.status {
+                    Status::Done => Style::new().add_modifier(Modifier::DIM),
+                    _ => Style::new(),
+                };
+                lines.push(Line::from(spans).style(style));
+            }
         }
         lines.push(Line::default());
     }
     lines.pop();
-    lines
+    (lines, cursor_line)
 }
 
 /// The keybindings (#14): `tab` peek is deferred; `enter` runs the ticket's
@@ -100,44 +136,50 @@ const KEY_HINTS: &str =
 
 /// The project heading in the title bar.
 ///
-/// `merge_maps` names the empty case "no projects — run wf inside a checkout to
-/// register it", and that is the truth in exactly one of the three ways the
-/// list can be empty. It is also still loading (#27), or every fetch failed —
-/// and telling a user with three registered projects that they have none is the
-/// exact ambiguity [`crate::refresh::Startup`] exists to remove. So both other
-/// cases are named before the merged map's own header is trusted.
+/// An empty screen has three meanings — still loading (#27), every fetch
+/// failed, or genuinely no projects — and telling a user with three registered
+/// projects that they have none is the exact ambiguity
+/// [`crate::refresh::Startup`] exists to remove. So both other cases are named
+/// before "no projects" is claimed. With clusters on screen, the heading
+/// counts the ground they cover: the one repo's slug, or how many projects.
 pub fn heading(app: &App) -> String {
-    if app.map.tickets.is_empty() {
+    if app.clusters.is_empty() {
         if !app.startup.is_loaded() {
             return "loading…".to_string();
         }
-        // Naming the repo is the whole value when there is one: "GitHub is
+        // Naming the map is the whole value when there is one: "GitHub is
         // unreachable" and "you have no projects" are different problems with
         // different fixes, and the empty list looks identical either way.
         match app.failed.len() {
             0 => {}
             1 => {
-                let repo = app.failed.iter().next().expect("len checked");
-                return format!("{repo} — fetch failed, ctrl-r retries");
+                let id = app.failed.iter().next().expect("len checked");
+                return format!("{}#{} — fetch failed, ctrl-r retries", id.repo, id.number);
             }
             n => return format!("{n} maps failed to fetch — ctrl-r retries"),
         }
+        return "no projects — run wf inside a checkout to register it".to_string();
     }
-    app.map.repo.clone()
+    let repos: std::collections::BTreeSet<&str> =
+        app.clusters.keys().map(|id| id.repo.as_str()).collect();
+    match repos.len() {
+        1 => (*repos.iter().next().expect("len checked")).to_string(),
+        n => format!("{n} projects"),
+    }
 }
 
 /// The persistent failure segment on the count line.
 ///
 /// Separate from [`heading`] because the case it exists for is the *partial*
-/// one: four maps on screen and a fifth missing draws a perfectly normal
+/// one: four clusters on screen and a fifth missing draws a perfectly normal
 /// screen, so the only place left to say so is here — and it has to survive
 /// the next keypress, which the one-shot notice does not.
 pub fn failure_note(app: &App) -> String {
     match app.failed.len() {
         0 => String::new(),
         1 => {
-            let repo = app.failed.iter().next().expect("len checked");
-            format!("· {repo} failed")
+            let id = app.failed.iter().next().expect("len checked");
+            format!("· {}#{} failed", id.repo, id.number)
         }
         n => format!("· {n} maps failed"),
     }
@@ -202,8 +244,8 @@ fn draw_overlay(frame: &mut Frame, app: &App) {
     );
 }
 
-/// Draw the full screen: bordered frame with the scope in the title, grouped
-/// list body, then the anchored bottom chrome — the match-count line (with the
+/// Draw the full screen: bordered frame with the scope in the title, the
+/// clusters, then the anchored bottom chrome — the match-count line (with the
 /// load hint and any one-shot notice), the fzf-style prompt, and the key hints.
 /// The which-checkout picker, when open, floats over all of it.
 pub fn draw(frame: &mut Frame, app: &App) {
@@ -227,7 +269,18 @@ pub fn draw(frame: &mut Frame, app: &App) {
     ])
     .areas(inner);
 
-    frame.render_widget(Paragraph::new(body_lines(app)), body_area);
+    // Scroll only as far as it takes to keep the cursor's line on screen —
+    // several clusters can be taller than the body area (#50), and a cursor
+    // below the fold would leave the picker unable to show what `enter` picks.
+    let (lines, cursor_line) = body_with_cursor(app);
+    let mut body = Paragraph::new(lines);
+    if let Some(line) = cursor_line {
+        let height = body_area.height as usize;
+        if height > 0 && line >= height {
+            body = body.scroll(((line + 1 - height) as u16, 0));
+        }
+    }
+    frame.render_widget(body, body_area);
 
     // The load hint and the failure note share one dim segment and can both be
     // live at once (map 2 of 3 is still coming *and* map 1 never arrived);
@@ -270,23 +323,36 @@ pub fn draw(frame: &mut Frame, app: &App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::launch::MapIssues;
-    use crate::model::{classify, Map, Ticket, TicketType};
+    use crate::model::{classify, Map, MapId, MapSet, Ticket, TicketType};
     use crate::refresh::Startup;
     use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::Terminal;
+    use std::collections::BTreeMap;
 
-    fn fixture_map() -> Map {
-        let t = |number: u64, title: &str, open: bool, assigned: bool, needs: Vec<u64>| Ticket {
-            repo: "blooop/wayfinder".to_string(),
+    fn ticket(
+        repo: &str,
+        number: u64,
+        title: &str,
+        open: bool,
+        assigned: bool,
+        needs: Vec<u64>,
+    ) -> Ticket {
+        Ticket {
+            repo: repo.to_string(),
             number,
             title: title.to_string(),
-            status: classify(open, assigned, needs),
+            status: classify(open, assigned, needs.clone()),
             ticket_type: TicketType::Task,
+            blocked_by: needs,
+        }
+    }
+
+    fn wf_map() -> Map {
+        let t = |number, title: &str, open, assigned, needs: Vec<u64>| {
+            ticket("blooop/wayfinder", number, title, open, assigned, needs)
         };
         Map {
-            repo: "blooop/wayfinder".to_string(),
             title: "Map: wf".to_string(),
             tickets: vec![
                 t(2, "Choose the stack", false, true, vec![]),
@@ -296,6 +362,12 @@ mod tests {
                 t(14, "Breadcrumb markers", true, false, vec![6, 9]),
             ],
         }
+    }
+
+    fn fixture_app() -> App {
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        App::new(clusters)
     }
 
     fn type_str(app: &mut App, s: &str) {
@@ -321,34 +393,78 @@ mod tests {
     }
 
     #[test]
-    fn groups_render_in_fixed_order_with_counts() {
-        let screen = render(&App::new(fixture_map()));
+    fn the_cluster_header_names_the_map_and_carries_the_counts() {
+        let screen = render(&fixture_app());
+        assert!(
+            screen.contains("▌ wayfinder · Map: wf  ○1  ◐1  ⊘2  ●1"),
+            "{screen}"
+        );
+    }
+
+    #[test]
+    fn groups_render_in_fixed_order_within_the_cluster() {
+        let screen = render(&fixture_app());
+        let cluster = screen.find("▌ wayfinder").expect("cluster header");
         let frontier = screen.find("FRONTIER — ready to claim — 1").expect("frontier header");
         let claimed = screen.find("CLAIMED — 1").expect("claimed header");
         let blocked = screen.find("BLOCKED — 2").expect("blocked header");
         let done = screen.find("DONE — 1").expect("done header");
-        assert!(frontier < claimed && claimed < blocked && blocked < done);
+        assert!(cluster < frontier && frontier < claimed && claimed < blocked && blocked < done);
     }
 
     #[test]
-    fn rows_carry_state_glyph_repo_number_title() {
-        let screen = render(&App::new(fixture_map()));
-        assert!(screen.contains("○ wayfinder  #6    Re-entry breadcrumbs"));
-        assert!(screen.contains("◐ wayfinder  #9    Main screen design"));
-        assert!(screen.contains("⊘ wayfinder  #7    Supervising AFK agents"));
-        assert!(screen.contains("● wayfinder  #2    Choose the stack"));
+    fn every_open_map_renders_as_its_own_cluster_even_on_one_repo() {
+        // The #50 acceptance case: two open maps on one repo are two clusters,
+        // where the old lowest-number rule showed only one.
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 47),
+            Map {
+                title: "Map: the selection view".to_string(),
+                tickets: vec![ticket(
+                    "blooop/wayfinder",
+                    50,
+                    "Build: clusters",
+                    true,
+                    false,
+                    vec![],
+                )],
+            },
+        );
+        let app = App::new(clusters);
+        let screen = render(&app);
+        let first = screen.find("▌ wayfinder · Map: wf").expect("map #1's cluster");
+        let second = screen
+            .find("▌ wayfinder · Map: the selection view")
+            .expect("map #47's cluster");
+        assert!(first < second, "clusters order by (repo, number)");
+        assert!(screen.contains("#50   Build: clusters"), "{screen}");
+        // One repo on screen, however many maps: the title names the repo.
+        assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
+    }
+
+    #[test]
+    fn rows_carry_state_glyph_number_title_without_a_repo_column() {
+        // The repo column is gone: the cluster header names the repo.
+        let screen = render(&fixture_app());
+        assert!(screen.contains("○ #6    Re-entry breadcrumbs"), "{screen}");
+        assert!(screen.contains("◐ #9    Main screen design"), "{screen}");
+        assert!(screen.contains("⊘ #7    Supervising AFK agents"), "{screen}");
+        assert!(screen.contains("● #2    Choose the stack"), "{screen}");
+        assert!(!screen.contains("○ wayfinder"), "{screen}");
     }
 
     #[test]
     fn blocked_rows_show_needs_suffix() {
-        let screen = render(&App::new(fixture_map()));
+        let screen = render(&fixture_app());
         assert!(screen.contains("#7    Supervising AFK agents  — needs #6"));
         assert!(screen.contains("#14   Breadcrumb markers  — needs #6, #9"));
     }
 
     #[test]
     fn bottom_chrome_has_count_prompt_and_hint_lines() {
-        let screen = render(&App::new(fixture_map()));
+        let screen = render(&fixture_app());
         assert!(screen.contains("5/5"));
         assert!(screen.contains("> █"));
         assert!(screen.contains("enter launch"));
@@ -359,7 +475,7 @@ mod tests {
 
     #[test]
     fn query_drops_nonmatching_rows_but_groups_persist() {
-        let mut app = App::new(fixture_map());
+        let mut app = fixture_app();
         type_str(&mut app, "bread");
         let screen = render(&app);
         // Surviving rows: #6 (frontier) and #14 (blocked).
@@ -369,14 +485,16 @@ mod tests {
         assert!(!screen.contains("Main screen design"));
         assert!(!screen.contains("Choose the stack"));
         assert!(!screen.contains("Supervising AFK agents"));
-        // Every group header persists, as matched/total — 2a, no flattening.
+        // Group headers persist as matched/total — 2a, no flattening — and the
+        // cluster header stays put above them.
+        let cluster = screen.find("▌ wayfinder").expect("cluster header");
         let frontier = screen
             .find("FRONTIER — ready to claim — 1/1")
             .expect("frontier header");
         let claimed = screen.find("CLAIMED — 0/1").expect("claimed header");
         let blocked = screen.find("BLOCKED — 1/2").expect("blocked header");
         let done = screen.find("DONE — 0/1").expect("done header");
-        assert!(frontier < claimed && claimed < blocked && blocked < done);
+        assert!(cluster < frontier && frontier < claimed && claimed < blocked && blocked < done);
         // Count line and prompt reflect the live query.
         assert!(screen.contains("2/5"));
         assert!(screen.contains("> bread█"));
@@ -384,23 +502,23 @@ mod tests {
 
     #[test]
     fn cursor_marks_first_visible_row_after_typing() {
-        let mut app = App::new(fixture_map());
+        let mut app = fixture_app();
         // Park the cursor lower first; typing must snap it to the first hit.
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         type_str(&mut app, "bread");
         let screen = render(&app);
-        assert!(screen.contains("▶ ○ wayfinder  #6    Re-entry breadcrumbs"));
+        assert!(screen.contains("▶ ○ #6    Re-entry breadcrumbs"));
         assert!(!screen.contains("▶ ⊘"));
     }
 
     #[test]
     fn cursor_moves_across_visible_rows_only() {
-        let mut app = App::new(fixture_map());
+        let mut app = fixture_app();
         type_str(&mut app, "bread");
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let screen = render(&app);
         // Cursor skipped the emptied CLAIMED group straight to blocked #14.
-        assert!(screen.contains("▶ ⊘ wayfinder  #14   Breadcrumb markers"));
+        assert!(screen.contains("▶ ⊘ #14   Breadcrumb markers"));
     }
 
     /// The fixture map plus Build 4 launch inputs: two checkouts of the repo,
@@ -410,20 +528,15 @@ mod tests {
             path: std::path::PathBuf::from(path),
             repo: "blooop/wayfinder".to_string(),
         };
-        let mut map_issues = crate::launch::MapIssues::new();
-        map_issues.insert("blooop/wayfinder".to_string(), 1);
-        App::new(fixture_map()).with_projects(
-            vec![
-                checkout("/data/k1/wayfinder"),
-                checkout("/data/k2/wayfinder"),
-            ],
-            map_issues,
-        )
+        fixture_app().with_checkouts(vec![
+            checkout("/data/k1/wayfinder"),
+            checkout("/data/k2/wayfinder"),
+        ])
     }
 
     #[test]
     fn the_hint_line_advertises_the_one_launch_key_and_no_afk() {
-        let screen = render(&App::new(fixture_map()));
+        let screen = render(&fixture_app());
         assert!(screen.contains("enter launch"));
         assert!(!screen.contains("ctrl-a"), "{screen}");
         assert!(!screen.contains("afk"), "{screen}");
@@ -432,7 +545,7 @@ mod tests {
     #[test]
     fn nothing_reserves_a_line_for_agents_any_more() {
         // The `agents: N tabs` slot went with the tabs it counted (#26).
-        let screen = render(&App::new(fixture_map()));
+        let screen = render(&fixture_app());
         assert!(!screen.contains("agents:"), "{screen}");
     }
 
@@ -446,7 +559,7 @@ mod tests {
         assert!(screen.contains("/data/k2/wayfinder"), "{screen}");
         assert!(screen.contains("esc cancel"));
         // It is a modal: the rows it covers are overwritten, not blended.
-        assert!(!screen.contains("Supervising AFK agents"), "{screen}");
+        assert!(!screen.contains("Breadcrumb markers"), "{screen}");
     }
 
     #[test]
@@ -464,19 +577,20 @@ mod tests {
         // Three registered projects and GitHub unreachable draws the same empty
         // list as no projects at all. Saying "no projects — run wf inside a
         // checkout" there sends the user to fix the one thing that is not
-        // broken, so the failure has to win the heading.
+        // broken, so the failure has to win the heading — and it names the
+        // *map*, because with several on one repo the repo alone is ambiguous.
         let mut app = App::empty();
         app.startup = Startup::loaded();
-        app.failed.insert("blooop/wayfinder".to_string());
+        app.failed.insert(MapId::new("blooop/wayfinder", 35));
         let screen = render(&app);
         assert!(!screen.contains("no projects"), "{screen}");
         assert!(
-            screen.contains("blooop/wayfinder — fetch failed, ctrl-r retries"),
+            screen.contains("blooop/wayfinder#35 — fetch failed, ctrl-r retries"),
             "{screen}"
         );
 
         // Several, and naming them all would not fit: say how many.
-        app.failed.insert("blooop/dotfiles".to_string());
+        app.failed.insert(MapId::new("blooop/dotfiles", 4));
         let screen = render(&app);
         assert!(screen.contains("2 maps failed to fetch"), "{screen}");
         assert!(!screen.contains("no projects"), "{screen}");
@@ -484,27 +598,27 @@ mod tests {
 
     #[test]
     fn a_partial_failure_is_visible_and_survives_the_next_keypress() {
-        // The case that hides best: the rows that did load look completely
+        // The case that hides best: the clusters that did load look completely
         // normal, so the count line is the only place left to say a map is
         // missing — and `notice` cannot be that place, because `handle_key`
         // clears it on every keypress and nothing polls to re-announce it.
-        let mut app = App::new(fixture_map());
-        app.failed.insert("blooop/dotfiles".to_string());
-        assert_eq!(failure_note(&app), "· blooop/dotfiles failed");
+        let mut app = fixture_app();
+        app.failed.insert(MapId::new("blooop/dotfiles", 4));
+        assert_eq!(failure_note(&app), "· blooop/dotfiles#4 failed");
         let screen = render(&app);
-        assert!(screen.contains("5/5  · blooop/dotfiles failed"), "{screen}");
+        assert!(screen.contains("5/5  · blooop/dotfiles#4 failed"), "{screen}");
 
         app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
         let screen = render(&app);
         assert!(
-            screen.contains("· blooop/dotfiles failed"),
+            screen.contains("· blooop/dotfiles#4 failed"),
             "a keypress must not erase it: {screen}"
         );
     }
 
     #[test]
     fn an_empty_list_reads_as_empty_only_once_the_load_finished() {
-        // Same empty map, opposite meaning — told apart by Startup alone.
+        // Same empty screen, opposite meaning — told apart by Startup alone.
         let mut app = App::empty();
         app.startup = Startup::loaded();
         let screen = render(&app);
@@ -513,17 +627,20 @@ mod tests {
     }
 
     #[test]
-    fn a_partial_load_shows_progress_beside_the_tickets_already_in() {
+    fn a_partial_load_shows_progress_beside_the_clusters_already_in() {
         // One map of three has landed: the rows are real and fresh, and the
         // count line still says more is coming.
-        let mut app = App::new(fixture_map());
-        let found: MapIssues = [("a/one", 1), ("b/two", 2), ("c/three", 3)]
-            .into_iter()
-            .map(|(slug, n)| (slug.to_string(), n))
-            .collect();
+        let mut app = fixture_app();
+        let found: MapSet = [
+            MapId::new("blooop/wayfinder", 1),
+            MapId::new("b/two", 2),
+            MapId::new("c/three", 3),
+        ]
+        .into_iter()
+        .collect();
         app.startup = Startup::seeded(&found);
         app.startup.searched(&found);
-        app.startup.record_arrival("a/one");
+        app.startup.record_arrival(&MapId::new("blooop/wayfinder", 1));
         let screen = render(&app);
         assert!(screen.contains("#6    Re-entry breadcrumbs"), "{screen}");
         assert!(screen.contains("5/5  · loading maps 1/3"), "{screen}");
@@ -532,13 +649,50 @@ mod tests {
     }
 
     #[test]
-    fn focus_mode_drops_repo_column_and_names_scope_in_title() {
-        let mut app = App::new(fixture_map());
+    fn the_body_scrolls_to_keep_the_cursor_on_screen() {
+        // One cluster of 30 done tickets ahead of a one-ticket cluster: the
+        // second cluster's rows start past the 24-row screen, and that is where
+        // the cursor must still be *visible* — a picker that cannot show what
+        // `enter` would pick is broken (the live 3-map repo hits exactly this).
+        let mut clusters = BTreeMap::new();
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 1),
+            Map {
+                title: "Map: wf".to_string(),
+                tickets: (1..=30)
+                    .map(|n| ticket("blooop/wayfinder", n, &format!("Done {n}"), false, false, vec![]))
+                    .collect(),
+            },
+        );
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 47),
+            Map {
+                title: "Map: the selection view".to_string(),
+                tickets: vec![ticket("blooop/wayfinder", 50, "Build: clusters", true, false, vec![])],
+            },
+        );
+        let mut app = App::new(clusters);
+        for _ in 0..40 {
+            app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+        assert_eq!(app.cursor_ticket().unwrap().number, 50);
+        let screen = render(&app);
+        assert!(screen.contains("▶ ○ #50   Build: clusters"), "{screen}");
+        // And with the cursor back at the top, the top is what shows.
+        for _ in 0..40 {
+            app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        }
+        let screen = render(&app);
+        assert!(screen.contains("▶ ● #1    Done 1"), "{screen}");
+    }
+
+    #[test]
+    fn focus_mode_names_the_scope_in_the_title() {
+        let mut app = fixture_app();
         app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
         let screen = render(&app);
         assert!(screen.contains("wf · blooop/wayfinder — focused"));
         assert!(screen.contains("ctrl-g all projects"));
         assert!(screen.contains("▶ ○ #6    Re-entry breadcrumbs"));
-        assert!(!screen.contains("○ wayfinder  #6"));
     }
 }

--- a/tests/live_discovery.rs
+++ b/tests/live_discovery.rs
@@ -30,18 +30,24 @@ async fn registering_this_checkout_finds_and_fetches_its_map() {
     assert_eq!(reloaded.checkouts[0].path, toplevel);
     std::fs::remove_dir_all(cache_file.parent().unwrap()).ok();
 
-    // Detect: one label search across the cached remotes finds the map.
+    // Detect: one label search across the cached remotes finds every open map
+    // (#50) — this repo keeps several open at once, and all of them must
+    // survive rather than only the lowest-numbered.
     let maps = wf::fetch::find_maps(&reloaded.repos())
         .await
         .expect("map label search");
-    let map_issue = *maps
-        .get(&slug)
-        .expect("blooop/wayfinder must have a wayfinder:map issue");
-    assert_eq!(map_issue, 1);
+    let map_id = wf::model::MapId::new(slug.clone(), 1);
+    assert!(
+        maps.contains(&map_id),
+        "blooop/wayfinder must have wayfinder:map issue #1; found {maps:?}"
+    );
+    assert!(
+        maps.iter().filter(|id| id.repo == slug).count() > 1,
+        "every open map must be found, not one per repo; found {maps:?}"
+    );
 
     // Render-ready: the discovered map fetches with real tickets.
-    let (owner, name) = slug.split_once('/').unwrap();
-    let map = wf::fetch::fetch_map(owner, name, map_issue)
+    let map = wf::fetch::fetch_map(&map_id)
         .await
         .expect("fetch the discovered map");
     assert!(

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -2,15 +2,14 @@
 //! blooop/wayfinder's live map (#1) through `gh api graphql`. Needs network
 //! and an authenticated `gh`.
 
-use wf::model::{Status, TicketType};
+use wf::model::{MapId, Status, TicketType};
 
 #[tokio::test]
 async fn fetches_the_live_wayfinder_map() {
-    let map = wf::fetch::fetch_map("blooop", "wayfinder", 1)
+    let map = wf::fetch::fetch_map(&MapId::new("blooop/wayfinder", 1))
         .await
         .expect("live fetch of blooop/wayfinder map #1");
 
-    assert_eq!(map.repo, "blooop/wayfinder");
     assert!(map.title.starts_with("Map:"), "map issue title: {}", map.title);
     assert!(
         map.tickets.len() >= 7,
@@ -29,6 +28,14 @@ async fn fetches_the_live_wayfinder_map() {
     assert!(
         map.tickets.iter().any(|t| t.status == Status::Done),
         "the live map has closed tickets; none classified as done"
+    );
+
+    // #50: the full edge set survives the parse. This map's builds were chained
+    // by blocking edges and are long closed, so if closed blockers were still
+    // being discarded the whole DAG would come back empty.
+    assert!(
+        map.tickets.iter().any(|t| !t.blocked_by.is_empty()),
+        "the live map's blocking edges must survive their blockers closing"
     );
 
     // #19's addition: the `labels` selection is accepted by the real API and

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -270,15 +270,19 @@ fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     );
     let (skip, prompt) = argv.split_once(' ').expect("two arguments");
     assert_eq!(skip, "--dangerously-skip-permissions");
-    // This repo's map is issue #1; which ticket the cursor was on is the live
-    // frontier's business, so only its shape is asserted.
-    let ticket = prompt
-        .strip_prefix("/wayfinder 1 ")
+    // This repo keeps several maps open (#50) and which cluster the cursor was
+    // in is the live tracker's business, so only the prompt's shape is
+    // asserted: `/wayfinder <map> <ticket>`, both numbers.
+    let numbers = prompt
+        .strip_prefix("/wayfinder ")
         .unwrap_or_else(|| panic!("prompt was {prompt:?}"));
-    assert!(
-        !ticket.is_empty() && ticket.chars().all(|c| c.is_ascii_digit()),
-        "prompt was {prompt:?}"
-    );
+    let (map, ticket) = numbers.split_once(' ').expect("map and ticket numbers");
+    for half in [map, ticket] {
+        assert!(
+            !half.is_empty() && half.chars().all(|c| c.is_ascii_digit()),
+            "prompt was {prompt:?}"
+        );
+    }
 
     // Claim 3a: the tty itself came back. `wf` runs raw the whole time it is
     // up, so an agent that finds a raw tty here is one that would have found a

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -3,21 +3,26 @@
 //! `gh`.
 //!
 //! What it pins down is the *shape* `main` now relies on: nothing is fetched
-//! before the loop exists, and everything the loop needs — which repos have
-//! maps, and each map — arrives afterwards through one channel. Before #27 the
+//! before the loop exists, and everything the loop needs — which maps are
+//! open, and each map — arrives afterwards through one channel. Before #27 the
 //! same information could only be had by awaiting it up front, which is exactly
 //! why the terminal stayed blank for it; before #28 the *search* still had to
-//! answer before a single map could be asked for.
+//! answer before a single map could be asked for. Since #50 every load is
+//! keyed by [`MapId`], and a repo with several open maps is several loads.
 
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use tokio::sync::mpsc;
-use wf::launch::MapIssues;
+use wf::model::{MapId, MapSet};
 use wf::projects::ProjectsCache;
 use wf::refresh::{spawn_discovery, LoadEvent, Loaders, MapFetch};
 
 const THIS_REPO: &str = "blooop/wayfinder";
+
+fn map_1() -> MapId {
+    MapId::new(THIS_REPO, 1)
+}
 
 /// Take the next event, failing loudly rather than hanging a CI run forever.
 async fn next(rx: &mut mpsc::UnboundedReceiver<LoadEvent>) -> LoadEvent {
@@ -43,7 +48,7 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
     // could be drawing a screen instead of blocking on this.
     spawn_discovery(vec![THIS_REPO.to_string()], cache_path.clone(), tx.clone());
 
-    let map_issues = loop {
+    let found = loop {
         match next(&mut rx).await {
             LoadEvent::Discovered(found) => break found,
             // The search retries, so a blip is survivable rather than fatal.
@@ -51,51 +56,58 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             other => panic!("expected discovery first, got {other:?}"),
         }
     };
-    assert_eq!(
-        map_issues.get(THIS_REPO),
-        Some(&1),
-        "this repo's map is issue #1"
+    assert!(
+        found.contains(&map_1()),
+        "this repo's original map is issue #1; found {found:?}"
+    );
+    assert!(
+        found.len() > 1,
+        "every open map is discovered, not one per repo (#50); found {found:?}"
     );
 
     // Reconciling the loaders *is* the initial load: no separate fetch happens
-    // anywhere, and the one thing each one emits is its repo's map.
+    // anywhere, and the one thing each one emits is its map.
     let mut loaders = Loaders::new();
-    loaders.reconcile(&map_issues, &tx);
-    assert_eq!(loaders.targets(), map_issues);
+    loaders.reconcile(&found, &tx);
+    assert_eq!(loaders.targets(), found);
 
-    match next(&mut rx).await {
-        LoadEvent::Fetched {
-            repo,
-            outcome: MapFetch::Loaded(map),
-        } => {
-            assert_eq!(repo, THIS_REPO);
-            assert_eq!(map.repo, THIS_REPO);
-            assert!(
-                map.tickets.len() >= 7,
-                "expected the real map's tickets, got {}",
-                map.tickets.len()
-            );
+    // Every discovered map reports — including the several on this one repo.
+    let mut arrived = MapSet::new();
+    while arrived.len() < found.len() {
+        match next(&mut rx).await {
+            LoadEvent::Fetched {
+                id,
+                outcome: MapFetch::Loaded(map),
+            } => {
+                assert!(found.contains(&id), "unexpected map {id:?}");
+                assert!(
+                    !map.tickets.is_empty(),
+                    "every open map on this repo has tickets"
+                );
+                arrived.insert(id);
+            }
+            other => panic!("a loader's one event must be its map, got {other:?}"),
         }
-        other => panic!("a loader's one event must be its map, got {other:?}"),
     }
+    assert_eq!(arrived, found);
 
     // The search's findings are written back — that is what makes the *next*
     // run warm, and it is the only thing that ever populates the seed.
     let saved = ProjectsCache::load_or_default(&cache_path);
     assert_eq!(
-        saved.map_seed().get(THIS_REPO),
-        Some(&1),
-        "the search must leave a head start behind"
+        saved.map_seed(),
+        found,
+        "the search must leave the full head start behind"
     );
     std::fs::remove_dir_all(cache_path.parent().expect("scratch dir")).ok();
 }
 
 #[tokio::test]
 async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
-    // The #28 claim, end to end: with the map number already in hand, the map
+    // The #28 claim, end to end: with the map id already in hand, the map
     // itself lands in one round trip — no ~2.5s search in front of it.
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let seed: MapIssues = [(THIS_REPO.to_string(), 1)].into_iter().collect();
+    let seed: MapSet = [map_1()].into_iter().collect();
 
     let started = Instant::now();
     let mut loaders = Loaders::new();
@@ -103,10 +115,10 @@ async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
 
     match next(&mut rx).await {
         LoadEvent::Fetched {
-            repo,
+            id,
             outcome: MapFetch::Loaded(map),
         } => {
-            assert_eq!(repo, THIS_REPO);
+            assert_eq!(id, map_1());
             assert!(!map.tickets.is_empty());
         }
         other => panic!("the seeded loader must fetch the map, got {other:?}"),
@@ -120,12 +132,12 @@ async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
 
 #[tokio::test]
 async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
-    // A cached number that no longer names a map — here the map's own *first
+    // A cached id that no longer names a map — here the map's own *first
     // ticket*, an issue that exists and is a sub-issue rather than a map. The
     // fetch must refuse it (a wrong map is worse than no map) and the search's
-    // answer must move the load onto the real number.
+    // answer must move the load onto the real id.
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let stale: MapIssues = [(THIS_REPO.to_string(), 2)].into_iter().collect();
+    let stale: MapSet = [MapId::new(THIS_REPO, 2)].into_iter().collect();
 
     let mut loaders = Loaders::new();
     loaders.reconcile(&stale, &tx);
@@ -137,12 +149,12 @@ async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
         other => panic!("a non-map must not fetch as a map, got {other:?}"),
     }
 
-    let truth: MapIssues = [(THIS_REPO.to_string(), 1)].into_iter().collect();
+    let truth: MapSet = [map_1()].into_iter().collect();
     loaders.reconcile(&truth, &tx);
     assert_eq!(
         loaders.targets(),
         truth,
-        "the corrected number must reach the task doing the fetching"
+        "the corrected id must reach the task doing the fetching"
     );
     loop {
         match next(&mut rx).await {
@@ -164,12 +176,12 @@ async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
 async fn restarting_the_loaders_refetches_and_cannot_be_beaten_by_the_load_it_replaced() {
     // `ctrl-r`'s path. It goes through `Loaders` rather than fetching alongside
     // them for one reason: a refetch started at t₁ and a load started at t₀ < t₁
-    // both write the same repo's map, and the *older* one can land second.
+    // both write the same map's cluster, and the *older* one can land second.
     // Nothing polls any more, so that stale map would be the last word. Every
     // result reaching the UI through one channel in send order is what makes
     // the newest write win, and that is what this pins.
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let seed: MapIssues = [(THIS_REPO.to_string(), 1)].into_iter().collect();
+    let seed: MapSet = [map_1()].into_iter().collect();
 
     let mut loaders = Loaders::new();
     loaders.reconcile(&seed, &tx);
@@ -181,17 +193,17 @@ async fn restarting_the_loaders_refetches_and_cannot_be_beaten_by_the_load_it_re
         other => panic!("the initial load must land first, got {other:?}"),
     }
 
-    // The refresh: same repo, same number, and it must fetch again rather than
-    // skip a repo it has already loaded — the `continue` in `reconcile` is
-    // exactly what `restart` exists to get past.
+    // The refresh: same map, and it must fetch again rather than skip a map it
+    // has already loaded — the `continue` in `reconcile` is exactly what
+    // `restart` exists to get past.
     loaders.restart(&seed, &tx);
     assert_eq!(loaders.targets(), seed);
     match next(&mut rx).await {
         LoadEvent::Fetched {
-            repo,
+            id,
             outcome: MapFetch::Loaded(map),
         } => {
-            assert_eq!(repo, THIS_REPO);
+            assert_eq!(id, map_1());
             assert!(!map.tickets.is_empty());
         }
         other => panic!("ctrl-r must refetch, got {other:?}"),
@@ -213,7 +225,7 @@ async fn shutdown_leaves_nothing_in_flight() {
     // task's `Child` is dropped, which only happens if someone waits for the
     // cancellation to actually run.
     let (tx, _rx) = mpsc::unbounded_channel();
-    let seed: MapIssues = [(THIS_REPO.to_string(), 1)].into_iter().collect();
+    let seed: MapSet = [map_1()].into_iter().collect();
 
     let mut loaders = Loaders::new();
     loaders.reconcile(&seed, &tx);


### PR DESCRIPTION
Lands the multi-map model for [#50](https://github.com/blooop/wayfinder/issues/50), the first build slice of [Map #47](https://github.com/blooop/wayfinder/issues/47).

## What changed

- **Map identity is now `MapId { repo, number }`.** `find_maps` returns every open `wayfinder:map` — the lowest-number-per-slug rule that hid [Map #35](https://github.com/blooop/wayfinder/issues/35) is gone. The projects cache, `Loaders`, `Startup`, and the failure set all key on the pair, so two maps on one repo are two loads, two arrivals, two possible failures.
- **`merge_maps` is deleted.** The screen holds one cluster per open map: a `▌ repo · map title  ○n ◐n ⊘n ●n` header with the map's tickets grouped beneath it (frontier / claimed / blocked / done). The repo column is gone — the header carries it. The body scrolls to keep the cursor visible, since several clusters can be taller than the terminal (the live 3-map repo hits this immediately).
- **The full blocking edge set is first-class** (`/constructive-modeling`): `parse_map` keeps closed-blocker edges on `Ticket::blocked_by` (structure) while `Status::Blocked { needs }` remains the open subset parsed at the `gh` boundary (status); `Map::unblocks` derives reverse edges by local inversion. Zero extra API points — the query always carried them.
- **Launch reads the map from the row's cluster**, so the "repo has no map" notice became unrepresentable and was deleted.
- **Cache migration:** the field is renamed `maps` → `open_maps`, so an old cache file loads with its checkouts intact and just loses the head start once.

## Testing

- 91 unit tests (multi-map fixtures throughout: two clusters on one repo, same ticket under two maps, moved map numbers, cache migration, scroll-to-cursor).
- All live integration tests updated and passing against the real tracker, including the pty end-to-end launch test — which is what caught the missing scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Render every open wayfinder map as its own on-screen cluster keyed by MapId, update startup/loading and discovery to work per-map instead of per-repo, and keep the full blocking edge set in the model while preserving cursor and launch behavior across multi-map refreshes.

New Features:
- Support multiple open maps per repo with each rendered as an individual cluster including per-status ticket counts.
- Allow focusing a project while still showing all of its open maps rather than a single map per repo.

Bug Fixes:
- Ensure the body view scrolls to keep the cursor-visible row on screen even when clusters exceed terminal height.
- Prevent cursor jumps when the same ticket appears on multiple maps by anchoring selection to (map, ticket) identity across refreshes.

Enhancements:
- Refactor map identity, cache, loaders, and failure tracking to use MapId-based sets instead of per-repo map numbers.
- Make blocked-by relationships first-class by preserving closed-blocker edges and deriving reverse unblocks edges locally from the full DAG.
- Simplify launch planning to read the map number from the cursor row’s cluster instead of a separate per-repo map table, removing the "repo has no map" path.
- Update UI layout and copy to remove the repo column, introduce map cluster headers, and adjust headings and failure notes to reflect per-map state.

Documentation:
- Document the per-machine cache as storing all open maps and describe the new per-map cluster rendering behavior in the README.

Tests:
- Extend unit, UI, and live integration tests to cover multi-map scenarios, cache migration, cursor anchoring, per-map failures, body scrolling, and the new MapId-based discovery and loading logic.