### PR TITLE
Build 12 — stage-aware tree + typed two-step launch (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Only repos with an open `wayfinder:map`-labelled issue show tickets; other
 checkouts stay cached but hidden.
 
 **Every open map renders as its own cluster** — a `▌ repo · map title` header
-carrying the per-status counts (`○` frontier `◐` claimed `⊘` blocked `●` done).
+carrying the per-**status** counts (`○` frontier `◐` claimed `⊘` blocked `●`
+done). Those are the ticket's own state, not the stage its rows draw below.
 A repo can keep several maps open at once and each gets its own cluster;
 focusing a project shows all of them.
 
@@ -57,6 +58,17 @@ chosen by what taking it unlocks, not by status alone. Rows are
 linked pull requests (GitHub's Development-panel set: closing keywords and
 manual links), shown as `draft`/`open`/`merged`/`closed` with `✓`/`✗` on an
 open PR when its checks and review are settled or need action.
+
+The leading glyph is the row's **stage**: `○` ready · `◐` building (in progress,
+for a decision node) · `◍` in review · `!` needs attention · `●` done, with `⊘`
+overriding on a blocked node, whose stage is unactionable until its blockers
+clear. Stage is derived from the linked PRs first and the ticket's own state
+only when they say nothing: an open PR with failing checks or a
+changes-requested review is needs-attention, a draft or pending checks is
+building, any other open PR is in review, and a node takes the **worst** of its
+open PRs — one red PR makes the node red. With no open PR, a merged one means
+done; with no PR at all it falls back to unclaimed → ready, claimed → building,
+closed → done.
 
 `↑`/`↓` prefer **siblings at the cursor's depth**, so on the default screen they
 move between tickets you can actually take and step over the blocked context
@@ -88,10 +100,14 @@ with something that means something else. The branch furniture stays uniformly
 dim: it is structure, not status.
 
 Done work collapses to a per-cluster `▸ ● N done (hidden)` line and blocked
-tickets no subtree reaches to `▸ ⊘ N blocked deeper down`. Both are ordinary
-cursor stops: put the cursor on one and `→` opens it in place (`▾`), listing
-what it held as rows you can select and launch, and `←` shuts it again — so
-nothing is ever merely a number you cannot reach. A map with nothing takeable
+tickets no subtree reaches to `▸ ⊘ N blocked deeper down`. **While shut, each
+carries a stage rollup** of what it is holding — the same glyphs as counts,
+`◍1 ●3` — so a branch you folded away still says whether anything in it wants
+you. Each held node is counted once, and only a shut row has a rollup: open it
+and the rows themselves are right there. Both are ordinary cursor stops: put
+the cursor on one and `→` opens it in place (`▾`), listing what it held as rows
+you can select and launch, and `←` shuts it again — so nothing is ever merely a
+number you cannot reach. A map with nothing takeable
 leaves the body entirely, counted on the bottom line as `· N idle maps hidden`.
 
 **`tab` shows the structure forest** instead: the whole blocking DAG, done
@@ -135,11 +151,39 @@ ask again.
 ## Launching
 
 Picking a ticket runs an agent on it — `claude --dangerously-skip-permissions
-"/wayfinder <map> <n>"`, with that project's checkout as its cwd — and that is
-the end of `wf`. It restores the terminal and **replaces its own process** with
-the agent: no picker underneath, no parent waiting, nothing to detach from. The
-agent holds the terminal, the exit code and the signals directly, because by
-then it *is* the process you started.
+"<skill> …"`, with that project's checkout as its cwd — and that is the end of
+`wf`. It restores the terminal and **replaces its own process** with the agent:
+no picker underneath, no parent waiting, nothing to detach from. The agent holds
+the terminal, the exit code and the signals directly, because by then it *is*
+the process you started.
+
+**Launching is two steps.** `enter` on the cursor's ticket does not launch: it
+opens the **launch line** where the count line was, showing where `enter` will
+go — `→ /tdd · #65 Author the /tdd skill`. What you type lands on that line, not
+in the query, and *is* the mode:
+
+| the line says | what launches |
+| --- | --- |
+| *(empty)* | interactive — the default |
+| `defer` | the subtree, resolved unattended |
+| `defer <text>` | deferred, with `<text>` as the steering prompt |
+| *anything else* | interactive, with what you typed as the steering prompt |
+
+`esc` backs out to the list with your query and cursor exactly as they were.
+`enter` on a **done** or **blocked** node opens nothing — it says why on the
+count line instead.
+
+**Which skill is a fact about the ticket**, from its type and its stage:
+
+| type | stage | launches |
+| --- | --- | --- |
+| `wayfinder:build` | ready · building · needs attention | `claude "/tdd <n>"` |
+| `wayfinder:build` | in review | `claude "/review <n>"` |
+| research · prototype · grilling · task | any unfinished stage | `claude "/wayfinder <map> <n>"` |
+| any | done | nothing — not launchable |
+
+The mode rides whichever route you got, as ` defer`, ` defer: <text>` or
+` steer: <text>` on the end of the prompt.
 
 | key | what it does |
 | --- | --- |
@@ -148,7 +192,8 @@ then it *is* the process you started.
 | `↑`/`↓`, `ctrl-j`/`ctrl-k` | move between siblings at the cursor's depth — on the default screen, the tickets you can take (cluster headers are never a stop) |
 | `→` | reveal: open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
 | `←` | close: shut an open group, else back out to the parent, else one stop back |
