### PR TITLE
Lint, format and test on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+# Formatting, lints, tests and docs — everything that can be judged without
+# building a package. `package.yml` is the other half: it proves the recipe
+# still installs and runs. Kept apart on purpose. A rattler build takes minutes
+# and downloads a toolchain of its own, so folding `cargo fmt` into it would
+# make the cheapest possible failure the slowest one to hear about.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # A warning is a failure here and only here. The lint levels themselves live
+  # in Cargo.toml's `[lints]` table, at `warn`, so a local `cargo build` stays
+  # readable while a pull request cannot merge with a warning in it — one place
+  # to change a level, one place that decides how loudly it lands.
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # One job, not four. Every step below needs the same dependency graph
+  # compiled, and separate jobs would each pay for it from scratch — the whole
+  # run is faster than a single cold `cargo clippy`. The steps are ordered by
+  # how cheap they are to fix, so the fastest failure is also the first one:
+  # formatting needs no compilation at all, lints need one check pass, tests
+  # need a build.
+  check:
+    name: fmt + clippy + test + doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install the Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      # Keyed on the lockfile and the compiler version, and scoped to this
+      # workflow so `package.yml`'s registry cache stays a separate thing.
+      - name: Cache cargo's registry and the target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ci
+
+      # First, because it is the one check that cannot be wrong about the code:
+      # it either matches `cargo fmt` or it does not. rustfmt.toml holds only
+      # stable options, so this runs on the stable toolchain above rather than
+      # needing nightly.
+      - name: Formatting
+        run: cargo fmt --all --check
+
+      # `--all-targets` reaches the tests, the example and the `#[cfg(test)]`
+      # modules — most of this crate's code is in one of those, and a lint that
+      # stopped at `src/` would miss it. `--locked` fails on a Cargo.lock that
+      # does not match Cargo.toml instead of quietly updating it, which is the
+      # same promise the recipe's `--locked` build makes.
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features --locked
+
+      # The unit tests, the ones that need nothing but a compiler. Everything
+      # under `tests/` is a `live_*` integration test — a real `gh`, real
+      # network, and assertions against this project's own tracker as it stands
+      # today — so running them here would make CI fail whenever the map moves
+      # on. They are compiled below instead of run.
+      - name: Unit tests
+        run: cargo test --locked --lib --bins --examples
+
+      # Compiled but not run: a test that no longer builds is rot, and this is
+      # what catches it at the commit that caused it rather than the next time
+      # somebody runs them by hand.
+      - name: The live tests still compile
+        run: cargo test --locked --all-targets --no-run
+
+      # `RUSTDOCFLAGS` above makes this fail on a broken intra-doc link. Worth a
+      # step of its own in a crate this heavily documented: the doc comments
+      # cross-reference each other constantly, and a link that silently stops
+      # resolving is a comment that has started lying about where its subject
+      # lives.
+      - name: Docs
+        run: cargo doc --no-deps --all-features --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,63 @@ description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over
 license = "MIT"
 repository = "https://github.com/blooop/wayfinder"
 
+# The lint level for every target in the crate — `src/`, `tests/`, and the
+# doctests — declared here rather than as `#![warn(...)]` in `src/lib.rs`,
+# because an inner attribute in the library root does not reach `tests/`.
+# Nothing is `deny` except `unsafe_code`: CI turns warnings into failures with
+# `-D warnings` (.github/workflows/ci.yml), so a local build stays readable
+# while a pull request still cannot merge with a warning in it.
+[lints.rust]
+# There is no `unsafe` in `src/` and there is no reason for any: everything
+# dangerous `wf` does, it does by handing work to another process. The one
+# genuine exception is the pty harness in tests/live_launch_exec.rs, which says
+# so with a file-level `allow` — so adding unsafe anywhere is now a visible,
+# deliberate act rather than a line that slips through review.
+unsafe_code = "deny"
+
+# `&Foo` in a signature where `Foo` has a lifetime, written `&Foo<'_>`. Purely
+# so the elision is visible at the call site.
+rust_2018_idioms = { level = "warn", priority = -1 }
+
+missing_debug_implementations = "warn"
+unused_qualifications = "warn"
+unused_lifetimes = "warn"
+trivial_casts = "warn"
+
+[lints.clippy]
+# `all` is correctness + suspicious + style + complexity + perf; `pedantic` is
+# the opinionated layer on top. Both at `priority = -1` so the individual
+# `allow`s below win over the group they belong to, whatever order cargo emits
+# them in.
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Every `allow` below is a lint that is right about the code and wrong about
+# this crate. Nothing else is silenced — the rest of `pedantic` was fixed rather
+# than switched off.
+
+# `#[must_use]` is a promise to a caller outside the crate, and there is none:
+# `wf` is a binary. Annotating ~55 internal accessors would be pure noise.
+must_use_candidate = "allow"
+
+# Laying out a terminal is `usize` arithmetic that has to end up in ratatui's
+# `u16` coordinates. The casts are the honest expression of that boundary, and
+# a screen wide enough to overflow one does not exist; `try_into().unwrap()` at
+# each site would only move the same assumption into a panic.
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_sign_loss = "allow"
+
+# Wants `Duration::from_mins(1)` where a test writes `from_secs(60)`. The
+# timeouts in tests/live_launch_exec.rs are meant to be compared with each other
+# at a glance — `from_secs(60)` beside `from_secs(30)` says more than one of each
+# unit does — and the suggested constructor is newer than the toolchain the
+# recipe asks for anyway.
+duration_suboptimal_units = "allow"
+
+# `dbg!` survives a review far too easily.
+dbg_macro = "warn"
+
 [dev-dependencies]
 # Only the pty end-to-end test needs it: driving the real binary through a real
 # terminal is the only way to prove `enter` execs the agent (tests/live_launch_exec.rs).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,36 @@ nothing else — there is no multiplexer to install.
 `wf --version` and `wf --help` are the only arguments; everything else is keys
 in the TUI.
 
