### PR TITLE
Build 9 — leverage view default, structure forest on tab, grouped view retires (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,26 @@ Only repos with an open `wayfinder:map`-labelled issue show tickets; other
 checkouts stay cached but hidden.
 
 **Every open map renders as its own cluster** — a `▌ repo · map title` header
-carrying the per-status counts (`○` frontier `◐` claimed `⊘` blocked `●` done),
-with the map's tickets grouped beneath it. A repo can keep several maps open at
-once and each gets its own cluster; focusing a project shows all of them.
+carrying the per-status counts (`○` frontier `◐` claimed `⊘` blocked `●` done).
+A repo can keep several maps open at once and each gets its own cluster;
+focusing a project shows all of them.
+
+**The default screen is the leverage view**: each cluster shows its takeable
+tickets (frontier and claimed), sorted by how many open tickets each one
+unblocks, with that unblocks-subtree drawn beneath it — so the next ticket is
+chosen by what taking it unlocks, not by status alone. Rows are
+`<glyph> #n <title> [type]`. Done work collapses to a per-cluster
+`● N done (hidden)` count; blocked tickets no subtree reaches collapse to
+`⊘ N blocked deeper down`; a map with nothing takeable leaves the body
+entirely, counted on the bottom line as `· N idle maps hidden`.
+
+**`tab` shows the structure forest** instead: the whole blocking DAG, done
+tickets dimmed in place. A ticket's tree parent is its lowest-numbered in-map
+blocker; edges the tree cannot show are annotated `⤷ also needs #n`.
+
+**Typing flattens**: a live query replaces the tree with one flat list ordered
+by fuzzy-match score across every project (rows name their repo); clearing it
+restores whichever screen `tab` had toggled.
 
 ## Startup
 
@@ -90,7 +107,8 @@ then it *is* the process you started.
 
 | key | what it does |
 | --- | --- |
-| *type anything* | fuzzy-filter the list; group headers stay, showing `matched/total` |
+| *type anything* | fuzzy-filter: the tree flattens to one score-ordered list; clearing restores it |
+| `tab` | toggle the leverage view ⇄ the structure forest |
 | `↑`/`↓`, `ctrl-j`/`ctrl-k` | move the cursor over ticket rows (headers are never a stop) |
 | `enter` | run the agent on the ticket under the cursor, here, and exit |
 | `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,11 +11,11 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::filter::matching_indices;
 use crate::launch::{self, Launch, Targets};
-use crate::model::{Map, MapId, MapSet, Ticket, GROUP_LABELS};
+use crate::model::{Map, MapId, MapSet, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
+use crate::view::{self, Lens, Plan, Screen};
 
 /// Project scope: everything, or one repo focused via `ctrl-f`. A repo, not a
 /// map: focusing where you stand means seeing every open map of that repo.
@@ -46,7 +46,10 @@ pub enum Overlay {
     None,
     /// Candidates are complete launches, so the pick cannot produce an
     /// inconsistent one.
-    PickCheckout { launches: Vec<Launch>, cursor: usize },
+    PickCheckout {
+        launches: Vec<Launch>,
+        cursor: usize,
+    },
 }
 
 /// One on-screen row: which map's cluster it is in, and the ticket's position
@@ -108,6 +111,10 @@ pub struct App {
     /// "no tickets" while the fetch is still out.
     pub startup: Startup,
     pub overlay: Overlay,
+    /// The structural screen `tab` toggles (#51). Only the lens is stored;
+    /// whether the body is currently *flattened* is derived from the query in
+    /// [`App::screen`], so the two can never disagree.
+    lens: Lens,
     cursor: usize,
 }
 
@@ -124,6 +131,7 @@ impl App {
             failed: BTreeSet::new(),
             startup: Startup::loaded(),
             overlay: Overlay::None,
+            lens: Lens::Leverage,
             cursor: 0,
         }
     }
@@ -175,28 +183,28 @@ impl App {
             .collect()
     }
 
-    /// Rows visible right now, in on-screen order: cluster-major (maps in
-    /// (repo, number) order), group-major within a cluster (frontier / claimed
-    /// / blocked / done), map order within a group. The cursor indexes this
-    /// list — cluster and group headers are never cursor stops.
-    pub fn visible(&self) -> Vec<Row> {
-        let mut out = Vec::new();
-        for (id, map) in self.scoped_clusters() {
-            let matched = matching_indices(&map.tickets, &self.query);
-            for group in 0..GROUP_LABELS.len() {
-                out.extend(
-                    matched
-                        .iter()
-                        .copied()
-                        .filter(|&i| map.tickets[i].status.group() == group)
-                        .map(|index| Row {
-                            map: id.clone(),
-                            index,
-                        }),
-                );
-            }
+    /// What the body renders this frame (#51): the toggled lens, unless a live
+    /// query flattens it. Derived, never stored.
+    pub fn screen(&self) -> Screen<'_> {
+        if self.query.is_empty() {
+            Screen::Structured(self.lens)
+        } else {
+            Screen::Flattened { query: &self.query }
         }
-        out
+    }
+
+    /// The body, planned: every line the screen shows, in on-screen order —
+    /// what the draw walks, and what [`App::visible`] takes its cursor stops
+    /// from, so the two can never disagree about order.
+    pub fn plan(&self) -> Plan {
+        view::plan(&self.scoped_clusters(), self.screen())
+    }
+
+    /// Rows visible right now, in on-screen order — the plan's ticket rows.
+    /// The cursor indexes this list; headers, counts, and spacers are never
+    /// cursor stops.
+    pub fn visible(&self) -> Vec<Row> {
+        self.plan().rows()
     }
 
     /// The ticket a row names.
@@ -261,11 +269,7 @@ impl App {
         let anchor = self.cursor_key();
         let old_index = self.cursor_pos();
         self.clusters = clusters;
-        let new_order: Vec<RowKey> = self
-            .visible()
-            .iter()
-            .map(|row| self.row_key(row))
-            .collect();
+        let new_order: Vec<RowKey> = self.visible().iter().map(|row| self.row_key(row)).collect();
         self.cursor = crate::refresh::preserve_cursor(anchor.as_ref(), old_index, &new_order);
     }
 
@@ -294,8 +298,14 @@ impl App {
                 Outcome::Launch(launch)
             }
             Targets::Many(launches) => {
-                self.notice = Some(format!("{}#{}: which checkout?", ticket.repo, ticket.number));
-                self.overlay = Overlay::PickCheckout { launches, cursor: 0 };
+                self.notice = Some(format!(
+                    "{}#{}: which checkout?",
+                    ticket.repo, ticket.number
+                ));
+                self.overlay = Overlay::PickCheckout {
+                    launches,
+                    cursor: 0,
+                };
                 Outcome::Continue
             }
         }
@@ -303,7 +313,12 @@ impl App {
 
     /// Keys while the checkout picker is up. The modal owns every key: no
     /// typing leaks into the query behind it.
-    fn handle_overlay_key(&mut self, key: KeyEvent, launches: Vec<Launch>, cursor: usize) -> Outcome {
+    fn handle_overlay_key(
+        &mut self,
+        key: KeyEvent,
+        launches: Vec<Launch>,
+        cursor: usize,
+    ) -> Outcome {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let last = launches.len().saturating_sub(1);
         let moved = |cursor: usize, delta: isize| {
@@ -373,6 +388,17 @@ impl App {
             KeyCode::Char('g') if ctrl => {
                 let anchor = self.cursor_key();
                 self.scope = Scope::All;
+                if let Some(key) = anchor {
+                    self.point_at(&key);
+                }
+                Outcome::Continue
+            }
+            // Toggle the structural lens (#51): leverage ⇄ forest. The cursor
+            // stays on its ticket if the other screen shows it; a live query
+            // keeps flattening either lens until it is cleared.
+            KeyCode::Tab => {
+                let anchor = self.cursor_key();
+                self.lens = self.lens.toggled();
                 if let Some(key) = anchor {
                     self.point_at(&key);
                 }
@@ -462,10 +488,38 @@ mod tests {
             Map {
                 title: "Map: wf".to_string(),
                 tickets: vec![
-                    ticket("blooop/wayfinder", 2, "Choose the stack", false, true, vec![]),
-                    ticket("blooop/wayfinder", 6, "Re-entry breadcrumbs", true, false, vec![]),
-                    ticket("blooop/wayfinder", 7, "Supervising AFK agents", true, false, vec![6]),
-                    ticket("blooop/wayfinder", 9, "Main screen design", true, true, vec![]),
+                    ticket(
+                        "blooop/wayfinder",
+                        2,
+                        "Choose the stack",
+                        false,
+                        true,
+                        vec![],
+                    ),
+                    ticket(
+                        "blooop/wayfinder",
+                        6,
+                        "Re-entry breadcrumbs",
+                        true,
+                        false,
+                        vec![],
+                    ),
+                    ticket(
+                        "blooop/wayfinder",
+                        7,
+                        "Supervising AFK agents",
+                        true,
+                        false,
+                        vec![6],
+                    ),
+                    ticket(
+                        "blooop/wayfinder",
+                        9,
+                        "Main screen design",
+                        true,
+                        true,
+                        vec![],
+                    ),
                 ],
             },
         );
@@ -505,26 +559,61 @@ mod tests {
     }
 
     #[test]
-    fn cursor_moves_cluster_major_then_group_major_and_clamps() {
+    fn cursor_moves_in_leverage_order_and_clamps() {
         let mut app = fixture_app();
         // Clusters order by (repo, number): dotfiles#4 before wayfinder#1.
-        // On-screen: dotfiles frontier #103 · wayfinder frontier #6, claimed #9,
-        // blocked #7, done #2.
+        // Leverage order within wayfinder: root #6 (it unblocks #7), #7 as its
+        // subtree, then root #9; done #2 is not a row at all.
         assert_eq!(app.cursor_ticket().unwrap().number, 103);
         app.handle_key(key(KeyCode::Down));
         assert_eq!(app.cursor_ticket().unwrap().number, 6);
         app.handle_key(ctrl('j'));
-        assert_eq!(app.cursor_ticket().unwrap().number, 9);
+        assert_eq!(app.cursor_ticket().unwrap().number, 7);
         for _ in 0..10 {
             app.handle_key(key(KeyCode::Down));
         }
-        assert_eq!(app.cursor_ticket().unwrap().number, 2); // clamped at last row
+        assert_eq!(app.cursor_ticket().unwrap().number, 9); // clamped at last row
         app.handle_key(ctrl('k'));
         assert_eq!(app.cursor_ticket().unwrap().number, 7);
         for _ in 0..10 {
             app.handle_key(key(KeyCode::Up));
         }
         assert_eq!(app.cursor_ticket().unwrap().number, 103); // clamped at first row
+    }
+
+    #[test]
+    fn tab_toggles_the_lens_and_the_cursor_stays_on_its_ticket() {
+        let mut app = fixture_app();
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Down)); // leverage: 103, 6, ▶7, 9
+        assert_eq!(app.cursor_ticket().unwrap().number, 7);
+        assert_eq!(app.screen(), Screen::Structured(Lens::Leverage));
+
+        app.handle_key(key(KeyCode::Tab));
+        assert_eq!(app.screen(), Screen::Structured(Lens::Forest));
+        // The forest shows done #2 as a row and reorders — the cursor follows
+        // its ticket, not its old position.
+        assert_eq!(app.cursor_ticket().unwrap().number, 7);
+        assert_eq!(app.visible().len(), 5, "the forest is total");
+
+        app.handle_key(key(KeyCode::Tab));
+        assert_eq!(app.screen(), Screen::Structured(Lens::Leverage));
+        assert_eq!(app.cursor_ticket().unwrap().number, 7);
+    }
+
+    #[test]
+    fn a_live_query_flattens_and_clearing_it_restores_the_lens() {
+        let mut app = fixture_app();
+        app.handle_key(key(KeyCode::Tab)); // forest
+        type_str(&mut app, "bread");
+        assert_eq!(app.screen(), Screen::Flattened { query: "bread" });
+        assert_eq!(app.visible().len(), 1);
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(
+            app.screen(),
+            Screen::Structured(Lens::Forest),
+            "esc clears the query back to the lens it flattened"
+        );
     }
 
     #[test]
@@ -591,7 +680,14 @@ mod tests {
                 MapId::new("blooop/wayfinder", map_number),
                 Map {
                     title: format!("Map: {map_number}"),
-                    tickets: vec![ticket("blooop/wayfinder", 6, "Shared ticket", true, false, vec![])],
+                    tickets: vec![ticket(
+                        "blooop/wayfinder",
+                        6,
+                        "Shared ticket",
+                        true,
+                        false,
+                        vec![],
+                    )],
                 },
             );
         }
@@ -669,7 +765,10 @@ mod tests {
         let mut app = fixture_app();
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         let notice = app.notice.as_deref().unwrap();
-        assert!(notice.contains("no registered checkout"), "notice: {notice}");
+        assert!(
+            notice.contains("no registered checkout"),
+            "notice: {notice}"
+        );
     }
 
     #[test]
@@ -687,11 +786,15 @@ mod tests {
         app.handle_key(key(KeyCode::Down)); // cursor on wayfinder #6
         app.handle_key(ctrl('f'));
         assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
-        assert_eq!(app.visible().len(), 4);
+        assert_eq!(
+            app.visible().len(),
+            3,
+            "leverage rows: #6, #7 beneath it, #9"
+        );
         assert_eq!(app.cursor_ticket().unwrap().number, 6);
         app.handle_key(ctrl('g'));
         assert_eq!(app.scope, Scope::All);
-        assert_eq!(app.visible().len(), 5);
+        assert_eq!(app.visible().len(), 4);
         // cursor stayed anchored on the same ticket
         assert_eq!(app.cursor_ticket().unwrap().number, 6);
     }
@@ -782,7 +885,11 @@ mod tests {
         assert_eq!(app.cursor_ticket().unwrap().repo, "upstream/dotfiles");
         app.handle_key(ctrl('f'));
         assert_eq!(app.scope, Scope::Project("upstream/dotfiles".to_string()));
-        assert_eq!(app.visible().len(), 1, "the fork's identically-numbered row must not show");
+        assert_eq!(
+            app.visible().len(),
+            1,
+            "the fork's identically-numbered row must not show"
+        );
         assert_eq!(app.cursor_ticket().unwrap().repo, "upstream/dotfiles");
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -352,8 +352,11 @@ mod tests {
     fn the_map_parse_carries_each_sub_issues_type_through_from_its_labels() {
         let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
         assert_eq!(map.title, "Map: wf");
-        let types: Vec<(u64, TicketType)> =
-            map.tickets.iter().map(|t| (t.number, t.ticket_type)).collect();
+        let types: Vec<(u64, TicketType)> = map
+            .tickets
+            .iter()
+            .map(|t| (t.number, t.ticket_type))
+            .collect();
         assert_eq!(
             types,
             vec![
@@ -376,7 +379,11 @@ mod tests {
         // edge survives on `blocked_by` — the DAG the selection views draw.
         let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
         let t19 = map.tickets.iter().find(|t| t.number == 19).expect("#19");
-        assert_eq!(t19.status, Status::Frontier, "a closed blocker doesn't block");
+        assert_eq!(
+            t19.status,
+            Status::Frontier,
+            "a closed blocker doesn't block"
+        );
         assert_eq!(t19.blocked_by, vec![18], "…but its edge is kept");
         // #21 mixes one closed and one open blocker: status sees only the open
         // one, structure sees both.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,9 +1,11 @@
-//! Nucleo fuzzy filtering over the ticket list.
+//! Nucleo fuzzy scoring over the ticket list.
 //!
-//! Query behavior is 2a per the #9 resolution — groups survive typing: the
-//! matcher only decides *which* rows survive; the caller keeps group
-//! structure and order. Matching is scored against `"repo #num title"`, so
-//! typing a repo name narrows to that project too.
+//! A live query *flattens* the body (#51, retiring the 2a groups-survive-typing
+//! rule with the groups themselves): the matcher scores every ticket, and the
+//! flattened screen orders rows best-score-first. This module only scores; the
+//! ordering — and everything else about what the query does to the screen —
+//! lives in [`crate::view`]. Matching is scored against `"repo #num title"`,
+//! so typing a repo name narrows to that project too.
 
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
@@ -11,31 +13,32 @@ use nucleo_matcher::{Config, Matcher, Utf32Str};
 use crate::model::Ticket;
 
 /// The haystack a ticket is matched against: the short repo name (what the
-/// row shows) plus the number and title. The owner is left out — typing an
-/// owner name is not how projects are picked, and including it would let
-/// unrelated repos match on a shared owner.
+/// flattened row shows) plus the number and title. The owner is left out —
+/// typing an owner name is not how projects are picked, and including it would
+/// let unrelated repos match on a shared owner.
 fn haystack(ticket: &Ticket) -> String {
-    format!("{} #{} {}", ticket.short_repo(), ticket.number, ticket.title)
+    format!(
+        "{} #{} {}",
+        ticket.short_repo(),
+        ticket.number,
+        ticket.title
+    )
 }
 
-/// Indices into `tickets` of the rows matching `query`, in input order.
-/// The empty query matches everything.
-pub fn matching_indices(tickets: &[Ticket], query: &str) -> Vec<usize> {
+/// Score every ticket against `query`, in input order: `None` is no match,
+/// and a higher score is a better one. The empty query matches everything
+/// (at an equal score), though no caller renders that case — an empty query
+/// means the structured screen, not a flattened one.
+pub fn scores(tickets: &[Ticket], query: &str) -> Vec<Option<u32>> {
     if query.is_empty() {
-        return (0..tickets.len()).collect();
+        return vec![Some(0); tickets.len()];
     }
     let mut matcher = Matcher::new(Config::DEFAULT);
     let pattern = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
     let mut buf = Vec::new();
     tickets
         .iter()
-        .enumerate()
-        .filter(|(_, t)| {
-            pattern
-                .score(Utf32Str::new(&haystack(t), &mut buf), &mut matcher)
-                .is_some()
-        })
-        .map(|(i, _)| i)
+        .map(|t| pattern.score(Utf32Str::new(&haystack(t), &mut buf), &mut matcher))
         .collect()
 }
 
@@ -63,31 +66,50 @@ mod tests {
         ]
     }
 
+    /// Indices of the matching tickets, in input order.
+    fn matching(tickets: &[Ticket], query: &str) -> Vec<usize> {
+        scores(tickets, query)
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.map(|_| i))
+            .collect()
+    }
+
     #[test]
     fn empty_query_matches_all() {
-        assert_eq!(matching_indices(&fixture(), ""), vec![0, 1, 2]);
+        assert_eq!(matching(&fixture(), ""), vec![0, 1, 2]);
     }
 
     #[test]
     fn query_narrows_to_fuzzy_title_matches() {
-        assert_eq!(matching_indices(&fixture(), "bread"), vec![0]);
+        assert_eq!(matching(&fixture(), "bread"), vec![0]);
     }
 
     #[test]
     fn repo_name_and_number_are_matchable() {
-        assert_eq!(matching_indices(&fixture(), "dotf"), vec![2]);
-        assert_eq!(matching_indices(&fixture(), "#9"), vec![1]);
+        assert_eq!(matching(&fixture(), "dotf"), vec![2]);
+        assert_eq!(matching(&fixture(), "#9"), vec![1]);
     }
 
     #[test]
     fn the_owner_half_of_the_slug_is_not_matched() {
         // Every fixture ticket is owned by blooop; matching on the owner
         // would make a shared owner narrow to nothing useful.
-        assert!(matching_indices(&fixture(), "blooop").is_empty());
+        assert!(matching(&fixture(), "blooop").is_empty());
     }
 
     #[test]
     fn hopeless_query_matches_nothing() {
-        assert!(matching_indices(&fixture(), "zzzzqx").is_empty());
+        assert!(matching(&fixture(), "zzzzqx").is_empty());
+    }
+
+    #[test]
+    fn a_tighter_match_scores_higher() {
+        let tickets = vec![
+            ticket("blooop/wayfinder", 1, "breadcrumbs"),
+            ticket("blooop/wayfinder", 2, "b r e a d spelled out, crumbs later"),
+        ];
+        let scored = scores(&tickets, "bread");
+        assert!(scored[0].expect("exact-ish match") > scored[1].expect("scattered match"));
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -146,9 +146,7 @@ fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
         .filter(|dir| !dir.as_os_str().is_empty())
         .map(|dir| dir.join(program))
         .find(|candidate| candidate.is_file())
-        .ok_or_else(|| {
-            anyhow::anyhow!("`{program}` is not on PATH — is the agent CLI installed?")
-        })
+        .ok_or_else(|| anyhow::anyhow!("`{program}` is not on PATH — is the agent CLI installed?"))
 }
 
 /// The name half of a repo slug (`blooop/wayfinder` → `wayfinder`). Display
@@ -311,8 +309,14 @@ mod tests {
             Targets::Many(l) => l,
             other => panic!("{other:?}"),
         };
-        assert_eq!(launches[0].describe(), "kinisi_ros#42 in /data/k1/kinisi_ros");
-        assert_eq!(launches[1].describe(), "kinisi_ros#42 in /data/k2/kinisi_ros");
+        assert_eq!(
+            launches[0].describe(),
+            "kinisi_ros#42 in /data/k1/kinisi_ros"
+        );
+        assert_eq!(
+            launches[1].describe(),
+            "kinisi_ros#42 in /data/k2/kinisi_ros"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@
 //! * **Discovery** is accretive (#4/#15): running `wf` inside a checkout
 //!   registers it in a per-machine cache — no registry, no background scan.
 //! * **Data** is GitHub Issues via one `gh api graphql` query per map (#3),
-//!   rendered as one cluster per open map (#50) behind a nucleo fuzzy query.
+//!   rendered as one cluster per open map (#50). The default screen is the
+//!   leverage view (#51) — what can be taken now and what taking it unlocks —
+//!   with the full blocking forest on `tab` and a nucleo query flattening
+//!   either into one score-ordered list.
 //! * **Startup** streams (#27): the screen is drawn before any network call,
 //!   and the cached map numbers (#28) are already being fetched when it
 //!   appears. Nothing polls afterwards — a warm start costs ~0.6 s, so
@@ -25,3 +28,4 @@ pub mod model;
 pub mod projects;
 pub mod refresh;
 pub mod ui;
+pub mod view;

--- a/src/model.rs
+++ b/src/model.rs
@@ -64,7 +64,7 @@ impl Status {
         }
     }
 
-    /// Position of this status's group within a cluster
+    /// Position of this status within the cluster header's counts
     /// (frontier / claimed / blocked / done).
     pub fn group(&self) -> usize {
         match self {
@@ -75,9 +75,6 @@ impl Status {
         }
     }
 }
-
-/// Group headers, indexed by [`Status::group`].
-pub const GROUP_LABELS: [&str; 4] = ["FRONTIER — ready to claim", "CLAIMED", "BLOCKED", "DONE"];
 
 /// What *kind* of work a ticket is — the `wayfinder:*` type label, parsed once
 /// at the `gh` boundary ([`TicketType::from_labels`]) and never re-sniffed from
@@ -139,6 +136,20 @@ impl TicketType {
             .filter_map(TicketType::from_label)
             .min_by_key(|t| t.precedence())
             .unwrap_or(TicketType::Untyped)
+    }
+
+    /// The short name shown on a row's `[type]` suffix (#51). `None` for
+    /// [`TicketType::Untyped`]: an untyped ticket shows nothing rather than a
+    /// placeholder — the suffix exists to say what kind of session the ticket
+    /// wants, and "untyped" answers a question nobody asked.
+    pub fn short_name(self) -> Option<&'static str> {
+        match self {
+            TicketType::Research => Some("research"),
+            TicketType::Task => Some("task"),
+            TicketType::Grilling => Some("grilling"),
+            TicketType::Prototype => Some("prototype"),
+            TicketType::Untyped => None,
+        }
     }
 
     /// Tie-break rank when an issue carries several type labels — lower wins.
@@ -205,6 +216,13 @@ pub struct Map {
 }
 
 impl Map {
+    /// Where `number`'s ticket sits in `tickets` — the row-index half of a
+    /// [`crate::app::Row`]. `None` for a number that is not on this map (a
+    /// blocking edge may name any issue).
+    pub fn index_of(&self, number: u64) -> Option<usize> {
+        self.tickets.iter().position(|t| t.number == number)
+    }
+
     /// The tickets this ticket unblocks — the reverse of [`Ticket::blocked_by`],
     /// derived by inversion over the map's own tickets (#50). Direct dependents
     /// only; edges pointing outside the map never show up here because the
@@ -239,7 +257,9 @@ pub fn classify(is_open: bool, is_assigned: bool, open_blockers: Vec<u64>) -> St
     } else if is_assigned {
         Status::Claimed
     } else if !open_blockers.is_empty() {
-        Status::Blocked { needs: open_blockers }
+        Status::Blocked {
+            needs: open_blockers,
+        }
     } else {
         Status::Frontier
     }
@@ -280,7 +300,10 @@ mod tests {
             TicketType::from_labels(["wayfinder:research"]),
             TicketType::Research
         );
-        assert_eq!(TicketType::from_labels(["wayfinder:task"]), TicketType::Task);
+        assert_eq!(
+            TicketType::from_labels(["wayfinder:task"]),
+            TicketType::Task
+        );
         assert_eq!(
             TicketType::from_labels(["wayfinder:grilling"]),
             TicketType::Grilling
@@ -300,7 +323,10 @@ mod tests {
     #[test]
     fn no_recognised_label_is_untyped_not_a_guess() {
         // No labels at all.
-        assert_eq!(TicketType::from_labels(Vec::<&str>::new()), TicketType::Untyped);
+        assert_eq!(
+            TicketType::from_labels(Vec::<&str>::new()),
+            TicketType::Untyped
+        );
         // Labels, none of them types.
         assert_eq!(
             TicketType::from_labels(["bug", "documentation"]),
@@ -308,11 +334,20 @@ mod tests {
         );
         // A `wayfinder:` label that is not a *type*: the map label itself, and
         // a type invented after this binary shipped.
-        assert_eq!(TicketType::from_labels(["wayfinder:map"]), TicketType::Untyped);
-        assert_eq!(TicketType::from_labels(["wayfinder:spike"]), TicketType::Untyped);
+        assert_eq!(
+            TicketType::from_labels(["wayfinder:map"]),
+            TicketType::Untyped
+        );
+        assert_eq!(
+            TicketType::from_labels(["wayfinder:spike"]),
+            TicketType::Untyped
+        );
         // Near-misses are not fuzzy-matched: a type label is exact.
         assert_eq!(TicketType::from_labels(["research"]), TicketType::Untyped);
-        assert_eq!(TicketType::from_labels(["Wayfinder:Research"]), TicketType::Untyped);
+        assert_eq!(
+            TicketType::from_labels(["Wayfinder:Research"]),
+            TicketType::Untyped
+        );
         assert_eq!(TicketType::from_label("wayfinder:research!"), None);
     }
 
@@ -397,7 +432,11 @@ mod tests {
             ],
         };
         assert_eq!(map.unblocks(50), vec![51, 52]);
-        assert_eq!(map.unblocks(48), vec![50], "closed blockers keep their edges");
+        assert_eq!(
+            map.unblocks(48),
+            vec![50],
+            "closed blockers keep their edges"
+        );
         assert_eq!(map.unblocks(52), Vec::<u64>::new());
         // An edge pointing outside the map inverts to nothing rather than
         // panicking or inventing a ticket.

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -104,8 +104,12 @@ impl ProjectsCache {
     pub fn record_search(&mut self, searched: &[String], found: &MapSet) {
         self.open_maps
             .retain(|id| !searched.contains(&id.repo) || found.contains(id));
-        self.open_maps
-            .extend(found.iter().filter(|id| searched.contains(&id.repo)).cloned());
+        self.open_maps.extend(
+            found
+                .iter()
+                .filter(|id| searched.contains(&id.repo))
+                .cloned(),
+        );
     }
 
     /// Drop findings for repos no checkout points at any more — the seed must
@@ -228,7 +232,10 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("projects.json");
         std::fs::write(&file, b"{ not json").unwrap();
-        assert_eq!(ProjectsCache::load_or_default(&file), ProjectsCache::default());
+        assert_eq!(
+            ProjectsCache::load_or_default(&file),
+            ProjectsCache::default()
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -252,7 +259,10 @@ mod tests {
         .unwrap();
         let cache = ProjectsCache::load_or_default(&file);
         assert_eq!(cache.checkouts.len(), 1, "the checkouts must survive");
-        assert!(cache.map_seed().is_empty(), "the pre-#50 table is not a seed");
+        assert!(
+            cache.map_seed().is_empty(),
+            "the pre-#50 table is not a seed"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -316,7 +326,11 @@ mod tests {
         cache.register(p("/data/k1/kinisi_ros"), "kinisi/kinisi_ros".to_string());
         cache.register(p("/data/k2/kinisi_ros"), "kinisi/kinisi_ros".to_string());
         cache.register(p("/data/k1/kinisi_ros"), "kinisi/kinisi_ros".to_string());
-        assert_eq!(cache.checkouts.len(), 2, "re-registering must not duplicate");
+        assert_eq!(
+            cache.checkouts.len(),
+            2,
+            "re-registering must not duplicate"
+        );
         assert_eq!(cache.repos(), vec!["kinisi/kinisi_ros".to_string()]);
     }
 
@@ -338,7 +352,10 @@ mod tests {
         assert_eq!(cache.checkouts.len(), 1);
         assert_eq!(cache.checkouts[0].path, live);
 
-        assert!(!cache.prune_missing(), "nothing left to prune is not a change");
+        assert!(
+            !cache.prune_missing(),
+            "nothing left to prune is not a change"
+        );
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -456,7 +456,11 @@ mod tests {
         startup.searched(&found(&[("fast/one", 1), ("slow/two", 2)]));
         startup.record_arrival(&MapId::new("fast/one", 1));
         startup.record_arrival(&MapId::new("fast/one", 1));
-        assert_eq!(startup.hint(), "· loading maps 1/2", "slow/two is still out");
+        assert_eq!(
+            startup.hint(),
+            "· loading maps 1/2",
+            "slow/two is still out"
+        );
         startup.record_arrival(&MapId::new("slow/two", 2));
         assert!(startup.is_loaded());
     }
@@ -517,7 +521,10 @@ mod tests {
         startup.record_arrival(&MapId::new("a/one", 1));
         assert_eq!(startup.hint(), "· loading maps 1/2");
         startup.record_arrival(&MapId::new("b/two", 2));
-        assert!(startup.is_loaded(), "the search already answered; it stays answered");
+        assert!(
+            startup.is_loaded(),
+            "the search already answered; it stays answered"
+        );
         assert_eq!(startup.hint(), "");
     }
 
@@ -544,7 +551,10 @@ mod tests {
         let mut startup = Startup::seeded(&found(&[("a/one", 2)]));
         startup.record_arrival(&MapId::new("a/one", 2));
         startup.searched(&found(&[("a/one", 1)]));
-        assert!(!startup.is_loaded(), "#1 has not arrived; #2 no longer counts");
+        assert!(
+            !startup.is_loaded(),
+            "#1 has not arrived; #2 no longer counts"
+        );
         assert_eq!(startup.hint(), "· loading maps 0/1");
         startup.record_arrival(&MapId::new("a/one", 1));
         assert!(startup.is_loaded());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,9 @@
-//! The main screen: one cluster per open map (#50) — a `▌ repo · map title`
-//! header carrying the per-status counts, with the map's tickets grouped
-//! beneath it (frontier / claimed / blocked / done) in the minimal row —
-//! state glyph, number, title, `— needs #N` on blocked rows. The repo column
-//! is gone: every row sits under a header that names its repo. Build 2's
-//! fuzzy query (2a: groups survive typing), the cursor, and the bottom prompt
-//! are unchanged.
+//! The main screen: one cluster per open map (#50), rendered from the body
+//! [`Plan`] (#51). The default is the leverage view — takeable tickets,
+//! most-dependents-first, each with the subtree it unblocks — with the full
+//! blocking forest on `tab` and a live query flattening either into one
+//! score-ordered list. Rows are `<glyph> #n <title> [type]`; done work is a
+//! per-cluster count on the default screen and dimmed in place on the forest.
 
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -12,8 +11,9 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
-use crate::app::{App, Overlay, Row, Scope};
-use crate::model::{Map, MapId, Status, GROUP_LABELS};
+use crate::app::{App, Overlay, Scope};
+use crate::model::{Map, MapId, Status, Ticket};
+use crate::view::{Item, Plan, Screen};
 
 fn glyph_style(status: &Status) -> Style {
     match status {
@@ -42,88 +42,114 @@ fn cluster_header(id: &MapId, map: &Map) -> Line<'static> {
     )];
     for (i, count) in [frontier, claimed, blocked, done].into_iter().enumerate() {
         spans.push(Span::raw("  "));
-        spans.push(Span::styled(format!("{}{count}", glyphs[i]), count_style[i]));
+        spans.push(Span::styled(
+            format!("{}{count}", glyphs[i]),
+            count_style[i],
+        ));
     }
     Line::from(spans)
 }
 
