### PR TITLE
Fix the clippy error that merged while CI was down, and add a manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
   push:
     branches: [main]
+  # A trigger that can be pulled by hand, because the automatic ones cannot be
+  # trusted to have fired. The Actions outage of 2026-08-06 (blooop/wayfinder#79)
+  # throttled webhooks to a fraction of deliveries, and three merges to `main`
+  # landed with no run at all — a dropped trigger leaves a commit looking clean
+  # while nothing ever ran, which is indistinguishable from green unless you go
+  # asking. This is how you re-fire one for a ref without an empty commit.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/src/app.rs
+++ b/src/app.rs
@@ -211,19 +211,21 @@ impl App {
     ///    activity never renders in an arbitrary order that shifts between
     ///    frames.
     pub fn scoped_clusters(&self) -> Vec<(&MapId, &Map)> {
-        let mut clusters: Vec<(&MapId, &Map)> = self
-            .clusters
-            .iter()
-            .filter(|(id, _)| self.in_scope(id))
-            .collect();
         // `!has_open_work` so `false` (live) sorts before `true` (finished), and
         // `Reverse` so the newest activity leads — with `None` last, since
-        // `None < Some` reversed puts the unknown stamps at the end.
+        // `None < Some` reversed puts the unknown stamps at the end. Declared
+        // before the first statement: an item after one is `clippy::pedantic`'s
+        // `items_after_statements`, which CI escalates to an error.
         fn key<'a>(
             (id, map): &(&'a MapId, &'a Map),
         ) -> (bool, Reverse<Option<Activity>>, &'a MapId) {
             (!map.has_open_work(), Reverse(map.last_activity), *id)
         }
+        let mut clusters: Vec<(&MapId, &Map)> = self
+            .clusters
+            .iter()
+            .filter(|(id, _)| self.in_scope(id))
+            .collect();
         clusters.sort_by(|a, b| key(a).cmp(&key(b)));
         clusters
     }


### PR DESCRIPTION
`main` is **red**, and has been since [#82](https://github.com/blooop/wayfinder/pull/82).

## What broke

`scoped_clusters` declares `fn key` *after* the `let mut clusters` statement — `clippy::pedantic`'s `items_after_statements`:

```
error: adding items after statements is confusing, since items exist from the start of the scope
   --> src/app.rs:222:9
error: could not compile `wf` (lib) due to 1 previous error
```

It is a **warning** locally, where `Cargo.toml`'s `[lints]` table sets `clippy::pedantic` to `warn`, and a **hard error** in CI, where `RUSTFLAGS: -D warnings` escalates it. That asymmetry is why it merged: `cargo clippy` on a laptop says nothing is wrong.

## Why nobody saw it

The run that would have caught it never happened. Querying `actions/runs?head_sha=` for each commit on `main` (with the **full** 40-char SHA — the endpoint silently returns `total_count: 0` for a short one):

| commit | runs |
|---|---|
| `5294329` Build 11 | 1 × `Package`, success |
| `797339c` Build 12 (#75) | **0** |
| `41bbfb1` cluster ordering (#82) | **0** |
| `ef76c1a` CI workflow (#81) ← HEAD | **0** |

Three merges to `main` with no workflow run at all, and the `CI` workflow that #81 added has **never executed once**, on any branch or PR — #81 and #82 each merged with GitGuardian as their only check. This is the outage recorded in [#79](https://github.com/blooop/wayfinder/issues/79): webhooks throttled to a fraction of deliveries. Dropped triggers do not fire retroactively, so those commits stay unbuilt forever.

GitHub is operational again and the repo's Actions config is healthy (`enabled: true`, `allowed_actions: all`), so this PR should be the first real execution of `ci.yml`.

## The two changes

- **`src/app.rs`** — hoist `key` above the first statement. The lint is correct, so this is the move it asks for rather than an `allow`; the sort comment travels with it.
- **`.github/workflows/ci.yml`** — add `workflow_dispatch`. A dropped trigger leaves a commit looking clean while nothing ran, which is indistinguishable from green unless someone goes asking per-SHA. A manual trigger re-fires a ref without an empty commit — which matters, since an empty commit changes the SHA and loses a review's fixed point.

## Verification

Run in a clean worktree at the exact CI flags (`RUSTFLAGS=-D warnings`, `RUSTDOCFLAGS=-D warnings`):

| step | before | after |
|---|---|---|
| `cargo fmt --all --check` | ✅ | ✅ |
| `cargo clippy --all-targets --all-features --locked` | ❌ **exit 101** | ✅ |
| `cargo test --locked --lib --bins --examples` | ✅ | ✅ 161 passed |
| `cargo test --locked --all-targets --no-run` | ✅ | ✅ |
| `cargo doc --no-deps --all-features --locked` | ✅ | ✅ |

`actionlint` 1.7.12 reports zero findings on both workflow files.

Note for [#78](https://github.com/blooop/wayfinder/issues/78), in flight: it branches off red `main`, so its first CI run inherits this failure. Landing this first is what lets that build be judged on its own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix a Clippy lint that was causing CI failures and add a manual CI workflow trigger to make rerunning builds possible when automatic triggers are missed.

Bug Fixes:
- Resolve a Clippy `items_after_statements` lint in `scoped_clusters` so the code compiles under `-D warnings` in CI.

CI:
- Add a `workflow_dispatch` trigger to the CI workflow to allow manually rerunning checks when automatic webhook-based triggers are missed.