### PR TITLE
Build 10 — PR badges on ticket rows (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ focusing a project shows all of them.
 tickets (frontier and claimed), sorted by how many open tickets each one
 unblocks, with that unblocks-subtree drawn beneath it — so the next ticket is
 chosen by what taking it unlocks, not by status alone. Rows are
-`<glyph> #n <title> [type]`. Done work collapses to a per-cluster
+`<glyph> #n <title> [type] ⇄ PR#n <state>` — the `⇄` badges are the ticket's
+linked pull requests (GitHub's Development-panel set: closing keywords and
+manual links), shown as `draft`/`open`/`merged`/`closed` with `✓`/`✗` on an
+open PR when its checks and review are settled or need action. Done work
+collapses to a per-cluster
 `● N done (hidden)` count; blocked tickets no subtree reaches collapse to
 `⊘ N blocked deeper down`; a map with nothing takeable leaves the body
 entirely, counted on the bottom line as `· N idle maps hidden`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -477,6 +477,7 @@ mod tests {
             status: classify(open, assigned, needs.clone()),
             ticket_type: TicketType::Task,
             blocked_by: needs,
+            prs: vec![],
         }
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -30,7 +30,9 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tokio::process::Command;
 
-use crate::model::{classify, Map, MapId, MapSet, Ticket, TicketType};
+use crate::model::{
+    classify, Checks, Map, MapId, MapSet, PrLink, PrStatus, Review, Ticket, TicketType,
+};
 
 /// The label that makes an issue a map. Both the search that *finds* maps and
 /// the fetch that *reads* one test for this, so a cached number can never be
@@ -50,6 +52,13 @@ query($owner: String!, $name: String!, $number: Int!) {
           labels(first: 10) { nodes { name } }
           assignees(first: 5) { nodes { login } }
           blockedBy(first: 50) { nodes { number state } }
+          closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
+            nodes {
+              number state isDraft reviewDecision
+              statusCheckRollup { state }
+              repository { nameWithOwner }
+            }
+          }
         }
       }
     }
@@ -92,6 +101,12 @@ struct Nodes<T> {
     nodes: Vec<T>,
 }
 
+impl<T> Default for Nodes<T> {
+    fn default() -> Self {
+        Self { nodes: Vec::new() }
+    }
+}
+
 #[derive(Deserialize)]
 struct SubIssue {
     number: u64,
@@ -101,6 +116,11 @@ struct SubIssue {
     assignees: Nodes<Assignee>,
     #[serde(rename = "blockedBy")]
     blocked_by: Nodes<Blocker>,
+    /// Defaulted so a response without the selection (older fixtures, a
+    /// GitHub edition without the field) parses as "no linked PRs" rather
+    /// than failing the whole map.
+    #[serde(rename = "closedByPullRequestsReferences", default)]
+    closed_by_prs: Nodes<PrNode>,
 }
 
 #[derive(Deserialize)]
@@ -118,6 +138,65 @@ struct Assignee {
 struct Blocker {
     number: u64,
     state: String,
+}
+
+#[derive(Deserialize)]
+struct PrNode {
+    number: u64,
+    state: String,
+    #[serde(rename = "isDraft")]
+    is_draft: bool,
+    /// Nullable with meaning: null is "no review required" (#49).
+    #[serde(rename = "reviewDecision")]
+    review_decision: Option<String>,
+    /// Nullable with meaning: null is "no checks configured" (#49).
+    #[serde(rename = "statusCheckRollup")]
+    status_check_rollup: Option<Rollup>,
+    repository: RepoRef,
+}
+
+#[derive(Deserialize)]
+struct Rollup {
+    state: String,
+}
+
+#[derive(Deserialize)]
+struct RepoRef {
+    #[serde(rename = "nameWithOwner")]
+    name_with_owner: String,
+}
+
+/// Interpret one linked PR (#52). `None` for a PR whose `state` this binary
+/// does not recognise — the badge is evidence, and no badge is better than a
+/// wrong one. The inner strings are open GraphQL enums too: an unknown check
+/// rollup or review decision reads as "in flight", the only claim that stays
+/// true whatever the new value means.
+fn parse_pr(pr: &PrNode) -> Option<PrLink> {
+    let status = match (pr.state.as_str(), pr.is_draft) {
+        ("MERGED", _) => PrStatus::Merged,
+        ("CLOSED", _) => PrStatus::Closed,
+        ("OPEN", true) => PrStatus::Draft,
+        ("OPEN", false) => PrStatus::Open {
+            checks: match pr.status_check_rollup.as_ref().map(|r| r.state.as_str()) {
+                None => Checks::Absent,
+                Some("SUCCESS") => Checks::Passing,
+                Some("FAILURE") | Some("ERROR") => Checks::Failing,
+                Some(_) => Checks::Pending, // EXPECTED, PENDING, or newer
+            },
+            review: match pr.review_decision.as_deref() {
+                None => Review::NotRequired,
+                Some("APPROVED") => Review::Approved,
+                Some("CHANGES_REQUESTED") => Review::ChangesRequested,
+                Some(_) => Review::Required, // REVIEW_REQUIRED, or newer
+            },
+        },
+        _ => return None,
+    };
+    Some(PrLink {
+        repo: pr.repository.name_with_owner.clone(),
+        number: pr.number,
+        status,
+    })
 }
 
 fn is_open(state: &str) -> bool {
@@ -205,6 +284,12 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
                 .map(|b| b.number)
                 .collect();
             let blocked_by: Vec<u64> = sub.blocked_by.nodes.iter().map(|b| b.number).collect();
+            let prs: Vec<PrLink> = sub
+                .closed_by_prs
+                .nodes
+                .iter()
+                .filter_map(parse_pr)
+                .collect();
             Ticket {
                 repo: id.repo.clone(),
                 number: sub.number,
@@ -218,6 +303,7 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
                     sub.labels.nodes.iter().map(|l| l.name.as_str()),
                 ),
                 blocked_by,
+                prs,
             }
         })
         .collect();
