### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.3.0"
+  version: "0.4.0"
 
 package:
   name: wf


### PR DESCRIPTION
Cuts **0.4.0**. [v0.3.0](https://github.com/blooop/wayfinder/releases/tag/v0.3.0) shipped Build 7; everything since is unreleased.

## What's in it

- **[Build 8 — every open map renders as its own cluster](https://github.com/blooop/wayfinder/pull/53)** ([#50](https://github.com/blooop/wayfinder/issues/50)): map identity became `MapId { repo, number }`, so `find_maps` keeps every open map instead of the lowest-numbered one per repo — [Map #35](https://github.com/blooop/wayfinder/issues/35) was invisible until now. `merge_maps` gave way to one `▌ repo · map title  ○n ◐n ⊘n ●n` cluster per map, the full blocking edge set is retained on tickets for the views [#51](https://github.com/blooop/wayfinder/issues/51) will draw, and the body scrolls to keep the cursor on screen.
- **[Docs: put the whole key table back](https://github.com/blooop/wayfinder/commit/07e62b7)**.

## Why minor, not patch

The screen looks different — clusters replace the single merged grouped list and the repo column is gone — and the projects cache field was renamed `maps` → `open_maps`. An existing `~/.cache/wf/projects.json` loads fine with its checkouts intact; it just loses its map head start once, so the next start pays the search before the first map lands.

## The bump

`Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` move together — CI fails the build if the recipe and the crate disagree, and a tag that does not match `Cargo.toml` is rejected before anything is published.

Merging this does not release anything. Pushing `v0.4.0` afterwards is what builds the recipe, creates the GitHub release, and publishes to prefix.dev/blooop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the project to release version 0.4.0 across code and packaging metadata.

Build:
- Update Cargo.toml package version to 0.4.0.
- Align recipe.yaml context version with the new 0.4.0 release.

Chores:
- Refresh Cargo.lock to reflect the 0.4.0 dependency state.