### PR TITLE
Build 13 — one glyph vocabulary: stage counts in cluster headers, rollups on branch roots (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ Only repos with an open `wayfinder:map`-labelled issue show tickets; other
 checkouts stay cached but hidden.
 
 **Every open map renders as its own cluster** — a `▌ repo · map title` header
-carrying the per-**status** counts (`○` frontier `◐` claimed `⊘` blocked `●`
-done). Those are the ticket's own state, not the stage its rows draw below.
-A repo can keep several maps open at once and each gets its own cluster;
-focusing a project shows all of them.
+carrying the map's **stage** counts, in the same glyph vocabulary the rows
+below it use (`○ ◐ ◍ ! ● ⊘`, described under the leading glyph). A stage the
+map has nobody in is left out rather than shown as a zero. A repo can keep
+several maps open at once and each gets its own cluster; focusing a project
+shows all of them.
 
 **Clusters are ordered by activity, with finished maps last**: the map issue
 touched most recently sits at the top, and a map whose every ticket is done
@@ -130,7 +131,7 @@ descend and the depth axis is something you can see:
 ```
 
 Orange because it is the one hue the screen does not otherwise spend — cyan is
-cluster headers and the prompt, green/yellow/red the status glyphs and counts,
+cluster headers and the prompt, green/yellow/red the stage glyphs and counts,
 magenta the PR badges, dim everything settled — so the selection never competes
 with something that means something else. The branch furniture stays uniformly
 dim: it is structure, not status.
@@ -145,6 +146,13 @@ the cursor on one and `→` opens it in place (`▾`), listing what it held as r
 you can select and launch, and `←` shuts it again — so nothing is ever merely a
 number you cannot reach. A map with nothing takeable
 leaves the body entirely, counted on the bottom line as `· N idle maps hidden`.
+
+**A row that heads a branch carries the same rollup of what is beneath it**,
+written `(beneath) ⊘2` at the end of the line — so a takeable ticket says the
+shape of what taking it unlocks without your reading the subtree. A node is
+counted once however many times the tree drew it: the leverage view draws a
+dependent under every root that unblocks it, so a diamond in the DAG genuinely
+renders one ticket twice inside a single branch.
 
 **`tab` shows the structure forest** instead: the whole blocking DAG, done
 tickets dimmed in place. A ticket's tree parent is its lowest-numbered in-map

--- a/src/model.rs
+++ b/src/model.rs
@@ -54,19 +54,6 @@ pub enum Status {
     Done,
 }
 
-impl Status {
-    /// Position of this status within the cluster header's counts
-    /// (frontier / claimed / blocked / done).
-    pub fn group(&self) -> usize {
-        match self {
-            Status::Frontier => 0,
-            Status::Claimed => 1,
-            Status::Blocked { .. } => 2,
-            Status::Done => 3,
-        }
-    }
-}
-
 /// Where a node stands in its lifecycle — one five-value lattice for every
 /// node (#61), **derived, never declared**: from its linked PRs when any are
 /// open or merged, from its ticket state otherwise. Blocked is deliberately
@@ -110,6 +97,22 @@ impl RowGlyph {
                 RowGlyph::Stage(stage(&ticket.prs, &ticket.status))
             }
         }
+    }
+
+    /// Tally a set of tickets by glyph: pairs in display order, one entry per
+    /// ticket, and glyphs nothing is in left out entirely.
+    ///
+    /// The one place counts-by-glyph is computed. Cluster headers and rollups
+    /// are the same question asked of different sets of tickets, so they are
+    /// the same call — a second tally would be a second glyph vocabulary, which
+    /// is exactly what #78 exists to remove.
+    pub fn tally<'a>(tickets: impl IntoIterator<Item = &'a Ticket>) -> Vec<(RowGlyph, usize)> {
+        let mut counts: std::collections::BTreeMap<RowGlyph, usize> =
+            std::collections::BTreeMap::new();
+        for ticket in tickets {
+            *counts.entry(RowGlyph::of(ticket)).or_default() += 1;
+        }
+        counts.into_iter().collect()
     }
 
     /// The character drawn: `○` ready · `◐` building/in progress · `◍` in
@@ -481,14 +484,11 @@ impl Map {
             .any(|t| !matches!(t.status, Status::Done))
     }
 
-    /// Ticket counts by status group (frontier / claimed / blocked / done) —
-    /// the cluster header's `○n ◐n ⊘n ●n`.
-    pub fn counts(&self) -> [usize; 4] {
-        let mut counts = [0; 4];
-        for t in &self.tickets {
-            counts[t.status.group()] += 1;
-        }
-        counts
+    /// The whole map tallied by glyph — the cluster header's counts (#78).
+    /// Stages, through the same [`RowGlyph`] the rows are drawn from, so a
+    /// ticket drawn `!` is counted under `!`.
+    pub fn tally(&self) -> Vec<(RowGlyph, usize)> {
+        RowGlyph::tally(&self.tickets)
     }
 }
 
@@ -1050,7 +1050,7 @@ mod tests {
     }
 
     #[test]
-    fn counts_tally_the_four_status_groups() {
+    fn a_map_tallies_by_glyph_in_display_order() {
         let mut done = ticket(2, false, vec![]);
         done.status = Status::Done;
         let mut claimed = ticket(9, true, vec![]);
@@ -1062,6 +1062,14 @@ mod tests {
             last_activity: None,
             tickets: vec![ticket(6, true, vec![]), claimed, blocked, done],
         };
-        assert_eq!(map.counts(), [1, 1, 1, 1]);
+        assert_eq!(
+            map.tally(),
+            vec![
+                (RowGlyph::Stage(Stage::Ready), 1),
+                (RowGlyph::Stage(Stage::Building), 1),
+                (RowGlyph::Stage(Stage::Done), 1),
+                (RowGlyph::Blocked, 1),
+            ]
+        );
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,7 @@ use ratatui::Frame;
 use crate::app::{App, Overlay, Scope};
 use crate::launch::Launch;
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
-use crate::view::{Fold, GroupKind, Item, Plan, Screen};
+use crate::view::{Branch, Fold, GroupKind, Item, Plan, Screen};
 
 /// One colour per glyph meaning, shared by the row column and the rollup
 /// pairs: calm colours for the flowing stages, red for the two that demand
@@ -56,6 +56,28 @@ fn cluster_header(id: &MapId, map: &Map) -> Line<'static> {
         ));
     }
     Line::from(spans)
+}
+
+/// A rollup's trailing spans: a dim word for what the counts are *of*, then
+/// the glyph+count pairs in display order, each in the colour its glyph means.
+///
+/// One function, because a collapsed group and a branch root are asking the
+/// same question of different sets of rows — what is under here, by stage — and
+/// two renderings of one answer is how the screen ended up speaking two glyph
+/// vocabularies in the first place (#78).
+fn rollup_spans(label: &str, rollup: &[(RowGlyph, usize)]) -> Vec<Span<'static>> {
+    let mut spans = vec![Span::styled(
+        format!(" ({label})"),
+        Style::new().add_modifier(Modifier::DIM),
+    )];
+    for &(glyph, count) in rollup {
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            format!("{}{count}", glyph.char()),
+            glyph_style(glyph),
+        ));
+    }
+    spans
 }
 
 /// The cursor marker, which sits **after** a row's tree furniture and directly
@@ -138,10 +160,16 @@ fn pr_badge(ticket_repo: &str, pr: &PrLink) -> Vec<Span<'static>> {
 /// extra blocking edges the tree position cannot show (`⤷ also needs #n`). The
 /// flattened screen has no cluster header above the row, so the row names its
 /// repo itself.
+///
+/// A row that heads a branch closes with the stage rollup of it (#62), so the
+/// shape of a subtree reads off its root without walking the subtree — the
+/// same glyph+count pairs a collapsed group carries, because they mean the
+/// same thing.
 fn ticket_line(
     ticket: &Ticket,
     prefix: &str,
     also_needs: &[u64],
+    branch: &Branch,
     name_repo: bool,
     under_cursor: bool,
 ) -> Line<'static> {
@@ -183,6 +211,9 @@ fn ticket_line(
             Style::new().add_modifier(Modifier::DIM),
         ));
     }
