### PR TITLE
Order clusters by activity, with finished maps last

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ carrying the per-status counts (`○` frontier `◐` claimed `⊘` blocked `●`
 A repo can keep several maps open at once and each gets its own cluster;
 focusing a project shows all of them.
 
+**Clusters are ordered by activity, with finished maps last**: the map issue
+touched most recently sits at the top, and a map whose every ticket is done
+sinks to the bottom however fresh it is — it is history, not work. Maps with
+equal (or unreadable) timestamps fall back to `repo`, then map number, so the
+order never shuffles between frames.
+
 **The default screen is the leverage view**: each cluster shows its takeable
 tickets (frontier and claimed), sorted by how many open tickets each one
 unblocks, with that unblocks-subtree drawn beneath it — so the next ticket is

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,12 +7,13 @@
 //! launch and `main` is the only thing that may act on it, because acting on
 //! it means giving the terminal back and never coming here again (#34).
 
+use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::launch::{self, Launch, Targets};
-use crate::model::{Map, MapId, MapSet, Ticket};
+use crate::model::{Activity, Map, MapId, MapSet, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
 use crate::view::{self, Expanded, GroupId, Lens, Plan, Screen, Stop, StopAt};
@@ -87,8 +88,9 @@ pub enum StopKey {
 }
 
 pub struct App {
-    /// The clusters on screen: every open map that has arrived, in
-    /// (repo, number) order — which is also render order.
+    /// The clusters on screen: every open map that has arrived, keyed by id.
+    /// Render order is *not* this map's key order — it is decided by
+    /// [`App::scoped_clusters`], which leads on activity.
     pub clusters: BTreeMap<MapId, Map>,
     /// The maps believed open — the cached seed until the search answers, the
     /// search's answer afterwards. This is what `ctrl-r` refetches.
@@ -176,12 +178,37 @@ impl App {
         }
     }
 
-    /// The clusters currently in scope, in render order.
+    /// The clusters currently in scope, in render order: **work before
+    /// history, most recently active first.**
+    ///
+    /// Three keys, in this order:
+    ///
+    /// 1. Whether the map still has open work ([`Map::has_open_work`]). A
+    ///    finished map is history, and history belongs at the bottom however
+    ///    recently it was finished — otherwise a map completed this morning
+    ///    outranks every live one, which is the exact inversion this order
+    ///    exists to fix.
+    /// 2. Last activity, newest first. `None` (a timestamp that did not parse)
+    ///    sorts after every known one rather than being guessed into place.
+    /// 3. The [`MapId`] — (repo, number), the stable tie-break, so equal
+    ///    activity never renders in an arbitrary order that shifts between
+    ///    frames.
     pub fn scoped_clusters(&self) -> Vec<(&MapId, &Map)> {
-        self.clusters
+        let mut clusters: Vec<(&MapId, &Map)> = self
+            .clusters
             .iter()
             .filter(|(id, _)| self.in_scope(id))
-            .collect()
+            .collect();
+        // `!has_open_work` so `false` (live) sorts before `true` (finished), and
+        // `Reverse` so the newest activity leads — with `None` last, since
+        // `None < Some` reversed puts the unknown stamps at the end.
+        fn key<'a>(
+            (id, map): &(&'a MapId, &'a Map),
+        ) -> (bool, Reverse<Option<Activity>>, &'a MapId) {
+            (!map.has_open_work(), Reverse(map.last_activity), *id)
+        }
+        clusters.sort_by(|a, b| key(a).cmp(&key(b)));
+        clusters
     }
 
     /// Rows currently in scope (before the fuzzy query), cluster-major.
@@ -652,6 +679,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 1),
             Map {
                 title: "Map: wf".to_string(),
+                last_activity: None,
                 tickets: vec![
                     ticket(
                         "blooop/wayfinder",
@@ -692,6 +720,7 @@ mod tests {
             MapId::new("blooop/dotfiles", 4),
             Map {
                 title: "Map: dotfiles".to_string(),
+                last_activity: None,
                 tickets: vec![ticket(
                     "blooop/dotfiles",
                     103,
@@ -703,6 +732,74 @@ mod tests {
             },
         );
         App::new(clusters)
+    }
+
+    /// A one-ticket cluster with a given last-activity stamp, open or finished.
+    fn cluster(repo: &str, number: u64, stamp: Option<&str>, open: bool) -> (MapId, Map) {
+        (
+            MapId::new(repo, number),
+            Map {
+                title: format!("Map: {repo}"),
+                last_activity: stamp.map(|s| Activity::parse(s).expect("fixture stamp parses")),
+                tickets: vec![ticket(repo, 1, "only ticket", open, false, vec![])],
+            },
+        )
+    }
+
+    fn cluster_order(app: &App) -> Vec<MapId> {
+        app.scoped_clusters()
+            .into_iter()
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn clusters_order_by_activity_with_finished_maps_last() {
+        // The bug this fixes: `blooop/finished` is both the lowest id *and* the
+        // most recently touched, and it still belongs at the bottom — a map with
+        // nothing left to do is history, however fresh.
+        let clusters: BTreeMap<MapId, Map> = [
+            cluster("blooop/finished", 1, Some("2026-08-06T12:00:00Z"), false),
+            cluster("blooop/stale", 2, Some("2026-08-01T09:00:00Z"), true),
+            cluster("blooop/fresh", 3, Some("2026-08-05T09:00:00Z"), true),
+            cluster("blooop/undated", 4, None, true),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            cluster_order(&App::new(clusters)),
+            vec![
+                MapId::new("blooop/fresh", 3),
+                MapId::new("blooop/stale", 2),
+                // An unparsed stamp is not guessed into the middle of the live
+                // maps: it sorts after every dated one…
+                MapId::new("blooop/undated", 4),
+                // …and the finished map is still below it.
+                MapId::new("blooop/finished", 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn equal_activity_falls_back_to_repo_then_number() {
+        // Same instant on three maps: the order has to be *some* fixed one, or
+        // the screen reshuffles itself between frames for no reason.
+        let stamp = Some("2026-08-06T12:00:00Z");
+        let clusters: BTreeMap<MapId, Map> = [
+            cluster("blooop/wayfinder", 47, stamp, true),
+            cluster("kinisi/zeta", 4, stamp, true),
+            cluster("blooop/wayfinder", 1, stamp, true),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            cluster_order(&App::new(clusters)),
+            vec![
+                MapId::new("blooop/wayfinder", 1),
+                MapId::new("blooop/wayfinder", 47),
+                MapId::new("kinisi/zeta", 4),
+            ]
+        );
     }
 
     fn type_str(app: &mut App, s: &str) {
@@ -797,6 +894,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 1),
             Map {
                 title: "Map: wf".to_string(),
+                last_activity: None,
                 tickets: vec![
                     ticket("blooop/wayfinder", 6, "root", true, false, vec![]),
                     ticket("blooop/wayfinder", 7, "dep a", true, false, vec![6]),
@@ -827,6 +925,7 @@ mod tests {
             MapId::new("blooop/bencher", 1064),
             Map {
                 title: "Map: endgame".to_string(),
+                last_activity: None,
                 tickets: vec![
                     ticket("blooop/bencher", 1, "done", false, false, vec![]),
                     ticket("blooop/bencher", 10, "root, chained", true, false, vec![]),
@@ -949,6 +1048,7 @@ mod tests {
             MapId::new("blooop/bencher", 1064),
             Map {
                 title: "Map: endgame".to_string(),
+                last_activity: None,
                 tickets: vec![
                     ticket("blooop/bencher", 1069, "root", true, false, vec![]),
                     ticket(
@@ -1165,6 +1265,7 @@ mod tests {
                 MapId::new("blooop/wayfinder", map_number),
                 Map {
                     title: format!("Map: {map_number}"),
+                    last_activity: None,
                     tickets: vec![ticket(
                         "blooop/wayfinder",
                         6,
@@ -1292,6 +1393,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 1),
             Map {
                 title: "Map: wf".to_string(),
+                last_activity: None,
                 tickets: vec![ticket("blooop/wayfinder", 6, "t6", true, false, vec![])],
             },
         );
@@ -1299,6 +1401,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 47),
             Map {
                 title: "Map: selection view".to_string(),
+                last_activity: None,
                 tickets: vec![ticket("blooop/wayfinder", 50, "t50", true, false, vec![])],
             },
         );
@@ -1306,6 +1409,7 @@ mod tests {
             MapId::new("blooop/dotfiles", 4),
             Map {
                 title: "Map: dotfiles".to_string(),
+                last_activity: None,
                 tickets: vec![ticket("blooop/dotfiles", 103, "t103", true, false, vec![])],
             },
         );
@@ -1354,6 +1458,7 @@ mod tests {
                 MapId::new(format!("{owner}/dotfiles"), 1),
                 Map {
                     title: "Map: dotfiles".to_string(),
+                    last_activity: None,
                     tickets: vec![ticket(
                         &format!("{owner}/dotfiles"),
                         5,

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -31,7 +31,7 @@ use serde::Deserialize;
 use tokio::process::Command;
 
 use crate::model::{
-    classify, Checks, Map, MapId, MapSet, PrLink, PrStatus, Review, Ticket, TicketType,
+    classify, Activity, Checks, Map, MapId, MapSet, PrLink, PrStatus, Review, Ticket, TicketType,
 };
 
 /// The label that makes an issue a map. Both the search that *finds* maps and
@@ -45,6 +45,7 @@ query($owner: String!, $name: String!, $number: Int!) {
     issue(number: $number) {
       title
       state
+      updatedAt
       labels(first: 20) { nodes { name } }
       subIssues(first: 100) {
         nodes {
@@ -91,6 +92,11 @@ struct Repository {
 struct MapIssue {
     title: String,
     state: String,
+    /// Defaulted so a response without the selection (an older fixture) parses
+    /// as "activity unknown" rather than failing the whole map — the same rule
+    /// the PR selection follows.
+    #[serde(rename = "updatedAt", default)]
+    updated_at: Option<String>,
     labels: Nodes<Label>,
     #[serde(rename = "subIssues")]
     sub_issues: Nodes<SubIssue>,
@@ -311,6 +317,8 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
 
     Ok(Map {
         title: issue.title,
+        // Interpreted here and nowhere inward, like every other tracker string.
+        last_activity: issue.updated_at.as_deref().and_then(Activity::parse),
         tickets,
     })
 }
@@ -517,6 +525,7 @@ mod tests {
     const PR_RESPONSE: &str = r#"{"data": {"repository": {"issue": {
         "title": "Map: wf",
         "state": "OPEN",
+        "updatedAt": "2026-08-06T12:34:56Z",
         "labels": {"nodes": [{"name": "wayfinder:map"}]},
         "subIssues": {"nodes": [
             {"number": 30, "title": "Raw tty leak", "state": "OPEN",
@@ -598,6 +607,20 @@ mod tests {
         // MAP_RESPONSE predates the #52 selection: absent connection, no PRs.
         let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
         assert!(map.tickets.iter().all(|t| t.prs.is_empty()));
+    }
+
+    #[test]
+    fn the_map_issues_own_timestamp_becomes_its_last_activity() {
+        // The cluster sort key, parsed at the boundary like every other tracker
+        // string — nothing inward ever sees the ISO-8601 text.
+        let map = parse_map(PR_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+        assert_eq!(map.last_activity, Activity::parse("2026-08-06T12:34:56Z"));
+        assert!(map.last_activity.is_some(), "the fixture stamp parsed");
+        // An absent selection is "activity unknown", not a fetch failure:
+        // MAP_RESPONSE predates the field and still yields a usable map.
+        let old = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+        assert_eq!(old.last_activity, None);
+        assert_eq!(old.tickets.len(), 3, "the rest of the map is unaffected");
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,7 +14,8 @@ use serde::{Deserialize, Serialize};
 /// says *which* map, and a second map on one repo is an ordinary value instead
 /// of the one the lowest-number rule silently hid.
 ///
-/// `Ord` is (repo, number), which is also the on-screen cluster order.
+/// `Ord` is (repo, number) — the stable tie-break under the cluster order
+/// ([`crate::app::App::scoped_clusters`]), which leads on activity.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct MapId {
     /// Full repo slug (e.g. "blooop/wayfinder") — the full slug, never the
@@ -260,6 +261,42 @@ impl Ticket {
     }
 }
 
+/// When the tracker last saw the map issue, reduced to the only thing wf asks
+/// of it: an order. Packed decimal `YYYYMMDDhhmmss`, so `Ord` is chronological
+/// and there is no second representation of the same instant to disagree with.
+///
+/// Constructible only by [`Activity::parse`] — a value of this type is a
+/// timestamp that parsed, never a string hoped to be one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Activity(u64);
+
+impl Activity {
+    /// Parse a tracker timestamp (`2026-08-06T12:34:56Z`, which is the only
+    /// shape GitHub's GraphQL `DateTime` emits).
+    ///
+    /// `None` for anything else. That is deliberately not a fallback instant:
+    /// an unrecognised format would have to be *guessed* into an order, and a
+    /// guess here silently reshuffles the screen. "Activity unknown" is a
+    /// meaning of its own, and [`crate::app::App::scoped_clusters`] sorts it
+    /// last among live maps rather than pretending it is ancient or fresh.
+    pub fn parse(stamp: &str) -> Option<Activity> {
+        let (date, time) = stamp.strip_suffix('Z')?.split_once('T')?;
+        let mut fields = date.split('-').chain(time.split(':'));
+        let mut packed = 0u64;
+        // Fixed widths, so every field below the year is < 100 and decimal
+        // packing keeps the ordering chronological. The year's own `* 100` is
+        // harmless: it is the first field, with nothing yet packed under it.
+        for width in [4, 2, 2, 2, 2, 2] {
+            let field = fields.next()?;
+            if field.len() != width || !field.bytes().all(|b| b.is_ascii_digit()) {
+                return None;
+            }
+            packed = packed * 100 + field.parse::<u64>().ok()?;
+        }
+        fields.next().is_none().then_some(Activity(packed))
+    }
+}
+
 /// One map's cluster: the map issue plus its sub-issue tickets.
 ///
 /// Deliberately *without* its own [`MapId`]: a map is always held under its id
@@ -269,6 +306,9 @@ impl Ticket {
 pub struct Map {
     /// Title of the map issue itself.
     pub title: String,
+    /// When the map issue was last touched, if the tracker's timestamp parsed
+    /// ([`Activity`]) — the cluster sort key.
+    pub last_activity: Option<Activity>,
     pub tickets: Vec<Ticket>,
 }
 
@@ -290,6 +330,16 @@ impl Map {
             .filter(|t| t.blocked_by.contains(&number))
             .map(|t| t.number)
             .collect()
+    }
+
+    /// Whether any ticket on this map is still open — whether the map is work
+    /// or history. A map whose every ticket is done is *finished*, and so is a
+    /// map with no tickets at all: both have nothing left to do, which is the
+    /// one question the cluster order asks (finished maps sort last).
+    pub fn has_open_work(&self) -> bool {
+        self.tickets
+            .iter()
+            .any(|t| !matches!(t.status, Status::Done))
     }
 
     /// Ticket counts by status group (frontier / claimed / blocked / done) —
@@ -448,7 +498,73 @@ mod tests {
     }
 
     #[test]
-    fn map_ids_order_by_repo_then_number_which_is_cluster_order() {
+    fn activity_orders_chronologically_across_every_field() {
+        let stamps = [
+            "2025-12-31T23:59:59Z",
+            "2026-01-01T00:00:00Z",
+            "2026-01-01T00:00:01Z",
+            "2026-01-01T00:01:00Z",
+            "2026-01-01T01:00:00Z",
+            "2026-01-02T00:00:00Z",
+            "2026-02-01T00:00:00Z",
+        ];
+        let parsed: Vec<Activity> = stamps
+            .iter()
+            .map(|s| Activity::parse(s).expect(s))
+            .collect();
+        let mut sorted = parsed.clone();
+        sorted.sort();
+        assert_eq!(parsed, sorted, "already in chronological order");
+        // …and the ordering is strict: no two distinct instants collide.
+        sorted.dedup();
+        assert_eq!(sorted.len(), stamps.len());
+    }
+
+    #[test]
+    fn an_unrecognised_timestamp_is_no_instant_rather_than_a_guessed_one() {
+        for junk in [
+            "",
+            "2026-08-06",                // date only
+            "2026-08-06T12:34:56",       // no zone marker
+            "2026-08-06T12:34:56+01:00", // an offset wf cannot pack
+            "2026-08-06T12:34:56.123Z",  // fractional seconds
+            "2026-8-6T12:34:56Z",        // unpadded fields
+            "26-08-06T12:34:56Z",        // two-digit year
+            "2026-08-06T12:34Z",         // no seconds
+            "2026-08-06T12:34:56:78Z",   // a seventh field
+            "yyyy-mm-ddThh:mm:ssZ",      // not digits
+            "2026-08-06 12:34:56Z",      // space where the T belongs
+        ] {
+            assert_eq!(Activity::parse(junk), None, "{junk:?} must not parse");
+        }
+    }
+
+    #[test]
+    fn a_map_has_open_work_until_every_ticket_is_done() {
+        let live = Map {
+            title: "Map: wf".to_string(),
+            last_activity: None,
+            tickets: vec![ticket(2, false, vec![]), ticket(6, true, vec![])],
+        };
+        assert!(live.has_open_work());
+        let finished = Map {
+            title: "Map: wf".to_string(),
+            last_activity: None,
+            tickets: vec![ticket(2, false, vec![]), ticket(6, false, vec![])],
+        };
+        assert!(!finished.has_open_work(), "every ticket done is finished");
+        // A map with no tickets has nothing left to do either — the same answer
+        // to the same question, not a third case.
+        let empty = Map {
+            title: "Map: wf".to_string(),
+            last_activity: None,
+            tickets: vec![],
+        };
+        assert!(!empty.has_open_work());
+    }
+
+    #[test]
+    fn map_ids_order_by_repo_then_number_which_is_the_cluster_tie_break() {
         let mut ids = vec![
             MapId::new("kinisi/zeta", 4),
             MapId::new("blooop/wayfinder", 47),
@@ -483,6 +599,7 @@ mod tests {
         // survives the blocker closing, which is exactly why closed edges stay.
         let map = Map {
             title: "Map: selection view".to_string(),
+            last_activity: None,
             tickets: vec![
                 ticket(48, false, vec![]),
                 ticket(50, true, vec![48]),
@@ -512,6 +629,7 @@ mod tests {
         blocked.status = Status::Blocked { needs: vec![6] };
         let map = Map {
             title: "Map: wf".to_string(),
+            last_activity: None,
             tickets: vec![ticket(6, true, vec![]), claimed, blocked, done],
         };
         assert_eq!(map.counts(), [1, 1, 1, 1]);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -480,7 +480,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, Map, MapId, MapSet, Ticket, TicketType};
+    use crate::model::{classify, Activity, Map, MapId, MapSet, Ticket, TicketType};
     use crate::refresh::Startup;
     use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -512,6 +512,7 @@ mod tests {
         };
         Map {
             title: "Map: wf".to_string(),
+            last_activity: None,
             tickets: vec![
                 t(2, "Choose the stack", false, true, vec![]),
                 t(6, "Re-entry breadcrumbs", true, false, vec![]),
@@ -734,6 +735,7 @@ mod tests {
             MapId::new("blooop/dotfiles", 4),
             Map {
                 title: "Map: dotfiles".to_string(),
+                last_activity: None,
                 tickets: vec![ticket(
                     "blooop/dotfiles",
                     103,
@@ -768,6 +770,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 47),
             Map {
                 title: "Map: the selection view".to_string(),
+                last_activity: None,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     50,
@@ -786,10 +789,66 @@ mod tests {
         let second = screen
             .find("▌ wayfinder · Map: the selection view")
             .expect("map #47's cluster");
-        assert!(first < second, "clusters order by (repo, number)");
+        assert!(
+            first < second,
+            "equal activity falls back to (repo, number)"
+        );
         assert!(screen.contains("#50 Build: clusters"), "{screen}");
         // One repo on screen, however many maps: the title names the repo.
         assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
+    }
+
+    #[test]
+    fn a_finished_map_renders_below_the_live_ones_however_recent_it_is() {
+        // The reported symptom: the finished map held the lowest issue number
+        // *and* the freshest activity, and so sat at the top of the tree. Both
+        // of the keys that would have put it there are deliberately set here.
+        let mut clusters = BTreeMap::new();
+        clusters.insert(
+            MapId::new("blooop/archive", 1),
+            Map {
+                title: "Map: archive".to_string(),
+                last_activity: Activity::parse("2026-08-06T12:00:00Z"),
+                tickets: vec![ticket(
+                    "blooop/archive",
+                    88,
+                    "Shipped last week",
+                    false,
+                    false,
+                    vec![],
+                )],
+            },
+        );
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 47),
+            Map {
+                title: "Map: the selection view".to_string(),
+                last_activity: Activity::parse("2026-08-01T12:00:00Z"),
+                tickets: vec![ticket(
+                    "blooop/wayfinder",
+                    50,
+                    "Build: clusters",
+                    true,
+                    false,
+                    vec![],
+                )],
+            },
+        );
+        let mut app = App::new(clusters);
+        // The forest, because that is the screen a finished map appears on at
+        // all — leverage drops it as idle.
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+        let screen = render(&app);
+        let live = screen
+            .find("▌ wayfinder · Map: the selection view")
+            .expect("the live cluster");
+        let finished = screen
+            .find("▌ archive · Map: archive")
+            .expect("the finished cluster");
+        assert!(
+            live < finished,
+            "finished maps sink to the bottom:\n{screen}"
+        );
     }
 
     #[test]
@@ -1034,6 +1093,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 1),
             Map {
                 title: "Map: wf".to_string(),
+                last_activity: None,
                 tickets: (1..=30)
                     .map(|n| {
                         ticket(
@@ -1052,6 +1112,7 @@ mod tests {
             MapId::new("blooop/wayfinder", 47),
             Map {
                 title: "Map: the selection view".to_string(),
+                last_activity: None,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     50,

--- a/src/view.rs
+++ b/src/view.rs
@@ -572,6 +572,7 @@ mod tests {
             .collect();
         Map {
             title: "Map: fixture".to_string(),
+            last_activity: None,
             tickets,
         }
     }
@@ -754,6 +755,7 @@ mod tests {
         // from in-map blockers, and this blocker is deliberately not one.
         let m = Map {
             title: "Map: fixture".to_string(),
+            last_activity: None,
             tickets: vec![
                 ticket(6, true, false, vec![]),
                 ticket(7, true, false, vec![999]),

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -28,6 +28,15 @@ async fn fetches_the_live_wayfinder_map() {
     sorted.dedup();
     assert_eq!(numbers, sorted);
 
+    // The cluster sort key, proven against the real API: a fixture can only
+    // show that *some* timestamp parses, and the thing that can actually go
+    // wrong is the live `updatedAt` selection or its format — either of which
+    // would silently demote every map to "activity unknown".
+    assert!(
+        map.last_activity.is_some(),
+        "the live map issue's updatedAt must parse into an Activity"
+    );
+
     // The map's charted decisions are closed tickets — DONE must be non-empty.
     assert!(
         map.tickets.iter().any(|t| t.status == Status::Done),


### PR DESCRIPTION
## Summary

- The cluster order was `MapId` order — `(repo, number)` — so a map whose every ticket was done sat at the **top** of the tree for no better reason than a low issue number. Two of the live wayfinder maps are exactly that, and #1 led the screen.
- `App::scoped_clusters` now orders on three keys: still-has-open-work, then last activity newest-first, then the id as a stable tie-break. A finished map is history, so it sinks however recently it was touched — #47 (finished, touched 16:16) still sorts below a live map last touched at 10:46.
- The date comes from the map issue's `updatedAt`, added to the map query and parsed at the `gh` boundary into `Activity` — packed `YYYYMMDDhhmmss`, so `Ord` is chronological and there is no second representation of the same instant to disagree with. Constructible only via `Activity::parse`.
- A timestamp wf cannot read is `None` — "activity unknown", sorted after every dated live map — rather than a guessed instant that would silently reshuffle the screen. An absent selection is likewise activity-unknown, not a fetch failure.
- `Map::has_open_work()` is the finished/live predicate: false when every ticket is `Status::Done`, and for a map with no tickets. Status, not stage — an open ticket with a merged PR reads as `Stage::Done` but the map still has work.
- Applies to every screen, not just the forest, and README documents the rule.

## Test plan

- `cargo test` — 156 lib tests + integration, all green; `cargo clippy --all-targets` and `cargo fmt --check` clean.
- New unit coverage: `Activity` chronological ordering across every field, 10 malformed stamps rejected, `has_open_work` over live/finished/empty maps, the three-key cluster order (including `None` placement), the equal-activity tie-break, and an on-screen assertion that a finished cluster renders below a live one in the forest.
- `tests/live_fetch.rs` now asserts the **real** tracker's `updatedAt` parses — a fixture can only show that some timestamp parses; what can actually break is the live selection or its format.
- Verified against the live maps via `cargo run --example preview_screen`: both fully-done maps (`○0 ◐0 ⊘0 ●6` and `●29`) render at the bottom, live ones leading by recency (21:13 → 20:50 → 10:46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Order map clusters by work status and recent activity so finished maps consistently render at the bottom across all screens.

Bug Fixes:
- Prevent finished maps with low issue numbers or recent updates from appearing above live maps by reordering clusters based on work status and activity.

Enhancements:
- Introduce an Activity timestamp type and last_activity field on maps to drive stable, chronological cluster ordering with a MapId tie-break.
- Treat maps with no open tickets as finished and maps with unparseable timestamps as activity-unknown, ensuring they sort after dated live maps but before finished ones.

Documentation:
- Document the cluster ordering rules in the README, clarifying that clusters are ordered by activity with finished maps last.

Tests:
- Add unit tests for Activity parsing and ordering, has_open_work behavior, cluster ordering (including tie-breaks and None placement), UI ordering of live vs finished clusters, and live API validation that updatedAt parses into Activity.