@@ -425,6 +511,93 @@ mod tests {
                 "unexpected error: {err}"
             );
         }
+    }
+
+    /// One sub-issue carrying the full PR-badge matrix (#52).
+    const PR_RESPONSE: &str = r#"{"data": {"repository": {"issue": {
+        "title": "Map: wf",
+        "state": "OPEN",
+        "labels": {"nodes": [{"name": "wayfinder:map"}]},
+        "subIssues": {"nodes": [
+            {"number": 30, "title": "Raw tty leak", "state": "OPEN",
+             "labels": {"nodes": []},
+             "assignees": {"nodes": []},
+             "blockedBy": {"nodes": []},
+             "closedByPullRequestsReferences": {"nodes": [
+                {"number": 33, "state": "MERGED", "isDraft": false,
+                 "reviewDecision": null, "statusCheckRollup": {"state": "SUCCESS"},
+                 "repository": {"nameWithOwner": "blooop/wayfinder"}},
+                {"number": 40, "state": "OPEN", "isDraft": false,
+                 "reviewDecision": "CHANGES_REQUESTED", "statusCheckRollup": {"state": "FAILURE"},
+                 "repository": {"nameWithOwner": "blooop/wayfinder"}},
+                {"number": 41, "state": "OPEN", "isDraft": false,
+                 "reviewDecision": null, "statusCheckRollup": null,
+                 "repository": {"nameWithOwner": "blooop/dotfiles"}},
+                {"number": 42, "state": "OPEN", "isDraft": true,
+                 "reviewDecision": "REVIEW_REQUIRED", "statusCheckRollup": {"state": "PENDING"},
+                 "repository": {"nameWithOwner": "blooop/wayfinder"}},
+                {"number": 43, "state": "CLOSED", "isDraft": false,
+                 "reviewDecision": null, "statusCheckRollup": null,
+                 "repository": {"nameWithOwner": "blooop/wayfinder"}},
+                {"number": 44, "state": "SOMETHING_NEW", "isDraft": false,
+                 "reviewDecision": null, "statusCheckRollup": null,
+                 "repository": {"nameWithOwner": "blooop/wayfinder"}}
+             ]}}
+        ]}
+    }}}}"#;
+
+    #[test]
+    fn linked_prs_parse_into_badge_facts_at_the_boundary() {
+        let map = parse_map(PR_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+        let prs = &map.tickets[0].prs;
+        assert_eq!(
+            prs,
+            &vec![
+                // Merged wins over whatever the rollup says: it is history.
+                PrLink {
+                    repo: "blooop/wayfinder".to_string(),
+                    number: 33,
+                    status: PrStatus::Merged,
+                },
+                PrLink {
+                    repo: "blooop/wayfinder".to_string(),
+                    number: 40,
+                    status: PrStatus::Open {
+                        checks: Checks::Failing,
+                        review: Review::ChangesRequested,
+                    },
+                },
+                // Nulls mean things (#49): no checks configured, no review
+                // required — not missing data.
+                PrLink {
+                    repo: "blooop/dotfiles".to_string(),
+                    number: 41,
+                    status: PrStatus::Open {
+                        checks: Checks::Absent,
+                        review: Review::NotRequired,
+                    },
+                },
+                // Draft is parsed with state, not left as a flag to remember.
+                PrLink {
+                    repo: "blooop/wayfinder".to_string(),
+                    number: 42,
+                    status: PrStatus::Draft,
+                },
+                PrLink {
+                    repo: "blooop/wayfinder".to_string(),
+                    number: 43,
+                    status: PrStatus::Closed,
+                },
+                // #44's unrecognised state produced no badge at all.
+            ]
+        );
+    }
+
+    #[test]
+    fn a_response_without_the_pr_selection_still_parses() {
+        // MAP_RESPONSE predates the #52 selection: absent connection, no PRs.
+        let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+        assert!(map.tickets.iter().all(|t| t.prs.is_empty()));
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -55,6 +55,7 @@ mod tests {
             status: Status::Frontier,
             ticket_type: TicketType::Task,
             blocked_by: vec![],
+            prs: vec![],
         }
     }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -209,6 +209,7 @@ mod tests {
             status: classify(true, false, vec![]),
             ticket_type: TicketType::Task,
             blocked_by: vec![],
+            prs: vec![],
         }
     }
 