-| `enter` | run the agent on the ticket under the cursor, here, and exit — on a group line it folds instead, since there is no agent to run |
+| `enter` | open the launch line on the cursor's ticket; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
+| *type, then `enter`* | on the launch line: the mode (`defer`, `defer <text>`, or steering text) — `esc` backs out with the query and cursor intact |
 | `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |
 | `ctrl-g` | widen back to every project |
 | `ctrl-r` | refetch every map in place, keeping your query, scope and cursor |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1418,7 +1418,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 4 103 defer");
+        assert_eq!(
+            launch.agent_argv().last().unwrap(),
+            "/wayfinder 4 103 defer"
+        );
     }
 
     #[test]
@@ -1483,7 +1486,13 @@ mod tests {
         let mut ready = build_app(vec![]);
         ready.handle_key(key(KeyCode::Enter));
         assert!(
-            matches!(&ready.overlay, Overlay::LaunchLine { route: Route::Tdd, .. }),
+            matches!(
+                &ready.overlay,
+                Overlay::LaunchLine {
+                    route: Route::Tdd,
+                    ..
+                }
+            ),
             "{:?}",
             ready.overlay
         );
@@ -1503,7 +1512,13 @@ mod tests {
         }]);
         in_review.handle_key(key(KeyCode::Enter));
         assert!(
-            matches!(&in_review.overlay, Overlay::LaunchLine { route: Route::Review, .. }),
+            matches!(
+                &in_review.overlay,
+                Overlay::LaunchLine {
+                    route: Route::Review,
+                    ..
+                }
+            ),
             "{:?}",
             in_review.overlay
         );

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Launch, LaunchMode, Route, Targets};
+use crate::launch::{self, Launch, LaunchMode, Staged, Targets};
 use crate::model::{stage, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
@@ -50,9 +50,13 @@ pub enum Overlay {
     /// already resolved from (type, stage), so the line can *show* where enter
     /// goes — and a line for an unlaunchable node is unrepresentable, because
     /// no `Route` exists to put in it.
+    ///
+    /// The staged launch is index-free ([`Staged`]) for the same reason the
+    /// picker's candidates are complete `Launch`es: a background map arrival
+    /// swaps the clusters underneath an open overlay, and a positional [`Row`]
+    /// held across that would name a different ticket, or none at all.
     LaunchLine {
-        row: Row,
-        route: Route,
+        staged: Staged,
         text: String,
     },
     /// Candidates are complete launches, so the pick cannot produce an
@@ -460,8 +464,7 @@ impl App {
             }
             Some(route) => {
                 self.overlay = Overlay::LaunchLine {
-                    row,
-                    route,
+                    staged: Staged::new(ticket, row.map.number, route),
                     text: String::new(),
                 };
                 Outcome::Continue
@@ -475,14 +478,15 @@ impl App {
     /// launch into. Which map the ticket belongs to is the cluster it sits in
     /// — a row without a map is unrepresentable, so the old "repo has no map"
     /// failure is gone with it.
-    fn resolve_launch(&mut self, row: Row, route: Route, mode: LaunchMode) -> Outcome {
-        let ticket = self.ticket(&row).clone();
-        let map_issue = row.map.number;
-        match launch::plan(&self.checkouts, &ticket, map_issue, route, mode) {
+    ///
+    /// Everything this needs came with the [`Staged`] launch, so a refetch
+    /// between the two enters cannot redirect it at another ticket.
+    fn resolve_launch(&mut self, staged: Staged, mode: LaunchMode) -> Outcome {
+        match launch::plan(&self.checkouts, &staged, mode) {
             Targets::Unregistered => {
                 self.notice = Some(format!(
                     "no registered checkout of {} on this machine — run wf inside one",
-                    ticket.repo
+                    staged.repo
                 ));
                 Outcome::Continue
             }
@@ -493,7 +497,7 @@ impl App {
             Targets::Many(launches) => {
                 self.notice = Some(format!(
                     "{}#{}: which checkout?",
-                    ticket.repo, ticket.number
+                    staged.repo, staged.ticket
                 ));
                 self.overlay = Overlay::PickCheckout {
                     launches,
@@ -512,8 +516,7 @@ impl App {
     fn handle_launch_line_key(
         &mut self,
         key: KeyEvent,
-        row: Row,
-        route: Route,
+        staged: Staged,
         mut text: String,
     ) -> Outcome {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
@@ -521,19 +524,19 @@ impl App {
             // Back to the list; the overlay is already None.
             KeyCode::Esc => Outcome::Continue,
             KeyCode::Char('c') if ctrl => Outcome::Quit,
-            KeyCode::Enter => self.resolve_launch(row, route, LaunchMode::parse(&text)),
+            KeyCode::Enter => self.resolve_launch(staged, LaunchMode::parse(&text)),
             KeyCode::Backspace => {
                 text.pop();
-                self.overlay = Overlay::LaunchLine { row, route, text };
+                self.overlay = Overlay::LaunchLine { staged, text };
                 Outcome::Continue
             }
             KeyCode::Char(c) if !ctrl && !key.modifiers.contains(KeyModifiers::ALT) => {
                 text.push(c);
-                self.overlay = Overlay::LaunchLine { row, route, text };
+                self.overlay = Overlay::LaunchLine { staged, text };
                 Outcome::Continue
             }
             _ => {
-                self.overlay = Overlay::LaunchLine { row, route, text };
+                self.overlay = Overlay::LaunchLine { staged, text };
                 Outcome::Continue
             }
         }
@@ -598,8 +601,8 @@ impl App {
             Overlay::PickCheckout { launches, cursor } => {
                 return self.handle_overlay_key(key, launches, cursor);
             }
-            Overlay::LaunchLine { row, route, text } => {
-                return self.handle_launch_line_key(key, row, route, text);
+            Overlay::LaunchLine { staged, text } => {
+                return self.handle_launch_line_key(key, staged, text);
             }
             Overlay::None => {}
         }
@@ -700,6 +703,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::launch::Route;
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
@@ -1227,8 +1231,10 @@ mod tests {
         app.handle_key(key(KeyCode::Down));
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
-            Overlay::LaunchLine { route, text, .. } => {
-                assert_eq!(*route, Route::Wayfinder, "a task is a decision node");
+            Overlay::LaunchLine { staged, text } => {
+                assert_eq!(staged.route, Route::Wayfinder, "a task is a decision node");
+                assert_eq!(staged.ticket, 6);
+                assert_eq!(staged.title, "Re-entry breadcrumbs", "the line names it");
                 assert_eq!(text, "", "the line opens empty");
             }
             other => panic!("expected the launch line, got {other:?}"),
@@ -1425,6 +1431,77 @@ mod tests {
     }
 
     #[test]
+    fn a_staged_launch_survives_a_refetch_moving_its_ticket() {
+        // The line stays up while background fetches are still landing (#27),
+        // and each arrival swaps the clusters underneath it. A staged launch
+        // is snapshotted index-free, so the line keeps naming — and launching
+        // — the ticket it was opened on, wherever that ticket now sits.
+        let staged = || {
+            let mut app = launchable_app();
+            app.handle_key(key(KeyCode::Down)); // wayfinder#6, at index 1
+            app.handle_key(key(KeyCode::Enter));
+            type_str(&mut app, "defer");
+            app
+        };
+        let wf = MapId::new("blooop/wayfinder", 1);
+
+        // Reordered: index 1 now names #9, not #6.
+        let mut app = staged();
+        let mut reordered = app.clusters.clone();
+        reordered.get_mut(&wf).expect("the map").tickets = vec![
+            ticket(
+                "blooop/wayfinder",
+                6,
+                "Re-entry breadcrumbs",
+                true,
+                false,
+                vec![],
+            ),
+            ticket(
+                "blooop/wayfinder",
+                9,
+                "Main screen design",
+                true,
+                true,
+                vec![],
+            ),
+        ];
+        app.replace_clusters(reordered);
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(
+            launch.agent_argv().last().unwrap(),
+            "/wayfinder 1 6 defer",
+            "the staged ticket, not whatever landed at its old index"
+        );
+
+        // Shorter: the old index is off the end entirely, and the map the row
+        // was picked in has gone. Neither may panic, and the launch still
+        // names the ticket the human chose.
+        let mut app = staged();
+        let mut shrunk = BTreeMap::new();
+        shrunk.insert(
+            MapId::new("blooop/dotfiles", 4),
+            app.clusters
+                .get(&MapId::new("blooop/dotfiles", 4))
+                .expect("the dotfiles map")
+                .clone(),
+        );
+        app.replace_clusters(shrunk);
+        match &app.overlay {
+            Overlay::LaunchLine { staged, .. } => assert_eq!(staged.ticket, 6),
+            other => panic!("expected the launch line, got {other:?}"),
+        }
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 1 6 defer");
+    }
+
+    #[test]
     fn enter_on_a_done_or_blocked_node_is_a_notice_not_a_launch_line() {
         let mut app = launchable_app();
         // Blocked: #7 hangs under #6 as context.
@@ -1489,7 +1566,10 @@ mod tests {
             matches!(
                 &ready.overlay,
                 Overlay::LaunchLine {
-                    route: Route::Tdd,
+                    staged: Staged {
+                        route: Route::Tdd,
+                        ..
+                    },
                     ..
                 }
             ),
@@ -1515,7 +1595,10 @@ mod tests {
             matches!(
                 &in_review.overlay,
                 Overlay::LaunchLine {
-                    route: Route::Review,
+                    staged: Staged {
+                        route: Route::Review,
+                        ..
+                    },
                     ..
                 }
             ),

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,8 +11,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Launch, Targets};
-use crate::model::{Map, MapId, MapSet, Ticket};
+use crate::launch::{self, Launch, LaunchMode, Route, Targets};
+use crate::model::{stage, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
 use crate::view::{self, Expanded, GroupId, Lens, Plan, Screen, Stop, StopAt};
@@ -38,12 +38,23 @@ pub enum Outcome {
     Launch(Launch),
 }
 
-/// A modal layer over the main screen. Only one thing needs one: a repo with
-/// several registered checkouts (the k1–k5 pattern) must be asked which tree
-/// the agent runs in.
+/// A modal layer over the main screen: the staged second step of a launch
+/// (#62), or the which-checkout prompt. Either owns every key while up, so no
+/// typing leaks into the query behind it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Overlay {
     None,
+    /// The launch line — enter on a launchable node staged this launch, and
+    /// the line now collects its mode: empty is interactive, `defer [text]`
+    /// defers, anything else steers ([`LaunchMode::parse`]). The route is
+    /// already resolved from (type, stage), so the line can *show* where enter
+    /// goes — and a line for an unlaunchable node is unrepresentable, because
+    /// no `Route` exists to put in it.
+    LaunchLine {
+        row: Row,
+        route: Route,
+        text: String,
+    },
     /// Candidates are complete launches, so the pick cannot produce an
     /// inconsistent one.
     PickCheckout {
@@ -412,11 +423,12 @@ impl App {
         self.cursor = crate::refresh::preserve_cursor(anchor.as_ref(), old_index, &new_order);
     }
 
-    /// Resolve a launch of the cursor's ticket: straight to the loop when
-    /// there is one candidate checkout, through the picker when there are
-    /// several, and a notice when there is none to launch into. Which map the
-    /// ticket belongs to is the cluster it sits in — a row without a map is
-    /// unrepresentable, so the old "repo has no map" failure is gone with it.
+    /// The first enter (#62): stage a launch of the cursor's ticket by opening
+    /// the launch line — or refuse, with a count-line notice, the two things
+    /// that cannot launch. Blocked is refused on *status* (its stage is
+    /// unactionable, whatever it is); done is refused by [`launch::route`]
+    /// returning no route — stage, not ticket state, so a merged PR on a
+    /// still-open ticket refuses too.
     fn request_launch(&mut self) -> Outcome {
         // On a group line there is no agent to run, and exactly one thing the
         // key could plausibly mean — so `enter` opens or shuts it rather than
@@ -431,15 +443,42 @@ impl App {
             self.notice = Some("nothing selected".to_string());
             return Outcome::Continue;
         };
+        let ticket = self.ticket(&row);
+        if let Status::Blocked { needs } = &ticket.status {
+            let needs: Vec<String> = needs.iter().map(|n| format!("#{n}")).collect();
+            self.notice = Some(format!(
+                "#{} is blocked — needs {}",
+                ticket.number,
+                needs.join(", ")
+            ));
+            return Outcome::Continue;
+        }
+        match launch::route(ticket.ticket_type, stage(&ticket.prs, &ticket.status)) {
+            None => {
+                self.notice = Some(format!("#{} is done — nothing to launch", ticket.number));
+                Outcome::Continue
+            }
+            Some(route) => {
+                self.overlay = Overlay::LaunchLine {
+                    row,
+                    route,
+                    text: String::new(),
+                };
+                Outcome::Continue
+            }
+        }
+    }
+
+    /// The second enter: resolve the staged launch against the projects cache
+    /// — straight to the loop when there is one candidate checkout, through
+    /// the picker when there are several, and a notice when there is none to
+    /// launch into. Which map the ticket belongs to is the cluster it sits in
+    /// — a row without a map is unrepresentable, so the old "repo has no map"
+    /// failure is gone with it.
+    fn resolve_launch(&mut self, row: Row, route: Route, mode: LaunchMode) -> Outcome {
         let ticket = self.ticket(&row).clone();
         let map_issue = row.map.number;
-        match launch::plan(
-            &self.checkouts,
-            &ticket,
-            map_issue,
-            launch::Route::Wayfinder,
-            launch::LaunchMode::Interactive,
-        ) {
+        match launch::plan(&self.checkouts, &ticket, map_issue, route, mode) {
             Targets::Unregistered => {
                 self.notice = Some(format!(
                     "no registered checkout of {} on this machine — run wf inside one",
@@ -460,6 +499,41 @@ impl App {
                     launches,
                     cursor: 0,
                 };
+                Outcome::Continue
+            }
+        }
+    }
+
+    /// Keys while the launch line is up (#62). The line owns every printable
+    /// key — filtering already happened, this text is the launch's mode — and
+    /// esc backs out to the list with the query and cursor untouched (they
+    /// were never touched to begin with; the invariant is that nothing here
+    /// may touch them).
+    fn handle_launch_line_key(
+        &mut self,
+        key: KeyEvent,
+        row: Row,
+        route: Route,
+        mut text: String,
+    ) -> Outcome {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        match key.code {
+            // Back to the list; the overlay is already None.
+            KeyCode::Esc => Outcome::Continue,
+            KeyCode::Char('c') if ctrl => Outcome::Quit,
+            KeyCode::Enter => self.resolve_launch(row, route, LaunchMode::parse(&text)),
+            KeyCode::Backspace => {
+                text.pop();
+                self.overlay = Overlay::LaunchLine { row, route, text };
+                Outcome::Continue
+            }
+            KeyCode::Char(c) if !ctrl && !key.modifiers.contains(KeyModifiers::ALT) => {
+                text.push(c);
+                self.overlay = Overlay::LaunchLine { row, route, text };
+                Outcome::Continue
+            }
+            _ => {
+                self.overlay = Overlay::LaunchLine { row, route, text };
                 Outcome::Continue
             }
         }
@@ -520,10 +594,14 @@ impl App {
     /// chord bindings.
     pub fn handle_key(&mut self, key: KeyEvent) -> Outcome {
         self.notice = None;
-        if let Overlay::PickCheckout { launches, cursor } =
-            std::mem::replace(&mut self.overlay, Overlay::None)
-        {
-            return self.handle_overlay_key(key, launches, cursor);
+        match std::mem::replace(&mut self.overlay, Overlay::None) {
+            Overlay::PickCheckout { launches, cursor } => {
+                return self.handle_overlay_key(key, launches, cursor);
+            }
+            Overlay::LaunchLine { row, route, text } => {
+                return self.handle_launch_line_key(key, row, route, text);
+            }
+            Overlay::None => {}
         }
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
@@ -622,7 +700,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, TicketType};
+    use crate::model::{classify, Checks, PrLink, PrStatus, Review, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -1141,10 +1219,20 @@ mod tests {
     }
 
     #[test]
-    fn enter_launches_the_cursors_ticket_with_its_clusters_map() {
+    fn enter_opens_the_launch_line_and_a_second_enter_launches() {
+        // The two-step (#62): the first enter stages the launch — nothing
+        // execs yet — and an empty line's enter is the interactive default.
         let mut app = launchable_app();
         // Move to wayfinder#6, whose repo has one checkout.
         app.handle_key(key(KeyCode::Down));
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::LaunchLine { route, text, .. } => {
+                assert_eq!(*route, Route::Wayfinder, "a task is a decision node");
+                assert_eq!(text, "", "the line opens empty");
+            }
+            other => panic!("expected the launch line, got {other:?}"),
+        }
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -1188,6 +1276,7 @@ mod tests {
         }]);
         // Row 0 is map #1's copy, row 1 is map #47's.
         app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Enter)); // stage it
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -1208,7 +1297,9 @@ mod tests {
     #[test]
     fn several_checkouts_open_the_picker_and_enter_launches_the_pick() {
         let mut app = launchable_app();
-        // Cursor starts on dotfiles#103 — two checkouts.
+        // Cursor starts on dotfiles#103 — two checkouts. The first enter
+        // stages the launch; the second resolves it to the picker.
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
             Overlay::PickCheckout { launches, cursor } => {
@@ -1233,7 +1324,8 @@ mod tests {
     #[test]
     fn the_picker_clamps_and_esc_cancels_it() {
         let mut app = launchable_app();
-        app.handle_key(key(KeyCode::Enter)); // dotfiles#103 under the cursor
+        app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage the launch
+        app.handle_key(key(KeyCode::Enter)); // resolve — two checkouts: picker
         for _ in 0..5 {
             app.handle_key(key(KeyCode::Down));
         }
@@ -1252,14 +1344,185 @@ mod tests {
     fn a_repo_with_no_checkout_says_so_instead_of_launching() {
         // No checkouts registered: every ticket is unlaunchable — and the one
         // reason left is the missing checkout, because a row's map is its
-        // cluster and cannot be missing.
+        // cluster and cannot be missing. The line still opens (the route is a
+        // fact about the ticket); the *resolution* is what has nowhere to run.
         let mut app = fixture_app();
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         let notice = app.notice.as_deref().unwrap();
         assert!(
             notice.contains("no registered checkout"),
             "notice: {notice}"
         );
+    }
+
+    #[test]
+    fn launch_line_typing_lands_in_the_line_and_esc_restores_the_list() {
+        // The line owns every printable key: nothing leaks into the query.
+        // Esc backs out with the query and the cursor exactly as they were.
+        let mut app = launchable_app();
+        type_str(&mut app, "bread"); // flattens to wayfinder#6
+        assert_eq!(app.cursor_ticket().unwrap().number, 6);
+        app.handle_key(key(KeyCode::Enter));
+        type_str(&mut app, "half a thought");
+        app.handle_key(key(KeyCode::Backspace));
+        match &app.overlay {
+            Overlay::LaunchLine { text, .. } => assert_eq!(text, "half a though"),
+            other => panic!("expected the launch line, got {other:?}"),
+        }
+        assert_eq!(app.query, "bread", "typing stayed out of the query");
+
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(app.overlay, Overlay::None);
+        assert_eq!(app.query, "bread", "esc kept the query");
+        assert_eq!(
+            app.cursor_ticket().unwrap().number,
+            6,
+            "esc kept the cursor"
+        );
+        // And esc means *back to the list*, never quit-from-the-line: the next
+        // esc clears the query, the one after quits — the ordinary ladder.
+        assert_eq!(app.handle_key(key(KeyCode::Esc)), Outcome::Continue);
+        assert!(app.query.is_empty());
+        assert_eq!(app.handle_key(key(KeyCode::Esc)), Outcome::Quit);
+    }
+
+    #[test]
+    fn defer_text_on_the_launch_line_launches_deferred_with_steering() {
+        // The acceptance shape: enter → `defer something` → enter produces a
+        // command carrying `defer: something`.
+        let mut app = launchable_app();
+        app.handle_key(key(KeyCode::Down)); // wayfinder#6, one checkout
+        app.handle_key(key(KeyCode::Enter));
+        type_str(&mut app, "defer something");
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(
+            launch.agent_argv().last().unwrap(),
+            "/wayfinder 1 6 defer: something"
+        );
+    }
+
+    #[test]
+    fn the_typed_mode_survives_the_checkout_picker() {
+        // Two checkouts of dotfiles: the mode is settled on the line, the
+        // picker only answers *where* — the pick must not lose the defer.
+        let mut app = launchable_app();
+        app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage
+        type_str(&mut app, "defer");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(matches!(app.overlay, Overlay::PickCheckout { .. }));
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 4 103 defer");
+    }
+
+    #[test]
+    fn enter_on_a_done_or_blocked_node_is_a_notice_not_a_launch_line() {
+        let mut app = launchable_app();
+        // Blocked: #7 hangs under #6 as context.
+        app.handle_key(key(KeyCode::Down)); // #6
+        app.handle_key(key(KeyCode::Right)); // into #7
+        assert_eq!(at(&app), "#7");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert_eq!(app.overlay, Overlay::None, "no line on a blocked node");
+        assert!(
+            app.notice.as_deref().unwrap().contains("blocked"),
+            "{:?}",
+            app.notice
+        );
+        // Done: #2 sits behind the Done group.
+        while at(&app) != "Done" {
+            app.handle_key(key(KeyCode::Down));
+        }
+        app.handle_key(key(KeyCode::Right)); // open the group
+        app.handle_key(key(KeyCode::Right)); // onto #2
+        assert_eq!(at(&app), "#2");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert_eq!(app.overlay, Overlay::None, "no line on a done node");
+        assert!(
+            app.notice.as_deref().unwrap().contains("done"),
+            "{:?}",
+            app.notice
+        );
+    }
+
+    #[test]
+    fn a_build_node_routes_by_its_stage() {
+        // One build ticket, staged by its PR: in review → /review; the same
+        // ticket with no PR evidence is ready → /tdd.
+        let build_app = |prs: Vec<PrLink>| -> App {
+            let mut t = ticket(
+                "blooop/wayfinder",
+                65,
+                "Author the /tdd skill",
+                true,
+                false,
+                vec![],
+            );
+            t.ticket_type = TicketType::Build;
+            t.prs = prs;
+            let mut clusters = BTreeMap::new();
+            clusters.insert(
+                MapId::new("blooop/wayfinder", 59),
+                Map {
+                    title: "Map: the spine".to_string(),
+                    tickets: vec![t],
+                },
+            );
+            App::new(clusters).with_checkouts(vec![Checkout {
+                path: std::path::PathBuf::from("/data/proj/wayfinder"),
+                repo: "blooop/wayfinder".to_string(),
+            }])
+        };
+
+        let mut ready = build_app(vec![]);
+        ready.handle_key(key(KeyCode::Enter));
+        assert!(
+            matches!(&ready.overlay, Overlay::LaunchLine { route: Route::Tdd, .. }),
+            "{:?}",
+            ready.overlay
+        );
+        let launch = match ready.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/tdd 65");
+
+        let mut in_review = build_app(vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::Approved,
+            },
+        }]);
+        in_review.handle_key(key(KeyCode::Enter));
+        assert!(
+            matches!(&in_review.overlay, Overlay::LaunchLine { route: Route::Review, .. }),
+            "{:?}",
+            in_review.overlay
+        );
+        let launch = match in_review.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/review 65");
+
+        // A merged PR with nothing open means done — stage, not ticket state,
+        // is what refuses the launch.
+        let mut done = build_app(vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status: PrStatus::Merged,
+        }]);
+        assert_eq!(done.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert_eq!(done.overlay, Overlay::None);
+        assert!(done.notice.as_deref().unwrap().contains("done"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -433,7 +433,13 @@ impl App {
         };
         let ticket = self.ticket(&row).clone();
         let map_issue = row.map.number;
-        match launch::plan(&self.checkouts, &ticket, map_issue) {
+        match launch::plan(
+            &self.checkouts,
+            &ticket,
+            map_issue,
+            launch::Route::Wayfinder,
+            launch::LaunchMode::Interactive,
+        ) {
             Targets::Unregistered => {
                 self.notice = Some(format!(
                     "no registered checkout of {} on this machine — run wf inside one",

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -126,6 +126,48 @@ pub fn route(ticket_type: TicketType, stage: Stage) -> Option<Route> {
     }
 }
 
+/// A launch the first enter staged but the machine has not answered yet (#62):
+/// everything the launch line draws and the second enter needs, snapshotted
+/// **index-free**.
+///
+/// Index-free is the whole point. `crate::app::Row` is positional — an index
+/// into a `Vec` that the next fetch replaces — and the line stays up while
+/// background map arrivals swap the clusters underneath it (#27). A `Row` held
+/// here would draw, and then launch, whichever ticket had landed at that
+/// index; a shorter map would panic on the next frame. So the staged launch
+/// carries the ticket's own facts, the way [`Targets::Many`] carries complete
+/// [`Launch`]es rather than a choice to re-resolve later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Staged {
+    /// The ticket's repo, full slug (`owner/name`) — what the checkout cache
+    /// is matched on (#15).
+    pub repo: String,
+    /// The ticket the launch line names.
+    pub ticket: u64,
+    /// Its title as it read when the line opened — the line is showing the
+    /// human what they picked, not re-reporting a row that may have moved.
+    pub title: String,
+    /// The map issue of the cluster the row was picked in (#50) — which map a
+    /// ticket listed twice was launched from.
+    pub map_issue: u64,
+    /// Resolved from (type, stage) by [`route`] at the first enter, which is
+    /// also where an unlaunchable node was refused: no `Route`, no `Staged`.
+    pub route: Route,
+}
+
+impl Staged {
+    /// Stage a launch of `ticket`, picked in the cluster of `map_issue`.
+    pub fn new(ticket: &Ticket, map_issue: u64, route: Route) -> Staged {
+        Staged {
+            repo: ticket.repo.clone(),
+            ticket: ticket.number,
+            title: ticket.title.clone(),
+            map_issue,
+            route,
+        }
+    }
+}
+
 /// A fully-resolved launch: which checkout the agent runs in, which ticket of
 /// which map it is handed, and — since the two-step (#62) — which skill it
 /// runs ([`Route`]) and in what mode ([`LaunchMode`]).
@@ -297,21 +339,15 @@ pub enum Targets {
 /// Resolve a launch request against the projects cache. Zero or one candidate
 /// never prompts. The route and mode arrive already settled — this function
 /// only answers *where* the agent can run.
-pub fn plan(
-    checkouts: &[Checkout],
-    ticket: &Ticket,
-    map_issue: u64,
-    route: Route,
-    mode: LaunchMode,
-) -> Targets {
-    let launches: Vec<Launch> = candidate_checkouts(checkouts, &ticket.repo)
+pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: LaunchMode) -> Targets {
+    let launches: Vec<Launch> = candidate_checkouts(checkouts, &staged.repo)
         .into_iter()
         .map(|c| Launch {
-            repo: ticket.repo.clone(),
-            ticket: ticket.number,
-            map_issue,
+            repo: staged.repo.clone(),
+            ticket: staged.ticket,
+            map_issue: staged.map_issue,
             cwd: c.path.clone(),
-            route,
+            route: staged.route,
             mode: mode.clone(),
         })
         .collect();
@@ -352,9 +388,7 @@ mod tests {
     fn plan_wf(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets {
         plan(
             checkouts,
-            ticket,
-            map_issue,
-            Route::Wayfinder,
+            &Staged::new(ticket, map_issue, Route::Wayfinder),
             LaunchMode::Interactive,
         )
     }
@@ -468,7 +502,8 @@ mod tests {
     #[test]
     fn the_agent_command_is_the_route_plus_the_mode_suffix() {
         let launch = |route: Route, mode: LaunchMode| -> String {
-            match plan(&cache(), &ticket("blooop/wayfinder", 16), 1, route, mode) {
+            let staged = Staged::new(&ticket("blooop/wayfinder", 16), 1, route);
+            match plan(&cache(), &staged, mode) {
                 Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
                 other => panic!("{other:?}"),
             }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -17,8 +17,67 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::model::Ticket;
+use crate::model::{Stage, Ticket, TicketType};
 use crate::projects::Checkout;
+
+/// Which skill the launched agent runs — the (type, stage) → skill table,
+/// hardcoded in `wf` (#61): not per-ticket config, not a Notes-parsed table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Route {
+    /// `/tdd <n>` — build work: ready, resuming, or acting on red checks and
+    /// requested changes (the reviewer's comments live on the PR).
+    Tdd,
+    /// `/review <n>` — a build whose PR awaits its independent look.
+    Review,
+    /// `/wayfinder <map> <n>` — every decision session.
+    Wayfinder,
+}
+
+impl Route {
+    /// How the route reads on the launch line: the slash command it execs.
+    pub fn label(self) -> &'static str {
+        match self {
+            Route::Tdd => "/tdd",
+            Route::Review => "/review",
+            Route::Wayfinder => "/wayfinder",
+        }
+    }
+}
+
+/// Resolve which skill a (type, stage) launches. Total, with `None` as the
+/// one honest refusal: done is not launchable, whatever the type. Blocked is
+/// refused *before* this is consulted — blocked is [`crate::model::Status`],
+/// not a stage, so an illegal blocked route is unrepresentable here.
+///
+/// Every arm is named on both axes: adding a stage or a type without deciding
+/// its route is a compile error, not a silent fall-through.
+pub fn route(ticket_type: TicketType, stage: Stage) -> Option<Route> {
+    match stage {
+        Stage::Done => None,
+        // Build rows of the #61 table: in-review hands off to the fresh-eyes
+        // reviewer; everything else on a build node is code work.
+        Stage::InReview => match ticket_type {
+            TicketType::Build => Some(Route::Review),
+            TicketType::Research
+            | TicketType::Task
+            | TicketType::Grilling
+            | TicketType::Prototype
+            | TicketType::Untyped => Some(Route::Wayfinder),
+        },
+        Stage::Ready | Stage::Building | Stage::NeedsAttention => match ticket_type {
+            TicketType::Build => Some(Route::Tdd),
+            // Decision types (untyped riding along, as it always launched):
+            // /wayfinder at every unfinished stage — PR-dominant derivation
+            // can put a decision node past "in progress" (a prototype's PR
+            // counts), and the skill owns its node's PR state.
+            TicketType::Research
+            | TicketType::Task
+            | TicketType::Grilling
+            | TicketType::Prototype
+            | TicketType::Untyped => Some(Route::Wayfinder),
+        },
+    }
+}
 
 /// A fully-resolved launch: which checkout the agent runs in, and which ticket
 /// of which map it is handed.
@@ -331,6 +390,65 @@ mod tests {
         assert_eq!(short_repo("blooop/wayfinder"), "wayfinder");
         // Not a slug at all: the whole thing is the name.
         assert_eq!(short_repo("wayfinder"), "wayfinder");
+    }
+
+    #[test]
+    fn build_nodes_route_to_tdd_except_in_review_which_routes_to_review() {
+        // The #61 routing table's build rows: failing checks and requested
+        // changes are code work, so needs-attention goes back to /tdd.
+        assert_eq!(route(TicketType::Build, Stage::Ready), Some(Route::Tdd));
+        assert_eq!(route(TicketType::Build, Stage::Building), Some(Route::Tdd));
+        assert_eq!(
+            route(TicketType::Build, Stage::NeedsAttention),
+            Some(Route::Tdd)
+        );
+        assert_eq!(
+            route(TicketType::Build, Stage::InReview),
+            Some(Route::Review)
+        );
+    }
+
+    #[test]
+    fn decision_types_route_to_wayfinder_at_every_unfinished_stage() {
+        // The table lists decision types at ready/in-progress, but PR-dominant
+        // derivation can put one at in-review or needs-attention (a
+        // prototype's PR counts) — the skill owns its node's PR state, so the
+        // route stays /wayfinder at every stage short of done. Untyped rides
+        // along: launching untyped tickets is today's behavior, kept.
+        for ticket_type in [
+            TicketType::Research,
+            TicketType::Task,
+            TicketType::Grilling,
+            TicketType::Prototype,
+            TicketType::Untyped,
+        ] {
+            for stage in [
+                Stage::Ready,
+                Stage::Building,
+                Stage::InReview,
+                Stage::NeedsAttention,
+            ] {
+                assert_eq!(
+                    route(ticket_type, stage),
+                    Some(Route::Wayfinder),
+                    "{ticket_type:?} at {stage:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn done_is_not_launchable_whatever_the_type() {
+        for ticket_type in [
+            TicketType::Build,
+            TicketType::Research,
+            TicketType::Task,
+            TicketType::Grilling,
+            TicketType::Prototype,
+            TicketType::Untyped,
+        ] {
+            assert_eq!(route(ticket_type, Stage::Done), None, "{ticket_type:?}");
+        }
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -3,9 +3,11 @@
 //! `wf` is a selector (#26/#34). There is no multiplexer, no tab, no session
 //! and no supervision: the picked ticket resolves to a checkout, `wf` gives the
 //! terminal back, and its own process image is replaced by
-//! `claude --dangerously-skip-permissions "/wayfinder <map> <n>"` in that
-//! checkout ([`Launch::exec`]). Unattended work is not a feature here — it is
-//! another terminal session you start and switch away from.
+//! `claude --dangerously-skip-permissions "<skill> …"` in that checkout
+//! ([`Launch::exec`]) — which skill is the (type, stage) [`route`], and the
+//! launch line's mode rides the prompt as a suffix (#61/#62). Unattended work
+//! is still not supervised here — a deferred launch is the same exec with
+//! ` defer` in the prompt, watched from another terminal or not at all.
 //!
 //! The one thing that can go wrong is ordering: the terminal must be restored
 //! *before* the image is replaced, because after that there is no `wf` left to
@@ -40,6 +42,51 @@ impl Route {
             Route::Tdd => "/tdd",
             Route::Review => "/review",
             Route::Wayfinder => "/wayfinder",
+        }
+    }
+}
+
+/// What the launch line's typed text meant — parsed once at the second enter
+/// (parse, don't validate: the exec never re-reads a string). The four
+/// meanings of #62's staged prompt step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchMode {
+    /// An empty line: today's behavior, the default.
+    Interactive,
+    /// `defer` — the whole subtree, resolved unattended (#63).
+    Deferred,
+    /// `defer <text>` — deferred, with a steering prompt.
+    DeferredSteered(String),
+    /// Any other text — a steering prompt on an interactive launch.
+    Steered(String),
+}
+
+impl LaunchMode {
+    /// Parse the launch line. Total: every string means one of the four
+    /// things. `defer` is matched as a *word* — `deferred work` is steering
+    /// text that happens to start with the same letters, not a mode.
+    pub fn parse(text: &str) -> LaunchMode {
+        let text = text.trim();
+        if text.is_empty() {
+            return LaunchMode::Interactive;
+        }
+        match text.strip_prefix("defer") {
+            Some("") => LaunchMode::Deferred,
+            Some(rest) if rest.starts_with(char::is_whitespace) => {
+                LaunchMode::DeferredSteered(rest.trim_start().to_string())
+            }
+            _ => LaunchMode::Steered(text.to_string()),
+        }
+    }
+
+    /// The suffix appended to the exec'd slash command (#62/#63): nothing,
+    /// ` defer`, ` defer: <text>`, or ` steer: <text>`.
+    fn suffix(&self) -> String {
+        match self {
+            LaunchMode::Interactive => String::new(),
+            LaunchMode::Deferred => " defer".to_string(),
+            LaunchMode::DeferredSteered(text) => format!(" defer: {text}"),
+            LaunchMode::Steered(text) => format!(" steer: {text}"),
         }
     }
 }
@@ -79,15 +126,16 @@ pub fn route(ticket_type: TicketType, stage: Stage) -> Option<Route> {
     }
 }
 
-/// A fully-resolved launch: which checkout the agent runs in, and which ticket
-/// of which map it is handed.
+/// A fully-resolved launch: which checkout the agent runs in, which ticket of
+/// which map it is handed, and — since the two-step (#62) — which skill it
+/// runs ([`Route`]) and in what mode ([`LaunchMode`]).
 ///
 /// The fields are private and [`plan`] is the only constructor, so a launch
 /// whose checkout belongs to a different repo than its ticket is
-/// unrepresentable rather than merely undocumented. It is also, now, exactly
-/// *(checkout, ticket, map)* and nothing else: with the tab gone there is no
-/// session, no label and no mode for it to carry, and so no way for it to name
-/// a place it cannot run.
+/// unrepresentable rather than merely undocumented. The route arrives already
+/// resolved from (type, stage) by [`route`], which is where an unlaunchable
+/// node was refused — a `Launch` for a done node cannot be built, because no
+/// `Route` for it exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Launch {
     /// The ticket's repo, full slug (`owner/name`) — the identity half, kept
@@ -99,6 +147,10 @@ pub struct Launch {
     map_issue: u64,
     /// The checkout the agent works in: the process's working directory.
     cwd: PathBuf,
+    /// The skill this launch execs, resolved from (type, stage).
+    route: Route,
+    /// What the launch line said: interactive, deferred, steered.
+    mode: LaunchMode,
 }
 
 /// Agent sessions are started from a picker rather than from a shell someone is
@@ -123,12 +175,18 @@ impl Launch {
     }
 
     /// What `wf` becomes. `claude` takes a single positional prompt, so the
-    /// slash command and its arguments are one argv entry, not three.
+    /// slash command, its arguments and the mode suffix are one argv entry,
+    /// not several. Only `/wayfinder` takes the map argument — `/tdd` and
+    /// `/review` resolve the repo from the checkout they run in.
     pub fn agent_argv(&self) -> Vec<String> {
+        let prompt = match self.route {
+            Route::Tdd | Route::Review => format!("{} {}", self.route.label(), self.ticket),
+            Route::Wayfinder => format!("/wayfinder {} {}", self.map_issue, self.ticket),
+        };
         vec![
             "claude".to_string(),
             SKIP_PERMISSIONS.to_string(),
-            format!("/wayfinder {} {}", self.map_issue, self.ticket),
+            format!("{prompt}{}", self.mode.suffix()),
         ]
     }
 
@@ -237,8 +295,15 @@ pub enum Targets {
 }
 
 /// Resolve a launch request against the projects cache. Zero or one candidate
-/// never prompts.
-pub fn plan(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets {
+/// never prompts. The route and mode arrive already settled — this function
+/// only answers *where* the agent can run.
+pub fn plan(
+    checkouts: &[Checkout],
+    ticket: &Ticket,
+    map_issue: u64,
+    route: Route,
+    mode: LaunchMode,
+) -> Targets {
     let launches: Vec<Launch> = candidate_checkouts(checkouts, &ticket.repo)
         .into_iter()
         .map(|c| Launch {
@@ -246,6 +311,8 @@ pub fn plan(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets 
             ticket: ticket.number,
             map_issue,
             cwd: c.path.clone(),
+            route,
+            mode: mode.clone(),
         })
         .collect();
     match launches.len() {
@@ -279,6 +346,19 @@ mod tests {
         }
     }
 
+    /// An interactive `/wayfinder` plan — the default launch, and the shape
+    /// every checkout-resolution test wants (route and mode are orthogonal to
+    /// which trees are candidates).
+    fn plan_wf(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets {
+        plan(
+            checkouts,
+            ticket,
+            map_issue,
+            Route::Wayfinder,
+            LaunchMode::Interactive,
+        )
+    }
+
     fn cache() -> Vec<Checkout> {
         vec![
             checkout("/data/k1/kinisi_ros", "kinisi/kinisi_ros"),
@@ -308,7 +388,7 @@ mod tests {
     #[test]
     fn one_candidate_never_prompts_and_none_is_unregistered() {
         let cache = cache();
-        match plan(&cache, &ticket("blooop/wayfinder", 16), 1) {
+        match plan_wf(&cache, &ticket("blooop/wayfinder", 16), 1) {
             Targets::One(launch) => {
                 assert_eq!(launch.cwd(), Path::new("/data/proj/wayfinder"));
                 assert_eq!(launch.key(), "wayfinder#16");
@@ -318,18 +398,18 @@ mod tests {
             other => panic!("expected One, got {other:?}"),
         }
         assert_eq!(
-            plan(&cache, &ticket("blooop/dotfiles", 3), 2),
+            plan_wf(&cache, &ticket("blooop/dotfiles", 3), 2),
             Targets::Unregistered
         );
         assert_eq!(
-            plan(&[], &ticket("blooop/wayfinder", 16), 1),
+            plan_wf(&[], &ticket("blooop/wayfinder", 16), 1),
             Targets::Unregistered
         );
     }
 
     #[test]
     fn several_checkouts_of_one_repo_offer_a_choice_of_trees() {
-        let launches = match plan(&cache(), &ticket("kinisi/kinisi_ros", 42), 7) {
+        let launches = match plan_wf(&cache(), &ticket("kinisi/kinisi_ros", 42), 7) {
             Targets::Many(launches) => launches,
             other => panic!("expected Many, got {other:?}"),
         };
@@ -347,7 +427,7 @@ mod tests {
 
     #[test]
     fn the_agent_runs_interactive_claude_with_one_prompt_argument() {
-        let launch = match plan(&cache(), &ticket("blooop/wayfinder", 16), 1) {
+        let launch = match plan_wf(&cache(), &ticket("blooop/wayfinder", 16), 1) {
             Targets::One(l) => l,
             other => panic!("{other:?}"),
         };
@@ -362,10 +442,70 @@ mod tests {
     }
 
     #[test]
+    fn the_launch_line_text_parses_to_its_mode() {
+        // The four meanings of the typed line (#62): empty is the interactive
+        // default, `defer` alone is the deferred subtree, `defer <text>` adds
+        // steering to it, anything else steers an interactive launch.
+        assert_eq!(LaunchMode::parse(""), LaunchMode::Interactive);
+        assert_eq!(LaunchMode::parse("   "), LaunchMode::Interactive);
+        assert_eq!(LaunchMode::parse("defer"), LaunchMode::Deferred);
+        assert_eq!(LaunchMode::parse("defer "), LaunchMode::Deferred);
+        assert_eq!(
+            LaunchMode::parse("defer skip the flaky suite"),
+            LaunchMode::DeferredSteered("skip the flaky suite".to_string())
+        );
+        assert_eq!(
+            LaunchMode::parse("try the other approach"),
+            LaunchMode::Steered("try the other approach".to_string())
+        );
+        // `defer` is a word, not a prefix: no fuzzy matching.
+        assert_eq!(
+            LaunchMode::parse("deferred work first"),
+            LaunchMode::Steered("deferred work first".to_string())
+        );
+    }
+
+    #[test]
+    fn the_agent_command_is_the_route_plus_the_mode_suffix() {
+        let launch = |route: Route, mode: LaunchMode| -> String {
+            match plan(&cache(), &ticket("blooop/wayfinder", 16), 1, route, mode) {
+                Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+                other => panic!("{other:?}"),
+            }
+        };
+        // The route picks the skill; only /wayfinder takes the map argument.
+        assert_eq!(launch(Route::Tdd, LaunchMode::Interactive), "/tdd 16");
+        assert_eq!(launch(Route::Review, LaunchMode::Interactive), "/review 16");
+        assert_eq!(
+            launch(Route::Wayfinder, LaunchMode::Interactive),
+            "/wayfinder 1 16"
+        );
+        // The mode rides as a suffix, whatever the route (#62/#63).
+        assert_eq!(
+            launch(Route::Wayfinder, LaunchMode::Deferred),
+            "/wayfinder 1 16 defer"
+        );
+        assert_eq!(
+            launch(
+                Route::Wayfinder,
+                LaunchMode::DeferredSteered("skip the flaky suite".to_string())
+            ),
+            "/wayfinder 1 16 defer: skip the flaky suite"
+        );
+        assert_eq!(
+            launch(
+                Route::Tdd,
+                LaunchMode::Steered("try the other approach".to_string())
+            ),
+            "/tdd 16 steer: try the other approach"
+        );
+    }
+
+    #[test]
     fn the_notice_names_the_ticket_and_the_tree_it_runs_in() {
         // With several checkouts, *which tree* is the only thing that varies —
         // so it is what the notice has to say.
-        let launches = match plan(&cache(), &ticket("kinisi/kinisi_ros", 42), 7) {
+        let launches = match plan_wf(&cache(), &ticket("kinisi/kinisi_ros", 42), 7) {
             Targets::Many(l) => l,
             other => panic!("{other:?}"),
         };
@@ -381,7 +521,7 @@ mod tests {
 
     #[test]
     fn the_key_is_the_short_repo_but_identity_stays_the_full_slug() {
-        let launch = match plan(&cache(), &ticket("upstream/dotfiles", 5), 4) {
+        let launch = match plan_wf(&cache(), &ticket("upstream/dotfiles", 5), 4) {
             Targets::One(l) => l,
             other => panic!("{other:?}"),
         };
@@ -462,7 +602,7 @@ mod tests {
             blocked_by: vec![],
             prs: vec![],
         };
-        match plan(&cache(), &done, 1) {
+        match plan_wf(&cache(), &done, 1) {
             Targets::One(launch) => assert_eq!(launch.key(), "wayfinder#2"),
             other => panic!("a done ticket still launches, got {other:?}"),
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -145,13 +145,17 @@ pub fn stage(prs: &[PrLink], status: &Status) -> Stage {
 /// at the `gh` boundary ([`TicketType::from_labels`]) and never re-sniffed from
 /// strings afterwards.
 ///
-/// Total over the four types the skill defines **plus** [`TicketType::Untyped`],
-/// so a ticket that carries no type label is an ordinary value rather than a
-/// missing one. Every site that decides something from a type matches all five
-/// arms with no wildcard, which is what makes a fifth `wayfinder:*` type a
-/// compile error rather than a silent misreading.
+/// Total over the five types the skill suite defines **plus**
+/// [`TicketType::Untyped`], so a ticket that carries no type label is an
+/// ordinary value rather than a missing one. Every site that decides something
+/// from a type matches all six arms with no wildcard, which is what makes a
+/// new `wayfinder:*` type a compile error rather than a silent misreading.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TicketType {
+    /// `wayfinder:build` — the one execution type (#61): a ticket that is a
+    /// build contract, worked by `/tdd` and `/review` across its stages rather
+    /// than resolved in a decision session.
+    Build,
     /// `wayfinder:research` — away-from-keyboard by definition: reading sources
     /// to surface a fact a decision waits on.
     Research,
@@ -179,6 +183,7 @@ impl TicketType {
     /// binary shipped.
     pub fn from_label(label: &str) -> Option<TicketType> {
         match label.trim() {
+            "wayfinder:build" => Some(TicketType::Build),
             "wayfinder:research" => Some(TicketType::Research),
             "wayfinder:task" => Some(TicketType::Task),
             "wayfinder:grilling" => Some(TicketType::Grilling),
@@ -209,6 +214,7 @@ impl TicketType {
     /// wants, and "untyped" answers a question nobody asked.
     pub fn short_name(self) -> Option<&'static str> {
         match self {
+            TicketType::Build => Some("build"),
             TicketType::Research => Some("research"),
             TicketType::Task => Some("task"),
             TicketType::Grilling => Some("grilling"),
@@ -230,9 +236,12 @@ impl TicketType {
             TicketType::Prototype => 1,
             TicketType::Task => 2,
             TicketType::Research => 3,
+            // The most autonomous type of all — its whole lifecycle runs
+            // unattended — so every other real type outranks it.
+            TicketType::Build => 4,
             // Never returned by `from_label`, so this rank is only a
             // total-ordering formality — and last, so a real type always wins.
-            TicketType::Untyped => 4,
+            TicketType::Untyped => 5,
         }
     }
 }
@@ -439,6 +448,32 @@ mod tests {
         assert_eq!(
             TicketType::from_labels(["enhancement", "wayfinder:research", "good first issue"]),
             TicketType::Research
+        );
+    }
+
+    #[test]
+    fn the_build_type_label_parses_and_ranks_last_among_real_types() {
+        // The vocabulary grows exactly one type (#61): `wayfinder:build`.
+        assert_eq!(
+            TicketType::from_labels(["wayfinder:build"]),
+            TicketType::Build
+        );
+        assert_eq!(TicketType::Build.short_name(), Some("build"));
+        // HITL-first still holds: build is the most autonomous type of all —
+        // its whole lifecycle runs unattended — so every other real type wins
+        // an ambiguous ticket, and build still beats having no type.
+        for other in [
+            "wayfinder:research",
+            "wayfinder:task",
+            "wayfinder:grilling",
+            "wayfinder:prototype",
+        ] {
+            let both = TicketType::from_labels(["wayfinder:build", other]);
+            assert_ne!(both, TicketType::Build, "build + {other}");
+        }
+        assert_eq!(
+            TicketType::from_labels(["bug", "wayfinder:build"]),
+            TicketType::Build
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -128,21 +128,52 @@ impl RowGlyph {
 /// What one **open** PR says about its node — the fixed per-PR table (#61).
 /// `None` for merged and closed PRs, which are not open and speak elsewhere
 /// (merged: the done fallback; closed: nothing at all).
+///
+/// The two axes are read separately and **exhaustively** — every `Checks` and
+/// every `Review` variant is named, and so is every [`Signal`], so adding a
+/// variant to any of the three is a compile error rather than a new value
+/// silently reading as "in review".
+///
+/// Never `Ready` and never `Done`: an open PR is evidence of work in flight,
+/// so [`stage`]'s `max` over open PRs can only ever land in the middle three.
 fn open_pr_stage(status: &PrStatus) -> Option<Stage> {
     match status {
         PrStatus::Draft => Some(Stage::Building),
-        PrStatus::Open { checks, review } => Some(
-            if matches!(checks, Checks::Failing) || matches!(review, Review::ChangesRequested) {
-                Stage::NeedsAttention
-            } else if matches!(checks, Checks::Pending) {
-                Stage::Building
-            } else {
-                // Otherwise open — approved-awaiting-merge included.
-                Stage::InReview
-            },
-        ),
+        PrStatus::Open { checks, review } => {
+            let from_checks = match checks {
+                Checks::Failing => Signal::Red,
+                Checks::Pending => Signal::Moving,
+                // Settled, or none configured at all: nothing left to wait on.
+                Checks::Passing | Checks::Absent => Signal::Settled,
+            };
+            let from_review = match review {
+                Review::ChangesRequested => Signal::Red,
+                // Approved-awaiting-merge included, and a review nobody is
+                // required to give: the PR is still up for its look.
+                Review::Approved | Review::Required | Review::NotRequired => Signal::Settled,
+            };
+            Some(match from_checks.max(from_review) {
+                Signal::Red => Stage::NeedsAttention,
+                Signal::Moving => Stage::Building,
+                Signal::Settled => Stage::InReview,
+            })
+        }
         PrStatus::Merged | PrStatus::Closed => None,
     }
+}
+
+/// What one axis of an open PR contributes to its stage — the #61 table read
+/// as two independent readings rather than a chain of `if`s.
+///
+/// `Ord` is the table's precedence, which is *not* the [`Stage`] lattice: a
+/// red signal wins ("checks `Failing` **or** review `ChangesRequested` → needs
+/// attention"), then work still moving ("draft, or checks `Pending` →
+/// building"), and a settled axis speaks last ("otherwise open → in review").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Signal {
+    Settled,
+    Moving,
+    Red,
 }
 
 /// Derive a node's stage from its linked PRs and its derived status (#61).
@@ -624,6 +655,84 @@ mod tests {
             ),
             Stage::InReview
         );
+    }
+
+    #[test]
+    fn the_two_axes_of_one_pr_settle_by_the_tables_own_precedence() {
+        // Where the rows overlap, row 1 wins: a changes-requested review is
+        // needs-attention even while the checks are still moving, or already
+        // red. Not the `Stage` lattice — building outranks in review *within
+        // one PR*, which is why the axes have their own order.
+        assert_eq!(
+            stage(
+                &[open_pr(Checks::Pending, Review::ChangesRequested)],
+                &Status::Frontier
+            ),
+            Stage::NeedsAttention
+        );
+        assert_eq!(
+            stage(
+                &[open_pr(Checks::Failing, Review::ChangesRequested)],
+                &Status::Frontier
+            ),
+            Stage::NeedsAttention
+        );
+        // Row 2 over row 3: pending checks hold the node at building however
+        // settled the review axis is.
+        assert_eq!(
+            stage(
+                &[open_pr(Checks::Pending, Review::Approved)],
+                &Status::Frontier
+            ),
+            Stage::Building
+        );
+        assert_eq!(
+            stage(
+                &[open_pr(Checks::Pending, Review::NotRequired)],
+                &Status::Frontier
+            ),
+            Stage::Building
+        );
+    }
+
+    #[test]
+    fn an_open_pr_never_speaks_the_ends_of_the_lattice() {
+        // The invariant the max-over-open-PRs rule rests on: an open PR is
+        // work in flight, so it can only ever contribute the middle three.
+        // Were one to yield `Done`, a single open PR would mark the node
+        // finished; were one to yield `Ready`, `max` would silently drop it.
+        let every_open = [PrStatus::Draft].into_iter().chain(
+            [
+                Checks::Absent,
+                Checks::Passing,
+                Checks::Pending,
+                Checks::Failing,
+            ]
+            .into_iter()
+            .flat_map(|checks| {
+                [
+                    Review::NotRequired,
+                    Review::Required,
+                    Review::Approved,
+                    Review::ChangesRequested,
+                ]
+                .into_iter()
+                .map(move |review| PrStatus::Open { checks, review })
+            }),
+        );
+        for status in every_open {
+            let derived = open_pr_stage(&status).expect("an open PR always says something");
+            assert!(
+                matches!(
+                    derived,
+                    Stage::Building | Stage::InReview | Stage::NeedsAttention
+                ),
+                "{status:?} gave {derived:?}"
+            );
+        }
+        // And the two that are not open say nothing at all here.
+        assert_eq!(open_pr_stage(&PrStatus::Merged), None);
+        assert_eq!(open_pr_stage(&PrStatus::Closed), None);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -76,6 +76,71 @@ impl Status {
     }
 }
 
+/// Where a node stands in its lifecycle — one five-value lattice for every
+/// node (#61), **derived, never declared**: from its linked PRs when any are
+/// open or merged, from its ticket state otherwise. Blocked is deliberately
+/// not here — it is [`Status`], and the glyph column overrides with `⊘` while
+/// the stage underneath stays whatever the derivation says.
+///
+/// `Ord` follows the lattice `ready → building → in review → needs attention
+/// → done`, which is also the constant max-over-open-PRs order (needs
+/// attention > in review > building): an open PR can only ever contribute the
+/// middle three, so `max` never has to special-case the ends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Stage {
+    Ready,
+    /// Building for build nodes, "in progress" for decision nodes — one slot,
+    /// two vocabularies, same glyph.
+    Building,
+    InReview,
+    NeedsAttention,
+    Done,
+}
+
+/// What one **open** PR says about its node — the fixed per-PR table (#61).
+/// `None` for merged and closed PRs, which are not open and speak elsewhere
+/// (merged: the done fallback; closed: nothing at all).
+fn open_pr_stage(status: &PrStatus) -> Option<Stage> {
+    match status {
+        PrStatus::Draft => Some(Stage::Building),
+        PrStatus::Open { checks, review } => Some(
+            if matches!(checks, Checks::Failing) || matches!(review, Review::ChangesRequested) {
+                Stage::NeedsAttention
+            } else if matches!(checks, Checks::Pending) {
+                Stage::Building
+            } else {
+                // Otherwise open — approved-awaiting-merge included.
+                Stage::InReview
+            },
+        ),
+        PrStatus::Merged | PrStatus::Closed => None,
+    }
+}
+
+/// Derive a node's stage from its linked PRs and its derived status (#61).
+///
+/// The node takes the **max over its open PRs** — a red PR anywhere makes the
+/// node red; nothing is silently ignored. With no open PRs, any merged PR
+/// means done, whatever the ticket still says; with no PR evidence at all it
+/// falls through to ticket state: ready (open, unblocked, unclaimed) / in
+/// progress (claimed) / done (closed). PR state dominates when present — a
+/// prototype's PR counts.
+pub fn stage(prs: &[PrLink], status: &Status) -> Stage {
+    if let Some(live) = prs.iter().filter_map(|pr| open_pr_stage(&pr.status)).max() {
+        return live;
+    }
+    if prs.iter().any(|pr| pr.status == PrStatus::Merged) {
+        return Stage::Done;
+    }
+    match status {
+        // A blocked node's work has not begun: ready underneath, with the `⊘`
+        // override and the launch refusal both keyed off status, not stage.
+        Status::Frontier | Status::Blocked { .. } => Stage::Ready,
+        Status::Claimed => Stage::Building,
+        Status::Done => Stage::Done,
+    }
+}
+
 /// What *kind* of work a ticket is — the `wayfinder:*` type label, parsed once
 /// at the `gh` boundary ([`TicketType::from_labels`]) and never re-sniffed from
 /// strings afterwards.
