### PR TITLE
Launch the agent inside the repo's devcontainer, via dl (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ pixi global install -c https://prefix.dev/blooop -c conda-forge wf
 The package declares no run dependencies. `wf` finds what it needs on PATH and
 says so plainly when something is missing, rather than dragging second copies
 into its own environment. It wants an authenticated `gh` and the agent CLI, and
-nothing else — there is no multiplexer to install.
+nothing else — there is no multiplexer to install. Add
+[`dl`](https://github.com/blooop/devlaunch) if you want the agent to run inside
+your repos' devcontainers ([Isolation](#isolation-the-agent-runs-in-the-repos-devcontainer));
+without it every launch runs on the host, which is what `wf` has always done.
 
 `wf --version` and `wf --help` are the only arguments; everything else is keys
 in the TUI.
@@ -199,7 +202,9 @@ Picking a ticket runs an agent on it — `claude --dangerously-skip-permissions
 `wf`. It restores the terminal and **replaces its own process** with the agent:
 no picker underneath, no parent waiting, nothing to detach from. The agent holds
 the terminal, the exit code and the signals directly, because by then it *is*
-the process you started.
+the process you started. A checkout that declares a devcontainer runs that same
+agent inside it — see
+[Isolation](#isolation-the-agent-runs-in-the-repos-devcontainer).
 
 **Launching is two steps.** `enter` on the cursor's ticket does not launch: it
 opens the **launch line** where the count line was, showing where `enter` will
@@ -261,6 +266,54 @@ picker rather than from a shell you are already watching, and stopping on a
 permission prompt at that moment would just be a stall you did not ask for.
 
 Going back means running `wf` again, which is cheap — a warm start is ~0.6 s.
+
+### Isolation: the agent runs in the repo's devcontainer
+
+A checkout that carries a **`.devcontainer/devcontainer.json`** (or a top-level
+`.devcontainer.json`) launches its agent *inside* that container, by way of
+[`dl`](https://github.com/blooop/devlaunch):
+
+```
+dl <the checkout> -- 'claude' '--dangerously-skip-permissions' '/wayfinder 67 80'
+```
+
+`wf` owns which ticket, which checkout, which skill and which prompt. `dl` owns
+the container — building it, reusing it, forwarding your `gh` login into it,
+keeping an editor from opening over the terminal. `wf` builds no flags, reads no
+`devcontainer.json` and writes none: **the repo's own config is the entire
+opt-in**, and there is nothing to configure on the `wf` side.
+
+The checkout reaches `dl` as a **path**, never as `owner/repo@branch`. Given a
+repo spec `dl` would clone a second copy into its own cache and run the agent
+there — abandoning the tree you picked in the checkout picker.
+
+Two things have to be true, and otherwise the agent runs on the host exactly as
+it always has:
+
+1. the checkout declares one of those two configs, and
+2. `dl` is on PATH.
+
+**A missing `dl` degrades rather than refuses.** Plenty of repos carry a
+`devcontainer.json` for their editor users, and refusing to launch on a machine
+that has never installed `dl` would be a regression for people who never asked
+for any of this. The launch notice names what you got — `→ wayfinder#80 in
+/data/proj/wayfinder (devlaunch)` — and so does each row of the which-checkout
+picker, since two trees of one repo can differ.
+
+A repo whose only configs are **variants**
+(`.devcontainer/<name>/devcontainer.json`, no default) runs on the host:
+choosing among variants would be `wf` picking a container shape, and it has no
+basis to pick. Host access, GPU passthrough and the rest are the repo's
+declarations to make — `wf` injects no `runArgs`.
+
+Two `dl` limits worth knowing, neither of them `wf`'s to fix:
+
+- `dl` names a path workspace after the **directory** alone, so
+  `~/k1/kinisi_ros` and `~/k2/kinisi_ros` collide on one container — the
+  multi-checkout pattern is not yet isolated per tree.
+- Container lifecycle is entirely `dl`'s: `wf` never stops, removes or rebuilds
+  one. `dl <ws> stop`, `dl <ws> reset` and `dl --prune-worktrees` are the tools,
+  and they are yours to run.
 
 ### Working while you are away
 

--- a/README.md
+++ b/README.md
@@ -306,14 +306,19 @@ choosing among variants would be `wf` picking a container shape, and it has no
 basis to pick. Host access, GPU passthrough and the rest are the repo's
 declarations to make — `wf` injects no `runArgs`.
 
-Two `dl` limits worth knowing, neither of them `wf`'s to fix:
+Container lifecycle is entirely `dl`'s: `wf` never stops, removes or rebuilds
+one, and could not — it `exec`s and is gone, so there is no `wf` left to observe
+an agent exiting. `dl <ws> stop`, `dl <ws> reset` and `dl --prune-worktrees` are
+the tools, and they are yours to run. Containers accumulate until you do.
 
-- `dl` names a path workspace after the **directory** alone, so
-  `~/k1/kinisi_ros` and `~/k2/kinisi_ros` collide on one container — the
-  multi-checkout pattern is not yet isolated per tree.
-- Container lifecycle is entirely `dl`'s: `wf` never stops, removes or rebuilds
-  one. `dl <ws> stop`, `dl <ws> reset` and `dl --prune-worktrees` are the tools,
-  and they are yours to run.
+**This container is not a security boundary, and is not trying to be.** It is
+for reproducible dependencies. Your host `~/.claude` is bind-mounted into it
+read-write and your `gh` login is forwarded as `GH_TOKEN`, so everything running
+in a repo's devcontainer — including a `postCreateCommand` you did not write —
+gets both. That is a deliberate trade for zero-friction auth, taken with eyes
+open ([#73](https://github.com/blooop/wayfinder/issues/73)); the repos this
+exists to serve want `network=host`, X11 and device passthrough anyway, which
+gives away as much again. Don't point `wf` at a repo you have not read.
 
 ### Working while you are away
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -9,6 +9,13 @@
 //! is still not supervised here — a deferred launch is the same exec with
 //! ` defer` in the prompt, watched from another terminal or not at all.
 //!
+//! A checkout that declares a devcontainer runs that same agent *inside* it,
+//! by way of `dl` ([`Isolation`], #80): `wf` owns which ticket, which checkout,
+//! which skill and which prompt, and `dl` owns the container, its lifecycle and
+//! its credentials. The seam is the checkout **path** — never `owner/repo@branch`,
+//! which would send `dl` off to clone a second tree and abandon the one the
+//! human picked.
+//!
 //! The one thing that can go wrong is ordering: the terminal must be restored
 //! *before* the image is replaced, because after that there is no `wf` left to
 //! do it. So this module never restores anything and never `exec`s itself off
@@ -168,6 +175,89 @@ impl Staged {
     }
 }
 
+/// Where the agent runs: on the host, as `wf` always has, or inside the
+/// checkout's own devcontainer by way of `dl` (#80).
+///
+/// Two states, not three: there is no "wanted isolation but could not get it".
+/// [`Isolation::detect`] is total — it answers with what will actually happen,
+/// so a launch cannot carry an intention the exec then fails to honour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Isolation {
+    /// No devcontainer in the checkout, or no `dl` on PATH: `claude` runs in
+    /// the checkout directly.
+    Host,
+    /// `dl <checkout> -- claude …`: the agent runs in the container the repo's
+    /// own `devcontainer.json` describes.
+    Devlaunch,
+}
+
+/// The devcontainer configs `wf` looks for — the two locations the
+/// devcontainer spec puts a *default* config in.
+///
+/// A variant-only layout (`.devcontainer/<name>/devcontainer.json` with no
+/// default) is deliberately absent: picking among variants would be `wf`
+/// choosing a container shape, and `wf` has no basis to choose. Those repos
+/// run on the host until someone decides how the variant is named.
+const DEVCONTAINER_CONFIGS: [&str; 2] = [".devcontainer/devcontainer.json", ".devcontainer.json"];
+
+/// The container front door, found on PATH like every other tool `wf` uses.
+const DEVLAUNCH: &str = "dl";
+
+impl Isolation {
+    /// Which environment `checkout` will actually get.
+    ///
+    /// Both halves are required, and a missing `dl` **degrades to the host**
+    /// rather than refusing the launch: a repo may carry a `devcontainer.json`
+    /// for its editor users on a machine that has never heard of `dl`, and
+    /// isolation here is for dependencies, not security (#73), so the host is
+    /// a worse environment rather than an unsafe one. The launch notice names
+    /// the mode ([`Launch::describe`]), so the degradation is visible.
+    pub fn detect(checkout: &Path) -> Isolation {
+        if has_devcontainer(checkout) && resolve_on_path(DEVLAUNCH).is_ok() {
+            Isolation::Devlaunch
+        } else {
+            Isolation::Host
+        }
+    }
+
+    /// How the mode reads on screen — the launch notice and the checkout
+    /// picker, which is where two trees of one repo can differ. The host is
+    /// the default and says nothing; anything else has to announce itself.
+    pub fn suffix(self) -> &'static str {
+        match self {
+            Isolation::Host => "",
+            Isolation::Devlaunch => " (devlaunch)",
+        }
+    }
+}
+
+/// Whether `checkout` declares a devcontainer `wf` can hand to `dl` as-is.
+///
+/// Existence only — `wf` never reads a `devcontainer.json`, never parses its
+/// JSONC and never rewrites it (#73). What is inside is the repo's business.
+fn has_devcontainer(checkout: &Path) -> bool {
+    DEVCONTAINER_CONFIGS
+        .iter()
+        .any(|rel| checkout.join(rel).is_file())
+}
+
+/// Wrap one argument so a POSIX shell hands it back unchanged.
+///
+/// Needed because `dl <ws> -- <cmd>` is a **shell command, not an argv**: `dl`
+/// joins everything after `--` with spaces and gives the single string to
+/// `devpod ssh --command`, which runs it through a shell inside the container.
+/// So [`Launch::agent_argv`]'s one-argv-entry-per-prompt invariant does not
+/// survive the trip on its own — unquoted, `/wayfinder 67 80` would arrive as
+/// three arguments.
+///
+/// Single quotes, uniformly, because inside them a POSIX shell interprets
+/// nothing at all; the one thing they cannot hold is a single quote, which
+/// closes, escapes and reopens. Quoting every argument rather than only the
+/// ones that "need" it keeps this total — there is no predicate to get wrong.
+fn shell_quote(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', r"'\''"))
+}
+
 /// A fully-resolved launch: which checkout the agent runs in, which ticket of
 /// which map it is handed, and — since the two-step (#62) — which skill it
 /// runs ([`Route`]) and in what mode ([`LaunchMode`]).
@@ -193,6 +283,8 @@ pub struct Launch {
     route: Route,
     /// What the launch line said: interactive, deferred, steered.
     mode: LaunchMode,
+    /// Host or container, decided from the checkout at [`plan`] time (#80).
+    isolation: Isolation,
 }
 
 /// Agent sessions are started from a picker rather than from a shell someone is
@@ -211,16 +303,27 @@ impl Launch {
         format!("{}#{}", short_repo(&self.repo), self.ticket)
     }
 
-    /// One-line description for the notice: what is being launched, and where.
-    pub fn describe(&self) -> String {
-        format!("{} in {}", self.key(), self.cwd.display())
+    /// Where this launch's agent runs.
+    pub fn isolation(&self) -> Isolation {
+        self.isolation
     }
 
-    /// What `wf` becomes. `claude` takes a single positional prompt, so the
+    /// One-line description for the notice: what is being launched, where, and
+    /// — when it is not the host default — in what.
+    pub fn describe(&self) -> String {
+        format!(
+            "{} in {}{}",
+            self.key(),
+            self.cwd.display(),
+            self.isolation.suffix()
+        )
+    }
+
+    /// The agent itself. `claude` takes a single positional prompt, so the
     /// slash command, its arguments and the mode suffix are one argv entry,
     /// not several. Only `/wayfinder` takes the map argument — `/tdd` and
     /// `/review` resolve the repo from the checkout they run in.
-    pub fn agent_argv(&self) -> Vec<String> {
+    fn claude_argv(&self) -> Vec<String> {
         let prompt = match self.route {
             Route::Tdd | Route::Review => format!("{} {}", self.route.label(), self.ticket),
             Route::Wayfinder => format!("/wayfinder {} {}", self.map_issue, self.ticket),
@@ -232,8 +335,35 @@ impl Launch {
         ]
     }
 
-    /// Become the agent: replace `wf`'s process image with `claude`, in the
-    /// checkout.
+    /// What `wf` becomes: the agent, or `dl` carrying the agent into the
+    /// container.
+    ///
+    /// The isolated form hands `dl` the checkout **path** — the tree the human
+    /// picked — rather than `owner/repo@branch`, which `dl` would answer by
+    /// cloning a second copy under its own cache and running the agent in
+    /// *that*. The path is a plain argv entry to `dl` and needs no quoting; the
+    /// agent command that follows `--` does, because `dl` runs it through a
+    /// shell (every argument is single-quoted), and it is one entry rather than several
+    /// because "a shell command" is exactly what `dl` documents it to be.
+    pub fn agent_argv(&self) -> Vec<String> {
+        let agent = self.claude_argv();
+        match self.isolation {
+            Isolation::Host => agent,
+            Isolation::Devlaunch => vec![
+                DEVLAUNCH.to_string(),
+                self.cwd.display().to_string(),
+                "--".to_string(),
+                agent
+                    .iter()
+                    .map(|arg| shell_quote(arg))
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            ],
+        }
+    }
+
+    /// Become the agent: replace `wf`'s process image with `claude` — or with
+    /// the `dl` that carries it into the container — in the checkout.
     ///
     /// Returns **only** on failure — on success there is no `wf` left to return
     /// to, which is why the return type is a bare error rather than a `Result`
@@ -302,6 +432,11 @@ impl Launch {
 ///
 /// A name containing a separator is a path already and is taken as given —
 /// that is the caller naming a file, not `$PATH` resolution.
+///
+/// Two callers, and the difference matters: [`Launch::exec`] resolves the
+/// program it is about to become and reports the miss, while
+/// [`Isolation::detect`] only asks whether `dl` is there and quietly answers
+/// [`Isolation::Host`] when it is not.
 fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
     if program.contains('/') {
         return Ok(PathBuf::from(program));
@@ -311,7 +446,7 @@ fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
         .filter(|dir| !dir.as_os_str().is_empty())
         .map(|dir| dir.join(program))
         .find(|candidate| candidate.is_file())
-        .ok_or_else(|| anyhow::anyhow!("`{program}` is not on PATH — is the agent CLI installed?"))
+        .ok_or_else(|| anyhow::anyhow!("`{program}` is not on PATH — is it installed?"))
 }
 
 /// The name half of a repo slug (`blooop/wayfinder` → `wayfinder`). Display
@@ -346,6 +481,12 @@ pub enum Targets {
 /// never prompts. The route and mode arrive already settled — this function
 /// only answers *where* the agent can run.
 ///
+/// Isolation is decided **here**, per candidate, rather than at the exec: a
+/// checkout that has a devcontainer and one that does not can both be
+/// candidates for the same ticket, the notice has to say which is which before
+/// the human picks, and by the exec there is nothing left to tell them with.
+/// It is the one filesystem read in this module's otherwise pure planning path.
+///
 /// # Panics
 ///
 /// Never: the `expect` in the one-candidate arm is guarded by the `match` on
@@ -360,6 +501,7 @@ pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targe
             cwd: c.path.clone(),
             route: staged.route,
             mode: mode.clone(),
+            isolation: Isolation::detect(&c.path),
         })
         .collect();
     match launches.len() {
@@ -634,6 +776,146 @@ mod tests {
             TicketType::Untyped,
         ] {
             assert_eq!(route(ticket_type, Stage::Done), None, "{ticket_type:?}");
+        }
+    }
+
+    /// A scratch directory of our own, removed by the test that made it. No
+    /// `tempfile` dependency for three tests that need a path to exist.
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(name: &str) -> Scratch {
+            let dir =
+                std::env::temp_dir().join(format!("wf-isolation-{}-{name}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("scratch dir");
+            Scratch(dir)
+        }
+
+        /// Create `rel` (and its parents) as an empty file.
+        fn touch(&self, rel: &str) {
+            let path = self.0.join(rel);
+            std::fs::create_dir_all(path.parent().expect("a parent")).expect("parents");
+            std::fs::write(&path, "").expect("touch");
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_checkout_declares_isolation_by_carrying_a_default_devcontainer_config() {
+        // Both spec locations count, and only files — a `.devcontainer/`
+        // directory with no config in it is not a declaration.
+        let bare = Scratch::new("bare");
+        assert!(!has_devcontainer(&bare.0));
+        bare.touch(".devcontainer/README.md");
+        assert!(!has_devcontainer(&bare.0));
+
+        let nested = Scratch::new("nested");
+        nested.touch(".devcontainer/devcontainer.json");
+        assert!(has_devcontainer(&nested.0));
+
+        let top = Scratch::new("top");
+        top.touch(".devcontainer.json");
+        assert!(has_devcontainer(&top.0));
+
+        // A variant-only layout is deliberately not a declaration: `wf` would
+        // have to choose the variant, and it has no basis to.
+        let variants = Scratch::new("variants");
+        variants.touch(".devcontainer/gpu/devcontainer.json");
+        assert!(!has_devcontainer(&variants.0));
+    }
+
+    #[test]
+    fn a_checkout_without_a_devcontainer_runs_on_the_host_whatever_is_on_path() {
+        // The other half — a devcontainer but no `dl` — is the degradation
+        // path, and it is what every other test in this module exercises by
+        // running on a machine that may or may not have `dl`. This direction is
+        // the one that must hold unconditionally.
+        let bare = Scratch::new("host");
+        assert_eq!(Isolation::detect(&bare.0), Isolation::Host);
+        assert_eq!(
+            plan_wf(&cache(), &ticket("blooop/wayfinder", 16), 1),
+            plan_wf(&cache(), &ticket("blooop/wayfinder", 16), 1)
+        );
+        // The cache's paths do not exist, so nothing in this module's planning
+        // tests can be anything but Host.
+        match plan_wf(&cache(), &ticket("blooop/wayfinder", 16), 1) {
+            Targets::One(launch) => assert_eq!(launch.isolation(), Isolation::Host),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    /// The same launch, forced into a container — the fields are private and
+    /// `plan` reads the real filesystem, so a test that wants the isolated
+    /// shape builds it here rather than arranging a `dl` on PATH.
+    fn isolated(route: Route, mode: LaunchMode) -> Launch {
+        Launch {
+            repo: "blooop/wayfinder".to_string(),
+            ticket: 80,
+            map_issue: 67,
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            route,
+            mode,
+            isolation: Isolation::Devlaunch,
+        }
+    }
+
+    #[test]
+    fn an_isolated_launch_hands_dl_the_checkout_path_and_a_quoted_shell_command() {
+        // `dl` joins everything after `--` and runs it through a shell in the
+        // container, so the prompt has to arrive already quoted or it lands as
+        // three arguments. The path is a plain argv entry to `dl` itself and is
+        // not quoted — and it is a path, never `owner/repo@branch`, which would
+        // send `dl` off to clone a second tree.
+        assert_eq!(
+            isolated(Route::Wayfinder, LaunchMode::Interactive).agent_argv(),
+            vec![
+                "dl".to_string(),
+                "/data/proj/wayfinder".to_string(),
+                "--".to_string(),
+                "'claude' '--dangerously-skip-permissions' '/wayfinder 67 80'".to_string(),
+            ]
+        );
+        // The mode suffix rides inside the same quoted argument.
+        assert_eq!(
+            isolated(Route::Wayfinder, LaunchMode::Deferred).agent_argv()[3],
+            "'claude' '--dangerously-skip-permissions' '/wayfinder 67 80 defer'"
+        );
+    }
+
+    #[test]
+    fn steering_text_cannot_break_out_of_the_shell_command() {
+        // The one string a user types that reaches a shell. A single quote
+        // closes, escapes, reopens — the argument stays one argument.
+        let launch = isolated(
+            Route::Tdd,
+            LaunchMode::Steered("don't touch the CI; rm -rf /".to_string()),
+        );
+        assert_eq!(
+            launch.agent_argv()[3],
+            r"'claude' '--dangerously-skip-permissions' '/tdd 80 steer: don'\''t touch the CI; rm -rf /'"
+        );
+        // Every metacharacter a shell would otherwise act on is inside quotes.
+        assert_eq!(shell_quote("a b|c;d&e$f`g"), "'a b|c;d&e$f`g'");
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn the_notice_names_the_container_when_there_is_one_and_stays_quiet_otherwise() {
+        assert_eq!(
+            isolated(Route::Wayfinder, LaunchMode::Interactive).describe(),
+            "wayfinder#80 in /data/proj/wayfinder (devlaunch)"
+        );
+        match plan_wf(&cache(), &ticket("blooop/wayfinder", 80), 67) {
+            Targets::One(launch) => {
+                assert_eq!(launch.describe(), "wayfinder#80 in /data/proj/wayfinder");
+            }
+            other => panic!("{other:?}"),
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -433,11 +433,18 @@ fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
     let mut lines = vec![Line::default()];
     for (i, launch) in launches.iter().enumerate() {
         let marker = if i == *cursor { '▶' } else { ' ' };
+        // Two trees of one repo can differ in what the agent will run in —
+        // one carrying a devcontainer and one not — so the choice has to say
+        // so here, where it is being made, not only in the notice after (#80).
         lines.push(Line::from(vec![
             Span::raw(format!("  {marker} ")),
             Span::styled(
                 launch.cwd().display().to_string(),
                 Style::new().fg(Color::Cyan),
+            ),
+            Span::styled(
+                launch.isolation().suffix(),
+                Style::new().add_modifier(Modifier::DIM),
             ),
         ]));
     }

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -8,8 +8,18 @@
 //! actually be wrong is what happens between the keypress and the agent's first
 //! frame, and that only happens once, in `main`.
 //!
-//! It pins down three claims, in the order they can fail:
+//! It pins down four claims, in the order they can fail:
 //!
+//! 0. **The container carries the agent.** This repo has a
+//!    `.devcontainer/devcontainer.json`, so its launches are isolated (#80):
+//!    `wf` execs `dl`, not `claude`. Both are shimmed, and the `dl` shim is
+//!    what makes the run deterministic — without it a machine with a real `dl`
+//!    installed and a machine without one would take different paths through
+//!    the same test. The shim records what `dl` was handed and then runs the
+//!    quoted command through a real `bash`, which is the only place the
+//!    quoting can be checked at all: `dl` joins everything after `--` and hands
+//!    it to a shell, so an unquoted prompt would arrive at `claude` as three
+//!    arguments and every assertion in claim 1 would fail.
 //! 1. **`enter` execs the agent.** Two enters since the two-step launch (#62):
 //!    the first stages the launch line, the second launches it interactive.
 //!    `claude` is shimmed to a script that records its argv and cwd, so the
@@ -53,8 +63,8 @@ const RAN: &str = "FAKE-CLAUDE-RAN";
 /// *and* not negated, because `stty -a` writes the off state as `-flag`.
 const COOKED: [&str; 4] = ["echo", "icanon", "isig", "opost"];
 
-/// A scratch tree of this test's own: a `claude` shim on PATH and a cache
-/// directory, so neither the user's PATH nor their real projects cache is
+/// A scratch tree of this test's own: `claude` and `dl` shims on PATH and a
+/// cache directory, so neither the user's PATH nor their real projects cache is
 /// touched. Removed on drop, panic or not.
 struct Scratch(PathBuf);
 
@@ -79,23 +89,45 @@ impl Scratch {
         self.0.join("report.txt")
     }
 
-    /// Write the `claude` shim. **No agent is ever launched by this test**: the
-    /// shim records what it was handed, the pid it is, and the tty it landed
-    /// on, then says so.
-    fn write_shim(&self) {
-        let script = format!(
-            "#!/usr/bin/env bash\n\
-             {{ echo \"pid=$$\"; echo \"cwd=$PWD\"; echo \"argv=$*\"; stty -a; }} > {report} 2>&1\n\
-             printf '{RAN}\\n'\n",
-            report = self.report().display(),
+    /// Where the `dl` shim records the container half of the launch.
+    fn dl_report(&self) -> PathBuf {
+        self.0.join("dl-report.txt")
+    }
+
+    /// Write the two shims. **No agent and no container are ever launched by
+    /// this test**: each shim records what it was handed, the pid it is, and
+    /// the tty it landed on.
+    ///
+    /// `dl` then `exec`s the command it was given, through a real `bash` and
+    /// with a real `exec`, which is what makes the chain observable: the whole
+    /// run stays one process, so claim 2's pid check reaches all the way from
+    /// the spawned `wf` to `claude`, and the shell that parses the quoted
+    /// command is a genuine one rather than this test's idea of one.
+    fn write_shims(&self) {
+        let record = |report: &Path| {
+            format!(
+                "{{ echo \"pid=$$\"; echo \"cwd=$PWD\"; echo \"argv=$*\"; stty -a; }} > {} 2>&1\n",
+                report.display()
+            )
+        };
+        let claude = format!(
+            "#!/usr/bin/env bash\n{}printf '{RAN}\\n'\n",
+            record(&self.report())
         );
-        let claude = self.bin().join("claude");
-        std::fs::write(&claude, script).expect("write the claude shim");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755))
-                .expect("chmod the claude shim");
+        // `dl <path> -- <command>`: $1 is the checkout, $3 the shell command.
+        let dl = format!(
+            "#!/usr/bin/env bash\n{}exec bash -c \"exec $3\"\n",
+            record(&self.dl_report())
+        );
+        for (name, script) in [("claude", claude), ("dl", dl)] {
+            let path = self.bin().join(name);
+            std::fs::write(&path, script).unwrap_or_else(|e| panic!("write the {name} shim: {e}"));
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                    .unwrap_or_else(|e| panic!("chmod the {name} shim: {e}"));
+            }
         }
     }
 }
@@ -104,6 +136,14 @@ impl Drop for Scratch {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
     }
+}
+
+/// One `key=value` line out of a shim's report.
+fn field<'a>(report: &'a str, key: &str) -> &'a str {
+    report
+        .lines()
+        .find_map(|l| l.strip_prefix(key))
+        .unwrap_or_else(|| panic!("the shim records {key:?}\n{report}"))
 }
 
 /// A pty pair with a real window size.