@@ -341,6 +342,7 @@ mod tests {
             status: Status::Done,
             ticket_type: TicketType::Task,
             blocked_by: vec![],
+            prs: vec![],
         };
         match plan(&cache(), &done, 1) {
             Targets::One(launch) => assert_eq!(launch.key(), "wayfinder#2"),

--- a/src/model.rs
+++ b/src/model.rs
@@ -172,6 +172,61 @@ impl TicketType {
     }
 }
 
+/// One pull request linked to a ticket — GitHub's Development-panel link set
+/// (closing keywords and manual links, mentions excluded; the #49 resolution),
+/// shown as a `⇄` badge on the ticket's row. Evidence of progress, never a row
+/// of its own (#47).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrLink {
+    /// Full slug of the repo the PR lives in. Links are cross-repo capable,
+    /// so this may differ from the ticket's repo — the badge says so when it
+    /// does.
+    pub repo: String,
+    pub number: u64,
+    pub status: PrStatus,
+}
+
+impl PrLink {
+    /// The short repo name (display only), for badges on cross-repo PRs.
+    pub fn short_repo(&self) -> &str {
+        self.repo.split('/').next_back().unwrap_or(&self.repo)
+    }
+}
+
+/// Where a linked PR stands — `state` + `isDraft` parsed together at the `gh`
+/// boundary, so "draft" is a state of its own rather than a flag to remember
+/// to check. Only an open, ready PR carries the live signals: checks and
+/// review are questions about something still in flight.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrStatus {
+    Draft,
+    Open { checks: Checks, review: Review },
+    Merged,
+    Closed,
+}
+
+/// The check rollup on an open PR. `Absent` is its own meaning — no checks
+/// configured — parsed from the *nullable* `statusCheckRollup` (#49), not a
+/// stand-in for "unknown".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Checks {
+    Absent,
+    Pending,
+    Passing,
+    Failing,
+}
+
+/// The review decision on an open PR. A null `reviewDecision` means no review
+/// is required (#49) — `NotRequired`, a settled state — where `Required` is a
+/// review asked for and not yet given.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Review {
+    NotRequired,
+    Required,
+    Approved,
+    ChangesRequested,
+}
+
 /// One ticket (sub-issue) on a map.
 #[derive(Debug, Clone)]
 pub struct Ticket {
@@ -193,6 +248,8 @@ pub struct Ticket {
     /// derived locally by inversion ([`Map::unblocks`]); the numbers may name
     /// issues outside the map, which inversion simply never visits.
     pub blocked_by: Vec<u64>,
+    /// The PRs linked to this ticket (#52), in the tracker's order.
+    pub prs: Vec<PrLink>,
 }
 
 impl Ticket {
@@ -385,6 +442,7 @@ mod tests {
             status: Status::Frontier,
             ticket_type: TicketType::Task,
             blocked_by: vec![],
+            prs: vec![],
         };
         assert_eq!(t.short_repo(), "wayfinder");
     }
@@ -415,6 +473,7 @@ mod tests {
             status: classify(open, false, vec![]),
             ticket_type: TicketType::Task,
             blocked_by,
+            prs: vec![],
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,8 +2,9 @@
 //! [`Plan`] (#51). The default is the leverage view — takeable tickets,
 //! most-dependents-first, each with the subtree it unblocks — with the full
 //! blocking forest on `tab` and a live query flattening either into one
-//! score-ordered list. Rows are `<glyph> #n <title> [type]`; done work is a
-//! per-cluster count on the default screen and dimmed in place on the forest.
+//! score-ordered list. Rows are `<glyph> #n <title> [type] ⇄ PR#n <state>`;
+//! done work is a per-cluster count on the default screen and dimmed in place
+//! on the forest.
 
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -12,7 +13,7 @@ use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
-use crate::model::{Map, MapId, Status, Ticket};
+use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, Status, Ticket};
 use crate::view::{Item, Plan, Screen};
 
 fn glyph_style(status: &Status) -> Style {
@@ -50,10 +51,50 @@ fn cluster_header(id: &MapId, map: &Map) -> Line<'static> {
     Line::from(spans)
 }
 
+/// The `⇄ PR#n <state>` badge spans for one linked PR (#52) — evidence of the
+/// ticket's progress, riding after the `[type]` suffix. An open PR folds its
+/// two live signals into one glyph: `✗` when something needs acting on (checks
+/// failing or changes requested), `✓` when nothing is outstanding, nothing
+/// while it is still in flight. A PR living in another repo names it — links
+/// are cross-repo capable and the badge must not imply otherwise.
+fn pr_badge(ticket_repo: &str, pr: &PrLink) -> Vec<Span<'static>> {
+    let repo = if pr.repo == ticket_repo {
+        String::new()
+    } else {
+        format!(" {}", pr.short_repo())
+    };
+    let (word, verdict) = match &pr.status {
+        PrStatus::Draft => ("draft", None),
+        PrStatus::Merged => ("merged", None),
+        PrStatus::Closed => ("closed", None),
+        PrStatus::Open { checks, review } => {
+            let acting_needed =
+                matches!(checks, Checks::Failing) || matches!(review, Review::ChangesRequested);
+            let settled = matches!(checks, Checks::Passing | Checks::Absent)
+                && matches!(review, Review::Approved | Review::NotRequired);
+            let verdict = if acting_needed {
+                Some(Span::styled(" ✗", Style::new().fg(Color::Red)))
+            } else if settled {
+                Some(Span::styled(" ✓", Style::new().fg(Color::Green)))
+            } else {
+                None
+            };
+            ("open", verdict)
+        }
+    };
+    let mut spans = vec![Span::styled(
+        format!("  ⇄ PR{repo}#{} {word}", pr.number),
+        Style::new().fg(Color::Magenta),
+    )];
+    spans.extend(verdict);
+    spans
+}
+
 /// One ticket row: cursor marker, tree furniture, state glyph, `#n title`,