@@ -429,6 +494,134 @@ mod tests {
         assert_eq!(
             TicketType::from_labels(["wayfinder:task", "wayfinder:grilling"]),
             TicketType::Grilling
+        );
+    }
+
+    fn pr(status: PrStatus) -> PrLink {
+        PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status,
+        }
+    }
+
+    fn open_pr(checks: Checks, review: Review) -> PrLink {
+        pr(PrStatus::Open { checks, review })
+    }
+
+    #[test]
+    fn each_open_pr_maps_to_a_stage_by_the_fixed_table() {
+        // Row 1 of the #61 table: failing checks or a changes-requested review
+        // → needs attention. Either signal alone is enough.
+        assert_eq!(
+            stage(&[open_pr(Checks::Failing, Review::NotRequired)], &Status::Frontier),
+            Stage::NeedsAttention
+        );
+        assert_eq!(
+            stage(
+                &[open_pr(Checks::Passing, Review::ChangesRequested)],
+                &Status::Frontier
+            ),
+            Stage::NeedsAttention
+        );
+        // Row 2: a draft, or checks still pending → building.
+        assert_eq!(
+            stage(&[pr(PrStatus::Draft)], &Status::Frontier),
+            Stage::Building
+        );
+        assert_eq!(
+            stage(&[open_pr(Checks::Pending, Review::Required)], &Status::Frontier),
+            Stage::Building
+        );
+        // Row 3: otherwise open — approved-awaiting-merge included → in review.
+        assert_eq!(
+            stage(&[open_pr(Checks::Passing, Review::Approved)], &Status::Frontier),
+            Stage::InReview
+        );
+        assert_eq!(
+            stage(&[open_pr(Checks::Absent, Review::NotRequired)], &Status::Frontier),
+            Stage::InReview
+        );
+        assert_eq!(
+            stage(&[open_pr(Checks::Passing, Review::Required)], &Status::Frontier),
+            Stage::InReview
+        );
+    }
+
+    #[test]
+    fn the_node_takes_the_max_over_its_open_prs() {
+        // The constant order: needs attention > in review > building. A red PR
+        // anywhere makes the node red, whichever way the tracker lists them.
+        let building = || pr(PrStatus::Draft);
+        let in_review = || open_pr(Checks::Passing, Review::Approved);
+        let attention = || open_pr(Checks::Failing, Review::NotRequired);
+        assert_eq!(
+            stage(&[building(), attention()], &Status::Frontier),
+            Stage::NeedsAttention
+        );
+        assert_eq!(
+            stage(&[attention(), building()], &Status::Frontier),
+            Stage::NeedsAttention
+        );
+        assert_eq!(
+            stage(&[building(), in_review()], &Status::Frontier),
+            Stage::InReview
+        );
+        assert_eq!(
+            stage(&[in_review(), attention()], &Status::Frontier),
+            Stage::NeedsAttention
+        );
+        // A merged PR alongside an open one is not silently ignored either —
+        // the open PR is the live signal and wins.
+        assert_eq!(
+            stage(&[pr(PrStatus::Merged), building()], &Status::Frontier),
+            Stage::Building
+        );
+    }
+
+    #[test]
+    fn with_no_open_prs_a_merged_pr_means_done() {
+        // The work landed: done, whatever the ticket itself still says.
+        assert_eq!(stage(&[pr(PrStatus::Merged)], &Status::Frontier), Stage::Done);
+        assert_eq!(stage(&[pr(PrStatus::Merged)], &Status::Claimed), Stage::Done);
+        assert_eq!(stage(&[pr(PrStatus::Merged)], &Status::Done), Stage::Done);
+    }
+
+    #[test]
+    fn a_closed_unmerged_pr_is_no_evidence_at_all() {
+        // Abandoned PRs neither advance nor hold the node: fall through to
+        // ticket state as if they were never linked.
+        assert_eq!(stage(&[pr(PrStatus::Closed)], &Status::Frontier), Stage::Ready);
+        assert_eq!(stage(&[pr(PrStatus::Closed)], &Status::Claimed), Stage::Building);
+    }
+
+    #[test]
+    fn with_no_prs_stage_derives_from_ticket_state() {
+        // The decision-node half of the lattice: ready (open, unblocked,
+        // unclaimed) / in progress (claimed — the building slot) / done.
+        assert_eq!(stage(&[], &Status::Frontier), Stage::Ready);
+        assert_eq!(stage(&[], &Status::Claimed), Stage::Building);
+        assert_eq!(stage(&[], &Status::Done), Stage::Done);
+        // A blocked node's work has not begun, so its stage is ready — the
+        // glyph column overrides with ⊘ and enter refuses it, but blocked is
+        // status, not a sixth stage.
+        assert_eq!(stage(&[], &Status::Blocked { needs: vec![7] }), Stage::Ready);
+    }
+
+    #[test]
+    fn pr_state_dominates_ticket_state_when_present() {
+        // Two derivation sources, one type — a prototype's PR counts (#61),
+        // and even a *closed* ticket with an open PR reads as that PR's stage.
+        assert_eq!(
+            stage(&[open_pr(Checks::Passing, Review::Approved)], &Status::Done),
+            Stage::InReview
+        );
+        assert_eq!(
+            stage(
+                &[open_pr(Checks::Failing, Review::NotRequired)],
+                &Status::Claimed
+            ),
+            Stage::NeedsAttention
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -54,16 +54,6 @@ pub enum Status {
 }
 
 impl Status {
-    /// The state glyph shown at the start of every row.
-    pub fn glyph(&self) -> char {
-        match self {
-            Status::Frontier => '○',
-            Status::Claimed => '◐',
-            Status::Blocked { .. } => '⊘',
-            Status::Done => '●',
-        }
-    }
-
     /// Position of this status within the cluster header's counts
     /// (frontier / claimed / blocked / done).
     pub fn group(&self) -> usize {
@@ -95,6 +85,44 @@ pub enum Stage {
     InReview,
     NeedsAttention,
     Done,
+}
+
+/// What a row's leading glyph column shows (#62): the node's stage, unless
+/// the node is blocked — `⊘` overrides, because a blocked node's stage is
+/// unactionable until its blockers clear. One sum type rather than a char, so
+/// the rollup counts and the row draw share meanings, not symbols.
+///
+/// `Ord` is display order — `○ ◐ ◍ ! ● ⊘` — which the derive gives for free:
+/// stages in lattice order, the blocked override after them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RowGlyph {
+    Stage(Stage),
+    Blocked,
+}
+
+impl RowGlyph {
+    /// The glyph column for one ticket: its stage, blocked overriding.
+    pub fn of(ticket: &Ticket) -> RowGlyph {
+        match ticket.status {
+            Status::Blocked { .. } => RowGlyph::Blocked,
+            Status::Frontier | Status::Claimed | Status::Done => {
+                RowGlyph::Stage(stage(&ticket.prs, &ticket.status))
+            }
+        }
+    }
+
+    /// The character drawn: `○` ready · `◐` building/in progress · `◍` in
+    /// review · `!` needs attention · `●` done · `⊘` blocked.
+    pub fn char(self) -> char {
+        match self {
+            RowGlyph::Stage(Stage::Ready) => '○',
+            RowGlyph::Stage(Stage::Building) => '◐',
+            RowGlyph::Stage(Stage::InReview) => '◍',
+            RowGlyph::Stage(Stage::NeedsAttention) => '!',
+            RowGlyph::Stage(Stage::Done) => '●',
+            RowGlyph::Blocked => '⊘',
+        }
+    }
 }
 
 /// What one **open** PR says about its node — the fixed per-PR table (#61).
@@ -549,7 +577,10 @@ mod tests {
         // Row 1 of the #61 table: failing checks or a changes-requested review
         // → needs attention. Either signal alone is enough.
         assert_eq!(
-            stage(&[open_pr(Checks::Failing, Review::NotRequired)], &Status::Frontier),
+            stage(
+                &[open_pr(Checks::Failing, Review::NotRequired)],
+                &Status::Frontier
+            ),
             Stage::NeedsAttention
         );
         assert_eq!(
@@ -565,20 +596,32 @@ mod tests {
             Stage::Building
         );
         assert_eq!(
-            stage(&[open_pr(Checks::Pending, Review::Required)], &Status::Frontier),
+            stage(
+                &[open_pr(Checks::Pending, Review::Required)],
+                &Status::Frontier
+            ),
             Stage::Building
         );
         // Row 3: otherwise open — approved-awaiting-merge included → in review.
         assert_eq!(
-            stage(&[open_pr(Checks::Passing, Review::Approved)], &Status::Frontier),
+            stage(
+                &[open_pr(Checks::Passing, Review::Approved)],
+                &Status::Frontier
+            ),
             Stage::InReview
         );
         assert_eq!(
-            stage(&[open_pr(Checks::Absent, Review::NotRequired)], &Status::Frontier),
+            stage(
+                &[open_pr(Checks::Absent, Review::NotRequired)],
+                &Status::Frontier
+            ),
             Stage::InReview
         );
         assert_eq!(
-            stage(&[open_pr(Checks::Passing, Review::Required)], &Status::Frontier),
+            stage(
+                &[open_pr(Checks::Passing, Review::Required)],
+                &Status::Frontier
+            ),
             Stage::InReview
         );
     }
@@ -617,8 +660,14 @@ mod tests {
     #[test]
     fn with_no_open_prs_a_merged_pr_means_done() {
         // The work landed: done, whatever the ticket itself still says.
-        assert_eq!(stage(&[pr(PrStatus::Merged)], &Status::Frontier), Stage::Done);
-        assert_eq!(stage(&[pr(PrStatus::Merged)], &Status::Claimed), Stage::Done);
+        assert_eq!(
+            stage(&[pr(PrStatus::Merged)], &Status::Frontier),
+            Stage::Done
+        );
+        assert_eq!(
+            stage(&[pr(PrStatus::Merged)], &Status::Claimed),
+            Stage::Done
+        );
         assert_eq!(stage(&[pr(PrStatus::Merged)], &Status::Done), Stage::Done);
     }
 
@@ -626,8 +675,14 @@ mod tests {
     fn a_closed_unmerged_pr_is_no_evidence_at_all() {
         // Abandoned PRs neither advance nor hold the node: fall through to
         // ticket state as if they were never linked.
-        assert_eq!(stage(&[pr(PrStatus::Closed)], &Status::Frontier), Stage::Ready);
-        assert_eq!(stage(&[pr(PrStatus::Closed)], &Status::Claimed), Stage::Building);
+        assert_eq!(
+            stage(&[pr(PrStatus::Closed)], &Status::Frontier),
+            Stage::Ready
+        );
+        assert_eq!(
+            stage(&[pr(PrStatus::Closed)], &Status::Claimed),
+            Stage::Building
+        );
     }
 
     #[test]
@@ -640,7 +695,39 @@ mod tests {
         // A blocked node's work has not begun, so its stage is ready — the
         // glyph column overrides with ⊘ and enter refuses it, but blocked is
         // status, not a sixth stage.
-        assert_eq!(stage(&[], &Status::Blocked { needs: vec![7] }), Stage::Ready);
+        assert_eq!(
+            stage(&[], &Status::Blocked { needs: vec![7] }),
+            Stage::Ready
+        );
+    }
+
+    #[test]
+    fn the_glyph_column_shows_the_stage_with_blocked_overriding() {
+        // The five stage glyphs (#62)…
+        assert_eq!(RowGlyph::Stage(Stage::Ready).char(), '○');
+        assert_eq!(RowGlyph::Stage(Stage::Building).char(), '◐');
+        assert_eq!(RowGlyph::Stage(Stage::InReview).char(), '◍');
+        assert_eq!(RowGlyph::Stage(Stage::NeedsAttention).char(), '!');
+        assert_eq!(RowGlyph::Stage(Stage::Done).char(), '●');
+        // …and the blocked override: whatever the PRs say, a blocked node's
+        // stage is unactionable and the column says so.
+        assert_eq!(RowGlyph::Blocked.char(), '⊘');
+        let mut blocked = Ticket {
+            repo: "blooop/wayfinder".to_string(),
+            number: 7,
+            title: "t7".to_string(),
+            status: Status::Blocked { needs: vec![6] },
+            ticket_type: TicketType::Build,
+            blocked_by: vec![6],
+            prs: vec![open_pr(Checks::Failing, Review::NotRequired)],
+        };
+        assert_eq!(RowGlyph::of(&blocked), RowGlyph::Blocked);
+        // The same ticket unblocked reads as its PR's stage.
+        blocked.status = Status::Frontier;
+        assert_eq!(
+            RowGlyph::of(&blocked),
+            RowGlyph::Stage(Stage::NeedsAttention)
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -439,28 +439,46 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
     frame.render_widget(body, body_area);
 
-    // The load hint, the failure note, and the idle count share one dim
-    // segment, and any of them can be live at once; empty ones drop out
-    // rather than leaving gaps.
-    let status = [app.startup.hint(), failure_note(app), idle_note(&plan)]
-        .into_iter()
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let mut count_spans = vec![
-        Span::raw(format!("  {}/{}", app.visible().len(), app.scoped().len())),
-        Span::styled(
-            format!("  {status}"),
-            Style::new().add_modifier(Modifier::DIM),
-        ),
-    ];
-    if let Some(notice) = &app.notice {
-        count_spans.push(Span::styled(
-            format!("   {notice}"),
-            Style::new().add_modifier(Modifier::DIM),
-        ));
+    // The count line's slot is shared: while a launch is staged (#62) the
+    // launch line lives there instead — the resolved route, the ticket it
+    // launches, and the mode text as it is typed.
+    if let Overlay::LaunchLine { row, route, text } = &app.overlay {
+        let ticket = app.ticket(row);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(
+                    format!("  → {}", route.label()),
+                    Style::new().fg(Color::Cyan),
+                ),
+                Span::raw(format!(" · #{} {}  {text}", ticket.number, ticket.title)),
+                Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
+            ])),
+            count_area,
+        );
+    } else {
+        // The load hint, the failure note, and the idle count share one dim
+        // segment, and any of them can be live at once; empty ones drop out
+        // rather than leaving gaps.
+        let status = [app.startup.hint(), failure_note(app), idle_note(&plan)]
+            .into_iter()
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let mut count_spans = vec![
+            Span::raw(format!("  {}/{}", app.visible().len(), app.scoped().len())),
+            Span::styled(
+                format!("  {status}"),
+                Style::new().add_modifier(Modifier::DIM),
+            ),
+        ];
+        if let Some(notice) = &app.notice {
+            count_spans.push(Span::styled(
+                format!("   {notice}"),
+                Style::new().add_modifier(Modifier::DIM),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(count_spans)), count_area);
     }
-    frame.render_widget(Paragraph::new(Line::from(count_spans)), count_area);
 
     frame.render_widget(
         Paragraph::new(Line::from(vec![
@@ -919,7 +937,8 @@ mod tests {
     #[test]
     fn the_checkout_picker_floats_over_the_list_with_one_row_per_tree() {
         let mut app = launchable_app();
-        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // stage
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // resolve
         let screen = render(&app);
         assert!(
             screen.contains("which checkout runs wayfinder#6?"),
@@ -928,6 +947,34 @@ mod tests {
         assert!(screen.contains("▶ /data/k1/wayfinder"), "{screen}");
         assert!(screen.contains("/data/k2/wayfinder"), "{screen}");
         assert!(screen.contains("esc cancel"));
+    }
+
+    #[test]
+    fn the_launch_line_replaces_the_count_line_and_shows_the_route() {
+        let mut app = fixture_app();
+        let screen = render(&app);
+        assert!(screen.contains("5/5"), "{screen}");
+
+        // Enter on #6 (a task at ready): the line opens where the count was,
+        // naming the resolved route and the ticket it launches.
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(
+            screen.contains("→ /wayfinder · #6 Re-entry breadcrumbs"),
+            "{screen}"
+        );
+        assert!(!screen.contains("5/5"), "the count line is replaced: {screen}");
+
+        // The typed mode shows on the line as it accumulates.
+        type_str(&mut app, "defer something");
+        let screen = render(&app);
+        assert!(screen.contains("defer something"), "{screen}");
+
+        // Esc gives the count line back.
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("5/5"), "{screen}");
+        assert!(!screen.contains("→ /wayfinder"), "{screen}");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -460,15 +460,14 @@ pub fn draw(frame: &mut Frame, app: &App) {
     // The count line's slot is shared: while a launch is staged (#62) the
     // launch line lives there instead — the resolved route, the ticket it
     // launches, and the mode text as it is typed.
-    if let Overlay::LaunchLine { row, route, text } = &app.overlay {
-        let ticket = app.ticket(row);
+    if let Overlay::LaunchLine { staged, text } = &app.overlay {
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled(
-                    format!("  → {}", route.label()),
+                    format!("  → {}", staged.route.label()),
                     Style::new().fg(Color::Cyan),
                 ),
-                Span::raw(format!(" · #{} {}  {text}", ticket.number, ticket.title)),
+                Span::raw(format!(" · #{} {}  {text}", staged.ticket, staged.title)),
                 Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
             ])),
             count_area,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,15 +13,20 @@ use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
-use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, Status, Ticket};
-use crate::view::{GroupKind, Item, Plan, Screen};
+use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
+use crate::view::{Fold, GroupKind, Item, Plan, Screen};
 
-fn glyph_style(status: &Status) -> Style {
-    match status {
-        Status::Frontier => Style::new().fg(Color::Green),
-        Status::Claimed => Style::new().fg(Color::Yellow),
-        Status::Blocked { .. } => Style::new().fg(Color::Red),
-        Status::Done => Style::new().add_modifier(Modifier::DIM),
+/// One colour per glyph meaning, shared by the row column and the rollup
+/// pairs: calm colours for the flowing stages, red for the two that demand
+/// someone (`!` act, `⊘` unblock), dim for what is finished.
+fn glyph_style(glyph: RowGlyph) -> Style {
+    match glyph {
+        RowGlyph::Stage(Stage::Ready) => Style::new().fg(Color::Green),
+        RowGlyph::Stage(Stage::Building) => Style::new().fg(Color::Yellow),
+        RowGlyph::Stage(Stage::InReview) => Style::new().fg(Color::Magenta),
+        RowGlyph::Stage(Stage::NeedsAttention) => Style::new().fg(Color::Red),
+        RowGlyph::Stage(Stage::Done) => Style::new().add_modifier(Modifier::DIM),
+        RowGlyph::Blocked => Style::new().fg(Color::Red),
     }
 }
 
@@ -150,14 +155,14 @@ fn ticket_line(
     } else {
         format!("  {prefix}")
     };
+    // The glyph column is the node's stage, `⊘` overriding when it is blocked
+    // (#61/#62) — one sum type, so the row and the rollups share meanings.
+    let glyph = RowGlyph::of(ticket);
     let mut spans = vec![
         Span::raw("  "),
         Span::styled(indent, FURNITURE),
         cursor_span(under_cursor),
-        Span::styled(
-            ticket.status.glyph().to_string(),
-            glyph_style(&ticket.status),
-        ),
+        Span::styled(glyph.char().to_string(), glyph_style(glyph)),
         Span::raw(format!(" {repo}#{} {}", ticket.number, ticket.title)),
     ];
     if let Some(name) = ticket.ticket_type.short_name() {
@@ -191,25 +196,42 @@ pub fn body_lines(app: &App) -> Vec<Line<'static>> {
 
 /// A collapsible group's line (#57): the cursor column, a `▸`/`▾` fold marker
 /// where a ticket row's tree furniture would be, then the count it is holding.
-/// It says `(hidden)` only while shut — once open, the rows are right there and
-/// claiming otherwise would be a lie.
-fn group_line(kind: GroupKind, hidden: usize, expanded: bool, under_cursor: bool) -> Line<'static> {
-    let fold = if expanded { '▾' } else { '▸' };
+/// It says `(hidden)` — and carries the stage rollup of what that is (#61) —
+/// only while shut: once open, the rows are right there and claiming otherwise
+/// would be a lie.
+fn group_line(kind: GroupKind, hidden: usize, fold: &Fold, under_cursor: bool) -> Line<'static> {
+    let marker = match fold {
+        Fold::Open => '▾',
+        Fold::Shut { .. } => '▸',
+    };
     let (glyph, label, color) = match kind {
         GroupKind::BlockedDeeper => ('⊘', "blocked deeper down", Color::Red),
         GroupKind::Done => ('●', "done", Color::Reset),
     };
-    let tail = if expanded { "" } else { " (hidden)" };
-    Line::from(vec![
+    let mut spans = vec![
         Span::raw("  "),
         cursor_span(under_cursor),
-        Span::styled(format!("{fold} "), FURNITURE),
+        Span::styled(format!("{marker} "), FURNITURE),
         Span::styled(glyph.to_string(), Style::new().fg(color)),
         Span::styled(
-            format!(" {hidden} {label}{tail}"),
+            format!(" {hidden} {label}"),
             Style::new().add_modifier(Modifier::DIM),
         ),
-    ])
+    ];
+    if let Fold::Shut { rollup } = fold {
+        spans.push(Span::styled(
+            " (hidden)".to_string(),
+            Style::new().add_modifier(Modifier::DIM),
+        ));
+        for (glyph, count) in rollup {
+            spans.push(Span::raw(" "));
+            spans.push(Span::styled(
+                format!("{}{count}", glyph.char()),
+                glyph_style(*glyph),
+            ));
+        }
+    }
+    Line::from(spans)
 }
 
 /// [`body_lines`] plus which line the cursor landed on — what the draw scrolls
@@ -257,13 +279,9 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     under_cursor,
                 ));
             }
-            Item::Group {
-                id,
-                hidden,
-                expanded,
-            } => {
+            Item::Group { id, hidden, fold } => {
                 let (_, under_cursor) = mark(&lines, &mut cursor_line);
-                lines.push(group_line(id.kind, *hidden, *expanded, under_cursor));
+                lines.push(group_line(id.kind, *hidden, fold, under_cursor));
             }
             Item::Blank => lines.push(Line::default()),
         }
@@ -696,6 +714,82 @@ mod tests {
     }
 
     #[test]
+    fn stage_glyphs_follow_the_prs_on_the_row() {
+        // The status column *is* the stage column now (#61/#62): an approved
+        // open PR reads ◍ in review, failing checks read ! needs attention —
+        // whatever the ticket's own state says.
+        let mut map = wf_map();
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 6)
+            .expect("#6")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::Approved,
+            },
+        }];
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 9)
+            .expect("#9")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 91,
+            status: PrStatus::Open {
+                checks: Checks::Failing,
+                review: Review::NotRequired,
+            },
+        }];
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let screen = render(&App::new(clusters));
+        assert!(screen.contains("◍ #6 Re-entry breadcrumbs"), "{screen}");
+        assert!(screen.contains("! #9 Main screen design"), "{screen}");
+        // Blocked still overrides whatever stage lies beneath.
+        assert!(screen.contains("⊘ #7 Supervising AFK agents"), "{screen}");
+    }
+
+    #[test]
+    fn a_shut_group_line_carries_its_stage_rollup() {
+        // Done ticket #2's PR is still open with pending checks: the shut
+        // group says so as a glyph+count pair, so a closed-but-unlanded branch
+        // is watched at a glance without opening it.
+        let mut map = wf_map();
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 2)
+            .expect("#2")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 92,
+            status: PrStatus::Open {
+                checks: Checks::Pending,
+                review: Review::Required,
+            },
+        }];
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let mut app = App::new(clusters);
+        let screen = render(&app);
+        assert!(screen.contains("● 1 done (hidden) ◐1"), "{screen}");
+
+        // Open, the rollup leaves with "(hidden)": the row is right there.
+        while !matches!(app.cursor_stop(), Some(crate::view::Stop::Group(_))) {
+            app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        let screen = render(&app);
+        let done_line = screen
+            .lines()
+            .find(|l| l.contains("done"))
+            .expect("the group line");
+        assert!(!done_line.contains("◐1"), "{screen}");
+    }
+
+    #[test]
     fn an_in_flight_open_pr_gets_no_verdict_glyph() {
         let mut map = wf_map();
         map.tickets
@@ -963,7 +1057,10 @@ mod tests {
             screen.contains("→ /wayfinder · #6 Re-entry breadcrumbs"),
             "{screen}"
         );
-        assert!(!screen.contains("5/5"), "the count line is replaced: {screen}");
+        assert!(
+            !screen.contains("5/5"),
+            "the count line is replaced: {screen}"
+        );
 
         // The typed mode shows on the line as it accumulates.
         type_str(&mut app, "defer something");

--- a/src/view.rs
+++ b/src/view.rs
@@ -743,12 +743,10 @@ mod tests {
     }
 
     #[test]
-    fn a_shut_group_carries_a_stage_rollup_counted_once_per_node() {
+    fn a_shut_group_carries_a_stage_rollup_of_what_it_holds() {
         // The done group holds #2 (plain done) and #4 — closed, but its PR is
         // still open and approved, so it reads in-review: a closed ticket
         // whose PR never landed is exactly what the rollup exists to surface.
-        // #2 unblocks two open tickets, so the DAG reaches it twice; the
-        // rollup counts the *held node*, once.
         let mut with_pr = ticket(4, false, false, vec![]);
         with_pr.prs = vec![PrLink {
             repo: "blooop/wayfinder".to_string(),
@@ -808,6 +806,61 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn a_node_the_rendered_tree_reaches_twice_is_counted_once() {
+        // The DAG's diamond: #6 and #9 are both takeable and both unblock #7,
+        // so the leverage view genuinely renders #7 *twice* — once under each
+        // root. That is the hazard the rollup rule exists for ("counted once
+        // per node via the rendered tree", #61): counts must come from the
+        // set of nodes a group holds, not from the rows on screen.
+        let m = map(vec![
+            ticket(6, true, false, vec![]),
+            ticket(7, true, false, vec![6, 9]),
+            ticket(9, true, false, vec![]),
+            ticket(2, false, false, vec![]),
+        ]);
+        let binding = id();
+        let plan = plan(
+            &[(&binding, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        // The premise, pinned: without it the rest of this test proves nothing.
+        assert_eq!(
+            stops(&plan, &m).into_iter().filter(|&n| n == 7).count(),
+            2,
+            "#7 hangs under both #6 and #9"
+        );
+
+        // Every shut group's counts sum to exactly what it holds — one entry
+        // per held node, and #7, rendered twice but held by nobody, is in no
+        // rollup at all.
+        let shut: Vec<(usize, Vec<(RowGlyph, usize)>)> = plan
+            .items
+            .iter()
+            .filter_map(|i| match i {
+                Item::Group {
+                    hidden,
+                    fold: Fold::Shut { rollup },
+                    ..
+                } => Some((*hidden, rollup.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            shut.len(),
+            1,
+            "only the done group holds anything: {shut:?}"
+        );
+        for (hidden, rollup) in shut {
+            assert_eq!(
+                rollup.iter().map(|(_, n)| n).sum::<usize>(),
+                hidden,
+                "rollup totals what the group holds, not what was drawn"
+            );
+        }
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -28,7 +28,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::app::Row;
 use crate::filter;
-use crate::model::{Map, MapId, Status, Ticket};
+use crate::model::{Map, MapId, RowGlyph, Status, Ticket};
 
 /// The structural screen `tab` toggles between — the half of the view state
 /// that is *stored*. The other half (whether a query is flattening the body)
@@ -120,15 +120,26 @@ pub enum Item {
         also_needs: Vec<u64>,
     },
     /// A collapsible group of held-back rows, always at depth 0 of its
-    /// cluster. Carries what it is holding (`hidden`) and whether it is open,
-    /// so the line can say so without consulting anything else.
+    /// cluster. Carries what it is holding (`hidden`) and its [`Fold`], so
+    /// the line can say so without consulting anything else.
     Group {
         id: GroupId,
         hidden: usize,
-        expanded: bool,
+        fold: Fold,
     },
     /// Spacer between clusters.
     Blank,
+}
+
+/// Whether a group line is folded — and, **only while it is**, the stage
+/// rollup of what it hides (#61): glyph+count pairs in display order, counted
+/// once per held node via the rendered tree, so a DAG that reaches a ticket
+/// twice cannot count it twice. An open group's rows are right on screen, so
+/// a rollup for it is unrepresentable rather than merely unshown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Fold {
+    Shut { rollup: Vec<(RowGlyph, usize)> },
+    Open,
 }
 
 /// The body, planned: the lines in on-screen order, plus how many in-scope
@@ -218,10 +229,12 @@ fn ticket_item(
 
 /// Push a collapsible group and, when it is open, the rows it holds — as
 /// depth-1 children of the group line, so `←` from a held row lands on the
-/// group that holds it.
+/// group that holds it. A shut group carries the stage rollup of its held
+/// rows instead: each held node contributes its glyph once.
 fn push_group(
     items: &mut Vec<Item>,
     id: &MapId,
+    map: &Map,
     kind: GroupKind,
     held: &[usize],
     expanded: &Expanded,
@@ -234,10 +247,21 @@ fn push_group(
         kind,
     };
     let is_expanded = expanded.contains(&group);
+    let fold = if is_expanded {
+        Fold::Open
+    } else {
+        let mut counts: BTreeMap<RowGlyph, usize> = BTreeMap::new();
+        for &index in held {
+            *counts.entry(RowGlyph::of(&map.tickets[index])).or_default() += 1;
+        }
+        Fold::Shut {
+            rollup: counts.into_iter().collect(),
+        }
+    };
     items.push(Item::Group {
         id: group,
         hidden: held.len(),
-        expanded: is_expanded,
+        fold,
     });
     if !is_expanded {
         return;
@@ -298,6 +322,7 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded) -> Plan {
         push_group(
             &mut plan.items,
             id,
+            map,
             GroupKind::BlockedDeeper,
             &deeper,
             expanded,
@@ -310,7 +335,7 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded) -> Plan {
             .filter(|(_, t)| !is_open(t))
             .map(|(i, _)| i)
             .collect();
-        push_group(&mut plan.items, id, GroupKind::Done, &done, expanded);
+        push_group(&mut plan.items, id, map, GroupKind::Done, &done, expanded);
 
         plan.items.push(Item::Blank);
     }
@@ -531,7 +556,7 @@ fn flattened(clusters: &[(&MapId, &Map)], query: &str) -> Plan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, TicketType};
+    use crate::model::{classify, Checks, PrLink, PrStatus, Review, Stage, TicketType};
 
     fn ticket(number: u64, open: bool, assigned: bool, blocked_by: Vec<u64>) -> Ticket {
         let open_blockers = blocked_by.clone(); // callers pass open blockers in fixtures
@@ -691,7 +716,7 @@ mod tests {
             i,
             Item::Group {
                 hidden: 2,
-                expanded: false,
+                fold: Fold::Shut { .. },
                 ..
             }
         )));
@@ -708,10 +733,114 @@ mod tests {
                 ("#4".to_string(), 1),
             ]
         );
-        assert!(expanded
+        assert!(expanded.items.iter().any(|i| matches!(
+            i,
+            Item::Group {
+                fold: Fold::Open,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn a_shut_group_carries_a_stage_rollup_counted_once_per_node() {
+        // The done group holds #2 (plain done) and #4 — closed, but its PR is
+        // still open and approved, so it reads in-review: a closed ticket
+        // whose PR never landed is exactly what the rollup exists to surface.
+        // #2 unblocks two open tickets, so the DAG reaches it twice; the
+        // rollup counts the *held node*, once.
+        let mut with_pr = ticket(4, false, false, vec![]);
+        with_pr.prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::Approved,
+            },
+        }];
+        let m = map(vec![
+            ticket(2, false, false, vec![]),
+            with_pr,
+            ticket(6, true, false, vec![2]),
+            ticket(9, true, false, vec![2]),
+        ]);
+        let binding = id();
+        let shut = plan(
+            &[(&binding, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        let fold = shut
             .items
             .iter()
-            .any(|i| matches!(i, Item::Group { expanded: true, .. })));
+            .find_map(|i| match i {
+                Item::Group { hidden, fold, .. } => Some((*hidden, fold.clone())),
+                _ => None,
+            })
+            .expect("the done group");
+        assert_eq!(
+            fold,
+            (
+                2,
+                Fold::Shut {
+                    rollup: vec![
+                        (RowGlyph::Stage(Stage::InReview), 1),
+                        (RowGlyph::Stage(Stage::Done), 1),
+                    ]
+                }
+            ),
+            "glyph+count pairs in display order, once per held node"
+        );
+
+        // Open, the rows are right there — the rollup only exists while shut,
+        // so a rollup on an expanded row is unrepresentable, not just unshown.
+        let open: Expanded = [GroupId {
+            map: binding.clone(),
+            kind: GroupKind::Done,
+        }]
+        .into_iter()
+        .collect();
+        let opened = plan(&[(&binding, &m)], Screen::Structured(Lens::Leverage), &open);
+        assert!(opened.items.iter().any(|i| matches!(
+            i,
+            Item::Group {
+                fold: Fold::Open,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn the_blocked_deeper_rollup_reads_blocked_not_stage() {
+        // A held-back blocked ticket rolls up as ⊘ — its stage is unactionable
+        // and the override carries into the counts (#62).
+        let m = Map {
+            title: "Map: fixture".to_string(),
+            tickets: vec![
+                ticket(6, true, false, vec![]),
+                ticket(7, true, false, vec![999]),
+            ],
+        };
+        let binding = id();
+        let plan = plan(
+            &[(&binding, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        let fold = plan
+            .items
+            .iter()
+            .find_map(|i| match i {
+                Item::Group { fold, .. } => Some(fold.clone()),
+                _ => None,
+            })
+            .expect("the blocked-deeper group");
+        assert_eq!(
+            fold,
+            Fold::Shut {
+                rollup: vec![(RowGlyph::Blocked, 1)]
+            }
+        );
     }
 
     #[test]
@@ -739,7 +868,7 @@ mod tests {
             .items
             .iter()
             .filter_map(|i| match i {
-                Item::Group { expanded, .. } => Some(*expanded),
+                Item::Group { fold, .. } => Some(matches!(fold, Fold::Open)),
                 _ => None,
             })
             .collect();

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -10,10 +10,12 @@
 //!
 //! It pins down three claims, in the order they can fail:
 //!
-//! 1. **`enter` execs the agent.** `claude` is shimmed to a script that records
-//!    its argv and cwd, so the assertion is on what `wf` actually handed the
-//!    agent — `--dangerously-skip-permissions "/wayfinder <map> <n>"`, in the
-//!    checkout — rather than on what it planned to.
+//! 1. **`enter` execs the agent.** Two enters since the two-step launch (#62):
+//!    the first stages the launch line, the second launches it interactive.
+//!    `claude` is shimmed to a script that records its argv and cwd, so the
+//!    assertion is on what `wf` actually handed the agent —
+//!    `--dangerously-skip-permissions "<skill> …"`, in the checkout — rather
+//!    than on what it planned to.
 //! 2. **`wf` is gone.** The shim is the *same process* as the `wf` that was
 //!    spawned: an `exec` replaces the image, so the pid the test is waiting on
 //!    exits with the shim's status. Spawn-and-wait would leave a `wf` parent
@@ -235,8 +237,14 @@ fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     // Generous, because a cold cache pays for the map search before the fetch.
     wait_for(&seen, "▶", Duration::from_secs(60), "the map to load");
 
+    // First enter stages the launch: the line shows the resolved route where
+    // the count line was. The second enter, on an empty line, launches
+    // interactive — today's default.
     keys.write_all(b"\r").expect("send enter");
     keys.flush().expect("flush enter");
+    wait_for(&seen, "→ /", Duration::from_secs(10), "the launch line");
+    keys.write_all(b"\r").expect("send the second enter");
+    keys.flush().expect("flush the second enter");
 
     let stream = wait_for(&seen, RAN, Duration::from_secs(30), "the agent to run");
     let screen = String::from_utf8_lossy(&stream).into_owned();
@@ -273,18 +281,25 @@ fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     );
     let (skip, prompt) = argv.split_once(' ').expect("two arguments");
     assert_eq!(skip, "--dangerously-skip-permissions");
-    // This repo keeps several maps open (#50) and which cluster the cursor was
-    // in is the live tracker's business, so only the prompt's shape is
-    // asserted: `/wayfinder <map> <ticket>`, both numbers.
-    let numbers = prompt
-        .strip_prefix("/wayfinder ")
-        .unwrap_or_else(|| panic!("prompt was {prompt:?}"));
-    let (map, ticket) = numbers.split_once(' ').expect("map and ticket numbers");
-    for half in [map, ticket] {
+    // This repo keeps several maps open (#50), and which cluster — and which
+    // ticket, at which stage — the cursor landed on is the live tracker's
+    // business. So only the prompt's shape is asserted: one of the three
+    // routes (#61), with its numeric arguments and no mode suffix (the line
+    // was empty — interactive).
+    let (skill, numbers) = prompt.split_once(' ').expect("a skill and arguments");
+    let halves: Vec<&str> = match skill {
+        "/wayfinder" => numbers.splitn(2, ' ').collect(),
+        "/tdd" | "/review" => vec![numbers],
+        other => panic!("unroutable skill {other:?} in prompt {prompt:?}"),
+    };
+    for half in &halves {
         assert!(
             !half.is_empty() && half.chars().all(|c| c.is_ascii_digit()),
             "prompt was {prompt:?}"
         );
+    }
+    if skill == "/wayfinder" {
+        assert_eq!(halves.len(), 2, "prompt was {prompt:?}");
     }
 
     // Claim 3a: the tty itself came back. `wf` runs raw the whole time it is


### PR DESCRIPTION
## What landed

wf's tree is stage-aware and its launch is a typed two-step, per the resolutions of #61 (stage lattice + routing) and #62 (two-step launch + glyphs). Built test-first at the ticket's four pre-agreed seams:

- **Stage derivation** (`model::stage`) — a pure function (linked-PR facts, ticket state) → `Stage`, a five-value lattice (`Ready → Building → InReview → NeedsAttention → Done`) whose derived `Ord` *is* the max-over-open-PRs order. Per-open-PR fixed table; no open PRs: merged → done, else ticket state; PR dominates when present. Table-driven tests cover every row of the #61 table.
- **Routing** (`launch::route`) — `(TicketType, Stage) → Option<Route>`, exhaustive on both axes with no wildcard, so a new stage or type without a route fails to compile. Done is the total-function refusal; blocked is refused on status before routing is consulted. The vocabulary grows exactly one type: `wayfinder:build` (ranked below the decision types in the multi-label tie-break — it is the most autonomous type).
- **Launch-line state machine** (`app`) — enter on a launchable node opens the launch line where the count line was, showing the resolved route (`→ /tdd · #65 …`); text accumulates on the line, never in the query; esc restores the list with query and cursor intact; enter launches with the typed mode (`LaunchMode::parse`: empty/`defer`/`defer <text>`/steering). Done and blocked nodes are a no-op with a count-line notice. The mode survives the which-checkout picker.
- **View planning** (`view`/`ui`) — the glyph column is the stage glyph (`○ ◐ ◍ ! ●`, `⊘` blocked overriding) via one `RowGlyph` sum type; shut group rows carry a stage rollup as glyph+count pairs (`Fold::Shut { rollup }` — a rollup on an open group is unrepresentable), counted once per held node.

Exec'd commands: build @ ready/building/needs-attention → `claude "/tdd <n>"`; build @ in-review → `claude "/review <n>"`; decision types → `claude "/wayfinder <map> <n>"`; the launch-line mode rides any route as ` defer` / ` defer: <text>` / ` steer: <text>`.

One recorded judgment (flagged on #74): decision types route to /wayfinder at every non-done stage — PR-dominant derivation can put a prototype at in-review, and the #61 table's ready/in-progress row is read as "any unfinished stage".

The live e2e (`tests/live_launch_exec.rs`) now drives the two-step (enter → launch line → enter) and accepts any of the three route shapes.

## Base

PRs #56 (`build10-pr-badges`) and #58 (`build11-depth-cursor`) have landed on main, so this branch is now **rebased onto main** rather than merging them: the diff is just this build's five commits plus the review fixes below. The `PrStatus{Draft, Open{checks, review}, Merged, Closed}` data plane and the depth-aware cursor are taken as given from main, not re-decided. (The `src/ui.rs` conflict was resolved main's way on the furniture — #58 landed with the lit-path highlight deliberately dropped — keeping only this build's stage glyph and rollup rendering.)

## Review fixes

`/review` ran on this PR and found three blocking defects, fixed here on the same branch:

- **A staged launch is index-free.** `Overlay::LaunchLine` held a `Row` — a positional index the module's own doc calls "only valid against the clusters it was read from". The line stays up while background map arrivals swap those clusters (#27), so the next frame drew, and the second `enter` launched, whatever ticket had landed at that index — or panicked outright when the map came back shorter or gone. A new `launch::Staged` snapshots the ticket's own facts at the first `enter`, the shape `PickCheckout` already used.
- **Both PR axes are read exhaustively.** `open_pr_stage` chained `if matches!(…)` and fell through to in-review, so a new `Checks` or `Review` variant would have read as "in review" in silence — the exact fall-through `route` was written to make impossible. Each axis now maps exhaustively to a `Signal`, combining by the table's own precedence (which is deliberately not the `Stage` lattice: within one PR, pending checks outrank a settled review). Behaviour unchanged.
- **The DAG-double-count test earns its claim.** It asserted "the DAG reaches it twice" of a fixture where nothing was rendered twice, and could not have failed. The hazard now gets a fixture that contains it — a diamond where one ticket hangs under both roots — with the premise pinned before the invariant that rests on it.

Plus the README, which still said `enter` "run[s] the agent … and exit[s]" and described none of the stage glyphs, routing or rollups.

Two review findings are **recorded rather than fixed**: rollups land only on collapsed group rows, not branch-root rows (#74's own acceptance criterion says "only on collapsed rows", narrowing #61); and the cluster header still counts *statuses* with the same glyph characters the rows now spend on *stages* — a rendering decision for #61/#62 to settle, not a defect to patch here. The README now says so explicitly.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce stage-aware ticket stages and typed two-step launches, integrating PR-derived status into routing, UI, and execution flow.

New Features:
- Add stage lattice and row glyph model, deriving ticket stage from linked PRs and ticket status, and expose stage-based glyphs and rollups in the UI.
- Introduce a two-step, typed launch flow with a launch-line overlay that stages routes and modes before resolving and executing agent commands.
- Add a stage- and type-based routing table that maps tickets to TDD, review, or wayfinder skills and supports deferred and steered launch modes.
- Surface linked pull requests on ticket rows via PR badges that show cross-repo PRs and their checks/review status, and fetch corresponding data from GitHub.
- Support collapsible blocked/done groups with durable identities, expansion state, and stage rollups, and treat group headers as navigable cursor stops.
- Add a non-interactive preview_screen example binary to render and inspect the main screen against live maps.

Bug Fixes:
- Prevent cursor wedging on only-child or deep chain structures by falling back to adjacent stops when no same-depth sibling exists.
- Fix forest/tree furniture alignment for deeper hierarchies so branch guides stay vertically aligned across three or more levels.

Enhancements:
- Refine body planning and navigation to operate over typed cursor stops with depth, enabling sibling- and depth-aware navigation across tickets and groups.
- Update UI rendering to show stage glyphs, lit tree paths to the cursor, and integrate launch-line rendering into the count-line area.
- Extend launch planning to carry explicit route and launch mode into the exec’d agent argv, while keeping checkout resolution logic unchanged.
- Generalize status glyph handling into a reusable RowGlyph abstraction shared between per-row rendering and group rollup computation.

Documentation:
- Update README to describe stage glyphs, PR badges, depth-aware navigation, group folding behavior, and revised keybindings for tree navigation and launch.

Tests:
- Add extensive navigation tests for sibling/depth-aware cursor movement, expansion persistence, and direction-key behavior across complex tree shapes.
- Expand view planning tests to cover group rollups, depth annotations, forest alignment, flattened view behavior, and cursor-path highlighting.
- Add launch tests for two-step staging, blocked/done refusal, build-stage routing, and propagation of launch modes through checkout selection.
- Add model-layer tests for build ticket type parsing, stage derivation from PRs and status, row glyph behavior, and PR status precedence rules.
- Add fetch-layer tests that validate parsing of linked PRs, including null review/check states and robustness to missing PR selections.
- Update live end-to-end exec test to drive the two-step launch sequence and accept any of the routed skill prompts.