+    if let Branch::Root { rollup } = branch {
+        spans.extend(rollup_spans("beneath", rollup));
+    }
     let style = match ticket.status {
         Status::Done => Style::new().add_modifier(Modifier::DIM),
         _ => Style::new(),
@@ -221,17 +252,7 @@ fn group_line(kind: GroupKind, hidden: usize, fold: &Fold, under_cursor: bool) -
         ),
     ];
     if let Fold::Shut { rollup } = fold {
-        spans.push(Span::styled(
-            " (hidden)".to_string(),
-            Style::new().add_modifier(Modifier::DIM),
-        ));
-        for (glyph, count) in rollup {
-            spans.push(Span::raw(" "));
-            spans.push(Span::styled(
-                format!("{}{count}", glyph.char()),
-                glyph_style(*glyph),
-            ));
-        }
+        spans.extend(rollup_spans("hidden", rollup));
     }
     Line::from(spans)
 }
@@ -270,6 +291,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                 row,
                 prefix,
                 also_needs,
+                branch,
                 depth: _,
             } => {
                 let (_, under_cursor) = mark(&lines, &mut cursor_line);
@@ -277,6 +299,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     app.ticket(row),
                     prefix,
                     also_needs,
+                    branch,
                     name_repo,
                     under_cursor,
                 ));