-/// then the dim `[type]` suffix — and on the forest, the extra blocking edges
-/// the tree position cannot show (`⤷ also needs #n`). The flattened screen has
-/// no cluster header above the row, so the row names its repo itself.
+/// then the dim `[type]` suffix and any `⇄ PR` badges — and on the forest, the
+/// extra blocking edges the tree position cannot show (`⤷ also needs #n`). The
+/// flattened screen has no cluster header above the row, so the row names its
+/// repo itself.
 fn ticket_line(
     ticket: &Ticket,
     prefix: &str,
@@ -81,6 +122,9 @@ fn ticket_line(
             format!(" [{name}]"),
             Style::new().add_modifier(Modifier::DIM),
         ));
+    }
+    for pr in &ticket.prs {
+        spans.extend(pr_badge(&ticket.repo, pr));
     }
     if !also_needs.is_empty() {
         let needs: Vec<String> = also_needs.iter().map(|n| format!("#{n}")).collect();
@@ -384,6 +428,7 @@ mod tests {
             status: classify(open, assigned, needs.clone()),
             ticket_type: TicketType::Task,
             blocked_by: needs,
+            prs: vec![],
         }
     }
 
@@ -503,6 +548,82 @@ mod tests {
             screen.contains("#6 Re-entry breadcrumbs [task]"),
             "{screen}"
         );