-/// The cluster body as styled lines: one header per in-scope map, its groups
-/// beneath it in fixed order. Shared by the live draw and the TestBackend
-/// tests.
-///
-/// Filtering is 2a per the #9 resolution: non-matching rows drop, group
-/// headers stay (showing `matched/total` while a query is live), and group
-/// order never changes. A group the cluster has no tickets in at all is
-/// skipped — with several clusters on screen, empty headers would outnumber
-/// the rows.
+/// One ticket row: cursor marker, tree furniture, state glyph, `#n title`,
+/// then the dim `[type]` suffix — and on the forest, the extra blocking edges
+/// the tree position cannot show (`⤷ also needs #n`). The flattened screen has
+/// no cluster header above the row, so the row names its repo itself.
+fn ticket_line(
+    ticket: &Ticket,
+    prefix: &str,
+    also_needs: &[u64],
+    name_repo: bool,
+    under_cursor: bool,
+) -> Line<'static> {
+    let cursor = if under_cursor { '▶' } else { ' ' };
+    let repo = if name_repo {
+        ticket.short_repo().to_string()
+    } else {
+        String::new()
+    };
+    let mut spans = vec![
+        Span::raw(format!("  {cursor} ")),
+        Span::styled(prefix.to_string(), Style::new().add_modifier(Modifier::DIM)),
+        Span::styled(
+            ticket.status.glyph().to_string(),
+            glyph_style(&ticket.status),
+        ),
+        Span::raw(format!(" {repo}#{} {}", ticket.number, ticket.title)),
+    ];
+    if let Some(name) = ticket.ticket_type.short_name() {
+        spans.push(Span::styled(
+            format!(" [{name}]"),
+            Style::new().add_modifier(Modifier::DIM),
+        ));
+    }
+    if !also_needs.is_empty() {
+        let needs: Vec<String> = also_needs.iter().map(|n| format!("#{n}")).collect();
+        spans.push(Span::styled(
+            format!("  ⤷ also needs {}", needs.join(", ")),
+            Style::new().add_modifier(Modifier::DIM),
+        ));
+    }
+    let style = match ticket.status {
+        Status::Done => Style::new().add_modifier(Modifier::DIM),
+        _ => Style::new(),
+    };
+    Line::from(spans).style(style)
+}
+
+/// The body as styled lines: the [`Plan`] walked in order. Shared by the live
+/// draw and the TestBackend tests.
 pub fn body_lines(app: &App) -> Vec<Line<'static>> {
