### PR TITLE
Release 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.5.0"
+  version: "0.5.1"
 
 package:
   name: wf


### PR DESCRIPTION
Cuts **0.5.1**, a one-bug patch on [v0.5.0](https://github.com/blooop/wayfinder/releases/tag/v0.5.0).

## The fix

**[Keep an untouched cursor on the top row as maps stream in](https://github.com/blooop/wayfinder/pull/89)** ([#88](https://github.com/blooop/wayfinder/issues/88)) — reported against 0.5.0: opening `wf` in a checkout landed the cursor on the **second** cluster.

The default cursor position was indistinguishable from a chosen one. `replace_clusters` anchored on the selected row's identity and handed it to `preserve_cursor`, whose contract — *identity wins over position* — is right for a selection someone made and wrong for the position the cursor merely starts at. During streaming startup the first map's fetch to land took the cursor; when a map with newer activity arrived, [#82](https://github.com/blooop/wayfinder/pull/82)'s ordering sorted it above and the cursor followed its anchored row **downward**. With five open maps you landed on whichever fetch returned first.

Both ingredients were individually correct — the identity-preserving cursor ([#50](https://github.com/blooop/wayfinder/issues/50)/[#57](https://github.com/blooop/wayfinder/issues/57)) and activity ordering (#82). They collided because nothing distinguished *"not moved"* from *"chose row 0"*.

```rust
enum Cursor {
    Untouched,      // means "the first stop on screen", whatever the screen becomes
    Chosen(usize),  // put here deliberately; pinned by identity across a reorder
}
```

`Untouched` carries no index because it does not have one — it is a rule, answered from the stops currently on screen. A sentinel could not have done this: `cursor == 0` cannot mean "untouched" when sitting on row 0 deliberately has to stay pinned like any other choice. `preserve_cursor` is byte-identical; its contract was never wrong, it was being asked the wrong question.

## Why patch, not minor

Behaviour that was already meant to work now works. No features, no interface change, no cache format change. A cursor you move yourself is pinned exactly as before.

## Known, and not fixed here

[#90](https://github.com/blooop/wayfinder/issues/90) — the review found a sibling bug on a different path: `main.rs` mutates the scope directly *then* calls `replace_clusters`, so the anchor is re-derived from the already-rescoped list and pins a row you never chose. It needs a decision about whether scope and cursor should move as one operation, so it is a ticket rather than a rushed second fix in a patch release.

## The bump

`Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` move together — CI fails the build if the recipe and the crate disagree, and a tag that does not match `Cargo.toml` is rejected before anything is published.

Merging this does not release anything. Pushing `v0.5.1` afterwards is what builds the recipe, creates the GitHub release, and publishes to prefix.dev/blooop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release patch version 0.5.1 to ship a single cursor-positioning bugfix and keep packaging metadata in sync across the crate and recipe.

Bug Fixes:
- Ensure the initial cursor remains on the top row as maps stream in instead of following reordered clusters during startup.

Build:
- Bump crate and recipe versions to 0.5.1, keeping Cargo.toml, Cargo.lock, and recipe metadata aligned for the release.