### PR TITLE
Release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.4.0"
+  version: "0.5.0"
 
 package:
   name: wf


### PR DESCRIPTION
Cuts **0.5.0**. [v0.4.0](https://github.com/blooop/wayfinder/releases/tag/v0.4.0) shipped Build 8; everything since is unreleased — four builds, a sort fix, and the CI that should have been watching all of them.

## What's in it

**The selection view ([Map #47](https://github.com/blooop/wayfinder/issues/47)) is complete** — every ticket on that map is closed, and this release is its destination.

- **[Build 9 — leverage view default, structure forest on tab](https://github.com/blooop/wayfinder/pull/55)** ([#51](https://github.com/blooop/wayfinder/issues/51)): new `src/view.rs` plans the body as one item list walked by both cursor and draw. Leverage view is now the default screen — takeable roots ordered by open dependents, each with its unblocks-subtree, `● N done (hidden)` and `⊘ N blocked deeper down` per cluster, idle maps dropped to a count line. The full structure forest moves to `tab`, and the grouped view retires.
- **[Build 10 — PR badges on ticket rows](https://github.com/blooop/wayfinder/pull/56)** ([#52](https://github.com/blooop/wayfinder/issues/52)): a ticket's PRs show inline as `⇄ #n state`, so a row's progress is visible without opening anything.
- **[Build 11 — depth-aware cursor](https://github.com/blooop/wayfinder/pull/58)** ([#57](https://github.com/blooop/wayfinder/issues/57)): up/down walk siblings, right/left reveal and close.
- **[Build 12 — stage-aware tree + typed two-step launch](https://github.com/blooop/wayfinder/pull/75)** ([#74](https://github.com/blooop/wayfinder/issues/74)): the `Stage` lattice (ready → building → in review → needs attention → done) whose derived `Ord` **is** the max-over-open-PRs order, `route(TicketType, Stage)` exhaustive on both axes so a new stage or type is a compile error, and `Overlay::LaunchLine` staging the typed second step — empty launches interactive, `defer [text]` hands a whole subtree to the agent, other text steers.
- **[Build 13 — one glyph vocabulary](https://github.com/blooop/wayfinder/pull/85)** ([#78](https://github.com/blooop/wayfinder/issues/78)): the tree spoke two glyph vocabularies at once — rows drew stages while cluster headers still counted statuses, so a ticket drawn `!` was counted under `○` above it and `◍`/`!` could never appear in a header at all. `Map::counts` and `Status::group` are deleted, `RowGlyph::tally` is the single counts-by-glyph site, and branch-root rows now carry the stage rollup of their subtree — each node counted once even when the DAG renders it twice.
- **[Order clusters by activity, finished maps last](https://github.com/blooop/wayfinder/pull/82)**: work before history, most recently active first, with a stable `MapId` tie-break so equal activity never shifts between frames.

## The part that isn't a feature

- **[Lint, format and test on every pull request](https://github.com/blooop/wayfinder/pull/81)** added `ci.yml` — and it merged during the [Actions outage of 2026-08-06](https://github.com/blooop/wayfinder/issues/79), so it had **never once executed**. Three merges to `main` (`797339c`, `41bbfb1`, `ef76c1a`) carry no workflow run at all: dropped webhooks do not fire retroactively.
- **[Fix the clippy error that merged while CI was down](https://github.com/blooop/wayfinder/pull/83)** ([#84](https://github.com/blooop/wayfinder/issues/84)): under that cover, `main` went **red** and stayed red — `clippy::items_after_statements`, a warning locally where `[lints]` sets `pedantic = warn`, a hard error under CI's `-D warnings`. Fixed, plus `workflow_dispatch` so a ref can be re-fired by hand after a dropped trigger.

Everything in this release has now been built by CI on all three triggers. That was not true of any commit in it when the day started.

## Why minor, not patch

The default screen is different. Leverage view replaces the grouped list, the structure forest moved to `tab`, rows gained PR badges and `[type]`, cluster ordering changed, and `enter` now opens a launch line instead of launching immediately. Nothing about an existing `~/.cache/wf/projects.json` breaks, but the screen you get on start is not the screen 0.4.0 gave you.

## The bump

`Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` move together — CI fails the build if the recipe and the crate disagree, and a tag that does not match `Cargo.toml` is rejected before anything is published.

Merging this does not release anything. Pushing `v0.5.0` afterwards is what builds the recipe, creates the GitHub release, and publishes to prefix.dev/blooop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update Cargo.toml, Cargo.lock, and recipe/recipe.yaml to version 0.5.0 to keep crate and release metadata in sync.