@@ -204,7 +244,7 @@ fn flags(stty: &str) -> Vec<&str> {
 #[test]
 fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     let scratch = Scratch::new();
-    scratch.write_shim();
+    scratch.write_shims();
     let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
 
     let (master, slave) = openpty_sized(40, 120);
@@ -266,27 +306,42 @@ fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     let status = child.wait().expect("wait for the exec'd agent");
     assert!(status.success(), "the agent exited {status}\n{screen}");
 
-    let report = std::fs::read_to_string(scratch.report()).expect("the shim's report");
-    let field = |key: &str| {
-        report
-            .lines()
-            .find_map(|l| l.strip_prefix(key))
-            .unwrap_or_else(|| panic!("the shim records {key:?}\n{report}"))
-    };
+    let report = std::fs::read_to_string(scratch.report()).expect("the claude shim's report");
+    let dl_report = std::fs::read_to_string(scratch.dl_report()).expect("the dl shim's report");
+
+    // Claim 0: `wf` handed the whole agent command to `dl`, as one shell
+    // command after `--`, with the checkout — a **path**, never
+    // `owner/repo@branch` — as the workspace. The prompt is the argument that
+    // has to survive a shell, so it is the one that has to be quoted.
+    let dl_argv = field(&dl_report, "argv=");
+    let (workspace, rest) = dl_argv.split_once(' ').expect("a workspace and a command");
+    assert_eq!(
+        Path::new(workspace).canonicalize().ok(),
+        repo.canonicalize().ok(),
+        "dl must be pointed at the checkout wf resolved, not at a repo spec"
+    );
+    let command = rest
+        .strip_prefix("-- ")
+        .unwrap_or_else(|| panic!("the agent command follows a bare `--`: {dl_argv:?}"));
+    assert!(
+        command.starts_with("'claude' '--dangerously-skip-permissions' '/"),
+        "every argument of the agent command must reach the container's shell \
+         quoted, or the prompt arrives as several: {command:?}"
+    );
 
     // Claim 2: the pid the test spawned *is* the agent. Asserted on the pid and
     // not on the exit status, because the shim exits 0 either way — under
     // spawn-and-wait `wf` would have waited for it and exited 0 too, so a
     // status check passes without distinguishing the two designs at all.
     assert_eq!(
-        field("pid=").parse::<u32>().ok(),
+        field(&report, "pid=").parse::<u32>().ok(),
         Some(wf_pid),
         "the agent must be the same process as wf, not a child of it"
     );
 
     // Claim 1: what the agent was actually handed.
-    let cwd = field("cwd=");
-    let argv = field("argv=");
+    let cwd = field(&report, "cwd=");
+    let argv = field(&report, "argv=");
     assert_eq!(
         Path::new(cwd).canonicalize().ok(),
         repo.canonicalize().ok(),


### PR DESCRIPTION
Resolves [#80](https://github.com/blooop/wayfinder/issues/80) and implements it, on map [Wayfinder provisions isolated agent environments](https://github.com/blooop/wayfinder/issues/67).

A checkout carrying a default `devcontainer.json` now launches its agent **inside** that container:

```
dl <the checkout> -- 'claude' '--dangerously-skip-permissions' '/wayfinder 67 80'
```

`wf` owns which ticket, which checkout, which skill and which prompt. `dl` owns the container, its lifecycle and its credentials. `wf` builds no flags, reads no `devcontainer.json` and writes none — the repo's own config is the entire opt-in, and there is nothing to configure on the `wf` side.

### Why `dl` and not `devcontainer` or `devpod`

Picking either of the lower layers means re-implementing the `gh` handoff, the `stop`/`rm` lifecycle the devcontainer CLI does not have ([#68](https://github.com/blooop/wayfinder/issues/68)), `--ide none`, per-branch container identity and variant selection — all of which `dl` has already shipped and verified ([devlaunch#50](https://github.com/blooop/devlaunch/pull/50), released as 0.0.7). That `dl` is Python costs `wf` nothing: it is exec'd by name on PATH, never imported, never parsed, never version-pinned. The full comparison is in [the resolution comment](https://github.com/blooop/wayfinder/issues/80#issuecomment-5221334333).

### The two details that were easy to get wrong

**The seam is the checkout *path*, never `owner/repo@branch`.** Given a repo spec, `dl` clones a *second* copy into `~/.cache/devlaunch/repos/` and runs the agent there — silently abandoning the tree the human picked in the checkout picker. `wf`'s whole model is "a ticket resolves to a registered checkout on this machine", and the path form keeps it exactly intact.

**`dl <ws> -- <cmd>` is a shell command, not an argv.** `dl` joins everything after `--` with spaces and hands the single string to `devpod ssh --command`, which runs it through a shell in the container. So `agent_argv`'s one-entry-per-prompt invariant does not survive the trip: unquoted, `/wayfinder 67 80` arrives as three arguments. Every argument is single-quoted on the way out — uniformly, so there is no "does this need quoting" predicate to get wrong.

### Degradation, not refusal

`Isolation` is two states rather than three: `detect` is total and answers with what will *actually* happen, so a launch can never carry an intention the exec then fails to honour. Isolation engages only when the checkout declares a config **and** `dl` is on PATH; otherwise the agent runs on the host exactly as it always has. Hard-failing would break `wf` against any repo carrying a `devcontainer.json` for its editor users, and per [#73](https://github.com/blooop/wayfinder/issues/73) the container is an environment, not a security boundary. The launch notice and every which-checkout picker row name the mode, so the choice is visible rather than silent.

### Tests

- Unit: config detection across both spec locations (and the variant-only layout that deliberately does *not* count), the `dl` argv shape, and steering text with a quote and a `;` in it that must not break out of the shell command.
- The live pty test now shims **`dl` as well as `claude`**. This repo has a `.devcontainer/`, so without that shim the test would take different paths on a machine with `dl` installed and one without. The shim runs the quoted command through a real `bash` with a real `exec`, so the whole chain stays one process — every existing claim (same pid, restored termios, restored screen) holds end to end, and the quoting is checked by the shell that will actually parse it.

`cargo fmt --check`, `clippy --all-targets -D warnings`, `cargo doc` and the 169 unit tests are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Run agents inside a repo’s devcontainer via devlaunch when available, while preserving existing host-based behaviour as a fallback.

New Features:
- Add isolation mode that runs the agent inside the checkout’s devcontainer via the `dl` CLI when a default devcontainer config is present and `dl` is on PATH.

Enhancements:
- Detect devcontainer configurations in checkouts to decide per-launch whether to use host or container, and surface the chosen mode in launch descriptions and checkout picker UI.
- Adjust agent launch argv construction to wrap the agent command for execution through `dl` and a shell, ensuring prompts are passed as a single, safely quoted argument.
- Clarify PATH resolution errors to cover generic tools rather than only the agent CLI.
- Document the new isolation behaviour and how to enable it using `dl` and devcontainer configs.

Tests:
- Add unit tests for devcontainer detection, isolation mode selection, shell quoting safety, and container-aware launch descriptions.
- Extend the live pty launch test to shim both `claude` and `dl`, verifying the end-to-end exec chain, PID continuity, working directory, arguments, and terminal restoration in the containerized flow.