+    }
+
+    #[test]
+    fn pr_badges_ride_their_ticket_row() {
+        let mut map = wf_map();
+        let t6 = map
+            .tickets
+            .iter_mut()
+            .find(|t| t.number == 6)
+            .expect("#6 in the fixture");
+        t6.prs = vec![
+            PrLink {
+                repo: "blooop/wayfinder".to_string(),
+                number: 46,
+                status: PrStatus::Merged,
+            },
+            // Cross-repo, and with both live signals demanding action.
+            PrLink {
+                repo: "blooop/dotfiles".to_string(),
+                number: 12,
+                status: PrStatus::Open {
+                    checks: Checks::Failing,
+                    review: Review::ChangesRequested,
+                },
+            },
+        ];
+        // Nothing outstanding on #9's PR: checks pass, no review required.
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 9)
+            .expect("#9 in the fixture")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 13,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::NotRequired,
+            },
+        }];
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let app = App::new(clusters);
+        let screen = render(&app);
+        // Same-repo badge: `⇄ PR#n <state>` after the [type] suffix.
+        assert!(
+            screen.contains("Re-entry breadcrumbs [task]  ⇄ PR#46 merged"),
+            "{screen}"
+        );
+        // Cross-repo badge names the PR's repo; ✗ folds failing checks and a
+        // changes-requested review into one act-on-it signal.
+        assert!(screen.contains("⇄ PR dotfiles#12 open ✗"), "{screen}");
+        // ✓ only when nothing is outstanding.
+        assert!(screen.contains("⇄ PR#13 open ✓"), "{screen}");
+    }
+
+    #[test]
+    fn an_in_flight_open_pr_gets_no_verdict_glyph() {
+        let mut map = wf_map();
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 6)
+            .expect("#6")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 14,
+            status: PrStatus::Open {
+                checks: Checks::Pending,
+                review: Review::Required,
+            },
+        }];
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let screen = render(&App::new(clusters));
+        assert!(screen.contains("⇄ PR#14 open"), "{screen}");
+        assert!(!screen.contains('✓'), "{screen}");
+        assert!(!screen.contains('✗'), "{screen}");
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -259,7 +259,7 @@ fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
                 id,
                 root,
                 "",
-                None,
+                "",
                 &children,
                 &in_map_blockers,
                 &mut visited,
@@ -280,7 +280,7 @@ fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
                 id,
                 orphan,
                 "",
-                None,
+                "",
                 &children,
                 &in_map_blockers,
                 &mut visited,
@@ -293,13 +293,20 @@ fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
     plan
 }
 