+## Checks
+
+`.github/workflows/ci.yml` runs four things on every pull request and every push
+to main, in the order they are cheap to fix:
+
+```
+cargo fmt --all --check
+cargo clippy --all-targets --all-features --locked
+cargo test --locked --lib --bins --examples
+cargo doc --no-deps --all-features --locked
+```
+
+Run them locally with the same commands. CI adds `RUSTFLAGS=-D warnings`, so
+anything that warns there fails; the lint *levels* live in one place,
+Cargo.toml's `[lints]` table, which is `clippy::all` + `clippy::pedantic` plus a
+handful of rustc lints, and denies `unsafe` outright — the only `unsafe` in the
+repo is the pty harness in `tests/live_launch_exec.rs`, which says so with a
+file-level `allow` and a reason. `rustfmt.toml` and `clippy.toml` hold the rest;
+every lint that is switched off carries a comment saying why, so the list stays
+arguable rather than accumulating.
+
+Everything under `tests/` is a `live_*` integration test — a real `gh`, real
+network, real assertions against this project's own tracker — so CI compiles
+them but does not run them, and a moving map never breaks a build. Run them
+yourself when the fetch or launch path changes:
+
+```
+cargo test --test live_fetch --test live_discovery
+```
+
 ## Releasing
 
 `recipe/recipe.yaml` builds the binary straight from the checkout, and

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+# `wf` is a binary. `src/lib.rs` exists so the integration tests under `tests/`
+# can reach the internals, not because anything outside this repository links
+# against it — there is no semver promise to keep. Telling clippy that turns on
+# the lints it otherwise suppresses for `pub` items (needless_pass_by_value,
+# wrong_self_convention, and the rest of the API-shape family), which is where
+# most of this crate's code lives.
+avoid-breaking-exported-api = false

--- a/examples/preview_screen.rs
+++ b/examples/preview_screen.rs
@@ -2,7 +2,7 @@
 //! see what `wf` will draw, and to drive its keys, without taking over the
 //! terminal. Throwaway.
 //!
-//! Run: cargo run --example preview_screen -- blooop/wayfinder 47 [more...]
+//! Run: `cargo run --example preview_screen -- blooop/wayfinder 47 [more...]`
 //! Keys to replay come from $KEYS, e.g. KEYS="down right right" — one of
 //! down/up/left/right/tab/<char>.
 