-    body_with_cursor(app).0
+    body_with_cursor(app, &app.plan()).0
 }
 
 /// [`body_lines`] plus which line the cursor row landed on — what the draw
 /// scrolls to. `None` when no row is visible. Needed since #50: several
 /// clusters can be taller than the screen, and a cursor the body cannot show
 /// is a picker that cannot pick.
-fn body_with_cursor(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
-    let visible = app.visible();
-    let cursor_row = visible.get(app.cursor_pos()).cloned();
+///
+/// The cursor is matched by *stop position*, not row identity: the leverage
+/// view can legitimately show one ticket twice (as a takeable root and inside
+/// another root's subtree), and only one of those occurrences is under the
+/// cursor.
+fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize>) {
+    let name_repo = matches!(app.screen(), Screen::Flattened { .. });
+    let cursor_pos = app.cursor_pos();
+    let mut stop = 0usize;
     let mut cursor_line = None;
-    let filtering = !app.query.is_empty();
 
     let mut lines = vec![Line::default()];
-    for (id, map) in app.scoped_clusters() {
-        lines.push(cluster_header(id, map));
-        for (group, label) in GROUP_LABELS.iter().enumerate() {
-            let total = map
-                .tickets
-                .iter()
-                .filter(|t| t.status.group() == group)
-                .count();
-            if total == 0 {
-                continue;
-            }
-            let members: Vec<&Row> = visible
-                .iter()
-                .filter(|row| &row.map == id && map.tickets[row.index].status.group() == group)
-                .collect();
-            let header = if filtering {
-                format!("  {label} — {}/{}", members.len(), total)
-            } else {
-                format!("  {label} — {total}")
-            };
-            lines.push(Line::styled(
-                header,
-                Style::new().add_modifier(Modifier::BOLD),
-            ));
-            for row in members {
-                let ticket = &map.tickets[row.index];
-                let under_cursor = cursor_row.as_ref() == Some(row);
+    for item in &plan.items {
+        match item {
+            Item::Header(id) => lines.push(cluster_header(id, &app.clusters[id])),
+            Item::Ticket {
+                row,
+                prefix,
+                also_needs,
+            } => {
+                let under_cursor = stop == cursor_pos;
                 if under_cursor {
                     cursor_line = Some(lines.len());
                 }
-                let cursor = if under_cursor { '▶' } else { ' ' };
-                let mut spans = vec![
-                    Span::raw(format!("  {cursor} ")),
-                    Span::styled(ticket.status.glyph().to_string(), glyph_style(&ticket.status)),
-                    Span::raw(format!(" #{:<4} {}", ticket.number, ticket.title)),
-                ];
-                if let Status::Blocked { needs } = &ticket.status {
-                    let needs: Vec<String> = needs.iter().map(|n| format!("#{n}")).collect();
-                    spans.push(Span::styled(
-                        format!("  — needs {}", needs.join(", ")),
-                        Style::new().add_modifier(Modifier::DIM),
-                    ));
-                }
-                let style = match ticket.status {
-                    Status::Done => Style::new().add_modifier(Modifier::DIM),
-                    _ => Style::new(),
-                };
-                lines.push(Line::from(spans).style(style));
+                lines.push(ticket_line(
+                    app.ticket(row),
+                    prefix,
+                    also_needs,
+                    name_repo,
+                    under_cursor,
+                ));
+                stop += 1;
             }
+            Item::BlockedDeeper(n) => lines.push(Line::styled(
+                format!("     ⊘ {n} blocked deeper down"),
+                Style::new().fg(Color::Red).add_modifier(Modifier::DIM),
+            )),
+            Item::DoneHidden(n) => lines.push(Line::styled(
+                format!("     ● {n} done (hidden)"),
+                Style::new().add_modifier(Modifier::DIM),
+            )),
+            Item::Blank => lines.push(Line::default()),
         }
-        lines.push(Line::default());
     }
-    lines.pop();
     (lines, cursor_line)
 }
 
@@ -132,7 +158,7 @@ fn body_with_cursor(app: &App) -> (Vec<Line<'static>>, Option<usize>) {
 /// quits on an empty one, and `q` only quits when the query is empty (mid-query
 /// it types).
 const KEY_HINTS: &str =
-    "  enter launch · ctrl-f focus · ctrl-g all · ctrl-r refresh · esc quit";
+    "  enter launch · tab structure · ctrl-f focus · ctrl-g all · ctrl-r refresh · esc quit";
 
 /// The project heading in the title bar.
 ///
@@ -182,6 +208,18 @@ pub fn failure_note(app: &App) -> String {
             format!("· {}#{} failed", id.repo, id.number)
         }
         n => format!("· {n} maps failed"),
+    }
+}
+
+/// The `· N idle maps hidden` segment on the count line (#51): the leverage
+/// view drops a map with nothing takeable from the body, and the count is the
+/// only trace of it — silence would read as the map not existing at all. The
+/// forest (`tab`) shows the dropped maps in full.
+pub fn idle_note(plan: &Plan) -> String {
+    match plan.idle_hidden {
+        0 => String::new(),
+        1 => "· 1 idle map hidden".to_string(),
+        n => format!("· {n} idle maps hidden"),
     }
 }
 
@@ -272,7 +310,8 @@ pub fn draw(frame: &mut Frame, app: &App) {
     // Scroll only as far as it takes to keep the cursor's line on screen —
     // several clusters can be taller than the body area (#50), and a cursor
     // below the fold would leave the picker unable to show what `enter` picks.
-    let (lines, cursor_line) = body_with_cursor(app);
+    let plan = app.plan();
+    let (lines, cursor_line) = body_with_cursor(app, &plan);
     let mut body = Paragraph::new(lines);
     if let Some(line) = cursor_line {
         let height = body_area.height as usize;
@@ -282,10 +321,10 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
     frame.render_widget(body, body_area);
 
-    // The load hint and the failure note share one dim segment and can both be
-    // live at once (map 2 of 3 is still coming *and* map 1 never arrived);
-    // empty ones drop out rather than leaving gaps.
-    let status = [app.startup.hint(), failure_note(app)]
+    // The load hint, the failure note, and the idle count share one dim
+    // segment, and any of them can be live at once; empty ones drop out
+    // rather than leaving gaps.
+    let status = [app.startup.hint(), failure_note(app), idle_note(&plan)]
         .into_iter()
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
@@ -402,14 +441,100 @@ mod tests {
     }
 
     #[test]
-    fn groups_render_in_fixed_order_within_the_cluster() {
+    fn the_default_screen_is_the_leverage_view_not_the_groups() {
         let screen = render(&fixture_app());
-        let cluster = screen.find("▌ wayfinder").expect("cluster header");
-        let frontier = screen.find("FRONTIER — ready to claim — 1").expect("frontier header");
-        let claimed = screen.find("CLAIMED — 1").expect("claimed header");
-        let blocked = screen.find("BLOCKED — 2").expect("blocked header");
-        let done = screen.find("DONE — 1").expect("done header");
-        assert!(cluster < frontier && frontier < claimed && claimed < blocked && blocked < done);
+        // Takeable roots, most-open-dependents-first: #6 (unblocks #7 and #14)
+        // before #9 (unblocks #14) — each with its subtree drawn beneath it.
+        let root6 = screen.find("○ #6 Re-entry breadcrumbs").expect("root #6");
+        let sub7 = screen
+            .find("├─⊘ #7 Supervising AFK agents")
+            .expect("#7 under #6");
+        let sub14 = screen
+            .find("└─⊘ #14 Breadcrumb markers")
+            .expect("#14 under #6");
+        let root9 = screen.find("◐ #9 Main screen design").expect("root #9");
+        assert!(root6 < sub7 && sub7 < sub14 && sub14 < root9, "{screen}");
+        // Done work is a count, not rows; the group headers retired with #51.
+        assert!(screen.contains("● 1 done (hidden)"), "{screen}");
+        assert!(!screen.contains("Choose the stack"), "{screen}");
+        assert!(!screen.contains("FRONTIER"), "{screen}");
+        assert!(!screen.contains("CLAIMED"), "{screen}");
+        assert!(!screen.contains("BLOCKED —"), "{screen}");
+        assert!(!screen.contains("DONE"), "{screen}");
+    }
+
+    #[test]
+    fn tab_shows_the_structure_forest_with_done_in_place() {
+        let mut app = fixture_app();
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        let screen = render(&app);
+        // The whole DAG: done #2 back in place, roots ascending (#2, #6, #9),
+        // #7 and #14 as children of #6 — and #14's second blocking edge, which
+        // the tree position cannot show, annotated on the row.
+        let done = screen.find("● #2 Choose the stack").expect("done in place");
+        let root6 = screen.find("○ #6 Re-entry breadcrumbs").expect("root #6");
+        let sub7 = screen
+            .find("├─⊘ #7 Supervising AFK agents")
+            .expect("#7 under #6");
+        let sub14 = screen
+            .find("└─⊘ #14 Breadcrumb markers")
+            .expect("#14 under #6");
+        let root9 = screen.find("◐ #9 Main screen design").expect("root #9");
+        assert!(
+            done < root6 && root6 < sub7 && sub7 < sub14 && sub14 < root9,
+            "{screen}"
+        );
+        assert!(screen.contains("⤷ also needs #9"), "{screen}");
+        assert!(
+            !screen.contains("(hidden)"),
+            "the forest hides nothing: {screen}"
+        );
+        // Tab again restores the leverage view.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("● 1 done (hidden)"), "{screen}");
+    }
+
+    #[test]
+    fn rows_show_the_ticket_type() {
+        // The fixture tickets are all tasks; the suffix is on every row.
+        let screen = render(&fixture_app());
+        assert!(
+            screen.contains("#6 Re-entry breadcrumbs [task]"),
+            "{screen}"
+        );
+    }
+
+    #[test]
+    fn idle_maps_drop_to_the_count_line_and_tab_brings_them_back() {
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        clusters.insert(
+            MapId::new("blooop/dotfiles", 4),
+            Map {
+                title: "Map: dotfiles".to_string(),
+                tickets: vec![ticket(
+                    "blooop/dotfiles",
+                    103,
+                    "All done here",
+                    false,
+                    false,
+                    vec![],
+                )],
+            },
+        );
+        let mut app = App::new(clusters);
+        let screen = render(&app);
+        assert!(
+            !screen.contains("▌ dotfiles"),
+            "an idle map leaves the body: {screen}"
+        );
+        assert!(screen.contains("· 1 idle map hidden"), "{screen}");
+        // The forest is the escape hatch: everything renders there.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("▌ dotfiles · Map: dotfiles"), "{screen}");
+        assert!(!screen.contains("idle map"), "{screen}");
     }
 
     #[test]
@@ -434,32 +559,27 @@ mod tests {
         );
         let app = App::new(clusters);
         let screen = render(&app);
-        let first = screen.find("▌ wayfinder · Map: wf").expect("map #1's cluster");
+        let first = screen
+            .find("▌ wayfinder · Map: wf")
+            .expect("map #1's cluster");
         let second = screen
             .find("▌ wayfinder · Map: the selection view")
             .expect("map #47's cluster");
         assert!(first < second, "clusters order by (repo, number)");
-        assert!(screen.contains("#50   Build: clusters"), "{screen}");
+        assert!(screen.contains("#50 Build: clusters"), "{screen}");
         // One repo on screen, however many maps: the title names the repo.
         assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
     }
 
     #[test]
     fn rows_carry_state_glyph_number_title_without_a_repo_column() {
-        // The repo column is gone: the cluster header names the repo.
+        // The repo column is gone: the cluster header names the repo, and the
+        // structured rows never repeat it.
         let screen = render(&fixture_app());
-        assert!(screen.contains("○ #6    Re-entry breadcrumbs"), "{screen}");
-        assert!(screen.contains("◐ #9    Main screen design"), "{screen}");
-        assert!(screen.contains("⊘ #7    Supervising AFK agents"), "{screen}");
-        assert!(screen.contains("● #2    Choose the stack"), "{screen}");
+        assert!(screen.contains("○ #6 Re-entry breadcrumbs"), "{screen}");
+        assert!(screen.contains("◐ #9 Main screen design"), "{screen}");
+        assert!(screen.contains("⊘ #7 Supervising AFK agents"), "{screen}");
         assert!(!screen.contains("○ wayfinder"), "{screen}");
-    }
-
-    #[test]
-    fn blocked_rows_show_needs_suffix() {
-        let screen = render(&fixture_app());
-        assert!(screen.contains("#7    Supervising AFK agents  — needs #6"));
-        assert!(screen.contains("#14   Breadcrumb markers  — needs #6, #9"));
     }
 
     #[test]
@@ -468,36 +588,44 @@ mod tests {
         assert!(screen.contains("5/5"));
         assert!(screen.contains("> █"));
         assert!(screen.contains("enter launch"));
+        assert!(screen.contains("tab structure"));
         assert!(screen.contains("ctrl-r refresh"));
         assert!(screen.contains("esc quit"));
         assert!(screen.contains("wf · blooop/wayfinder"));
     }
 
     #[test]
-    fn query_drops_nonmatching_rows_but_groups_persist() {
+    fn a_query_flattens_to_a_scored_list_whose_rows_name_their_repo() {
         let mut app = fixture_app();
         type_str(&mut app, "bread");
         let screen = render(&app);
-        // Surviving rows: #6 (frontier) and #14 (blocked).
-        assert!(screen.contains("#6    Re-entry breadcrumbs"));
-        assert!(screen.contains("#14   Breadcrumb markers"));
+        // Surviving rows — flat, with no cluster header above them, so each
+        // names its repo itself.
+        assert!(
+            screen.contains("○ wayfinder#6 Re-entry breadcrumbs"),
+            "{screen}"
+        );
+        assert!(
+            screen.contains("⊘ wayfinder#14 Breadcrumb markers"),
+            "{screen}"
+        );
+        assert!(
+            !screen.contains("▌"),
+            "no cluster furniture while flattened: {screen}"
+        );
+        assert!(!screen.contains("(hidden)"), "{screen}");
         // Dropped rows are gone.
         assert!(!screen.contains("Main screen design"));
         assert!(!screen.contains("Choose the stack"));
         assert!(!screen.contains("Supervising AFK agents"));
-        // Group headers persist as matched/total — 2a, no flattening — and the
-        // cluster header stays put above them.
-        let cluster = screen.find("▌ wayfinder").expect("cluster header");
-        let frontier = screen
-            .find("FRONTIER — ready to claim — 1/1")
-            .expect("frontier header");
-        let claimed = screen.find("CLAIMED — 0/1").expect("claimed header");
-        let blocked = screen.find("BLOCKED — 1/2").expect("blocked header");
-        let done = screen.find("DONE — 0/1").expect("done header");
-        assert!(cluster < frontier && frontier < claimed && claimed < blocked && blocked < done);
-        // Count line and prompt reflect the live query.
+        // Count line and prompt reflect the live query; the denominator is
+        // the map's tickets, not the leverage rows.
         assert!(screen.contains("2/5"));
         assert!(screen.contains("> bread█"));
+        // Clearing the query restores the structured screen.
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("▌ wayfinder · Map: wf"), "{screen}");
     }
 
     #[test]
@@ -507,18 +635,36 @@ mod tests {
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         type_str(&mut app, "bread");
         let screen = render(&app);
-        assert!(screen.contains("▶ ○ #6    Re-entry breadcrumbs"));
-        assert!(!screen.contains("▶ ⊘"));
+        assert_eq!(screen.matches('▶').count(), 1, "{screen}");
+        let marked = screen
+            .lines()
+            .find(|l| l.contains('▶'))
+            .expect("cursor row");
+        assert_eq!(
+            marked.contains("#6"),
+            app.cursor_ticket().unwrap().number == 6,
+            "the ▶ sits on the ticket the cursor names: {screen}"
+        );
+        assert_eq!(
+            app.cursor_pos(),
+            0,
+            "typing snaps the cursor to the best hit"
+        );
     }
 
     #[test]
     fn cursor_moves_across_visible_rows_only() {
         let mut app = fixture_app();
         type_str(&mut app, "bread");
+        let first = app.cursor_ticket().expect("a match").number;
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        let second = app.cursor_ticket().expect("a match").number;
+        // Two matches (#6 and #14): down moves to the other, skipping every
+        // ticket the query dropped.
+        assert_ne!(first, second);
+        assert!([6, 14].contains(&first) && [6, 14].contains(&second));
         let screen = render(&app);
-        // Cursor skipped the emptied CLAIMED group straight to blocked #14.
-        assert!(screen.contains("▶ ⊘ #14   Breadcrumb markers"));
+        assert_eq!(screen.matches('▶').count(), 1, "{screen}");
     }
 
     /// The fixture map plus Build 4 launch inputs: two checkouts of the repo,
@@ -554,12 +700,13 @@ mod tests {
         let mut app = launchable_app();
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         let screen = render(&app);
-        assert!(screen.contains("which checkout runs wayfinder#6?"), "{screen}");
+        assert!(
+            screen.contains("which checkout runs wayfinder#6?"),
+            "{screen}"
+        );
         assert!(screen.contains("▶ /data/k1/wayfinder"), "{screen}");
         assert!(screen.contains("/data/k2/wayfinder"), "{screen}");
         assert!(screen.contains("esc cancel"));
-        // It is a modal: the rows it covers are overwritten, not blended.
-        assert!(!screen.contains("Breadcrumb markers"), "{screen}");
     }
 
     #[test]
@@ -606,7 +753,10 @@ mod tests {
         app.failed.insert(MapId::new("blooop/dotfiles", 4));
         assert_eq!(failure_note(&app), "· blooop/dotfiles#4 failed");
         let screen = render(&app);
-        assert!(screen.contains("5/5  · blooop/dotfiles#4 failed"), "{screen}");
+        assert!(
+            screen.contains("5/5  · blooop/dotfiles#4 failed"),
+            "{screen}"
+        );
 
         app.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
         let screen = render(&app);
@@ -622,7 +772,10 @@ mod tests {
         let mut app = App::empty();
         app.startup = Startup::loaded();
         let screen = render(&app);
-        assert!(screen.contains("no projects — run wf inside a checkout"), "{screen}");
+        assert!(
+            screen.contains("no projects — run wf inside a checkout"),
+            "{screen}"
+        );
         assert!(!screen.contains("loading"), "{screen}");
     }
 
@@ -640,9 +793,10 @@ mod tests {
         .collect();
         app.startup = Startup::seeded(&found);
         app.startup.searched(&found);
-        app.startup.record_arrival(&MapId::new("blooop/wayfinder", 1));
+        app.startup
+            .record_arrival(&MapId::new("blooop/wayfinder", 1));
         let screen = render(&app);
-        assert!(screen.contains("#6    Re-entry breadcrumbs"), "{screen}");
+        assert!(screen.contains("#6 Re-entry breadcrumbs"), "{screen}");
         assert!(screen.contains("5/5  · loading maps 1/3"), "{screen}");
         // Rows exist, so the title names the project rather than the wait.
         assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
@@ -650,17 +804,26 @@ mod tests {
 
     #[test]
     fn the_body_scrolls_to_keep_the_cursor_on_screen() {
-        // One cluster of 30 done tickets ahead of a one-ticket cluster: the
-        // second cluster's rows start past the 24-row screen, and that is where
-        // the cursor must still be *visible* — a picker that cannot show what
-        // `enter` would pick is broken (the live 3-map repo hits exactly this).
+        // One cluster of 30 takeable tickets ahead of a one-ticket cluster:
+        // the second cluster's rows start past the 24-row screen, and that is
+        // where the cursor must still be *visible* — a picker that cannot show
+        // what `enter` would pick is broken.
         let mut clusters = BTreeMap::new();
         clusters.insert(
             MapId::new("blooop/wayfinder", 1),
             Map {
                 title: "Map: wf".to_string(),
                 tickets: (1..=30)
-                    .map(|n| ticket("blooop/wayfinder", n, &format!("Done {n}"), false, false, vec![]))
+                    .map(|n| {
+                        ticket(
+                            "blooop/wayfinder",
+                            n,
+                            &format!("Open {n}"),
+                            true,
+                            false,
+                            vec![],
+                        )
+                    })
                     .collect(),
             },
         );
@@ -668,7 +831,14 @@ mod tests {
             MapId::new("blooop/wayfinder", 47),
             Map {
                 title: "Map: the selection view".to_string(),
-                tickets: vec![ticket("blooop/wayfinder", 50, "Build: clusters", true, false, vec![])],
+                tickets: vec![ticket(
+                    "blooop/wayfinder",
+                    50,
+                    "Build: clusters",
+                    true,
+                    false,
+                    vec![],
+                )],
             },
         );
         let mut app = App::new(clusters);
@@ -677,13 +847,13 @@ mod tests {
         }
         assert_eq!(app.cursor_ticket().unwrap().number, 50);
         let screen = render(&app);
-        assert!(screen.contains("▶ ○ #50   Build: clusters"), "{screen}");
+        assert!(screen.contains("▶ ○ #50 Build: clusters"), "{screen}");
         // And with the cursor back at the top, the top is what shows.
         for _ in 0..40 {
             app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
         }
         let screen = render(&app);
-        assert!(screen.contains("▶ ● #1    Done 1"), "{screen}");
+        assert!(screen.contains("▶ ○ #1 Open 1"), "{screen}");
     }
 
     #[test]
@@ -693,6 +863,6 @@ mod tests {
         let screen = render(&app);
         assert!(screen.contains("wf · blooop/wayfinder — focused"));
         assert!(screen.contains("ctrl-g all projects"));
-        assert!(screen.contains("▶ ○ #6    Re-entry breadcrumbs"));
+        assert!(screen.contains("▶ ○ #6 Re-entry breadcrumbs"));
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,0 +1,595 @@
+//! The body plan (#51): which rows the screen shows, in what order, with what
+//! tree furniture.
+//!
+//! Everything the body draws is decided here as a [`Plan`] — one list that the
+//! cursor and the draw both walk, so the rows the cursor stops on are exactly
+//! the ticket rows on screen, in on-screen order. Three screens share it:
+//!
+//! - **Leverage** (the default): per cluster, the takeable tickets (frontier +
+//!   claimed) sorted most-open-dependents-first, each with the subtree of open
+//!   tickets it unblocks. Done collapses to a count; blocked tickets no subtree
+//!   reaches collapse to a count; a map with nothing takeable leaves the body
+//!   entirely and is only counted ([`Plan::idle_hidden`]).
+//! - **Forest** (`tab`): the whole DAG, done dimmed in place. Tree parent =
+//!   lowest-numbered in-map blocker; the other in-map blockers annotate the row
+//!   (`⤷ also needs #n`).
+//! - **Flattened** (a live query): one nucleo-score-ordered flat list across
+//!   every cluster in scope — no headers, no tree. Clearing the query restores
+//!   the structured screen.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::app::Row;
+use crate::filter;
+use crate::model::{Map, MapId, Status, Ticket};
+
+/// The structural screen `tab` toggles between — the half of the view state
+/// that is *stored*. The other half (whether a query is flattening the body)
+/// is derived from the query itself in [`Screen`], so the two can never
+/// disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lens {
+    /// The default: what can be taken now, and what taking it unlocks.
+    Leverage,
+    /// The whole DAG, done included — the escape hatch when the shape of the
+    /// finished work matters.
+    Forest,
+}
+
+impl Lens {
+    pub fn toggled(self) -> Lens {
+        match self {
+            Lens::Leverage => Lens::Forest,
+            Lens::Forest => Lens::Leverage,
+        }
+    }
+}
+
+/// What the body renders this frame. Derived (never stored) from the lens and
+/// the query: a live query flattens whichever lens is toggled, and clearing it
+/// restores that lens. `Flattened` carries the query, so a flattened screen
+/// without one is unrepresentable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Screen<'a> {
+    Structured(Lens),
+    Flattened { query: &'a str },
+}
+
+/// One line of the body. Only [`Item::Ticket`] is a cursor stop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Item {
+    /// A cluster header — the map this and the following rows belong to.
+    Header(MapId),
+    /// A ticket row.
+    Ticket {
+        row: Row,
+        /// Tree branch furniture ("├─", "│ └─", …). Empty at roots and on
+        /// every flattened row.
+        prefix: String,
+        /// Forest only: in-map blockers beyond the primary parent.
+        also_needs: Vec<u64>,
+    },
+    /// Leverage: `⊘ N blocked deeper down` — blocked tickets no rendered
+    /// subtree reached, so they are on screen only as this count.
+    BlockedDeeper(usize),
+    /// Leverage: `● N done (hidden)`.
+    DoneHidden(usize),
+    /// Spacer between clusters.
+    Blank,
+}
+
+/// The body, planned: the items in on-screen order, plus how many in-scope
+/// maps the leverage screen dropped for having nothing takeable.
+#[derive(Debug, Default)]
+pub struct Plan {
+    pub items: Vec<Item>,
+    pub idle_hidden: usize,
+}
+
+impl Plan {
+    /// The cursor stops, in on-screen order.
+    pub fn rows(&self) -> Vec<Row> {
+        self.items
+            .iter()
+            .filter_map(|item| match item {
+                Item::Ticket { row, .. } => Some(row.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// Plan the body for the clusters in scope, in their given (render) order.
+pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen) -> Plan {
+    match screen {
+        Screen::Structured(Lens::Leverage) => leverage(clusters),
+        Screen::Structured(Lens::Forest) => forest(clusters),
+        Screen::Flattened { query } => flattened(clusters, query),
+    }
+}
+
+fn takeable(t: &Ticket) -> bool {
+    matches!(t.status, Status::Frontier | Status::Claimed)
+}
+
+fn is_open(t: &Ticket) -> bool {
+    !matches!(t.status, Status::Done)
+}
+
+/// Open direct dependents of `number`, ascending — the subtree children in the
+/// leverage view, and the leverage sort key at the roots (done dependents are
+/// not leverage: they are already unlocked).
+fn open_unblocks(map: &Map, number: u64) -> Vec<u64> {
+    map.unblocks(number)
+        .into_iter()
+        .filter(|&n| map.index_of(n).map(|i| is_open(&map.tickets[i])) == Some(true))
+        .collect()
+}
+
+fn ticket_item(id: &MapId, index: usize, prefix: String, also_needs: Vec<u64>) -> Item {
+    Item::Ticket {
+        row: Row {
+            map: id.clone(),
+            index,
+        },
+        prefix,
+        also_needs,
+    }
+}
+
+fn leverage(clusters: &[(&MapId, &Map)]) -> Plan {
+    let mut plan = Plan::default();
+    for (id, map) in clusters {
+        let mut roots: Vec<&Ticket> = map.tickets.iter().filter(|t| takeable(t)).collect();
+        if roots.is_empty() {
+            plan.idle_hidden += 1;
+            continue;
+        }
+        roots.sort_by_key(|t| (Reverse(open_unblocks(map, t.number).len()), t.number));
+
+        plan.items.push(Item::Header((*id).clone()));
+        let mut reached = BTreeSet::new();
+        for root in roots {
+            let index = map
+                .index_of(root.number)
+                .expect("root is one of map.tickets");
+            plan.items
+                .push(ticket_item(id, index, String::new(), vec![]));
+            let mut path = vec![root.number];
+            walk_unblocks(
+                map,
+                id,
+                root.number,
+                "",
+                &mut path,
+                &mut reached,
+                &mut plan.items,
+            );
+        }
+
+        // Blocked tickets no subtree reached — blocked only through issues
+        // outside the map (or a blocking cycle): the screen owes a count for
+        // what it is not showing.
+        let deeper = map
+            .tickets
+            .iter()
+            .filter(|t| matches!(t.status, Status::Blocked { .. }) && !reached.contains(&t.number))
+            .count();
+        if deeper > 0 {
+            plan.items.push(Item::BlockedDeeper(deeper));
+        }
+        let done = map.tickets.iter().filter(|t| !is_open(t)).count();
+        if done > 0 {
+            plan.items.push(Item::DoneHidden(done));
+        }
+        plan.items.push(Item::Blank);
+    }
+    plan.items.pop();
+    plan
+}
+
+/// Render `number`'s open dependents as a subtree. A dependent that is itself
+/// takeable still shows here (what taking the root unlocks includes it) *and*
+/// as its own root; a dependent already on the current path is a blocking
+/// cycle and is skipped rather than recursed into.
+fn walk_unblocks(
+    map: &Map,
+    id: &MapId,
+    number: u64,
+    stem: &str,
+    path: &mut Vec<u64>,
+    reached: &mut BTreeSet<u64>,
+    items: &mut Vec<Item>,
+) {
+    let children: Vec<u64> = open_unblocks(map, number)
+        .into_iter()
+        .filter(|n| !path.contains(n))
+        .collect();
+    for (i, &child) in children.iter().enumerate() {
+        let last = i + 1 == children.len();
+        let index = map
+            .index_of(child)
+            .expect("dependent is one of map.tickets");
+        let branch = if last { "└─" } else { "├─" };
+        items.push(ticket_item(id, index, format!("{stem}{branch}"), vec![]));
+        reached.insert(child);
+        let next = if last {
+            format!("{stem}  ")
+        } else {
+            format!("{stem}│ ")
+        };
+        path.push(child);
+        walk_unblocks(map, id, child, &next, path, reached, items);
+        path.pop();
+    }
+}
+
+fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
+    let mut plan = Plan::default();
+    for (id, map) in clusters {
+        plan.items.push(Item::Header((*id).clone()));
+
+        // Primary parent = lowest-numbered in-map blocker; everything else on
+        // the edge list annotates the row.
+        let in_map_blockers = |t: &Ticket| -> Vec<u64> {
+            let mut blockers: Vec<u64> = t
+                .blocked_by
+                .iter()
+                .copied()
+                .filter(|&b| map.index_of(b).is_some())
+                .collect();
+            blockers.sort_unstable();
+            blockers
+        };
+        let mut children: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+        let mut roots: Vec<u64> = vec![];
+        for t in &map.tickets {
+            match in_map_blockers(t).first() {
+                Some(&parent) => children.entry(parent).or_default().push(t.number),
+                None => roots.push(t.number),
+            }
+        }
+        roots.sort_unstable();
+
+        let mut visited = BTreeSet::new();
+        for &root in &roots {
+            walk_forest(
+                map,
+                id,
+                root,
+                "",
+                None,
+                &children,
+                &in_map_blockers,
+                &mut visited,
+                &mut plan.items,
+            );
+        }
+        // A blocking cycle leaves its members parented to each other and
+        // reachable from no root; sweep them in as roots so the forest stays
+        // total — every ticket of the map is a row.
+        while let Some(orphan) = map
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .find(|n| !visited.contains(n))
+        {
+            walk_forest(
+                map,
+                id,
+                orphan,
+                "",
+                None,
+                &children,
+                &in_map_blockers,
+                &mut visited,
+                &mut plan.items,
+            );
+        }
+        plan.items.push(Item::Blank);
+    }
+    plan.items.pop();
+    plan
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_forest(
+    map: &Map,
+    id: &MapId,
+    number: u64,
+    stem: &str,
+    branch: Option<&str>,
+    children: &BTreeMap<u64, Vec<u64>>,
+    in_map_blockers: &dyn Fn(&Ticket) -> Vec<u64>,
+    visited: &mut BTreeSet<u64>,
+    items: &mut Vec<Item>,
+) {
+    if !visited.insert(number) {
+        return;
+    }
+    let index = map
+        .index_of(number)
+        .expect("forest node is one of map.tickets");
+    let also_needs: Vec<u64> = in_map_blockers(&map.tickets[index])
+        .into_iter()
+        .skip(1)
+        .collect();
+    let prefix = branch.map(|b| format!("{stem}{b}")).unwrap_or_default();
+    items.push(ticket_item(id, index, prefix, also_needs));
+
+    let kids = children.get(&number).cloned().unwrap_or_default();
+    for (i, &kid) in kids.iter().enumerate() {
+        let last = i + 1 == kids.len();
+        let next = match branch {
+            None => stem.to_string(),
+            Some(_) if last => format!("{stem}  "),
+            Some(_) => format!("{stem}│ "),
+        };
+        let kid_branch = if last { "└─" } else { "├─" };
+        walk_forest(
+            map,
+            id,
+            kid,
+            &next,
+            Some(kid_branch),
+            children,
+            in_map_blockers,
+            visited,
+            items,
+        );
+    }
+}
+
+fn flattened(clusters: &[(&MapId, &Map)], query: &str) -> Plan {
+    let mut scored: Vec<(Reverse<u32>, &MapId, u64, usize)> = Vec::new();
+    for (id, map) in clusters {
+        for (index, (ticket, score)) in map
+            .tickets
+            .iter()
+            .zip(filter::scores(&map.tickets, query))
+            .enumerate()
+        {
+            if let Some(score) = score {
+                scored.push((Reverse(score), id, ticket.number, index));
+            }
+        }
+    }
+    // Best score first; ties break to the stable (map, number) screen order.
+    scored.sort_by(|a, b| (a.0, a.1, a.2).cmp(&(b.0, b.1, b.2)));
+    Plan {
+        items: scored
+            .into_iter()
+            .map(|(_, id, _, index)| ticket_item(id, index, String::new(), vec![]))
+            .collect(),
+        idle_hidden: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{classify, TicketType};
+
+    fn ticket(number: u64, open: bool, assigned: bool, blocked_by: Vec<u64>) -> Ticket {
+        let open_blockers = blocked_by.clone(); // callers pass open blockers in fixtures
+        Ticket {
+            repo: "blooop/wayfinder".to_string(),
+            number,
+            title: format!("t{number}"),
+            status: classify(open, assigned, if open { open_blockers } else { vec![] }),
+            ticket_type: TicketType::Task,
+            blocked_by,
+        }
+    }
+
+    /// Blocked status honestly derived: a blocker is "open" iff it is an open
+    /// ticket of this map (fixtures never blocked on out-of-map issues unless
+    /// the test says so).
+    fn map(tickets: Vec<Ticket>) -> Map {
+        let open: BTreeSet<u64> = tickets
+            .iter()
+            .filter(|t| is_open(t))
+            .map(|t| t.number)
+            .collect();
+        let tickets = tickets
+            .into_iter()
+            .map(|mut t| {
+                if matches!(t.status, Status::Frontier | Status::Blocked { .. }) {
+                    let needs: Vec<u64> = t
+                        .blocked_by
+                        .iter()
+                        .copied()
+                        .filter(|b| open.contains(b))
+                        .collect();
+                    t.status = classify(true, false, needs);
+                }
+                t
+            })
+            .collect();
+        Map {
+            title: "Map: fixture".to_string(),
+            tickets,
+        }
+    }
+
+    /// Ticket numbers of the plan's cursor stops, resolved against `map`.
+    fn stops(plan: &Plan, m: &Map) -> Vec<u64> {
+        plan.rows()
+            .iter()
+            .map(|r| m.tickets[r.index].number)
+            .collect()
+    }
+
+    fn id() -> MapId {
+        MapId::new("blooop/wayfinder", 47)
+    }
+
+    #[test]
+    fn leverage_sorts_takeable_by_open_dependents_and_walks_subtrees() {
+        // #6 unblocks #7 and #8 (both blocked); #9 unblocks nothing; #2 done.
+        let m = map(vec![
+            ticket(2, false, false, vec![]),
+            ticket(6, true, false, vec![]),
+            ticket(7, true, false, vec![6]),
+            ticket(8, true, false, vec![6]),
+            ticket(9, true, false, vec![]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Leverage));
+        // Roots: #6 (2 dependents) before #9 (0); each root's subtree follows it.
+        assert_eq!(stops(&plan, &m), vec![6, 7, 8, 9]);
+        // The blocked tickets were reached, and the done one collapsed.
+        assert!(!plan.items.contains(&Item::BlockedDeeper(2)));
+        assert!(plan.items.contains(&Item::DoneHidden(1)));
+    }
+
+    #[test]
+    fn leverage_counts_what_no_subtree_reaches() {
+        // #7 blocked only by an out-of-map issue: no root's subtree reaches it.
+        // Built without the `map` helper — that helper derives blocked status
+        // from in-map blockers, and this blocker is deliberately not one.
+        let m = Map {
+            title: "Map: fixture".to_string(),
+            tickets: vec![
+                ticket(6, true, false, vec![]),
+                ticket(7, true, false, vec![999]),
+            ],
+        };
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Leverage));
+        assert_eq!(stops(&plan, &m), vec![6]);
+        assert!(
+            plan.items.contains(&Item::BlockedDeeper(1)),
+            "{:?}",
+            plan.items
+        );
+    }
+
+    #[test]
+    fn leverage_drops_idle_maps_and_counts_them() {
+        let idle = map(vec![ticket(2, false, false, vec![])]);
+        let live = map(vec![ticket(6, true, false, vec![])]);
+        let idle_id = MapId::new("blooop/dotfiles", 4);
+        let live_id = id();
+        let plan = plan(
+            &[(&idle_id, &idle), (&live_id, &live)],
+            Screen::Structured(Lens::Leverage),
+        );
+        assert_eq!(plan.idle_hidden, 1);
+        assert!(
+            plan.items
+                .iter()
+                .all(|i| !matches!(i, Item::Header(h) if h == &idle_id)),
+            "the idle cluster left the body: {:?}",
+            plan.items
+        );
+        assert!(plan.items.contains(&Item::Header(live_id)));
+    }
+
+    #[test]
+    fn leverage_shows_a_claimed_dependent_in_the_subtree_and_as_a_root() {
+        // #9 is claimed *and* a dependent of frontier #6 — the accepted
+        // prototype shows both: it is takeable, and taking #6 concerns it.
+        let mut claimed = ticket(9, true, true, vec![6]);
+        claimed.status = Status::Claimed;
+        let m = map(vec![ticket(6, true, false, vec![]), claimed]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Leverage));
+        assert_eq!(stops(&plan, &m), vec![6, 9, 9]);
+    }
+
+    #[test]
+    fn a_blocking_cycle_does_not_hang_the_leverage_walk() {
+        // #7 and #8 block each other, both unblocked-by frontier #6.
+        let m = map(vec![
+            ticket(6, true, false, vec![]),
+            ticket(7, true, false, vec![6, 8]),
+            ticket(8, true, false, vec![7]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Leverage));
+        // #7 under #6; #8 under #7; the back-edge #8→#7 is skipped, not recursed.
+        assert_eq!(stops(&plan, &m), vec![6, 7, 8]);
+    }
+
+    #[test]
+    fn forest_is_total_with_done_in_place_and_extra_edges_annotated() {
+        // #14 needs #6 and #9: parent is #6 (lowest), #9 annotates.
+        let m = map(vec![
+            ticket(2, false, false, vec![]),
+            ticket(6, true, false, vec![]),
+            ticket(9, true, true, vec![]),
+            ticket(14, true, false, vec![6, 9]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Forest));
+        assert_eq!(
+            stops(&plan, &m),
+            vec![2, 6, 14, 9],
+            "roots ascend, children under parents"
+        );
+        let annotated = plan.items.iter().any(|item| {
+            matches!(item, Item::Ticket { row, also_needs, .. }
+                if m.tickets[row.index].number == 14 && also_needs == &vec![9])
+        });
+        assert!(annotated, "{:?}", plan.items);
+        assert_eq!(plan.idle_hidden, 0, "the forest hides nothing");
+    }
+
+    #[test]
+    fn forest_sweeps_a_blocking_cycle_in_rather_than_losing_it() {
+        let m = map(vec![
+            ticket(7, true, false, vec![8]),
+            ticket(8, true, false, vec![7]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Forest));
+        assert_eq!(
+            stops(&plan, &m),
+            vec![7, 8],
+            "every ticket is a row exactly once"
+        );
+    }
+
+    #[test]
+    fn flattened_orders_by_score_across_clusters_with_no_furniture() {
+        let a = map(vec![
+            ticket(6, true, false, vec![]),
+            ticket(7, false, false, vec![]),
+        ]);
+        let b = map(vec![ticket(103, true, false, vec![])]);
+        let a_id = id();
+        let b_id = MapId::new("blooop/dotfiles", 4);
+        let plan = plan(
+            &[(&b_id, &b), (&a_id, &a)],
+            Screen::Flattened { query: "t" },
+        );
+        // Everything matches "t"; no headers, blanks, or counts — rows only.
+        assert!(
+            plan.items.iter().all(|i| matches!(i, Item::Ticket { .. })),
+            "{:?}",
+            plan.items
+        );
+        assert_eq!(plan.rows().len(), 3, "done tickets stay findable by query");
+        assert_eq!(plan.idle_hidden, 0);
+    }
+
+    #[test]
+    fn flattened_puts_the_better_match_first_regardless_of_cluster_order() {
+        let mut exact = ticket(6, true, false, vec![]);
+        exact.title = "breadcrumbs".to_string();
+        let mut loose = ticket(103, true, false, vec![]);
+        loose.title = "b-r-e-a-d spelled out crumbs".to_string();
+        let a = map(vec![loose]);
+        let b = map(vec![exact]);
+        let a_id = MapId::new("blooop/dotfiles", 4); // sorts before wayfinder
+        let b_id = id();
+        let plan = plan(
+            &[(&a_id, &a), (&b_id, &b)],
+            Screen::Flattened { query: "bread" },
+        );
+        let first = plan.rows()[0].clone();
+        assert_eq!(first.map, b_id, "score outranks cluster order");
+    }
+}

--- a/tests/live_discovery.rs
+++ b/tests/live_discovery.rs
@@ -16,7 +16,10 @@ async fn registering_this_checkout_finds_and_fetches_its_map() {
         .await
         .expect("this test must run inside the wayfinder checkout");
     assert_eq!(slug, "blooop/wayfinder");
-    assert!(toplevel.join("Cargo.toml").exists(), "toplevel: {toplevel:?}");
+    assert!(
+        toplevel.join("Cargo.toml").exists(),
+        "toplevel: {toplevel:?}"
+    );
 
     // Register: the explicit-open act, into a throwaway cache file.
     let cache_file = std::env::temp_dir()

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -10,7 +10,11 @@ async fn fetches_the_live_wayfinder_map() {
         .await
         .expect("live fetch of blooop/wayfinder map #1");
 
-    assert!(map.title.starts_with("Map:"), "map issue title: {}", map.title);
+    assert!(
+        map.title.starts_with("Map:"),
+        "map issue title: {}",
+        map.title
+    );
     assert!(
         map.tickets.len() >= 7,
         "expected the real map's tickets, got {}",
@@ -42,15 +46,34 @@ async fn fetches_the_live_wayfinder_map() {
     // every ticket's `wayfinder:*` type comes back parsed. This map's types are
     // known facts — #3 is research, #19 is the build task, #18 is a grilling —
     // so a query GitHub silently dropped labels from would show up as Untyped.
-    let typed = |n: u64| map.tickets.iter().find(|t| t.number == n).map(|t| t.ticket_type);
-    assert_eq!(typed(3), Some(TicketType::Research), "#3 is wayfinder:research");
+    let typed = |n: u64| {
+        map.tickets
+            .iter()
+            .find(|t| t.number == n)
+            .map(|t| t.ticket_type)
+    };
+    assert_eq!(
+        typed(3),
+        Some(TicketType::Research),
+        "#3 is wayfinder:research"
+    );
     assert_eq!(typed(19), Some(TicketType::Task), "#19 is wayfinder:task");
-    assert_eq!(typed(18), Some(TicketType::Grilling), "#18 is wayfinder:grilling");
-    assert_eq!(typed(9), Some(TicketType::Prototype), "#9 is wayfinder:prototype");
+    assert_eq!(
+        typed(18),
+        Some(TicketType::Grilling),
+        "#18 is wayfinder:grilling"
+    );
+    assert_eq!(
+        typed(9),
+        Some(TicketType::Prototype),
+        "#9 is wayfinder:prototype"
+    );
     // The map issue itself is not a sub-issue, so nothing on the map carries
     // `wayfinder:map`; every ticket here is one of the four real types.
     assert!(
-        map.tickets.iter().all(|t| t.ticket_type != TicketType::Untyped),
+        map.tickets
+            .iter()
+            .all(|t| t.ticket_type != TicketType::Untyped),
         "every ticket on this map is labelled: {:?}",
         map.tickets
             .iter()

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -143,7 +143,10 @@ fn spawn_reader(master: OwnedFd) -> Arc<Mutex<Vec<u8>>> {
                 // The child exited, or the pty master gave `EIO` because the
                 // last slave closed. Both mean "no more output".
                 Ok(0) | Err(_) => break,
-                Ok(n) => sink.lock().expect("reader mutex").extend_from_slice(&buf[..n]),
+                Ok(n) => sink
+                    .lock()
+                    .expect("reader mutex")
+                    .extend_from_slice(&buf[..n]),
             }
         }
     });


### PR DESCRIPTION
Closes #51 — lands the view model chosen in #48.

## What changed

- **New `src/view.rs`**: the body is planned as one list of items that both the cursor and the draw walk, so cursor order and screen order cannot disagree. The view state is a sum type — `Screen::Structured(Lens::{Leverage,Forest}) | Flattened { query }` — derived from the stored `Lens` plus the query, never stored itself, so *flattened without a query* is unrepresentable.
- **Leverage view is the default screen**: per cluster, takeable tickets (frontier + claimed) sorted by open direct dependents, each with the subtree of open tickets it unblocks. Done collapses to `● N done (hidden)`; blocked tickets no subtree reaches collapse to `⊘ N blocked deeper down`; a map with nothing takeable leaves the body, counted on the count line as `· N idle maps hidden`.
- **`tab` toggles the structure forest**: the whole DAG with done dimmed in place, tree parent = lowest-numbered in-map blocker, `⤷ also needs #n` for edges the tree cannot show. Blocking cycles are swept in rather than lost, and the walks are cycle-guarded.
- **A live query flattens** either screen into one nucleo-score-ordered flat list whose rows name their repo; clearing the query restores the toggled lens. The grouped frontier/claimed/blocked/done view and its 2a groups-survive-typing rule retire.
- **Row anatomy** `<glyph> #n <title> [type]` — ticket types visible for the first time. PR badges are #52's slice, not this one.

## Judgment calls (also breadcrumbed on #51)

- Leverage roots sort by **open** direct dependents — a root whose dependents are all done has no leverage left.
- `⊘ N blocked deeper down` counts blocked tickets *not rendered in any subtree* (truthful), rather than the prototype's no-direct-takeable-blocker approximation.
- A claimed dependent shows both in its blocker's subtree and as its own root, per the accepted prototype; the cursor matches by stop position, not row identity, so the duplicate is harmless.

Tests: 113 pass, including the live pty end-to-end launch test; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a unified view planning layer that drives the main screen, making the leverage view the default and adding a toggleable structure forest and query-driven flattened screen.

New Features:
- Add a leverage-based default view per map cluster, showing takeable tickets with their unlocked subtrees and collapsing done/blocked summaries into counts.
- Introduce a structure forest screen toggled by tab that renders the full blocking DAG with in-place done tickets and explicit extra blocking edges.
- Enable live fuzzy queries to flatten all clusters into a single score-ordered list where rows name their repo and can be navigated independently of structured views.
- Display ticket types on rows via a compact [type] suffix derived from wayfinder:* labels.

Enhancements:
- Refactor UI rendering to use a shared Plan and Item model so cursor stops and visible rows are always consistent across leverage, forest, and flattened views.
- Update cursor behavior, scrolling, and project focusing to respect the new planned views, preserving ticket anchors across lens toggles and scope changes.
- Adjust bottom chrome to show idle map counts and new key hints for tab-based structure toggling and flattened queries.

Documentation:
- Revise README and top-level crate documentation to describe leverage as the default screen, the structure forest on tab, and query-driven flattened views, including updated keybindings and row format.

Tests:
- Expand unit and integration tests to cover leverage ordering, forest completeness, flattened scoring behavior, idle map handling, lens toggling, cursor anchoring, and live query semantics.
- Update live fetch and discovery tests to validate ticket typing, map parsing, and startup hints under the new view model.