@@ -667,6 +690,17 @@ mod tests {
             .expect("#14 under #6");
         let root9 = screen.find("◐ #9 Main screen design").expect("root #9");
         assert!(root6 < sub7 && sub7 < sub14 && sub14 < root9, "{screen}");
+        // Each root closes with the stage rollup of the branch beneath it, in
+        // the same glyph vocabulary as the header above and the rows below:
+        // #6 unlocks #7 and #14, #9 unlocks #14 alone.
+        assert!(
+            screen.contains("#6 Re-entry breadcrumbs [task] (beneath) ⊘2"),
+            "{screen}"
+        );
+        assert!(
+            screen.contains("#9 Main screen design [task] (beneath) ⊘1"),
+            "{screen}"
+        );
         // Done work is a count, not rows; the group headers retired with #51.
         assert!(screen.contains("● 1 done (hidden)"), "{screen}");
         assert!(!screen.contains("Choose the stack"), "{screen}");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -32,27 +32,27 @@ fn glyph_style(glyph: RowGlyph) -> Style {
     }
 }
 
-/// The cluster header: `▌ <repo> · <map title>  ○n ◐n ⊘n ●n`. The counts are
-/// the whole map's, not the query's — they describe the cluster's shape, and
-/// the group headers already carry `matched/total` while a query is live.
+/// The cluster header: `▌ <repo> · <map title>  ○n ◐n ◍n !n ●n ⊘n`. The counts
+/// are the whole map's, not the query's — they describe the cluster's shape,
+/// and the group headers already carry `matched/total` while a query is live.
+///
+/// They are **stage** counts (#78), tallied through the same [`RowGlyph`] the
+/// rows below are drawn from and coloured by the same [`glyph_style`]. The
+/// header used to keep its own four-status tally with its own glyph array and
+/// its own colour table, which meant the same characters said different things
+/// a line apart: a node the row drew `!` was counted under `○`, and `◍`/`!`
+/// could not appear here at all. Glyphs the map has nobody in drop out rather
+/// than showing a zero.
 fn cluster_header(id: &MapId, map: &Map) -> Line<'static> {
-    let [frontier, claimed, blocked, done] = map.counts();
-    let count_style = [
-        Style::new().fg(Color::Green),
-        Style::new().fg(Color::Yellow),
-        Style::new().fg(Color::Red),
-        Style::new().add_modifier(Modifier::DIM),
-    ];
-    let glyphs = ['○', '◐', '⊘', '●'];
     let mut spans = vec![Span::styled(
         format!("▌ {} · {}", id.short_repo(), map.title),
         Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
     )];
-    for (i, count) in [frontier, claimed, blocked, done].into_iter().enumerate() {
+    for (glyph, count) in map.tally() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
-            format!("{}{count}", glyphs[i]),
-            count_style[i],
+            format!("{}{count}", glyph.char()),
+            glyph_style(glyph),
         ));
     }
     Line::from(spans)