@@ -74,8 +74,8 @@ async fn main() {
         "cursor: {} of {} → {} at depth {}",
         pos,
         stops.len(),
-        stops.get(pos).map(&label).unwrap_or("nothing".into()),
-        stops.get(pos).map(|at| at.depth as isize).unwrap_or(-1),
+        stops.get(pos).map_or("nothing".into(), &label),
+        stops.get(pos).map_or(-1, |at| at.depth as isize),
     );
     if std::env::var("NAV").is_ok() {
         for (i, at) in stops.iter().enumerate() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,18 @@
+# Formatting is not a matter of taste here — it is `cargo fmt` and nothing else,
+# so a diff never contains a line that only moved. Everything below is a
+# *stable* rustfmt option on purpose: `cargo fmt --check` runs on stable in CI
+# (.github/workflows/ci.yml), and a single nightly-only key makes rustfmt reject
+# the whole file, so the pretty import-grouping options are deliberately absent.
+edition = "2021"
+
+# The default width, stated rather than implied, because the doc comments in
+# this crate are hand-wrapped to it and a future change here would silently
+# invalidate all of them.
+max_width = 100
+
+# `\n`, never `\r\n`, whatever the checkout's platform does.
+newline_style = "Unix"
+
+# `Self { name }` over `Self { name: name }`, and `?` over `try!`.
+use_field_init_shorthand = true
+use_try_shorthand = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,6 +101,7 @@ pub enum StopKey {
     Group(GroupId),
 }
 
+#[derive(Debug)]
 pub struct App {
     /// The clusters on screen: every open map that has arrived, in
     /// (repo, number) order — which is also render order.
@@ -179,6 +180,7 @@ impl App {
     /// Attach the launch input: the cached checkouts (the candidate trees an
     /// agent could run in). Which map a ticket belongs to is no longer a
     /// lookup — every row sits in a cluster that *is* its map (#50).
+    #[must_use]
     pub fn with_checkouts(mut self, checkouts: Vec<Checkout>) -> Self {
         self.checkouts = checkouts;
         self
@@ -481,8 +483,8 @@ impl App {
     ///
     /// Everything this needs came with the [`Staged`] launch, so a refetch
     /// between the two enters cannot redirect it at another ticket.
-    fn resolve_launch(&mut self, staged: Staged, mode: LaunchMode) -> Outcome {
-        match launch::plan(&self.checkouts, &staged, mode) {
+    fn resolve_launch(&mut self, staged: &Staged, mode: &LaunchMode) -> Outcome {
+        match launch::plan(&self.checkouts, staged, mode) {
             Targets::Unregistered => {
                 self.notice = Some(format!(
                     "no registered checkout of {} on this machine — run wf inside one",
@@ -524,7 +526,7 @@ impl App {
             // Back to the list; the overlay is already None.
             KeyCode::Esc => Outcome::Continue,
             KeyCode::Char('c') if ctrl => Outcome::Quit,
-            KeyCode::Enter => self.resolve_launch(staged, LaunchMode::parse(&text)),
+            KeyCode::Enter => self.resolve_launch(&staged, &LaunchMode::parse(&text)),
             KeyCode::Backspace => {
                 text.pop();
                 self.overlay = Overlay::LaunchLine { staged, text };
@@ -1312,7 +1314,9 @@ mod tests {
                 assert_eq!(launches.len(), 2);
                 assert_eq!(*cursor, 0);
             }
-            other => panic!("expected the picker, got {other:?}"),
+            other @ (Overlay::None | Overlay::LaunchLine { .. }) => {
+                panic!("expected the picker, got {other:?}")
+            }
         }
         // The picker owns every key: typing must not leak into the query.
         app.handle_key(key(KeyCode::Char('x')));
@@ -1337,7 +1341,9 @@ mod tests {
         }
         match &app.overlay {
             Overlay::PickCheckout { cursor, .. } => assert_eq!(*cursor, 1),
-            other => panic!("expected the picker, got {other:?}"),
+            other @ (Overlay::None | Overlay::LaunchLine { .. }) => {
+                panic!("expected the picker, got {other:?}")
+            }
         }
         assert_eq!(app.handle_key(key(KeyCode::Esc)), Outcome::Continue);
         assert_eq!(app.overlay, Overlay::None);

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -11,9 +11,9 @@
 //!
 //! The `blockedBy` selection already carries the *full* edge set — closed
 //! blockers included — and since #50 the parse keeps it: the open subset
-//! becomes [`Status::Blocked`]'s `needs`, the whole set becomes
-//! [`Ticket::blocked_by`] (the DAG), and neither is re-derived from the other
-//! afterwards.
+//! becomes [`Status::Blocked`](crate::model::Status::Blocked)'s `needs`, the
+//! whole set becomes [`Ticket::blocked_by`] (the DAG), and neither is
+//! re-derived from the other afterwards.
 //!
 //! Both invocations are `stdin`-nulled and `kill_on_drop`. Neither is
 //! decoration. `tokio`'s `Command::output()` pipes only stdout and stderr and
@@ -180,7 +180,7 @@ fn parse_pr(pr: &PrNode) -> Option<PrLink> {
             checks: match pr.status_check_rollup.as_ref().map(|r| r.state.as_str()) {
                 None => Checks::Absent,
                 Some("SUCCESS") => Checks::Passing,
-                Some("FAILURE") | Some("ERROR") => Checks::Failing,
+                Some("FAILURE" | "ERROR") => Checks::Failing,
                 Some(_) => Checks::Pending, // EXPECTED, PENDING, or newer
             },
             review: match pr.review_decision.as_deref() {
@@ -205,6 +205,14 @@ fn is_open(state: &str) -> bool {
 
 /// Fetch one map live: the map issue named by `id`, its sub-issues, and their
 /// blocking edges — one `gh api graphql` round trip.
+///
+/// # Errors
+///
+/// A malformed repo slug, a `gh` that is missing or unauthenticated, a network
+/// failure, or a response that does not parse. Every one of them is the same
+/// thing to the caller — the cluster for this map does not arrive — and
+/// [`refresh`](crate::refresh) turns it into the failure note on screen rather
+/// than an exit.
 pub async fn fetch_map(id: &MapId) -> Result<Map> {
     let (owner, name) = id
         .repo
@@ -333,6 +341,12 @@ struct SearchResponse {
 /// contributes several ids (#50 — the lowest-number-per-slug rule that used to
 /// hide all but one is gone), and repos without maps are simply absent. Only
 /// open map issues count — a closed map is a finished map.
+///
+/// # Errors
+///
+/// The search itself failing: no `gh`, no credentials, no network, or a
+/// response that does not parse. An empty `repos` is not an error — it is an
+/// empty [`MapSet`], which is what a machine with nothing discovered yet has.
 pub async fn find_maps(repos: &[String]) -> Result<MapSet> {
     if repos.is_empty() {
         return Ok(MapSet::new());

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -246,9 +246,15 @@ impl Launch {
     /// **The caller must have restored the terminal first.** There is no second
     /// chance after the image is replaced, so that ordering lives in `main`,
     /// where it is one statement above the call, rather than in here.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: [`agent_argv`](Self::agent_argv) builds the vector
+    /// literally and always starts it with the program name, so the split below
+    /// cannot come up empty. The `expect` is there to say so.
     pub fn exec(&self) -> anyhow::Error {
         let argv = self.agent_argv();
-        let (program, args) = argv.split_first().expect("agent argv is never empty");
+        let (program, rest) = argv.split_first().expect("agent argv is never empty");
 
         // Resolved against `$PATH` *before* the chdir, deliberately. `exec`
         // chdirs into `cwd` and only then runs `execvp`, so a `$PATH` holding
@@ -275,13 +281,13 @@ impl Launch {
 
         // `CommandExt::exec` only ever returns on failure.
         let err = Command::new(&program)
-            .args(args)
+            .args(rest)
             .current_dir(&self.cwd)
             .exec();
         // Quoted, so the prompt reads as the single argument it is — the whole
         // invariant `agent_argv` exists to hold.
         let quoted: Vec<String> = std::iter::once(program.display().to_string())
-            .chain(args.iter().cloned())
+            .chain(rest.iter().cloned())
             .map(|a| format!("{a:?}"))
             .collect();
         anyhow::Error::new(err).context(format!(
@@ -339,7 +345,12 @@ pub enum Targets {
 /// Resolve a launch request against the projects cache. Zero or one candidate
 /// never prompts. The route and mode arrive already settled — this function
 /// only answers *where* the agent can run.
-pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: LaunchMode) -> Targets {
+///
+/// # Panics
+///
+/// Never: the `expect` in the one-candidate arm is guarded by the `match` on
+/// the length immediately above it.
+pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
     let launches: Vec<Launch> = candidate_checkouts(checkouts, &staged.repo)
         .into_iter()
         .map(|c| Launch {
@@ -389,7 +400,7 @@ mod tests {
         plan(
             checkouts,
             &Staged::new(ticket, map_issue, Route::Wayfinder),
-            LaunchMode::Interactive,
+            &LaunchMode::Interactive,
         )
     }
 
@@ -449,7 +460,7 @@ mod tests {
         };
         assert_eq!(launches.len(), 2);
         assert_eq!(
-            launches.iter().map(|l| l.cwd()).collect::<Vec<_>>(),
+            launches.iter().map(Launch::cwd).collect::<Vec<_>>(),
             vec![
                 Path::new("/data/k1/kinisi_ros"),
                 Path::new("/data/k2/kinisi_ros")
@@ -503,7 +514,7 @@ mod tests {
     fn the_agent_command_is_the_route_plus_the_mode_suffix() {
         let launch = |route: Route, mode: LaunchMode| -> String {
             let staged = Staged::new(&ticket("blooop/wayfinder", 16), 1, route);
-            match plan(&cache(), &staged, mode) {
+            match plan(&cache(), &staged, &mode) {
                 Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
                 other => panic!("{other:?}"),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,7 @@ mod tests {
     use super::*;
 
     fn argv(args: &[&str]) -> Vec<String> {
-        args.iter().map(|s| s.to_string()).collect()
+        args.iter().copied().map(String::from).collect()
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -255,8 +255,8 @@ impl TicketType {
     /// recognised label is [`TicketType::Untyped`].
     ///
     /// Labels are a *set*, so several type labels on one issue is a
-    /// representable input and needs a rule. It resolves by
-    /// [`TicketType::precedence`], HITL-first, so an ambiguous ticket never
+    /// representable input and needs a rule. It resolves by `precedence`
+    /// (private, just below), HITL-first, so an ambiguous ticket never
     /// reads as the kind you could walk away from:
     /// `wayfinder:research` + `wayfinder:task` is a `Task`.
     pub fn from_labels<'a, I: IntoIterator<Item = &'a str>>(labels: I) -> TicketType {
@@ -372,6 +372,12 @@ pub struct Ticket {
     pub title: String,
     pub status: Status,
     /// The `wayfinder:*` type, parsed from the issue's labels at fetch time.
+    ///
+    /// Named after the label vocabulary it carries rather than shortened to
+    /// `kind`: on the tracker this is literally the ticket's *type*, and
+    /// `ticket.ticket_type` matching `wayfinder:type/*` is worth more than
+    /// avoiding the repeated word.
+    #[allow(clippy::struct_field_names)]
     pub ticket_type: TicketType,
     /// Every issue this ticket is blocked by — the full DAG edge set, closed
     /// blockers included (#50). This is *structure*, where

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -36,12 +36,12 @@ pub struct Checkout {
 /// The per-machine cache of touched checkouts, plus the last map search's
 /// findings (#28).
 ///
-/// The findings are a set of [`MapId`]s, not held on a [`Checkout`]: which
-/// issues are a repo's maps is a property of the repo, and two checkouts of
-/// one repo would otherwise each carry a copy that can disagree with the
-/// other. A set of ids rather than a per-repo number because a repo can hold
-/// several open maps at once (#50) — the old `repo → one number` table could
-/// not even represent that.
+/// The findings are a set of [`MapId`](crate::model::MapId)s, not held on a
+/// [`Checkout`]: which issues are a repo's maps is a property of the repo, and
+/// two checkouts of one repo would otherwise each carry a copy that can
+/// disagree with the other. A set of ids rather than a per-repo number because
+/// a repo can hold several open maps at once (#50) — the old
+/// `repo → one number` table could not even represent that.
 ///
 /// There is deliberately no third "not yet searched" state. The search is
 /// unconditional — the cache is a head start, never a skip (see
@@ -70,6 +70,13 @@ impl ProjectsCache {
     }
 
     /// Persist the cache, creating parent directories as needed.
+    ///
+    /// # Errors
+    ///
+    /// An unwritable cache directory or file. The counterpart
+    /// [`load_or_default`](Self::load_or_default) swallows its errors because a
+    /// cache that will not load is merely empty; one that will not *save*
+    /// silently loses the registration this run just made, so it is reported.
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(dir) = path.parent() {
             std::fs::create_dir_all(dir)

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -3,7 +3,7 @@
 //!
 //! `wf` is on screen for seconds and restarts warm in ~0.6 s, so there is
 //! nothing here to keep fresh — [Build 7](https://github.com/blooop/wayfinder/issues/34)
-//! deleted the two-tier ETag poll ([Build 5](https://github.com/blooop/wayfinder/issues/17))
+//! deleted the two-tier `ETag` poll ([Build 5](https://github.com/blooop/wayfinder/issues/17))
 //! along with the event loop it served. What is left is a **one-shot load per
 //! map**, streamed:
 //!
@@ -126,7 +126,7 @@ impl Startup {
     /// unless it has already reported.
     pub fn searched(&mut self, maps: &MapSet) {
         self.search = Search::Answered;
-        self.expected = maps.clone();
+        self.expected.clone_from(maps);
     }
 
     /// Record `id`'s map reporting. A *failed* fetch counts as reported: the
@@ -187,7 +187,7 @@ impl Startup {
 /// set is reconciled against the truth instead. The id *is* the whole target
 /// — repo and number both — so "same repo, different map number" is simply a
 /// different key, not a number to compare.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Loaders {
     running: BTreeMap<MapId, JoinHandle<()>>,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,6 +13,7 @@ use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
+use crate::launch::Launch;
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
 use crate::view::{Fold, GroupKind, Item, Plan, Screen};
 
@@ -24,9 +25,10 @@ fn glyph_style(glyph: RowGlyph) -> Style {
         RowGlyph::Stage(Stage::Ready) => Style::new().fg(Color::Green),
         RowGlyph::Stage(Stage::Building) => Style::new().fg(Color::Yellow),
         RowGlyph::Stage(Stage::InReview) => Style::new().fg(Color::Magenta),
-        RowGlyph::Stage(Stage::NeedsAttention) => Style::new().fg(Color::Red),
+        // One arm, because it is one meaning: both of these are waiting on a
+        // person, and the colour is what says so.
+        RowGlyph::Stage(Stage::NeedsAttention) | RowGlyph::Blocked => Style::new().fg(Color::Red),
         RowGlyph::Stage(Stage::Done) => Style::new().add_modifier(Modifier::DIM),
-        RowGlyph::Blocked => Style::new().fg(Color::Red),
     }
 }
 
@@ -189,7 +191,7 @@ fn ticket_line(
 }
 
 /// The body as styled lines: the [`Plan`] walked in order. Shared by the live
-/// draw and the TestBackend tests.
+/// draw and the `TestBackend` tests.
 pub fn body_lines(app: &App) -> Vec<Line<'static>> {
     body_with_cursor(app, &app.plan()).0
 }
@@ -304,6 +306,11 @@ const KEY_HINTS: &str =
 /// [`crate::refresh::Startup`] exists to remove. So both other cases are named
 /// before "no projects" is claimed. With clusters on screen, the heading
 /// counts the ground they cover: the one repo's slug, or how many projects.
+///
+/// # Panics
+///
+/// Never: the arm that takes the single failed id has already matched on
+/// `len() == 1`.
 pub fn heading(app: &App) -> String {
     if app.clusters.is_empty() {
         if !app.startup.is_loaded() {
@@ -336,6 +343,11 @@ pub fn heading(app: &App) -> String {
 /// one: four clusters on screen and a fifth missing draws a perfectly normal
 /// screen, so the only place left to say so is here — and it has to survive
 /// the next keypress, which the one-shot notice does not.
+///
+/// # Panics
+///
+/// Never: as in [`heading`], the arm that takes the single failed id has
+/// already matched on `len() == 1`.
 pub fn failure_note(app: &App) -> String {
     match app.failed.len() {
         0 => String::new(),
@@ -377,7 +389,7 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
 /// exactly one, and `wf` cannot guess which. The path *is* the row — it is what
 /// distinguishes the candidates, and with no session to name there is nothing
 /// shorter to show alongside it.
-fn draw_overlay(frame: &mut Frame, app: &App) {
+fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
     let Overlay::PickCheckout { launches, cursor } = &app.overlay else {
         return;
     };
@@ -399,7 +411,7 @@ fn draw_overlay(frame: &mut Frame, app: &App) {
     ));
     // This asks *which checkout*, so the ticket only needs identifying — its
     // title is already on the row behind the prompt.
-    let key = launches.first().map(|l| l.key()).unwrap_or_default();
+    let key = launches.first().map(Launch::key).unwrap_or_default();
     let width = lines
         .iter()
         .map(|l| l.width() as u16 + 4)
@@ -422,7 +434,7 @@ fn draw_overlay(frame: &mut Frame, app: &App) {
 /// clusters, then the anchored bottom chrome — the match-count line (with the
 /// load hint and any one-shot notice), the fzf-style prompt, and the key hints.
 /// The which-checkout picker, when open, floats over all of it.
-pub fn draw(frame: &mut Frame, app: &App) {
+pub fn draw(frame: &mut Frame<'_>, app: &App) {
     let mut block = match &app.scope {
         Scope::All => Block::bordered().title(format!(" wf · {} ", heading(app))),
         // The focused title names the project by its full slug — with one
@@ -569,7 +581,7 @@ mod tests {
         }
     }
 
-    /// Render the app through TestBackend and return the screen as text.
+    /// Render the app through `TestBackend` and return the screen as text.
     fn render(app: &App) -> String {
         let backend = TestBackend::new(90, 24);
         let mut terminal = Terminal::new(backend).expect("terminal");

--- a/src/view.rs
+++ b/src/view.rs
@@ -44,6 +44,7 @@ pub enum Lens {
 }
 
 impl Lens {
+    #[must_use]
     pub fn toggled(self) -> Lens {
         match self {
             Lens::Leverage => Lens::Forest,
@@ -183,7 +184,7 @@ impl Plan {
 }
 
 /// Plan the body for the clusters in scope, in their given (render) order.
-pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen, expanded: &Expanded) -> Plan {
+pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
     match screen {
         Screen::Structured(Lens::Leverage) => leverage(clusters, expanded),
         Screen::Structured(Lens::Forest) => forest(clusters),
@@ -205,7 +206,7 @@ fn is_open(t: &Ticket) -> bool {
 fn open_unblocks(map: &Map, number: u64) -> Vec<u64> {
     map.unblocks(number)
         .into_iter()
-        .filter(|&n| map.index_of(n).map(|i| is_open(&map.tickets[i])) == Some(true))
+        .filter(|&n| map.index_of(n).is_some_and(|i| is_open(&map.tickets[i])))
         .collect()
 }
 
@@ -1098,7 +1099,7 @@ mod tests {
         assert_eq!(
             furniture,
             vec![
-                (13, "".to_string(), 0),
+                (13, String::new(), 0),
                 (14, "├─".to_string(), 1),
                 (15, "│ └─".to_string(), 2),
                 (17, "└─".to_string(), 1),

--- a/tests/live_discovery.rs
+++ b/tests/live_discovery.rs
@@ -2,7 +2,7 @@
 //! very checkout is discovered from its git metadata, registered into a
 //! throwaway cache, its map found via the one-shot label search, and the
 //! map fetched. Needs network, an authenticated `gh`, and this test running
-//! from inside the wayfinder checkout (CARGO_MANIFEST_DIR).
+//! from inside the wayfinder checkout (`CARGO_MANIFEST_DIR`).
 
 use std::path::Path;
 

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -29,6 +29,14 @@
 //! Needs network, an authenticated `gh`, and a `blooop/wayfinder` checkout with
 //! at least one ticket on its map — i.e. this repo.
 
+// The crate denies `unsafe_code` (see `[lints.rust]` in Cargo.toml) and `src/`
+// contains none. This file is the single exception, and it is the reason the
+// deny is worth having elsewhere: `openpty`, `fork`/`exec`, and turning the raw
+// fds it hands back into `OwnedFd`s are libc calls with no safe equivalent in
+// std, and a real pty is the only way to observe the launch at all. Nothing here
+// is part of the shipped binary.
+#![allow(unsafe_code)]
+
 use std::io::{Read, Write};
 use std::os::fd::{FromRawFd, OwnedFd};
 use std::os::unix::process::CommandExt;
@@ -111,11 +119,11 @@ fn openpty_sized(rows: u16, cols: u16) -> (OwnedFd, OwnedFd) {
     size.ws_col = cols;
     let rc = unsafe {
         libc::openpty(
-            &mut master,
-            &mut slave,
+            std::ptr::from_mut(&mut master),
+            std::ptr::from_mut(&mut slave),
             std::ptr::null_mut(),
             std::ptr::null_mut(),
-            &size,
+            std::ptr::from_ref(&size),
         )
     };
     assert_eq!(rc, 0, "openpty failed");
@@ -188,6 +196,11 @@ fn flags(stty: &str) -> Vec<&str> {
         .collect()
 }
 
+// One test rather than several because it is one *run*: the pty, the shim, the
+// two enters and the exec all have to happen in one process's lifetime, and
+// three claims read off one launch is what makes them claims about the same
+// launch. Splitting it to satisfy a line count would mean three real starts.
+#[allow(clippy::too_many_lines)]
 #[test]
 fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     let scratch = Scratch::new();

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -51,9 +51,12 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
     let found = loop {
         match next(&mut rx).await {
             LoadEvent::Discovered(found) => break found,
-            // The search retries, so a blip is survivable rather than fatal.
-            LoadEvent::SearchFailed => continue,
-            other => panic!("expected discovery first, got {other:?}"),
+            // The search retries, so a blip is survivable rather than fatal:
+            // go round and wait for the next event.
+            LoadEvent::SearchFailed => {}
+            other @ LoadEvent::Fetched { .. } => {
+                panic!("expected discovery first, got {other:?}")
+            }
         }
     };
     assert!(
@@ -165,8 +168,9 @@ async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
                 assert!(!map.tickets.is_empty());
                 break;
             }
-            // The aborted load may have queued one last failure first.
-            LoadEvent::Fetched { .. } => continue,
+            // The aborted load may have queued one last failure first: go round
+            // and keep waiting for the loaded one.
+            LoadEvent::Fetched { .. } => {}
             other => panic!("unexpected event {other:?}"),
         }
     }


### PR DESCRIPTION
Nothing in this repository has ever run `cargo fmt --check`, `cargo clippy` or `cargo test` in CI. `package.yml` builds the conda recipe and installs it, which proves the *package* works and says nothing about the code — so a build could merge with a clippy error in it and nothing would notice. This adds the other half.

## The workflow

`.github/workflows/ci.yml`, one job:

```
cargo fmt --all --check
cargo clippy --all-targets --all-features --locked
cargo test --locked --lib --bins --examples
cargo test --locked --all-targets --no-run      # the live tests still compile
cargo doc --no-deps --all-features --locked
```

One job rather than four because every step needs the same dependency graph compiled and separate jobs would each pay for it from scratch — the whole run is faster than a single cold `cargo clippy`. Steps are ordered by how cheap they are to fix, so the fastest failure is also the first one.

Deliberately kept apart from `package.yml`: a rattler build takes minutes and downloads a toolchain of its own, and folding `cargo fmt` into it would make the cheapest possible failure the slowest one to hear about. This does not fix #79 — it does mean main gets *some* CI evidence from a workflow that finishes in a couple of minutes.

## Where the lint levels live

`Cargo.toml`'s `[lints]` table, at `warn`; CI turns them into failures with `RUSTFLAGS=-D warnings`. One place to change a level, one place that decides how loudly it lands — and a local `cargo build` stays readable. Declared there rather than as `#![warn(...)]` in `lib.rs` because an inner attribute in the library root does not reach `tests/`.

It is `clippy::all` + `clippy::pedantic`, plus `missing_debug_implementations`, `rust_2018_idioms`, `unused_qualifications`, `unused_lifetimes`, `trivial_casts` and `dbg_macro`. `unsafe_code` is **denied**: `src/` has none and needs none — everything dangerous `wf` does, it does by handing work to another process. The pty harness in `tests/live_launch_exec.rs` is the single exception and now says so with a file-level `allow` and a reason, which is what makes adding `unsafe` anywhere a visible act.

`clippy.toml` sets `avoid-breaking-exported-api = false`, since `src/lib.rs` exists so `tests/` can reach the internals, not because anything links against it — that turns on the API-shape lints for `pub` items, which is where most of this crate's code lives. `rustfmt.toml` is stable options only, on purpose: `--check` runs on stable, and one nightly-only key makes rustfmt reject the whole file.

Four lints are switched off, each with a comment saying why rather than a bare `allow`: `must_use_candidate` (this is a binary; there is no caller to promise anything to), the three `cast_*` lints (laying out a terminal is `usize` arithmetic that has to land in ratatui's `u16`), and `duration_suboptimal_units` (it wants `from_mins(1)` where a test writes `from_secs(60)` beside `from_secs(30)`). Two more are local one-site `allow`s with reasons: `struct_field_names` on `Ticket::ticket_type`, and `too_many_lines` on the end-to-end pty test.

## The rest of the diff

Fixing what that surfaced — about 50 warnings and three broken intra-doc links, all small and none behavioural: nested or-patterns, `is_some_and`, `clone_from`, method references for redundant closures, `Frame<'_>`/`Screen<'_>`, `Debug` on `App` and `Loaders`, `&LaunchMode` where it was cloned anyway, `# Errors`/`# Panics` sections on the public functions that needed them, and backticks in prose.

One change earns a second look: the two `panic!` arms in `app.rs`'s launch tests are now exhaustive (`other @ (Overlay::None | Overlay::LaunchLine { .. })`) instead of wildcards, so a new `Overlay` variant breaks the test that claims to know what the overlay is. That is not hypothetical — rebasing this onto Build 12 is exactly how it caught `Overlay::LaunchLine`.

## The live tests

Everything under `tests/` is a `live_*` integration test: real `gh`, real network, real assertions against this project's own tracker as it stands today. Running them in CI would make a build fail whenever the map moves on, so CI **compiles them but does not run them** — a test that no longer builds is rot, and this catches it at the commit that caused it. Deciding what they should become, and making a bare `cargo test` end green in a fresh workspace, is #42 and is untouched here.

## Verified locally

`fmt --check` clean; `clippy --all-targets --all-features` clean under `-D warnings`; 154 unit tests pass; the live tests compile; `cargo doc` clean with `RUSTDOCFLAGS=-D warnings`; and the recipe's own `cargo build --release --locked --bin wf` still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a Rust-focused CI workflow and tighten linting, documentation, and tests to keep the codebase warning-free and well-described without changing runtime behavior.

New Features:
- Add a GitHub Actions workflow that runs formatting, clippy, tests, and docs on every push to main and pull request.

Enhancements:
- Define crate-wide Rust and Clippy lint levels in Cargo.toml, denying unsafe code by default and documenting explicit exceptions.
- Refine function signatures, pattern matches, and iterator usage to satisfy new lints while keeping behavior the same.
- Derive Debug for core runtime types and add must_use annotations to selected methods to improve debuggability and API clarity.
- Add explicit error and panic sections to key public functions and clarify doc links and references across modules.

Documentation:
- Document the CI checks, lint configuration, and live test strategy in the README for contributors.
- Clarify and fix intra-doc links and prose in module- and type-level documentation throughout the crate.

Tests:
- Annotate and adjust live integration tests and UI tests to reflect lint rules, ensure they still compile in CI, and strengthen pattern matching in test assertions.

Chores:
- Add project-wide rustfmt and clippy configuration files to standardize formatting and lint behavior across environments.