+/// Render `number` and its subtree.
+///
+/// The two prefixes are deliberately separate values. `prefix` is this node's
+/// own line furniture, complete; `stem` is the continuation its *children*
+/// hang from — the ancestors' vertical bars. Deriving one from the other is
+/// what makes deep trees drift a level: a node's line and its children's lines
+/// belong to different depths.
 #[allow(clippy::too_many_arguments)]
 fn walk_forest(
     map: &Map,
     id: &MapId,
     number: u64,
+    prefix: &str,
     stem: &str,
-    branch: Option<&str>,
     children: &BTreeMap<u64, Vec<u64>>,
     in_map_blockers: &dyn Fn(&Ticket) -> Vec<u64>,
     visited: &mut BTreeSet<u64>,
@@ -315,24 +322,24 @@ fn walk_forest(
         .into_iter()
         .skip(1)
         .collect();
-    let prefix = branch.map(|b| format!("{stem}{b}")).unwrap_or_default();
-    items.push(ticket_item(id, index, prefix, also_needs));
+    items.push(ticket_item(id, index, prefix.to_string(), also_needs));
 
     let kids = children.get(&number).cloned().unwrap_or_default();
     for (i, &kid) in kids.iter().enumerate() {
         let last = i + 1 == kids.len();
-        let next = match branch {
-            None => stem.to_string(),
-            Some(_) if last => format!("{stem}  "),
-            Some(_) => format!("{stem}│ "),
+        // The last child closes its branch and its subtree hangs from blank
+        // space; every earlier child keeps the vertical bar running past it.
+        let (branch, continuation) = if last {
+            ("└─", "  ")
+        } else {
+            ("├─", "│ ")
         };
-        let kid_branch = if last { "└─" } else { "├─" };
         walk_forest(
             map,
             id,
             kid,
-            &next,
-            Some(kid_branch),
+            &format!("{stem}{branch}"),
+            &format!("{stem}{continuation}"),
             children,
             in_map_blockers,
             visited,
@@ -536,6 +543,42 @@ mod tests {
         });
         assert!(annotated, "{:?}", plan.items);
         assert_eq!(plan.idle_hidden, 0, "the forest hides nothing");
+    }
+
+    #[test]
+    fn forest_furniture_stays_aligned_three_levels_deep() {
+        // The shape the live wf map exposed: a root with two children, the
+        // *first* of which has a child of its own. The grandchild must hang
+        // from its parent's running bar (`│ └─`) — a node's own line and its
+        // children's lines are different depths, and deriving one from the
+        // other drifts by a level.
+        let m = map(vec![
+            ticket(13, false, false, vec![]),
+            ticket(14, false, false, vec![13]),
+            ticket(15, false, false, vec![14]),
+            ticket(17, false, false, vec![13]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], Screen::Structured(Lens::Forest));
+        let furniture: Vec<(u64, String)> = plan
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                Item::Ticket { row, prefix, .. } => {
+                    Some((m.tickets[row.index].number, prefix.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            furniture,
+            vec![
+                (13, "".to_string()),
+                (14, "├─".to_string()),
+                (15, "│ └─".to_string()),
+                (17, "└─".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -380,6 +380,7 @@ mod tests {
             status: classify(open, assigned, if open { open_blockers } else { vec![] }),
             ticket_type: TicketType::Task,
             blocked_by,
+            prs: vec![],
         }
     }
 


### PR DESCRIPTION
Closes #52 — the last build ticket on [Map #47](https://github.com/blooop/wayfinder/issues/47).

## What changed

- **`MAP_QUERY`** gains `closedByPullRequestsReferences(first: 5, includeClosedPrs: true)` inside `subIssues.nodes` — exactly the fragment the #49 research recommended (Development-panel link set: closing keywords + manual links, mentions excluded). Measured cost +1 rate-limit point per map fetch.
- **Parsed once at the `gh` boundary** into `PrLink { repo, number, status }` with `PrStatus::Draft | Open { checks, review } | Merged | Closed`. The nullable fields keep their meaning: null `statusCheckRollup` = `Checks::Absent` (no checks configured), null `reviewDecision` = `Review::NotRequired` — settled states, not missing data. A PR whose `state` this binary doesn't recognise gets **no badge rather than a wrong one**; unknown check/review strings read as "in flight".
- **Rendered as `⇄ PR#n <state>`** after the `[type]` suffix, on all three screens (leverage, forest, flattened). An open PR folds its two live signals into one glyph: `✗` when checks fail **or** changes are requested, `✓` when nothing is outstanding (checks passing/absent **and** review approved/not-required), nothing while in flight. A cross-repo PR names its repo (`⇄ PR dotfiles#12 …`) — the connection is cross-repo capable and `repository { nameWithOwner }` is selected defensively per #49.

Tests: 122 pass, including the live fetch test exercising the new selection against real GitHub; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add pull-request badges to ticket rows by wiring GitHub-linked PR metadata into the ticket model and UI.

New Features:
- Track pull requests linked to each ticket using a new PR metadata model, including status, checks, and review state.
- Display linked PR badges on all ticket rows, including cross-repo links, summarizing draft/open/merged/closed state with a single action-needed or settled glyph.

Enhancements:
- Extend the GitHub map query and parsing to include linked pull-request references while remaining compatible with older responses.
- Clarify README documentation to describe the new PR badge behavior on ticket rows.

Tests:
- Add parsing and UI tests to cover PR metadata handling, badge rendering, and behavior when the PR selection is absent or in-flight.