@@ -601,8 +601,54 @@ mod tests {
     #[test]
     fn the_cluster_header_names_the_map_and_carries_the_counts() {
         let screen = render(&fixture_app());
+        // Glyph display order, the same one the rows and the rollups use:
+        // the stage lattice, then the blocked override after it.
         assert!(
-            screen.contains("▌ wayfinder · Map: wf  ○1  ◐1  ⊘2  ●1"),
+            screen.contains("▌ wayfinder · Map: wf  ○1  ◐1  ●1  ⊘2"),
+            "{screen}"
+        );
+    }
+
+    #[test]
+    fn the_cluster_header_counts_stages_not_statuses() {
+        // #6 is unblocked and unclaimed — `○` ready — until a PR with failing
+        // checks makes it needs-attention. The row already drew that as `!`;
+        // the header has to agree, because they are one vocabulary. Counting
+        // statuses instead sweeps it back under `○`, and `◍`/`!` could never
+        // appear in a header at all.
+        let mut map = wf_map();
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 6)
+            .expect("#6 in the fixture")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 46,
+            status: PrStatus::Open {
+                checks: Checks::Failing,
+                review: Review::Required,
+            },
+        }];
+        // #9 is claimed with a passing, approved PR: in review — the other
+        // stage the four-status header had no glyph for.
+        map.tickets
+            .iter_mut()
+            .find(|t| t.number == 9)
+            .expect("#9 in the fixture")
+            .prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 13,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::Approved,
+            },
+        }];
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let screen = render(&App::new(clusters));
+        // ○0 is not drawn: the counts name the stages the map is actually in.
+        assert!(
+            screen.contains("▌ wayfinder · Map: wf  ◍1  !1  ●1  ⊘2"),
             "{screen}"
         );
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -237,15 +237,29 @@ fn group_line(kind: GroupKind, hidden: usize, fold: &Fold, under_cursor: bool) -
         Fold::Open => '▾',
         Fold::Shut { .. } => '▸',
     };
-    let (glyph, label, color) = match kind {
-        GroupKind::BlockedDeeper => ('⊘', "blocked deeper down", Color::Red),
-        GroupKind::Done => ('●', "done", Color::Reset),
+    // The glyph is never written here: each group stands for one row meaning, so
+    // it names the [`RowGlyph`] and lets that type say which character it draws
+    // (#78). Only the style is a local decision.
+    let (glyph, label, style) = match kind {
+        GroupKind::BlockedDeeper => (
+            RowGlyph::Blocked,
+            "blocked deeper down",
+            glyph_style(RowGlyph::Blocked),
+        ),
+        // Deliberately not [`glyph_style`]'s DIM: that dims a *tally* of finished
+        // rows, and this is a heading for a group you can open — the count beside
+        // it is already dim, and dimming the glyph too would sink the line.
+        GroupKind::Done => (
+            RowGlyph::Stage(Stage::Done),
+            "done",
+            Style::new().fg(Color::Reset),
+        ),
     };
     let mut spans = vec![
         Span::raw("  "),
         cursor_span(under_cursor),
         Span::styled(format!("{marker} "), FURNITURE),
-        Span::styled(glyph.to_string(), Style::new().fg(color)),
+        Span::styled(glyph.char().to_string(), style),
         Span::styled(
             format!(" {hidden} {label}"),
             Style::new().add_modifier(Modifier::DIM),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -101,7 +101,7 @@ fn cursor_span(under_cursor: bool) -> Span<'static> {
 
 /// The marker's colour: orange, and deliberately not one of the six the screen
 /// already spends — cyan on cluster headers and the prompt, green/yellow/red on
-/// the status glyphs and counts, magenta on PR badges, dim on everything
+/// the stage glyphs and counts, magenta on PR badges, dim on everything
 /// settled. A selection drawn in any of those competes with something that means
 /// something else, which is how the cursor got hard to find in the first place.
 ///

--- a/src/view.rs
+++ b/src/view.rs
@@ -119,6 +119,8 @@ pub enum Item {
         prefix: String,
         /// Forest only: in-map blockers beyond the primary parent.
         also_needs: Vec<u64>,
+        /// Whether this row heads a branch, and what is in it.
+        branch: Branch,
     },
     /// A collapsible group of held-back rows, always at depth 0 of its
     /// cluster. Carries what it is holding (`hidden`) and its [`Fold`], so
@@ -141,6 +143,30 @@ pub enum Item {
 pub enum Fold {
     Shut { rollup: Vec<(RowGlyph, usize)> },
     Open,
+}
+
+/// Whether a ticket row **heads a branch** — sits at the top of its cluster
+/// with a subtree drawn beneath it — and, only when it does, the stage rollup
+/// of that subtree (#62): glyph+count pairs in display order.
+///
+/// One entry per *node*, not per row. This is the place the double-count
+/// hazard actually lives: the leverage walk draws a dependent under every root
+/// that unblocks it, so a diamond in the DAG — two dependents of one root that
+/// both unblock the same ticket — genuinely renders that ticket twice inside
+/// the same branch. Counting rows would count it twice; counting the nodes the
+/// branch reached counts it once.
+///
+/// A row inside somebody else's subtree, and a top-level row with nothing
+/// beneath it, head no branch — so a rollup on either is unrepresentable
+/// rather than merely empty, the same shape [`Fold::Shut`] gives the collapsed
+/// groups.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Branch {
+    /// This row heads no branch: either a row inside another row's subtree, or
+    /// a top-level row with nothing drawn beneath it.
+    Plain,
+    /// A branch root, and the stage counts of what it drew beneath itself.
+    Root { rollup: Vec<(RowGlyph, usize)> },
 }
 
 /// The body, planned: the lines in on-screen order, plus how many in-scope
@@ -185,10 +211,56 @@ impl Plan {
 
 /// Plan the body for the clusters in scope, in their given (render) order.
 pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
-    match screen {
+    let mut plan = match screen {
         Screen::Structured(Lens::Leverage) => leverage(clusters, expanded),
         Screen::Structured(Lens::Forest) => forest(clusters),
         Screen::Flattened { query } => flattened(clusters, query),
+    };
+    attach_rollups(&mut plan.items, clusters);
+    plan
+}
+
+/// Fill in each branch root's rollup, read off the rows the plan actually laid
+/// out.
+///
+/// A pass over the finished list rather than something the walks carry down:
+/// "what is beneath this row" is a fact about the *rendered* tree, and the
+/// rendered tree is exactly this list — so every screen gets the same answer
+/// from the same code, and there is no second notion of a subtree to drift
+/// from the one on screen. A top-level ticket row opens a branch and every
+/// deeper ticket row until the next top-level one is in it, each node kept
+/// once however many times the walk drew it. A header, a spacer, or a group
+/// line closes the open branch: the rows a group holds hang from the group,
+/// not from the last ticket above it.
+fn attach_rollups(items: &mut [Item], clusters: &[(&MapId, &Map)]) {
+    let maps: BTreeMap<&MapId, &Map> = clusters.iter().copied().collect();
+    let mut branches: Vec<(usize, Vec<Row>)> = Vec::new();
+    let mut open: Option<(usize, Vec<Row>)> = None;
+    for (i, item) in items.iter().enumerate() {
+        match item {
+            Item::Ticket { depth: 0, .. } => {
+                branches.extend(open.replace((i, Vec::new())));
+            }
+            Item::Ticket { row, .. } => {
+                if let Some((_, beneath)) = &mut open {
+                    if !beneath.contains(row) {
+                        beneath.push(row.clone());
+                    }
+                }
+            }
+            Item::Header(_) | Item::Group { .. } | Item::Blank => branches.extend(open.take()),
+        }
+    }
+    branches.extend(open);
+
+    for (i, beneath) in branches {
+        if beneath.is_empty() {
+            continue;
+        }
+        let rollup = RowGlyph::tally(beneath.iter().map(|row| &maps[&row.map].tickets[row.index]));
+        if let Item::Ticket { branch, .. } = &mut items[i] {
+            *branch = Branch::Root { rollup };
+        }
     }
 }
 
@@ -225,6 +297,9 @@ fn ticket_item(
         depth,
         prefix,
         also_needs,
+        // Filled in by `attach_rollups` once the whole list exists: whether a
+        // row heads a branch is a property of the rows that follow it.
+        branch: Branch::Plain,
     }
 }
 
@@ -622,6 +697,23 @@ mod tests {
             .collect()
     }
 
+    /// Every top-level ticket row as (number, what it heads) — the branch
+    /// roots and what each says about the subtree drawn beneath it.
+    fn roots(plan: &Plan, m: &Map) -> Vec<(u64, Branch)> {
+        plan.items
+            .iter()
+            .filter_map(|item| match item {
+                Item::Ticket {
+                    row,
+                    depth: 0,
+                    branch,
+                    ..
+                } => Some((m.tickets[row.index].number, branch.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
     fn id() -> MapId {
         MapId::new("blooop/wayfinder", 47)
     }
@@ -892,6 +984,80 @@ mod tests {
             Fold::Shut {
                 rollup: vec![(RowGlyph::Blocked, 1)]
             }
+        );
+    }
+
+    #[test]
+    fn a_branch_root_carries_the_stage_rollup_of_its_subtree() {
+        // #6 unblocks blocked #7 and claimed #9; #20 is takeable and unblocks
+        // nothing. So #6 heads a branch and says what is in it, while #20 —
+        // and #9 in its own turn as a root — head nothing and say nothing.
+        let m = map(vec![
+            ticket(6, true, false, vec![]),
+            ticket(7, true, false, vec![6]),
+            ticket(9, true, true, vec![6]),
+            ticket(20, true, false, vec![]),
+        ]);
+        let binding = id();
+        let plan = plan(
+            &[(&binding, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        assert_eq!(
+            roots(&plan, &m),
+            vec![
+                (
+                    6,
+                    Branch::Root {
+                        rollup: vec![
+                            (RowGlyph::Stage(Stage::Building), 1),
+                            (RowGlyph::Blocked, 1),
+                        ]
+                    }
+                ),
+                // Claimed #9 is drawn under #6 *and* as its own root. As a
+                // root it heads nothing, so it carries no rollup — the copy
+                // inside #6's branch is what #6 counted.
+                (9, Branch::Plain),
+                (20, Branch::Plain),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_node_the_branch_renders_twice_is_counted_once() {
+        // The diamond, inside one root's branch: #6 unblocks #7 and #8, and
+        // both of those unblock #10 — so the leverage walk genuinely draws #10
+        // twice under #6. Counting the rows drawn would say four; the branch
+        // holds three nodes.
+        let m = map(vec![
+            ticket(6, true, false, vec![]),
+            ticket(7, true, false, vec![6]),
+            ticket(8, true, false, vec![6]),
+            ticket(10, true, false, vec![7, 8]),
+        ]);
+        let binding = id();
+        let plan = plan(
+            &[(&binding, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        // The premise, pinned: without it the assertion below proves nothing.
+        assert_eq!(
+            stops(&plan, &m),
+            vec![6, 7, 10, 8, 10],
+            "#10 hangs under both #7 and #8"
+        );
+        assert_eq!(
+            roots(&plan, &m),
+            vec![(
+                6,
+                Branch::Root {
+                    rollup: vec![(RowGlyph::Blocked, 3)]
+                }
+            )],
+            "three nodes beneath #6, not the four rows drawn for them"
         );
     }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -251,12 +251,8 @@ fn push_group(
     let fold = if is_expanded {
         Fold::Open
     } else {
-        let mut counts: BTreeMap<RowGlyph, usize> = BTreeMap::new();
-        for &index in held {
-            *counts.entry(RowGlyph::of(&map.tickets[index])).or_default() += 1;
-        }
         Fold::Shut {
-            rollup: counts.into_iter().collect(),
+            rollup: RowGlyph::tally(held.iter().map(|&index| &map.tickets[index])),
         }
     };
     items.push(Item::Group {


### PR DESCRIPTION
Closes #78.

The tree spoke two glyph vocabularies at once. Both halves of that are now one.

## 1. Cluster headers count stages

`cluster_header` kept its own four-status tally — `map.counts()` through
`Status::group()`, with a hardcoded `['○', '◐', '⊘', '●']` array and a parallel
colour table beside it. The same characters meant stages on every row below, so
a ticket the row drew `!` was counted under `○` in the header above it, and
`◍`/`!` could never appear in a header at all.

The header now tallies through `RowGlyph` — the mapping the rows are already
drawn from — and colours through the same `glyph_style`. `Map::counts` and
`Status::group` are gone; `RowGlyph::tally` is the one place counts-by-glyph is
computed, shared with the shut-group rollups that had been doing it inline.

Glyphs the map has nobody in drop out rather than showing a zero, and the order
is the glyph display order (`○ ◐ ◍ ! ● ⊘`) rather than the old status order —
so `⊘` now trails the stages instead of sitting third.

## 2. Branch-root rows carry rollups

Only shut groups had them; #62 settled that branch roots do too, and branch
roots are where the double-count hazard actually lives. The leverage walk draws
a dependent under every root that unblocks it, so a diamond in the DAG — two
dependents of one root that both unblock the same ticket — genuinely renders
that ticket twice inside a single branch.

`Branch::{Plain, Root { rollup }}` follows the shape `Fold::Shut { rollup }`
established last build: a row that heads nothing cannot carry a rollup at all.
`attach_rollups` fills it in as one pass over the finished item list rather than
something the walks carry down — "what is beneath this row" is a fact about the
*rendered* tree, and the rendered tree is exactly that list, so leverage, forest
and flattened all get the same answer from the same code and there is no second
notion of a subtree to drift from the one on screen. Each node is kept once
however many times the walk drew it.

```
▌ wayfinder · Map: wf  ○1  ◐1  ●1  ⊘2
  ▶ ○ #6 Re-entry breadcrumbs [task] (beneath) ⊘2
    ├─  ⊘ #7 Supervising AFK agents [task]
    └─  ⊘ #14 Breadcrumb markers [task]
    ◐ #9 Main screen design [task] (beneath) ⊘1
    └─  ⊘ #14 Breadcrumb markers [task]
    ▸ ● 1 done (hidden) ●1
```

## Tests, at the two seams the ticket pre-agreed

**View planning** (`src/view.rs`)

- `a_branch_root_carries_the_stage_rollup_of_its_subtree` — catches a rollup
  that never arrives, one computed over the wrong set, and a rollup appearing on
  a row that heads nothing. Claimed #9 is drawn inside #6's branch *and* as its
  own root: #6 counts it, #9-as-root carries nothing.
- `a_node_the_branch_renders_twice_is_counted_once` — the diamond, inside one
  root's branch. It pins the premise first (`#10` really is drawn twice) so the
  test can fail, and it does: with the dedup removed it reports `⊘4` against the
  expected `⊘3`. This is the test the last review killed for asserting the rule
  against a fixture that could not exercise it.

**Header rendering** (`src/ui.rs`)

- `the_cluster_header_counts_stages_not_statuses` — a ready ticket pushed to
  needs-attention by a failing-checks PR and a claimed one pushed to in-review
  by an approved one. Catches exactly the reported bug: counting statuses puts
  the first back under `○` and gives the second no glyph at all.
- `the_cluster_header_names_the_map_and_carries_the_counts` (existing) updated
  to the glyph display order.
- `the_default_screen_is_the_leverage_view_not_the_groups` (existing) gained the
  two branch-root rollups, so the plan's rollup reaching the screen is asserted
  rather than assumed.

`RowGlyph::tally`'s existing model test moved to the new return shape.

## Notes

- Rebased onto `main` after #83 landed the same `items_after_statements` hoist
  this branch had independently; the duplicate commit dropped clean.
- README's screen documentation described the header as per-status counts and
  said in as many words that they were *not* the stage the rows drew below —
  the exact split this closes. Updated, along with the branch-root rollup.
- `group_line` still hardcodes `⊘`/`●` for the two group *kinds*. That is a
  label for what the group is, not a stage tally, and `GroupKind::Done` draws
  its `●` undimmed on purpose — left alone rather than folded in on the way past.

Verified locally at the CI flags (`RUSTFLAGS=-D warnings`): `cargo fmt --all
--check` clean, `cargo clippy --all-targets --all-features --locked` clean,
`cargo test --locked --lib --bins --examples` 159 + 5 passed, live tests
compile, docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify glyph-based stage counting across cluster headers and rollups, and add stage rollups to branch-root rows based on the rendered tree structure.

New Features:
- Display stage rollups on branch-root ticket rows showing the composition of their subtrees.

Bug Fixes:
- Ensure cluster headers count ticket stages using the same glyph vocabulary as row glyphs, fixing mismatches between header counts and row stages.

Enhancements:
- Share a single glyph tallying mechanism between headers and rollups, and attach branch rollups in a post-planning pass over the rendered item list.

Documentation:
- Update README to describe stage-based counts, branch-root rollups, and clarify colour usage for stage glyphs.

Tests:
- Add and update tests around branch-root rollups, glyph-based tallies, and cluster header rendering to cover the new behaviour.