### PR TITLE
Sift the tree on a query: keep the structure, underline what matched, and tighten what counts as a match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+Notes for agents working in this repo. `README.md` is the real documentation —
+what `wf` is, what every key does, and why the screen is shaped the way it is.
+This file covers only what an agent needs that a user does not.
+
+## Two binaries: `wf` and `wf-next`
+
+`wf` on PATH is the **released** build, installed by pixi global from the
+`blooop` channel (`~/.pixi/bin/wf`). Leave it alone: it is the thing that keeps
+working while this checkout is mid-change, and it is what the user picks tickets
+with.
+
+`wf-next` is **this working tree**, built and copied to `~/.local/bin/wf-next`.
+It is how a change in `src/` gets driven for real — the same binary, under a
+name that cannot collide with the installed one, so both are on PATH at once and
+running the wrong one is not possible by accident.
+
+Refresh it after any change worth looking at:
+
+```
+cargo build --release --locked --bin wf && install -Dm755 target/release/wf ~/.local/bin/wf-next
+```
+
+A copy, deliberately, not a symlink into `target/`: `cargo clean` would leave a
+dangling `wf-next` on PATH, and a snapshot that only moves when you ask it to is
+easier to reason about than one that changes under you on the next build.
+
+Two things to know about it:
+
+- **It reports the crate version, not its provenance.** `wf-next --version` says
+  `wf 0.5.1` — the same string a released 0.5.1 would say. The name is the only
+  thing that distinguishes the builds, so if you need to know what is in a
+  `wf-next`, the answer is "whatever the tree looked like the last time the
+  command above was run", and the way to be sure is to run it again.
+- **It fetches live GitHub data** through `gh`, the same as `wf`. It is a
+  read-only picker until `enter`, which execs the agent on the ticket under the
+  cursor — so drive it as far as the list and stop there unless launching is the
+  thing being tested. `examples/preview_screen.rs` dumps the real screen against
+  live maps non-interactively, with keys replayed from `$KEYS`, when you want to
+  see a frame without taking over the terminal:
+
+  ```
+  KEYS="down right" cargo run --example preview_screen -- blooop/wayfinder 47
+  ```
+
+## Checks
+
+CI runs four things, in the order they are cheap to fix, with
+`RUSTFLAGS=-D warnings` — so anything that warns locally fails there:
+
+```
+cargo fmt --all --check
+cargo clippy --all-targets --all-features --locked
+cargo test --locked --lib --bins --examples
+cargo doc --no-deps --all-features --locked
+```
+
+Run all four before pushing. `cargo fmt --all` first — a formatting diff fails
+the build before any of the interesting checks get a chance to run.
+
+The `tests/live_*.rs` files are excluded from that test command on purpose: they
+talk to real GitHub and drive a real pty. Run them by name when the thing you
+changed is what they cover.
+
+## House style
+
+The code explains *why*, not *what*, and the doc comments carry the design
+decisions — including the ones that were tried and dropped. Match that: a new
+type or screen rule wants the reasoning next to it, and a comment that only
+restates the line below it is worse than none. Illegal states are kept
+unrepresentable rather than checked for at the point of use; where a sum type
+already says something, do not add a bool that can disagree with it.
+
+Every lint switched off in `Cargo.toml`, `clippy.toml` or `rustfmt.toml` carries
+a comment saying why. Adding an `allow` means adding that comment too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,17 +46,22 @@ Two things to know about it:
 
 ## Checks
 
-CI runs four things, in the order they are cheap to fix, with
-`RUSTFLAGS=-D warnings` — so anything that warns locally fails there:
+CI runs four things, in the order they are cheap to fix, with **both**
+`RUSTFLAGS=-D warnings` and `RUSTDOCFLAGS=-D warnings` — so anything that warns
+locally fails there. Set them when you run the checks, or the last one lies to
+you: a doc comment linking to a private item is a warning locally and a failed
+build in CI.
 
 ```
-cargo fmt --all --check
-cargo clippy --all-targets --all-features --locked
-cargo test --locked --lib --bins --examples
-cargo doc --no-deps --all-features --locked
+cargo fmt --all
+RUSTFLAGS=-D\ warnings RUSTDOCFLAGS=-D\ warnings sh -c '
+  cargo fmt --all --check &&
+  cargo clippy --all-targets --all-features --locked &&
+  cargo test --locked --lib --bins --examples &&
+  cargo doc --no-deps --all-features --locked'
 ```
 
-Run all four before pushing. `cargo fmt --all` first — a formatting diff fails
+Run all four before pushing, `cargo fmt --all` first — a formatting diff fails
 the build before any of the interesting checks get a chance to run.
 
 The `tests/live_*.rs` files are excluded from that test command on purpose: they

--- a/README.md
+++ b/README.md
@@ -158,9 +158,19 @@ renders one ticket twice inside a single branch.
 tickets dimmed in place. A ticket's tree parent is its lowest-numbered in-map
 blocker; edges the tree cannot show are annotated `⤷ also needs #n`.
 
-**Typing flattens**: a live query replaces the tree with one flat list ordered
-by fuzzy-match score across every project (rows name their repo); clearing it
-restores whichever screen `tab` had toggled.
+**Typing sifts**: a live query prunes whichever screen `tab` had toggled down to
+the rows that matched, keeping the tree they sit in; clearing it restores that
+screen whole. What survives with a match is the cluster header (which project)
+and the branch root it hangs from (which takeable ticket unlocks it) — the two
+things a hit cannot say about itself. Everything between them is chain length
+and elides, leaving a `⋯` in the furniture (`├⋯`) where levels went missing; an
+unmatched row that *forks* keeps its line, because two matches need something to
+hang from. Rows kept only to place a match are dimmed whole and cannot be landed
+on: the cursor still visits nothing but hits, in best-score-first order, so
+`↓ ↓ enter` works exactly as it did over a flat list. A query reaches inside the
+collapsed groups too — a done ticket stays findable, and the group opens onto
+its matches alone, saying `▾ ● 1 of 5 done`. Clusters with nothing matching
+leave the body, header and all.
 
 ## Startup
 
@@ -231,7 +241,7 @@ The mode rides whichever route you got, as ` defer`, ` defer: <text>` or
 
 | key | what it does |
 | --- | --- |
-| *type anything* | fuzzy-filter: the tree flattens to one score-ordered list; clearing restores it |
+| *type anything* | fuzzy-filter: the tree is pruned to the matches, best-first, with the rows that place them dimmed; clearing restores it |
 | `tab` | toggle the leverage view ⇄ the structure forest |
 | `↑`/`↓`, `ctrl-j`/`ctrl-k` | move between siblings at the cursor's depth — on the default screen, the tickets you can take (cluster headers are never a stop) |
 | `→` | reveal: open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,13 @@ blocker; edges the tree cannot show are annotated `⤷ also needs #n`.
 
 **Typing sifts**: a live query prunes whichever screen `tab` had toggled down to
 the rows that matched, keeping the tree they sit in; clearing it restores that
-screen whole. What survives with a match is the cluster header (which project)
+screen whole. Matching is fuzzy but **tight** — every character the query lands
+on has to start a word or sit against another matched one, so `map` finds "the
+**m**anager-**a**gent **p**rotocol" and sub`tree` matches mid-word, while
+letters picked out of the middles of three unrelated words do not: `tree`
+matched 23 of 30 real tickets under plain fuzzy matching and matches 3 under
+this rule. The cost is that an abbreviation skipping *inside* a word — `wf` for
+"wayfinder" — no longer matches; `wayf` does. What survives with a match is the cluster header (which project)
 and the branch root it hangs from (which takeable ticket unlocks it) — the two
 things a hit cannot say about itself. Everything between them is chain length
 and elides, leaving a `⋯` in the furniture (`├⋯`) where levels went missing; an

--- a/README.md
+++ b/README.md
@@ -167,7 +167,10 @@ and elides, leaving a `⋯` in the furniture (`├⋯`) where levels went missin
 unmatched row that *forks* keeps its line, because two matches need something to
 hang from. Rows kept only to place a match are dimmed whole and cannot be landed
 on: the cursor still visits nothing but hits, in best-score-first order, so
-`↓ ↓ enter` works exactly as it did over a flat list. A query reaches inside the
+`↓ ↓ enter` works exactly as it did over a flat list. **The characters the query
+actually landed on are underlined** where they were matched — in the row, or in
+the cluster header's repo name, since typing a project name is a match on the
+one part of the haystack no row draws. A query reaches inside the
 collapsed groups too — a done ticket stays findable, and the group opens onto
 its matches alone, saying `▾ ● 1 of 5 done`. Clusters with nothing matching
 leave the body, header and all.

--- a/src/app.rs
+++ b/src/app.rs
@@ -77,7 +77,9 @@ pub enum Overlay {
 /// half. They are separate named types rather than two same-shaped tuples
 /// because that is the distinction that matters and the one a `.0`/`.1` at a
 /// call site cannot show.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// `Ord` is (map, index) — screen order within a cluster, and the key the
+/// sifted view looks a row's query score up by.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Row {
     pub map: MapId,
     /// Index into that cluster's `tickets`.
@@ -277,13 +279,16 @@ impl App {
             .collect()
     }
 
-    /// What the body renders this frame (#51): the toggled lens, unless a live
-    /// query flattens it. Derived, never stored.
+    /// What the body renders this frame (#51): the toggled lens, sifted down to
+    /// the matches while a query is live. Derived, never stored.
     pub fn screen(&self) -> Screen<'_> {
         if self.query.is_empty() {
             Screen::Structured(self.lens)
         } else {
-            Screen::Flattened { query: &self.query }
+            Screen::Sifted {
+                lens: self.lens,
+                query: &self.query,
+            }
         }
     }
 
@@ -1525,17 +1530,24 @@ mod tests {
     }
 
     #[test]
-    fn a_live_query_flattens_and_clearing_it_restores_the_lens() {
+    fn a_live_query_sifts_the_lens_and_clearing_it_restores_it() {
         let mut app = fixture_app();
         app.handle_key(key(KeyCode::Tab)); // forest
         type_str(&mut app, "bread");
-        assert_eq!(app.screen(), Screen::Flattened { query: "bread" });
+        assert_eq!(
+            app.screen(),
+            Screen::Sifted {
+                lens: Lens::Forest,
+                query: "bread"
+            },
+            "a query sifts the lens it is typed over, it does not replace it"
+        );
         assert_eq!(app.visible().len(), 1);
         app.handle_key(key(KeyCode::Esc));
         assert_eq!(
             app.screen(),
             Screen::Structured(Lens::Forest),
-            "esc clears the query back to the lens it flattened"
+            "esc clears the query back to the lens it sifted"
         );
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -7,8 +7,8 @@
 //! screen is built out of the answers.
 //!
 //! Matching is fuzzy but *tight* — a query has to land on word starts or on
-//! runs, never on single letters picked out of the middles of words. [`tight`]
-//! is that rule and says why the screen needs it.
+//! runs, never on single letters picked out of the middles of words. The
+//! private `tight` below is that rule, and says why the screen needs it.
 //!
 //! Matching is scored against `"repo #num title"`, so typing a repo name
 //! narrows to that project too. That haystack spans two things the screen draws
@@ -136,7 +136,7 @@ impl Query {
     }
 
     /// The match, with the characters it landed on — and `None` when it landed
-    /// badly enough not to count, which [`tight`] decides.
+    /// badly enough not to count, which `tight` decides.
     pub fn hit(&mut self, ticket: &Ticket) -> Option<Hit> {
         let hay = haystack(ticket);
         let mut indices = Vec::new();

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,45 +1,157 @@
-//! Nucleo fuzzy scoring over the ticket list.
+//! Nucleo fuzzy scoring over the ticket list, and where each match landed.
 //!
-//! A live query *flattens* the body (#51, retiring the 2a groups-survive-typing
-//! rule with the groups themselves): the matcher scores every ticket, and the
-//! flattened screen orders rows best-score-first. This module only scores; the
-//! ordering — and everything else about what the query does to the screen —
-//! lives in [`crate::view`]. Matching is scored against `"repo #num title"`,
-//! so typing a repo name narrows to that project too.
+//! A live query *sifts* the body (#51): the matcher scores every ticket, and
+//! [`crate::view`] prunes the tree to what matched and orders what is left
+//! best-score-first. This module answers only two questions about one ticket —
+//! how well it matched, and which characters the query landed on — and the
+//! screen is built out of the answers.
+//!
+//! Matching is scored against `"repo #num title"`, so typing a repo name
+//! narrows to that project too. That haystack spans two things the screen draws
+//! in different places: the repo appears once in the cluster header, the rest on
+//! the row. [`Hit`] therefore reports the two halves separately rather than
+//! handing out raw haystack offsets nobody could map back — a query that lands
+//! entirely on the repo name (`dotf`) has nothing to underline on any row, and
+//! would look like a screen full of matches with no matches in it if the header
+//! could not answer for it.
+
+use std::fmt;
 
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
 
-use crate::model::Ticket;
+use crate::model::{Map, Ticket};
+
+/// The part of the haystack the row itself draws: `#n title`. Public because
+/// the screen underlines characters *by index* into it — the string drawn and
+/// the string matched have to be the same string, and this is what makes that
+/// true by construction rather than by two format strings agreeing.
+pub fn row_text(ticket: &Ticket) -> String {
+    format!("#{} {}", ticket.number, ticket.title)
+}
 
 /// The haystack a ticket is matched against: the short repo name (what the
-/// flattened row shows) plus the number and title. The owner is left out —
+/// cluster header shows) then the row's own text. The owner is left out —
 /// typing an owner name is not how projects are picked, and including it would
 /// let unrelated repos match on a shared owner.
 fn haystack(ticket: &Ticket) -> String {
-    format!(
-        "{} #{} {}",
-        ticket.short_repo(),
-        ticket.number,
-        ticket.title
-    )
+    format!("{} {}", ticket.short_repo(), row_text(ticket))
+}
+
+/// Where a query landed in one ticket, in char indices into each of the two
+/// strings the screen draws — never into the haystack, which is drawn nowhere.
+/// Both are sorted and unique. The space between the halves belongs to neither
+/// and is dropped.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Hit {
+    pub score: u32,
+    /// Indices into the short repo name, as the cluster header draws it.
+    pub in_repo: Vec<usize>,
+    /// Indices into [`row_text`].
+    pub in_row: Vec<usize>,
+}
+
+/// A parsed query, ready to score tickets and to say where it landed in them.
+///
+/// Built once and reused: [`Matcher`] owns the scratch buffers every match runs
+/// in and is meant to be handed to one match after another, so building one per
+/// row would allocate them again for every line on screen.
+pub struct Query {
+    matcher: Matcher,
+    pattern: Pattern,
+    /// Scratch for the `Utf32Str` conversion, reused for the same reason.
+    buf: Vec<char>,
+}
+
+impl fmt::Debug for Query {
+    /// Hand-written because [`Matcher`] has no `Debug` of its own — and the two
+    /// fields left out are the reusable scratch buffers, whose contents are
+    /// whatever the last match happened to leave in them. The pattern is the
+    /// whole of what this value *is*, so the rest is `non_exhaustive`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Query")
+            .field("pattern", &self.pattern)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Query {
+    /// `None` for the empty query — there is nothing to match and nothing to
+    /// highlight, and a caller holding a `Query` is a caller with a live one.
+    pub fn new(query: &str) -> Option<Query> {
+        if query.is_empty() {
+            return None;
+        }
+        Some(Query {
+            matcher: Matcher::new(Config::DEFAULT),
+            pattern: Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart),
+            buf: Vec::new(),
+        })
+    }
+
+    /// How well this ticket matched, or `None` for no match at all.
+    pub fn score(&mut self, ticket: &Ticket) -> Option<u32> {
+        let hay = haystack(ticket);
+        self.pattern
+            .score(Utf32Str::new(&hay, &mut self.buf), &mut self.matcher)
+    }
+
+    /// The same match, with the characters it landed on. Strictly more work
+    /// than [`Query::score`], so the sieve asks for the score and only the draw
+    /// asks for this.
+    pub fn hit(&mut self, ticket: &Ticket) -> Option<Hit> {
+        let hay = haystack(ticket);
+        let mut indices = Vec::new();
+        let score = self.pattern.indices(
+            Utf32Str::new(&hay, &mut self.buf),
+            &mut self.matcher,
+            &mut indices,
+        )?;
+        // Nucleo makes no promise about order and can repeat an index across
+        // atoms of a multi-atom pattern; the screen walks these in step with
+        // the characters, so they have to be sorted and unique.
+        indices.sort_unstable();
+        indices.dedup();
+
+        let repo_len = ticket.short_repo().chars().count();
+        let mut hit = Hit {
+            score,
+            ..Hit::default()
+        };
+        for i in indices.into_iter().map(|i| i as usize) {
+            if i < repo_len {
+                hit.in_repo.push(i);
+            } else if i > repo_len {
+                hit.in_row.push(i - repo_len - 1);
+            }
+        }
+        Some(hit)
+    }
+
+    /// Where the query landed in a cluster's repo name, taken from whichever of
+    /// its tickets matched best. Every ticket in a map shares one repo name but
+    /// not one match — `wf6` can reach the repo through one row and not
+    /// another — and the header is drawn once, so it answers for the row the
+    /// query liked most, which is the row it put at the top.
+    pub fn in_repo(&mut self, map: &Map) -> Vec<usize> {
+        map.tickets
+            .iter()
+            .filter_map(|ticket| self.hit(ticket))
+            .max_by_key(|hit| hit.score)
+            .map(|hit| hit.in_repo)
+            .unwrap_or_default()
+    }
 }
 
 /// Score every ticket against `query`, in input order: `None` is no match,
 /// and a higher score is a better one. The empty query matches everything
 /// (at an equal score), though no caller renders that case — an empty query
-/// means the structured screen, not a flattened one.
+/// means the structured screen, not a sifted one.
 pub fn scores(tickets: &[Ticket], query: &str) -> Vec<Option<u32>> {
-    if query.is_empty() {
+    let Some(mut query) = Query::new(query) else {
         return vec![Some(0); tickets.len()];
-    }
-    let mut matcher = Matcher::new(Config::DEFAULT);
-    let pattern = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
-    let mut buf = Vec::new();
-    tickets
-        .iter()
-        .map(|t| pattern.score(Utf32Str::new(&haystack(t), &mut buf), &mut matcher))
-        .collect()
+    };
+    tickets.iter().map(|t| query.score(t)).collect()
 }
 
 #[cfg(test)]
@@ -112,5 +224,114 @@ mod tests {
         ];
         let scored = scores(&tickets, "bread");
         assert!(scored[0].expect("exact-ish match") > scored[1].expect("scattered match"));
+    }
+
+    /// A hit rendered against the strings it indexes: the characters it landed
+    /// on wrapped in `«»`, repo first, then the row text. This is what the
+    /// screen underlines, written so a test can read it.
+    fn landed(ticket: &Ticket, query: &str) -> (String, String) {
+        let hit = Query::new(query)
+            .expect("a live query")
+            .hit(ticket)
+            .expect("a match");
+        let mark = |text: &str, lit: &[usize]| {
+            text.chars()
+                .enumerate()
+                .map(|(i, ch)| {
+                    if lit.contains(&i) {
+                        format!("«{ch}»")
+                    } else {
+                        ch.to_string()
+                    }
+                })
+                .collect()
+        };
+        (
+            mark(ticket.short_repo(), &hit.in_repo),
+            mark(&row_text(ticket), &hit.in_row),
+        )
+    }
+
+    #[test]
+    fn a_hit_reports_where_it_landed_in_each_half_it_is_drawn_in() {
+        let t = ticket("blooop/wayfinder", 6, "Re-entry breadcrumbs");
+        assert_eq!(
+            landed(&t, "bread"),
+            (
+                "wayfinder".to_string(),
+                "#6 Re-entry «b»«r»«e»«a»«d»crumbs".to_string()
+            ),
+            "the title half is lit and the repo is untouched"
+        );
+    }
+
+    #[test]
+    fn a_query_that_lands_only_on_the_repo_lights_nothing_on_the_row() {
+        // The case the header highlight exists for: `dotf` sifts the screen
+        // down to one project while matching no character any row draws.
+        let t = ticket("blooop/dotfiles", 103, "Prune legacy bash aliases");
+        assert_eq!(
+            landed(&t, "dotf"),
+            (
+                "«d»«o»«t»«f»iles".to_string(),
+                "#103 Prune legacy bash aliases".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn a_hit_spans_both_halves_and_never_the_space_between_them() {
+        // "wayf6" reaches across the boundary: the repo name, then the number
+        // on the row. The space that joins them in the haystack is drawn by
+        // neither, so no index may point at it.
+        let t = ticket("blooop/wayfinder", 6, "Re-entry breadcrumbs");
+        assert_eq!(
+            landed(&t, "wayf6"),
+            (
+                "«w»«a»«y»«f»inder".to_string(),
+                "#«6» Re-entry breadcrumbs".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn hit_indices_come_back_sorted_and_unique() {
+        // The screen walks these in step with the characters, so out-of-order
+        // or repeated indices would silently skip highlights. Nucleo promises
+        // neither, which is why this is pinned rather than assumed.
+        let t = ticket("blooop/wayfinder", 6, "Re-entry breadcrumbs");
+        for query in ["bread", "e e", "wayf6", "re-entry breadcrumbs"] {
+            let hit = Query::new(query)
+                .expect("a live query")
+                .hit(&t)
+                .unwrap_or_else(|| panic!("{query} matches"));
+            for half in [&hit.in_repo, &hit.in_row] {
+                let mut sorted = half.clone();
+                sorted.sort_unstable();
+                sorted.dedup();
+                assert_eq!(*half, sorted, "{query}");
+            }
+        }
+    }
+
+    #[test]
+    fn a_hit_agrees_with_the_score_the_sieve_used() {
+        // Two nucleo calls, one answer: the row the screen lights up has to be
+        // the row the sieve kept, and by the same margin it ranked it on.
+        let tickets = fixture();
+        let mut query = Query::new("bread").expect("a live query");
+        for ticket in &tickets {
+            assert_eq!(
+                query.hit(ticket).map(|hit| hit.score),
+                query.score(ticket),
+                "{}",
+                ticket.title
+            );
+        }
+    }
+
+    #[test]
+    fn the_empty_query_is_no_query_at_all() {
+        assert!(Query::new("").is_none());
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,6 +6,10 @@
 //! how well it matched, and which characters the query landed on — and the
 //! screen is built out of the answers.
 //!
+//! Matching is fuzzy but *tight* — a query has to land on word starts or on
+//! runs, never on single letters picked out of the middles of words. [`tight`]
+//! is that rule and says why the screen needs it.
+//!
 //! Matching is scored against `"repo #num title"`, so typing a repo name
 //! narrows to that project too. That haystack spans two things the screen draws
 //! in different places: the repo appears once in the cluster header, the rest on
@@ -36,6 +40,40 @@ pub fn row_text(ticket: &Ticket) -> String {
 /// let unrelated repos match on a shared owner.
 fn haystack(ticket: &Ticket) -> String {
     format!("{} {}", ticket.short_repo(), row_text(ticket))
+}
+
+/// Whether a match is *tight* enough to count: every character it landed on
+/// either starts a word or sits against another matched character.
+///
+/// Nucleo, like fzf, will match a query as a subsequence of very nearly
+/// anything — `tree` finds "**T**he stage lattice: de**r**iving stag**e** from
+/// PR stat**e**", three letters plucked out of the middles of three words. On a
+/// ranked flat list that is harmless: junk sorts to the bottom and nobody
+/// scrolls that far. This screen is not a ranked flat list. A sifted tree draws
+/// every row that matched, with its branch root and cluster header around it,
+/// so one junk match costs three lines and a cursor stop rather than a line you
+/// skim past — `tree` kept 23 of 30 real tickets before this rule and 3 after.
+/// Precision is worth more here than recall.
+///
+/// A letter picked out of the middle of a word is what separates the two: it is
+/// never how anyone means to find something, while a letter that *starts* a
+/// word (`m`anager `a`gent `p`rotocol) and a run of letters (sub`tree`) both
+/// are. The cost is real and deliberate: an abbreviation that skips inside a
+/// word — `stgawr` for "stage-aware", `wf` for "wayfinder" — no longer matches.
+/// Typing more of the word, or the word itself, does.
+///
+/// A pattern of nothing but negations (`!bread`) lands on no characters at all,
+/// and vacuously passes: there is nothing there to be loose about.
+fn tight(chars: &[char], indices: &[u32]) -> bool {
+    let matched = |i: usize| indices.binary_search(&(i as u32)).is_ok();
+    indices.iter().all(|&i| {
+        let i = i as usize;
+        let word_start = i == 0
+            || !chars[i - 1].is_alphanumeric()
+            // camelCase: the capital that opens a word inside one.
+            || (!chars[i - 1].is_uppercase() && chars[i].is_uppercase());
+        word_start || (i > 0 && matched(i - 1)) || matched(i + 1)
+    })
 }
 
 /// Where a query landed in one ticket, in char indices into each of the two
@@ -89,16 +127,16 @@ impl Query {
         })
     }
 
-    /// How well this ticket matched, or `None` for no match at all.
+    /// How well this ticket matched, or `None` for no match at all. Defined in
+    /// terms of [`Query::hit`] rather than beside it: whether a row matches now
+    /// depends on *where* the match landed, so the sieve that keeps the row and
+    /// the draw that underlines it have to be reading one answer.
     pub fn score(&mut self, ticket: &Ticket) -> Option<u32> {
-        let hay = haystack(ticket);
-        self.pattern
-            .score(Utf32Str::new(&hay, &mut self.buf), &mut self.matcher)
+        self.hit(ticket).map(|hit| hit.score)
     }
 
-    /// The same match, with the characters it landed on. Strictly more work
-    /// than [`Query::score`], so the sieve asks for the score and only the draw
-    /// asks for this.
+    /// The match, with the characters it landed on — and `None` when it landed
+    /// badly enough not to count, which [`tight`] decides.
     pub fn hit(&mut self, ticket: &Ticket) -> Option<Hit> {
         let hay = haystack(ticket);
         let mut indices = Vec::new();
@@ -108,10 +146,14 @@ impl Query {
             &mut indices,
         )?;
         // Nucleo makes no promise about order and can repeat an index across
-        // atoms of a multi-atom pattern; the screen walks these in step with
-        // the characters, so they have to be sorted and unique.
+        // atoms of a multi-atom pattern; both the tightness rule and the screen
+        // walk these in step with the characters, so they have to be sorted and
+        // unique before either does.
         indices.sort_unstable();
         indices.dedup();
+        if !tight(&hay.chars().collect::<Vec<char>>(), &indices) {
+            return None;
+        }
 
         let repo_len = ticket.short_repo().chars().count();
         let mut hit = Hit {
@@ -316,18 +358,78 @@ mod tests {
 
     #[test]
     fn a_hit_agrees_with_the_score_the_sieve_used() {
-        // Two nucleo calls, one answer: the row the screen lights up has to be
-        // the row the sieve kept, and by the same margin it ranked it on.
+        // One answer, two callers: the row the screen lights up has to be the
+        // row the sieve kept, and by the same margin it ranked it on. Since
+        // whether a row matches now depends on *where* the match landed, these
+        // agreeing is a structural property rather than a lucky one — but the
+        // sieve reaches matching through `scores`, so that path is what is
+        // pinned here.
         let tickets = fixture();
         let mut query = Query::new("bread").expect("a live query");
-        for ticket in &tickets {
-            assert_eq!(
-                query.hit(ticket).map(|hit| hit.score),
-                query.score(ticket),
-                "{}",
-                ticket.title
-            );
-        }
+        let by_hit: Vec<Option<u32>> = tickets
+            .iter()
+            .map(|t| query.hit(t).map(|h| h.score))
+            .collect();
+        assert_eq!(by_hit, scores(&tickets, "bread"));
+    }
+
+    #[test]
+    fn a_letter_picked_out_of_the_middle_of_a_word_is_no_match() {
+        // The subsequence nucleo will happily find and nobody means: `tree`
+        // spelled out of "The … deriving … state". It was 3 lines and a cursor
+        // stop on the sifted screen before this rule.
+        let t = ticket(
+            "blooop/wayfinder",
+            61,
+            "The stage lattice: deriving stage from PR state",
+        );
+        assert_eq!(Query::new("tree").expect("a live query").hit(&t), None);
+    }
+
+    #[test]
+    fn a_run_of_letters_matches_wherever_in_a_word_it_sits() {
+        // The other half of the rule: `tree` inside "subtree" is a real match,
+        // and nothing about it being mid-word makes it less of one.
+        let t = ticket("blooop/wayfinder", 63, "Deferred subtree resolution");
+        assert!(Query::new("tree").expect("a live query").hit(&t).is_some());
+    }
+
+    #[test]
+    fn initials_still_match() {
+        // What the rule is careful to keep: every letter starts a word, which
+        // is exactly how an acronym is meant to be typed.
+        let t = ticket("blooop/wayfinder", 64, "The manager-agent protocol");
+        assert!(Query::new("map").expect("a live query").hit(&t).is_some());
+    }
+
+    #[test]
+    fn an_abbreviation_that_skips_inside_a_word_no_longer_matches() {
+        // The deliberate cost, pinned so it is a decision rather than a
+        // surprise: `stgawr` reads as "stage-aware" to a human and as three
+        // mid-word letters to this rule, and the rule wins. So does `wf` for
+        // "wayfinder" — `wayf` is the shortest thing that still finds it.
+        let t = ticket("blooop/wayfinder", 74, "Build: stage-aware tree");
+        assert_eq!(Query::new("stgawr").expect("a live query").hit(&t), None);
+        assert_eq!(Query::new("wf").expect("a live query").hit(&t), None);
+        assert!(Query::new("wayf").expect("a live query").hit(&t).is_some());
+    }
+
+    #[test]
+    fn the_tightness_rule_reaches_the_sieve_and_not_only_the_draw() {
+        // A loose match dropped at the draw but kept by the sieve would be a
+        // row on screen with nothing lit and no reason to be there.
+        let tickets = vec![
+            ticket("blooop/wayfinder", 61, "The stage lattice: deriving state"),
+            ticket("blooop/wayfinder", 74, "Build: stage-aware tree"),
+        ];
+        assert_eq!(matching(&tickets, "tree"), vec![1]);
+    }
+
+    #[test]
+    fn a_negation_matches_the_rows_it_names_nothing_in() {
+        // fzf's `!` syntax lands on no characters at all, so there is nothing
+        // for the tightness rule to reject — it must not reject everything.
+        assert_eq!(matching(&fixture(), "!bread"), vec![1, 2]);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,6 +14,7 @@ use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
+use crate::filter;
 use crate::launch::Launch;
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
 use crate::view::{Branch, Fold, GroupKind, Item, Plan};
@@ -44,11 +45,16 @@ fn glyph_style(glyph: RowGlyph) -> Style {
 /// a line apart: a node the row drew `!` was counted under `○`, and `◍`/`!`
 /// could not appear here at all. Glyphs the map has nobody in drop out rather
 /// than showing a zero.
-fn cluster_header(id: &MapId, map: &Map) -> Line<'static> {
-    let mut spans = vec![Span::styled(
-        format!("▌ {} · {}", id.short_repo(), map.title),
-        Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-    )];
+///
+/// The repo name carries the query's match on it (`lit`), because the repo is
+/// half of what a ticket is matched against and the rows below do not draw it:
+/// typing a project name would otherwise sift the whole screen down to one
+/// cluster while underlining nothing anywhere.
+fn cluster_header(id: &MapId, map: &Map, lit: &[usize]) -> Line<'static> {
+    let cyan = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+    let mut spans = vec![Span::styled("▌ ", cyan)];
+    spans.extend(lit_spans(id.short_repo(), lit, cyan));
+    spans.push(Span::styled(format!(" · {}", map.title), cyan));
     for (glyph, count) in map.tally() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
@@ -117,6 +123,48 @@ const CURSOR_COLOR: Color = Color::Indexed(208);
 /// marker is what says where the cursor is.
 const FURNITURE: Style = Style::new().add_modifier(Modifier::DIM);
 
+/// What a live query underlines: the characters it actually landed on, bold and
+/// underlined, over whatever the text was already wearing.
+///
+/// Deliberately not a colour. Every colour on this screen already means
+/// something — cyan is a cluster, green/yellow/red are stages, magenta is a PR,
+/// orange is the cursor and nothing else, dim is finished — and a match is not
+/// a *kind* of thing, it is a property any of them can have: the query has to
+/// be able to land on a done row inside a group and a ready row at the top of a
+/// branch and say the same thing about both. A modifier composes with the
+/// colour already there; a seventh colour would have had to overrule it.
+const MATCHED: Modifier = Modifier::BOLD.union(Modifier::UNDERLINED);
+
+/// `text` as spans, with the characters at `lit` wearing [`MATCHED`] over
+/// `base`. Runs are coalesced, so a contiguous match is one span rather than
+/// one per character. `lit` must be sorted and unique — [`filter::Hit`]
+/// guarantees it — because this walks the two in step.
+fn lit_spans(text: &str, lit: &[usize], base: Style) -> Vec<Span<'static>> {
+    if lit.is_empty() {
+        return vec![Span::styled(text.to_string(), base)];
+    }
+    let matched = base.add_modifier(MATCHED);
+    let mut spans = Vec::new();
+    let mut run = String::new();
+    let mut run_lit = false;
+    let mut next = 0;
+    for (i, ch) in text.chars().enumerate() {
+        let now = lit.get(next) == Some(&i);
+        if now {
+            next += 1;
+        }
+        if !run.is_empty() && now != run_lit {
+            let style = if run_lit { matched } else { base };
+            spans.push(Span::styled(std::mem::take(&mut run), style));
+        }
+        run_lit = now;
+        run.push(ch);
+    }
+    let style = if run_lit { matched } else { base };
+    spans.push(Span::styled(run, style));
+    spans
+}
+
 /// The `⇄ PR#n <state>` badge spans for one linked PR (#52) — evidence of the
 /// ticket's progress, riding after the `[type]` suffix. An open PR folds its
 /// two live signals into one glyph: `✗` when something needs acting on (checks
@@ -166,11 +214,16 @@ fn pr_badge(ticket_repo: &str, pr: &PrLink) -> Vec<Span<'static>> {
 /// shape of a subtree reads off its root without walking the subtree — the
 /// same glyph+count pairs a collapsed group carries, because they mean the
 /// same thing.
+///
+/// `lit` is where a live query landed in the `#n title` half — the only part of
+/// the row that was matched against, and so the only part that can honestly
+/// claim to be why the row is on screen.
 fn ticket_line(
     ticket: &Ticket,
     prefix: &str,
     also_needs: &[u64],
     branch: &Branch,
+    lit: &[usize],
     under_cursor: bool,
 ) -> Line<'static> {
     // Nested rows carry the cursor column as extra indent, so a branch begins
@@ -188,8 +241,9 @@ fn ticket_line(
         Span::styled(indent, FURNITURE),
         cursor_span(under_cursor),
         Span::styled(glyph.char().to_string(), glyph_style(glyph)),
-        Span::raw(format!(" #{} {}", ticket.number, ticket.title)),
+        Span::raw(" "),
     ];
+    spans.extend(lit_spans(&filter::row_text(ticket), lit, Style::new()));
     if let Some(name) = ticket.ticket_type.short_name() {
         spans.push(Span::styled(
             format!(" [{name}]"),
@@ -219,9 +273,11 @@ fn ticket_line(
 /// A context row on a sifted screen: the same row, dimmed whole. It is drawn to
 /// say where the matches under it live — which map, and which takeable ticket
 /// unlocks them — and nothing about it is actionable, so it carries no cursor
-/// marker, no `also needs`, and no rollup.
+/// marker, no `also needs`, and no rollup. Nothing lit, either, and not merely
+/// by omission: a row the query landed on is a match, and a match is drawn as
+/// [`Item::Ticket`], never as one of these.
 fn context_line(ticket: &Ticket, prefix: &str) -> Line<'static> {
-    ticket_line(ticket, prefix, &[], &Branch::Plain, false)
+    ticket_line(ticket, prefix, &[], &Branch::Plain, &[], false)
         .patch_style(Style::new().add_modifier(Modifier::DIM))
 }
 
@@ -302,24 +358,41 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
         under_cursor
     };
 
+    // One query for the whole frame, not one per row: it carries the matcher's
+    // scratch buffers. `None` on a structured screen, where there is nothing to
+    // light up, so the rows below ask for a match only when a query is live.
+    let mut query = filter::Query::new(&app.query);
     let mut lines = vec![Line::default()];
     for item in &plan.items {
         let under_cursor = item.stop_at().is_some() && mark(&lines, &mut cursor_line);
         match item {
-            Item::Header(id) => lines.push(cluster_header(id, &app.clusters[id])),
+            Item::Header(id) => {
+                let map = &app.clusters[id];
+                let lit = query.as_mut().map(|q| q.in_repo(map)).unwrap_or_default();
+                lines.push(cluster_header(id, map, &lit));
+            }
             Item::Ticket {
                 row,
                 prefix,
                 also_needs,
                 branch,
                 depth: _,
-            } => lines.push(ticket_line(
-                app.ticket(row),
-                prefix,
-                also_needs,
-                branch,
-                under_cursor,
-            )),
+            } => {
+                let ticket = app.ticket(row);
+                let lit = query
+                    .as_mut()
+                    .and_then(|q| q.hit(ticket))
+                    .map(|hit| hit.in_row)
+                    .unwrap_or_default();
+                lines.push(ticket_line(
+                    ticket,
+                    prefix,
+                    also_needs,
+                    branch,
+                    &lit,
+                    under_cursor,
+                ));
+            }
             Item::Context { row, prefix } => lines.push(context_line(app.ticket(row), prefix)),
             Item::Group { id, held, fold } => {
                 lines.push(group_line(id.kind, *held, fold, under_cursor));
@@ -1133,6 +1206,65 @@ mod tests {
         let screen = render(&app);
         assert!(screen.contains("Supervising AFK agents"), "{screen}");
         assert!(screen.contains("1 done"), "{screen}");
+    }
+
+    /// The body with the characters a live query lit wrapped in `«»` — the
+    /// underlining, in a form a test can read.
+    fn lit_body(app: &App) -> Vec<String> {
+        body_lines(app)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| {
+                        if span.style.add_modifier.contains(MATCHED) {
+                            format!("«{}»", span.content)
+                        } else {
+                            span.content.to_string()
+                        }
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_live_query_underlines_the_characters_it_matched() {
+        let mut app = fixture_app();
+        type_str(&mut app, "bread");
+        assert_eq!(
+            lit_body(&app)
+                .into_iter()
+                .filter(|l| l.contains('#'))
+                .collect::<Vec<_>>(),
+            vec![
+                "  ▶ ○ #6 Re-entry «bread»crumbs [task]",
+                "    └─  ⊘ #14 «Bread»crumb markers [task]",
+                // The context row is why the match above it is on screen, not
+                // a match itself: nothing on it is lit.
+                "    ◐ #9 Main screen design [task]",
+                "    └─  ⊘ #14 «Bread»crumb markers [task]",
+            ],
+        );
+    }
+
+    #[test]
+    fn a_query_that_matched_the_repo_underlines_it_in_the_cluster_header() {
+        // Typing a project name sifts the screen down to that project while
+        // landing on no character any row draws. Without the header answering
+        // for it, the screen would show a wall of matches with no match in it.
+        let mut app = fixture_app();
+        type_str(&mut app, "wayf");
+        let body = lit_body(&app);
+        assert!(
+            body.iter()
+                .any(|l| l.starts_with("▌ «wayf»inder · Map: wf")),
+            "{body:?}"
+        );
+        assert!(
+            body.iter().all(|l| !l.contains('#') || !l.contains('«')),
+            "the match is on the repo, so no row claims it: {body:?}"
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,11 @@
 //! The main screen: one cluster per open map (#50), rendered from the body
 //! [`Plan`] (#51). The default is the leverage view — takeable tickets,
 //! most-dependents-first, each with the subtree it unblocks — with the full
-//! blocking forest on `tab` and a live query flattening either into one
-//! score-ordered list. Rows are `<glyph> #n <title> [type] ⇄ PR#n <state>`;
+//! blocking forest on `tab` and a live query sifting either one down to its
+//! matches, tree and all. Rows are `<glyph> #n <title> [type] ⇄ PR#n <state>`;
 //! done work is a per-cluster count on the default screen and dimmed in place
-//! on the forest.
+//! on the forest. A sifted screen dims whole rows: those are the ones kept only
+//! to place a match, and the cursor cannot land on them.
 
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -15,7 +16,7 @@ use ratatui::Frame;
 use crate::app::{App, Overlay, Scope};
 use crate::launch::Launch;
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
-use crate::view::{Branch, Fold, GroupKind, Item, Plan, Screen};
+use crate::view::{Branch, Fold, GroupKind, Item, Plan};
 
 /// One colour per glyph meaning, shared by the row column and the rollup
 /// pairs: calm colours for the flowing stages, red for the two that demand
@@ -158,8 +159,8 @@ fn pr_badge(ticket_repo: &str, pr: &PrLink) -> Vec<Span<'static>> {
 /// One ticket row: cursor marker, tree furniture, state glyph, `#n title`,
 /// then the dim `[type]` suffix and any `⇄ PR` badges — and on the forest, the
 /// extra blocking edges the tree position cannot show (`⤷ also needs #n`). The
-/// flattened screen has no cluster header above the row, so the row names its
-/// repo itself.
+/// repo is never named here: every screen keeps its cluster headers, and those
+/// name it once for all the rows beneath.
 ///
 /// A row that heads a branch closes with the stage rollup of it (#62), so the
 /// shape of a subtree reads off its root without walking the subtree — the
@@ -170,14 +171,8 @@ fn ticket_line(
     prefix: &str,
     also_needs: &[u64],
     branch: &Branch,
-    name_repo: bool,
     under_cursor: bool,
 ) -> Line<'static> {
-    let repo = if name_repo {
-        ticket.short_repo().to_string()
-    } else {
-        String::new()
-    };
     // Nested rows carry the cursor column as extra indent, so a branch begins
     // directly under the glyph of the row it hangs from instead of to its left.
     let indent = if prefix.is_empty() {
@@ -193,7 +188,7 @@ fn ticket_line(
         Span::styled(indent, FURNITURE),
         cursor_span(under_cursor),
         Span::styled(glyph.char().to_string(), glyph_style(glyph)),
-        Span::raw(format!(" {repo}#{} {}", ticket.number, ticket.title)),
+        Span::raw(format!(" #{} {}", ticket.number, ticket.title)),
     ];
     if let Some(name) = ticket.ticket_type.short_name() {
         spans.push(Span::styled(
@@ -221,6 +216,15 @@ fn ticket_line(
     Line::from(spans).style(style)
 }
 
+/// A context row on a sifted screen: the same row, dimmed whole. It is drawn to
+/// say where the matches under it live — which map, and which takeable ticket
+/// unlocks them — and nothing about it is actionable, so it carries no cursor
+/// marker, no `also needs`, and no rollup.
+fn context_line(ticket: &Ticket, prefix: &str) -> Line<'static> {
+    ticket_line(ticket, prefix, &[], &Branch::Plain, false)
+        .patch_style(Style::new().add_modifier(Modifier::DIM))
+}
+
 /// The body as styled lines: the [`Plan`] walked in order. Shared by the live
 /// draw and the `TestBackend` tests.
 pub fn body_lines(app: &App) -> Vec<Line<'static>> {
@@ -231,10 +235,11 @@ pub fn body_lines(app: &App) -> Vec<Line<'static>> {
 /// where a ticket row's tree furniture would be, then the count it is holding.
 /// It says `(hidden)` — and carries the stage rollup of what that is (#61) —
 /// only while shut: once open, the rows are right there and claiming otherwise
-/// would be a lie.
-fn group_line(kind: GroupKind, hidden: usize, fold: &Fold, under_cursor: bool) -> Line<'static> {
+/// would be a lie. A query opens the group onto its matches alone, and the
+/// count says `n of m` for as long as that leaves anything out.
+fn group_line(kind: GroupKind, held: usize, fold: &Fold, under_cursor: bool) -> Line<'static> {
     let marker = match fold {
-        Fold::Open => '▾',
+        Fold::Open | Fold::Sifted { .. } => '▾',
         Fold::Shut { .. } => '▸',
     };
     // The glyph is never written here: each group stands for one row meaning, so
@@ -255,15 +260,16 @@ fn group_line(kind: GroupKind, hidden: usize, fold: &Fold, under_cursor: bool) -
             Style::new().fg(Color::Reset),
         ),
     };
+    let count = match fold {
+        Fold::Sifted { shown } if *shown < held => format!(" {shown} of {held} {label}"),
+        _ => format!(" {held} {label}"),
+    };
     let mut spans = vec![
         Span::raw("  "),
         cursor_span(under_cursor),
         Span::styled(format!("{marker} "), FURNITURE),
         Span::styled(glyph.char().to_string(), style),
-        Span::styled(
-            format!(" {hidden} {label}"),
-            Style::new().add_modifier(Modifier::DIM),
-        ),
+        Span::styled(count, Style::new().add_modifier(Modifier::DIM)),
     ];
     if let Fold::Shut { rollup } = fold {
         spans.extend(rollup_spans("hidden", rollup));
@@ -281,24 +287,24 @@ fn group_line(kind: GroupKind, hidden: usize, fold: &Fold, under_cursor: bool) -
 /// another root's subtree), and only one of those occurrences is under the
 /// cursor.
 fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize>) {
-    let name_repo = matches!(app.screen(), Screen::Flattened { .. });
     let cursor_pos = app.cursor_pos();
     let mut stop = 0usize;
     let mut cursor_line = None;
     // Every stop the plan lists gets one line, in the same order, so this
     // single counter is what keeps the drawn ▶ and the cursor in agreement.
+    // Which lines are stops is [`Item::stop_at`]'s call, not this loop's.
     let mut mark = |lines: &Vec<Line<'static>>, cursor_line: &mut Option<usize>| {
-        let here = stop;
-        let under_cursor = here == cursor_pos;
+        let under_cursor = stop == cursor_pos;
         if under_cursor {
             *cursor_line = Some(lines.len());
         }
         stop += 1;
-        (here, under_cursor)
+        under_cursor
     };
 
     let mut lines = vec![Line::default()];
     for item in &plan.items {
+        let under_cursor = item.stop_at().is_some() && mark(&lines, &mut cursor_line);
         match item {
             Item::Header(id) => lines.push(cluster_header(id, &app.clusters[id])),
             Item::Ticket {
@@ -307,20 +313,16 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                 also_needs,
                 branch,
                 depth: _,
-            } => {
-                let (_, under_cursor) = mark(&lines, &mut cursor_line);
-                lines.push(ticket_line(
-                    app.ticket(row),
-                    prefix,
-                    also_needs,
-                    branch,
-                    name_repo,
-                    under_cursor,
-                ));
-            }
-            Item::Group { id, hidden, fold } => {
-                let (_, under_cursor) = mark(&lines, &mut cursor_line);
-                lines.push(group_line(id.kind, *hidden, fold, under_cursor));
+            } => lines.push(ticket_line(
+                app.ticket(row),
+                prefix,
+                also_needs,
+                branch,
+                under_cursor,
+            )),
+            Item::Context { row, prefix } => lines.push(context_line(app.ticket(row), prefix)),
+            Item::Group { id, held, fold } => {
+                lines.push(group_line(id.kind, *held, fold, under_cursor));
             }
             Item::Blank => lines.push(Line::default()),
         }
@@ -1092,37 +1094,73 @@ mod tests {
     }
 
     #[test]
-    fn a_query_flattens_to_a_scored_list_whose_rows_name_their_repo() {
+    fn a_query_sifts_the_tree_rather_than_flattening_it() {
         let mut app = fixture_app();
         type_str(&mut app, "bread");
         let screen = render(&app);
-        // Surviving rows — flat, with no cluster header above them, so each
-        // names its repo itself.
-        assert!(
-            screen.contains("○ wayfinder#6 Re-entry breadcrumbs"),
+        // The cluster keeps its header, and each match keeps the takeable row
+        // it hangs from — #14 needs both #6 and #9, so it is drawn under both,
+        // exactly as the unsifted leverage screen draws it.
+        assert!(screen.contains("▌ wayfinder · Map: wf"), "{screen}");
+        let body: Vec<&str> = screen
+            .lines()
+            .filter(|l| l.contains('#'))
+            .map(|l| l.trim_matches('│').trim_end())
+            .collect();
+        assert_eq!(
+            body,
+            vec![
+                "  ▶ ○ #6 Re-entry breadcrumbs [task]",
+                "    └─  ⊘ #14 Breadcrumb markers [task]",
+                "    ◐ #9 Main screen design [task]",
+                "    └─  ⊘ #14 Breadcrumb markers [task]",
+            ],
             "{screen}"
         );
-        assert!(
-            screen.contains("⊘ wayfinder#14 Breadcrumb markers"),
-            "{screen}"
-        );
-        assert!(
-            !screen.contains("▌"),
-            "no cluster furniture while flattened: {screen}"
-        );
-        assert!(!screen.contains("(hidden)"), "{screen}");
-        // Dropped rows are gone.
-        assert!(!screen.contains("Main screen design"));
-        assert!(!screen.contains("Choose the stack"));
-        assert!(!screen.contains("Supervising AFK agents"));
+        // #9 is on screen only to place the match beneath it — the cursor
+        // cannot land on it, and it is not counted as a hit.
+        assert_eq!(screen.matches('▶').count(), 1, "{screen}");
+        // Rows the query dropped are gone, group and all.
+        assert!(!screen.contains("Choose the stack"), "{screen}");
+        assert!(!screen.contains("Supervising AFK agents"), "{screen}");
+        assert!(!screen.contains("done"), "{screen}");
         // Count line and prompt reflect the live query; the denominator is
         // the map's tickets, not the leverage rows.
-        assert!(screen.contains("2/5"));
-        assert!(screen.contains("> bread█"));
-        // Clearing the query restores the structured screen.
+        assert!(screen.contains("3/5"), "{screen}");
+        assert!(screen.contains("> bread█"), "{screen}");
+        // Clearing the query restores the lens whole.
         app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         let screen = render(&app);
-        assert!(screen.contains("▌ wayfinder · Map: wf"), "{screen}");
+        assert!(screen.contains("Supervising AFK agents"), "{screen}");
+        assert!(screen.contains("1 done"), "{screen}");
+    }
+
+    #[test]
+    fn a_sifted_group_says_how_many_of_how_many_it_is_showing() {
+        // Two done tickets, one of them matching: typing has to reach inside
+        // the group that holds it, and the group has to stay honest about the
+        // one it is still holding back.
+        let mut map = wf_map();
+        map.tickets.push(ticket(
+            "blooop/wayfinder",
+            3,
+            "Stack the PRs",
+            false,
+            false,
+            vec![],
+        ));
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let mut app = App::new(clusters);
+        type_str(&mut app, "choose");
+        let screen = render(&app);
+        assert!(screen.contains("▾ ● 1 of 2 done"), "{screen}");
+        assert!(screen.contains("● #2 Choose the stack"), "{screen}");
+        assert!(!screen.contains("Stack the PRs"), "{screen}");
+        // The cursor is on the match, not on the group heading above it —
+        // there is no fold to toggle while a query is what opened it.
+        assert_eq!(app.cursor_ticket().map(|t| t.number), Some(2));
+        assert_eq!(screen.matches('▶').count(), 1, "{screen}");
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -13,9 +13,20 @@
 //! - **Forest** (`tab`): the whole DAG, done dimmed in place. Tree parent =
 //!   lowest-numbered in-map blocker; the other in-map blockers annotate the row
 //!   (`⤷ also needs #n`).
-//! - **Flattened** (a live query): one nucleo-score-ordered flat list across
-//!   every cluster in scope — no headers, no tree, every stop at depth 0.
-//!   Clearing the query restores the structured screen.
+//! - **Sifted** (a live query): whichever of those two trees is toggled, pruned
+//!   to the rows that matched. Clearing the query restores it whole.
+//!
+//! Sifting keeps the structure and drops the rows (the earlier rule flattened
+//! both). A cluster keeps its header, a match keeps the branch root it hangs
+//! from — the takeable ticket that unlocks it is the one ancestor that says
+//! something a match cannot say about itself — and everything between them is
+//! chain length: an unmatched link with a single surviving child is elided, and
+//! the `⋯` in the next row's furniture (`├⋯`) is what says a level went
+//! missing. An unmatched link that *forks* is drawn, because two surviving
+//! children need something to hang from. The rows kept only to place other rows
+//! are [`Item::Context`] — drawn, never landed on: under a query the only
+//! cursor stops are matches, all of them at depth 0, so `↑`/`↓` walk the hits
+//! and nothing else, exactly as they did over the flat list.
 //!
 //! Every stop carries its **depth** (#57), because that is what navigation is
 //! expressed in: `↑`/`↓` walk siblings at the cursor's own depth, `→` descends
@@ -31,9 +42,8 @@ use crate::filter;
 use crate::model::{Map, MapId, RowGlyph, Status, Ticket};
 
 /// The structural screen `tab` toggles between — the half of the view state
-/// that is *stored*. The other half (whether a query is flattening the body)
-/// is derived from the query itself in [`Screen`], so the two can never
-/// disagree.
+/// that is *stored*. The other half (whether a query is sifting the body) is
+/// derived from the query itself in [`Screen`], so the two can never disagree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Lens {
     /// The default: what can be taken now, and what taking it unlocks.
@@ -54,13 +64,25 @@ impl Lens {
 }
 
 /// What the body renders this frame. Derived (never stored) from the lens and
-/// the query: a live query flattens whichever lens is toggled, and clearing it
-/// restores that lens. `Flattened` carries the query, so a flattened screen
-/// without one is unrepresentable.
+/// the query: a live query *sifts* whichever lens is toggled — the same tree,
+/// pruned to what matched — and clearing it restores that lens whole. `Sifted`
+/// carries both halves, so a sifted screen without a query, or one that has
+/// forgotten which tree it is pruning, is unrepresentable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Screen<'a> {
     Structured(Lens),
-    Flattened { query: &'a str },
+    Sifted { lens: Lens, query: &'a str },
+}
+
+impl Screen<'_> {
+    /// The tree this screen draws, whole or pruned. Sifting changes which rows
+    /// survive, never which shape they are laid out in.
+    #[must_use]
+    pub fn lens(self) -> Lens {
+        match self {
+            Screen::Structured(lens) | Screen::Sifted { lens, .. } => lens,
+        }
+    }
 }
 
 /// Which of a cluster's two collapsible groups. Both are the same *kind* of
@@ -104,8 +126,8 @@ pub struct StopAt {
     pub depth: usize,
 }
 
-/// One line of the body. [`Item::Ticket`] and [`Item::Group`] are cursor
-/// stops; headers and spacers are not.
+/// One line of the body. [`Item::Ticket`] and [`Item::Group`] are cursor stops;
+/// headers, spacers and context rows are not — [`Item::stop_at`] is the rule.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Item {
     /// A cluster header — the map this and the following lines belong to.
@@ -114,24 +136,61 @@ pub enum Item {
     Ticket {
         row: Row,
         depth: usize,
-        /// Tree branch furniture ("├─", "│ └─", …). Empty at depth 0 and on
-        /// every flattened row.
+        /// Tree branch furniture ("├─", "│ └─", …), empty at the top of a
+        /// branch. On a sifted screen it places a match that navigation still
+        /// treats as depth 0, and a `⋯` in it marks an elided ancestor.
         prefix: String,
         /// Forest only: in-map blockers beyond the primary parent.
         also_needs: Vec<u64>,
         /// Whether this row heads a branch, and what is in it.
         branch: Branch,
     },
+    /// A ticket row drawn only to place the rows beneath it: on a sifted
+    /// screen, the branch root a match hangs from, or an unmatched fork two
+    /// matches share. Never a cursor stop and never a match, which is why it is
+    /// its own line rather than a flag on [`Item::Ticket`] — the count line and
+    /// the cursor would both have to remember to check that flag.
+    Context { row: Row, prefix: String },
     /// A collapsible group of held-back rows, always at depth 0 of its
-    /// cluster. Carries what it is holding (`hidden`) and its [`Fold`], so
-    /// the line can say so without consulting anything else.
+    /// cluster. Carries how many rows it stands for (`held`) and its [`Fold`],
+    /// so the line can say so without consulting anything else.
     Group {
         id: GroupId,
-        hidden: usize,
+        held: usize,
         fold: Fold,
     },
     /// Spacer between clusters.
     Blank,
+}
+
+impl Item {
+    /// The cursor stop this line is, if it is one. The single place that rule
+    /// lives: [`Plan::stops`] and the drawn `▶` both read it, so the stop list
+    /// and the marker cannot drift apart.
+    #[must_use]
+    pub fn stop_at(&self) -> Option<StopAt> {
+        match self {
+            Item::Ticket { row, depth, .. } => Some(StopAt {
+                stop: Stop::Ticket(row.clone()),
+                depth: *depth,
+            }),
+            // Nothing to land on. A sifted group leads this arm because it is
+            // the narrower pattern: it is a heading the query wrote, not a fold
+            // anyone can toggle — clearing the query is what puts the group
+            // back — so it is no more a stop than a header is.
+            Item::Group {
+                fold: Fold::Sifted { .. },
+                ..
+            }
+            | Item::Context { .. }
+            | Item::Header(_)
+            | Item::Blank => None,
+            Item::Group { id, .. } => Some(StopAt {
+                stop: Stop::Group(id.clone()),
+                depth: 0,
+            }),
+        }
+    }
 }
 
 /// Whether a group line is folded — and, **only while it is**, the stage
@@ -141,8 +200,18 @@ pub enum Item {
 /// a rollup for it is unrepresentable rather than merely unshown.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Fold {
-    Shut { rollup: Vec<(RowGlyph, usize)> },
+    Shut {
+        rollup: Vec<(RowGlyph, usize)>,
+    },
     Open,
+    /// A live query is showing `shown` of the group's held rows and holding the
+    /// rest back — `shown` is never zero, because a group with nothing matching
+    /// leaves the body entirely. The rollup is gone here on purpose: a query
+    /// already says what it was looking for, and the group line answers it with
+    /// `shown of held` instead.
+    Sifted {
+        shown: usize,
+    },
 }
 
 /// Whether a ticket row **heads a branch** — sits at the top of its cluster
@@ -180,24 +249,12 @@ pub struct Plan {
 impl Plan {
     /// The cursor stops, in on-screen order, each with its depth.
     pub fn stops(&self) -> Vec<StopAt> {
-        self.items
-            .iter()
-            .filter_map(|item| match item {
-                Item::Ticket { row, depth, .. } => Some(StopAt {
-                    stop: Stop::Ticket(row.clone()),
-                    depth: *depth,
-                }),
-                Item::Group { id, .. } => Some(StopAt {
-                    stop: Stop::Group(id.clone()),
-                    depth: 0,
-                }),
-                Item::Header(_) | Item::Blank => None,
-            })
-            .collect()
+        self.items.iter().filter_map(Item::stop_at).collect()
     }
 
     /// The ticket rows on screen — what the match count counts. A subset of
-    /// [`Plan::stops`]: group lines are stops but not tickets.
+    /// [`Plan::stops`]: group lines are stops but not tickets, and a sifted
+    /// screen's context rows are neither.
     pub fn rows(&self) -> Vec<Row> {
         self.items
             .iter()
@@ -211,13 +268,243 @@ impl Plan {
 
 /// Plan the body for the clusters in scope, in their given (render) order.
 pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
-    let mut plan = match screen {
-        Screen::Structured(Lens::Leverage) => leverage(clusters, expanded),
-        Screen::Structured(Lens::Forest) => forest(clusters),
-        Screen::Flattened { query } => flattened(clusters, query),
+    let sieve = Sieve::new(clusters, screen);
+    // Under a query the cluster order is the query's to decide: the project
+    // holding the best hit leads, as it did when the hits were one flat list.
+    // Without one the caller's order stands — that is the activity order the
+    // multi-project screen is built on.
+    let by_score;
+    let clusters = match &sieve {
+        Sieve::Everything => clusters,
+        Sieve::Kept(kept) => {
+            by_score = best_first(clusters, kept);
+            &by_score
+        }
     };
-    attach_rollups(&mut plan.items, clusters);
+    let mut plan = match screen.lens() {
+        Lens::Leverage => leverage(clusters, expanded, &sieve),
+        Lens::Forest => forest(clusters, &sieve),
+    };
+    // Rollups describe the tree that was actually drawn, and a sifted tree
+    // draws only the hits: a root there heads its matches, not its subtree, so
+    // there is nothing left for a rollup to summarise honestly.
+    if !sieve.sifting() {
+        attach_rollups(&mut plan.items, clusters);
+    }
     plan
+}
+
+/// What a live query keeps, and how well each surviving row scored — the whole
+/// of what filtering does to a plan. [`Sieve::Everything`] is the no-query
+/// case, so the walks below take a sieve unconditionally instead of threading
+/// an `Option` no screen can tell them the meaning of.
+enum Sieve {
+    Everything,
+    Kept(BTreeMap<Row, u32>),
+}
+
+impl Sieve {
+    fn new(clusters: &[(&MapId, &Map)], screen: Screen<'_>) -> Sieve {
+        let Screen::Sifted { query, .. } = screen else {
+            return Sieve::Everything;
+        };
+        let mut kept = BTreeMap::new();
+        for (id, map) in clusters {
+            for (index, score) in filter::scores(&map.tickets, query).into_iter().enumerate() {
+                if let Some(score) = score {
+                    kept.insert(
+                        Row {
+                            map: (*id).clone(),
+                            index,
+                        },
+                        score,
+                    );
+                }
+            }
+        }
+        Sieve::Kept(kept)
+    }
+
+    fn sifting(&self) -> bool {
+        matches!(self, Sieve::Kept(_))
+    }
+
+    /// One cluster's rendered tree, pruned to what the query kept — or handed
+    /// straight back when there is no query.
+    fn sift(&self, tree: Vec<Item>) -> Vec<Item> {
+        match self {
+            Sieve::Everything => tree,
+            Sieve::Kept(kept) => prune_tree(&tree, kept),
+        }
+    }
+}
+
+/// The clusters ordered by the best score anywhere inside them. Stable, so
+/// clusters that match equally well (or not at all — they are about to leave
+/// the body) keep the order they came in.
+fn best_first<'a>(
+    clusters: &[(&'a MapId, &'a Map)],
+    kept: &BTreeMap<Row, u32>,
+) -> Vec<(&'a MapId, &'a Map)> {
+    let mut ordered = clusters.to_vec();
+    ordered.sort_by_key(|(id, _)| {
+        Reverse(
+            kept.iter()
+                .filter(|(row, _)| &row.map == *id)
+                .map(|(_, score)| *score)
+                .max(),
+        )
+    });
+    ordered
+}
+
+/// One node of a rendered branch, rebuilt from the flat item list so the prune
+/// works on exactly the tree the lens laid out — the same reason
+/// [`attach_rollups`] reads the list rather than the DAG. In the leverage view
+/// those are different trees: a ticket two roots both unblock is genuinely two
+/// nodes here, one under each, and each is pruned on its own.
+struct Node {
+    row: Row,
+    also_needs: Vec<u64>,
+    /// This row's own query score — `None` when it is here only for what hangs
+    /// beneath it.
+    score: Option<u32>,
+    kids: Vec<Node>,
+}
+
+impl Node {
+    /// The best score anywhere in this node's surviving subtree. Sibling order
+    /// is decided by it, so the branch holding the top hit leads the screen the
+    /// way the flat score-ordered list used to.
+    fn best(&self) -> Option<u32> {
+        self.kids
+            .iter()
+            .filter_map(Node::best)
+            .chain(self.score)
+            .max()
+    }
+
+    /// Whether this node earns a line of its own. A match always does; an
+    /// unmatched node does only when it forks, because two surviving children
+    /// need something to hang from. Everything else is chain length.
+    fn drawn(&self) -> bool {
+        self.score.is_some() || self.kids.len() > 1
+    }
+}
+
+/// Rebuild the nodes of a preorder run of ticket rows: a row's subtree is
+/// everything after it that is deeper than it is.
+fn nodes(run: &[(Row, usize, Vec<u64>)], kept: &BTreeMap<Row, u32>) -> Vec<Node> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < run.len() {
+        let (row, depth, also_needs) = &run[i];
+        let mut end = i + 1;
+        while end < run.len() && run[end].1 > *depth {
+            end += 1;
+        }
+        out.push(Node {
+            row: row.clone(),
+            also_needs: also_needs.clone(),
+            score: kept.get(row).copied(),
+            kids: nodes(&run[i + 1..end], kept),
+        });
+        i = end;
+    }
+    out
+}
+
+/// Drop everything the query did not keep or is not needed to place what it
+/// kept, and order what is left best-first at every level.
+fn prune(node: Node) -> Option<Node> {
+    let mut kids: Vec<Node> = node.kids.into_iter().filter_map(prune).collect();
+    if node.score.is_none() && kids.is_empty() {
+        return None;
+    }
+    kids.sort_by_key(|kid| Reverse(kid.best()));
+    Some(Node { kids, ..node })
+}
+
+/// The children that earn a line, each flagged with whether it was reached
+/// through elided ancestors. An unmatched single-child link is not drawn: its
+/// child is pulled up into its place, and the `⋯` on that child's link is the
+/// only trace left of the levels skipped.
+fn drawn_kids(kids: &[Node]) -> Vec<(&Node, bool)> {
+    let mut out = Vec::new();
+    for kid in kids {
+        if kid.drawn() {
+            out.push((kid, false));
+        } else {
+            out.extend(drawn_kids(&kid.kids).into_iter().map(|(n, _)| (n, true)));
+        }
+    }
+    out
+}
+
+/// The two-cell link a child hangs from, and the continuation its own children
+/// hang from — the two prefixes [`walk_forest`] keeps deliberately separate.
+fn link(last: bool, elided: bool) -> (&'static str, &'static str) {
+    match (last, elided) {
+        (false, false) => ("├─", "│ "),
+        (false, true) => ("├⋯", "│ "),
+        (true, false) => ("└─", "  "),
+        (true, true) => ("└⋯", "  "),
+    }
+}
+
+/// Draw a surviving node and what survived beneath it. A match is a depth-0
+/// stop wherever it sits in the tree — the indentation places it, the depth
+/// says only that `↑`/`↓` walk every hit — and everything else is context.
+fn emit(node: &Node, prefix: String, stem: &str, out: &mut Vec<Item>) {
+    out.push(match node.score {
+        Some(_) => Item::Ticket {
+            row: node.row.clone(),
+            depth: 0,
+            prefix,
+            also_needs: node.also_needs.clone(),
+            branch: Branch::Plain,
+        },
+        None => Item::Context {
+            row: node.row.clone(),
+            prefix,
+        },
+    });
+    let kids = drawn_kids(&node.kids);
+    for (i, (kid, elided)) in kids.iter().enumerate() {
+        let (branch, continuation) = link(i + 1 == kids.len(), *elided);
+        emit(
+            kid,
+            format!("{stem}{branch}"),
+            &format!("{stem}{continuation}"),
+            out,
+        );
+    }
+}
+
+/// One cluster's rendered tree, pruned to the matches and the rows that place
+/// them. The branch roots always survive; see the module header for why.
+fn prune_tree(tree: &[Item], kept: &BTreeMap<Row, u32>) -> Vec<Item> {
+    // The trees handed here are built by the lens walks, which push nothing but
+    // ticket rows; headers, groups and spacers are added around them afterwards.
+    let run: Vec<(Row, usize, Vec<u64>)> = tree
+        .iter()
+        .filter_map(|item| match item {
+            Item::Ticket {
+                row,
+                depth,
+                also_needs,
+                ..
+            } => Some((row.clone(), *depth, also_needs.clone())),
+            _ => None,
+        })
+        .collect();
+    let mut roots: Vec<Node> = nodes(&run, kept).into_iter().filter_map(prune).collect();
+    roots.sort_by_key(|root| Reverse(root.best()));
+    let mut out = Vec::new();
+    for root in &roots {
+        emit(root, String::new(), "", &mut out);
+    }
+    out
 }
 
 /// Fill in each branch root's rollup, read off the rows the plan actually laid
@@ -248,7 +535,11 @@ fn attach_rollups(items: &mut [Item], clusters: &[(&MapId, &Map)]) {
                     }
                 }
             }
-            Item::Header(_) | Item::Group { .. } | Item::Blank => branches.extend(open.take()),
+            // `Item::Context` cannot appear here: rollups are attached only to
+            // the unsifted screens, and only a sift produces context rows.
+            Item::Header(_) | Item::Group { .. } | Item::Context { .. } | Item::Blank => {
+                branches.extend(open.take());
+            }
         }
     }
     branches.extend(open);
@@ -307,6 +598,12 @@ fn ticket_item(
 /// depth-1 children of the group line, so `←` from a held row lands on the
 /// group that holds it. A shut group carries the stage rollup of its held
 /// rows instead: each held node contributes its glyph once.
+///
+/// A live query reaches inside: the group renders [`Fold::Sifted`] holding only
+/// its matches (at depth 0, like every other match) and says how many of how
+/// many that is, so done work stays findable by typing without the screen
+/// having to pretend the rest of the group is not there. A group with nothing
+/// matching does not render at all.
 fn push_group(
     items: &mut Vec<Item>,
     id: &MapId,
@@ -314,6 +611,7 @@ fn push_group(
     kind: GroupKind,
     held: &[usize],
     expanded: &Expanded,
+    sieve: &Sieve,
 ) {
     if held.is_empty() {
         return;
@@ -322,50 +620,72 @@ fn push_group(
         map: (*id).clone(),
         kind,
     };
-    let is_expanded = expanded.contains(&group);
-    let fold = if is_expanded {
-        Fold::Open
-    } else {
-        Fold::Shut {
-            rollup: RowGlyph::tally(held.iter().map(|&index| &map.tickets[index])),
+    let (fold, shown, depth) = match sieve {
+        Sieve::Kept(kept) => {
+            let mut matched: Vec<(usize, u32)> = held
+                .iter()
+                .filter_map(|&index| {
+                    let row = Row {
+                        map: (*id).clone(),
+                        index,
+                    };
+                    kept.get(&row).map(|&score| (index, score))
+                })
+                .collect();
+            if matched.is_empty() {
+                return;
+            }
+            // Stable, so held rows that score alike keep the map's own order.
+            matched.sort_by_key(|&(_, score)| Reverse(score));
+            (
+                Fold::Sifted {
+                    shown: matched.len(),
+                },
+                matched.into_iter().map(|(index, _)| index).collect(),
+                0,
+            )
         }
+        Sieve::Everything if expanded.contains(&group) => (Fold::Open, held.to_vec(), 1),
+        Sieve::Everything => (
+            Fold::Shut {
+                rollup: RowGlyph::tally(held.iter().map(|&index| &map.tickets[index])),
+            },
+            vec![],
+            1,
+        ),
     };
     items.push(Item::Group {
         id: group,
-        hidden: held.len(),
+        held: held.len(),
         fold,
     });
-    if !is_expanded {
-        return;
-    }
-    for (i, &index) in held.iter().enumerate() {
-        let branch = if i + 1 == held.len() {
-            "└─"
-        } else {
-            "├─"
-        };
-        items.push(ticket_item(id, index, 1, branch.to_string(), vec![]));
+    for (i, &index) in shown.iter().enumerate() {
+        let (branch, _) = link(i + 1 == shown.len(), false);
+        items.push(ticket_item(id, index, depth, branch.to_string(), vec![]));
     }
 }
 
-fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded) -> Plan {
+fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded, sieve: &Sieve) -> Plan {
     let mut plan = Plan::default();
     for (id, map) in clusters {
         let mut roots: Vec<&Ticket> = map.tickets.iter().filter(|t| takeable(t)).collect();
-        if roots.is_empty() {
+        // A map with nothing takeable leaves the leverage body and is only
+        // counted. Not while a query is live, though: its done and blocked work
+        // is exactly as findable by typing as anyone else's, so the cluster is
+        // built anyway and the sieve decides whether any of it survives.
+        if roots.is_empty() && !sieve.sifting() {
             plan.idle_hidden += 1;
             continue;
         }
         roots.sort_by_key(|t| (Reverse(open_unblocks(map, t.number).len()), t.number));
 
-        plan.items.push(Item::Header((*id).clone()));
+        let mut tree = Vec::new();
         let mut reached = BTreeSet::new();
         for root in roots {
             let index = map
                 .index_of(root.number)
                 .expect("root is one of map.tickets");
-            plan.items
-                .push(ticket_item(id, index, 0, String::new(), vec![]));
+            tree.push(ticket_item(id, index, 0, String::new(), vec![]));
             let mut path = vec![root.number];
             walk_unblocks(
                 map,
@@ -375,13 +695,16 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded) -> Plan {
                 "",
                 &mut path,
                 &mut reached,
-                &mut plan.items,
+                &mut tree,
             );
         }
+        let mut body = sieve.sift(tree);
 
         // Blocked tickets no subtree reached — blocked only through issues
         // outside the map (or a blocking cycle): the screen owes a count for
-        // what it is not showing, and a way to look.
+        // what it is not showing, and a way to look. Reached-ness is read off
+        // the whole walk, before the sieve, so a query cannot push a ticket
+        // into this group by pruning the branch that reached it.
         let deeper: Vec<usize> = map
             .tickets
             .iter()
@@ -392,12 +715,13 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded) -> Plan {
             .map(|(i, _)| i)
             .collect();
         push_group(
-            &mut plan.items,
+            &mut body,
             id,
             map,
             GroupKind::BlockedDeeper,
             &deeper,
             expanded,
+            sieve,
         );
 
         let done: Vec<usize> = map
@@ -407,8 +731,16 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded) -> Plan {
             .filter(|(_, t)| !is_open(t))
             .map(|(i, _)| i)
             .collect();
-        push_group(&mut plan.items, id, map, GroupKind::Done, &done, expanded);
+        push_group(&mut body, id, map, GroupKind::Done, &done, expanded, sieve);
 
+        // Only a sift can empty a cluster — a map with a takeable root always
+        // has a row — and a cluster a query emptied leaves the body header and
+        // all, the way filtering is expected to work.
+        if body.is_empty() {
+            continue;
+        }
+        plan.items.push(Item::Header((*id).clone()));
+        plan.items.append(&mut body);
         plan.items.push(Item::Blank);
     }
     plan.items.pop();
@@ -435,15 +767,10 @@ fn walk_unblocks(
         .filter(|n| !path.contains(n))
         .collect();
     for (i, &child) in children.iter().enumerate() {
-        let last = i + 1 == children.len();
         let index = map
             .index_of(child)
             .expect("dependent is one of map.tickets");
-        let (branch, continuation) = if last {
-            ("└─", "  ")
-        } else {
-            ("├─", "│ ")
-        };
+        let (branch, continuation) = link(i + 1 == children.len(), false);
         items.push(ticket_item(
             id,
             index,
@@ -467,10 +794,10 @@ fn walk_unblocks(
     }
 }
 
-fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
+fn forest(clusters: &[(&MapId, &Map)], sieve: &Sieve) -> Plan {
     let mut plan = Plan::default();
     for (id, map) in clusters {
-        plan.items.push(Item::Header((*id).clone()));
+        let mut tree = Vec::new();
 
         // Primary parent = lowest-numbered in-map blocker; everything else on
         // the edge list annotates the row.
@@ -506,7 +833,7 @@ fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
                 &children,
                 &in_map_blockers,
                 &mut visited,
-                &mut plan.items,
+                &mut tree,
             );
         }
         // A blocking cycle leaves its members parented to each other and
@@ -528,9 +855,17 @@ fn forest(clusters: &[(&MapId, &Map)]) -> Plan {
                 &children,
                 &in_map_blockers,
                 &mut visited,
-                &mut plan.items,
+                &mut tree,
             );
         }
+        let mut body = sieve.sift(tree);
+        // The forest is total, so an empty cluster here is always a query's
+        // doing: nothing in this map matched, and the cluster goes with it.
+        if body.is_empty() {
+            continue;
+        }
+        plan.items.push(Item::Header((*id).clone()));
+        plan.items.append(&mut body);
         plan.items.push(Item::Blank);
     }
     plan.items.pop();
@@ -577,14 +912,9 @@ fn walk_forest(
 
     let kids = children.get(&number).cloned().unwrap_or_default();
     for (i, &kid) in kids.iter().enumerate() {
-        let last = i + 1 == kids.len();
         // The last child closes its branch and its subtree hangs from blank
         // space; every earlier child keeps the vertical bar running past it.
-        let (branch, continuation) = if last {
-            ("└─", "  ")
-        } else {
-            ("├─", "│ ")
-        };
+        let (branch, continuation) = link(i + 1 == kids.len(), false);
         walk_forest(
             map,
             id,
@@ -597,31 +927,6 @@ fn walk_forest(
             visited,
             items,
         );
-    }
-}
-
-fn flattened(clusters: &[(&MapId, &Map)], query: &str) -> Plan {
-    let mut scored: Vec<(Reverse<u32>, &MapId, u64, usize)> = Vec::new();
-    for (id, map) in clusters {
-        for (index, (ticket, score)) in map
-            .tickets
-            .iter()
-            .zip(filter::scores(&map.tickets, query))
-            .enumerate()
-        {
-            if let Some(score) = score {
-                scored.push((Reverse(score), id, ticket.number, index));
-            }
-        }
-    }
-    // Best score first; ties break to the stable (map, number) screen order.
-    scored.sort_by(|a, b| (a.0, a.1, a.2).cmp(&(b.0, b.1, b.2)));
-    Plan {
-        items: scored
-            .into_iter()
-            .map(|(_, id, _, index)| ticket_item(id, index, 0, String::new(), vec![]))
-            .collect(),
-        idle_hidden: 0,
     }
 }
 
@@ -805,7 +1110,7 @@ mod tests {
         assert!(collapsed.items.iter().any(|i| matches!(
             i,
             Item::Group {
-                hidden: 2,
+                held: 2,
                 fold: Fold::Shut { .. },
                 ..
             }
@@ -862,7 +1167,7 @@ mod tests {
             .items
             .iter()
             .find_map(|i| match i {
-                Item::Group { hidden, fold, .. } => Some((*hidden, fold.clone())),
+                Item::Group { held, fold, .. } => Some((*held, fold.clone())),
                 _ => None,
             })
             .expect("the done group");
@@ -932,10 +1237,10 @@ mod tests {
             .iter()
             .filter_map(|i| match i {
                 Item::Group {
-                    hidden,
+                    held,
                     fold: Fold::Shut { rollup },
                     ..
-                } => Some((*hidden, rollup.clone())),
+                } => Some((*held, rollup.clone())),
                 _ => None,
             })
             .collect();
@@ -1291,48 +1596,248 @@ mod tests {
         );
     }
 
-    #[test]
-    fn flattened_orders_by_score_across_clusters_with_no_furniture() {
-        let a = map(vec![
-            ticket(6, true, false, vec![]),
-            ticket(7, false, false, vec![]),
-        ]);
-        let b = map(vec![ticket(103, true, false, vec![])]);
-        let a_id = id();
-        let b_id = MapId::new("blooop/dotfiles", 4);
-        let plan = plan(
-            &[(&b_id, &b), (&a_id, &a)],
-            Screen::Flattened { query: "t" },
-            &nothing(),
-        );
-        // Everything matches "t"; no headers, blanks, or groups — rows only,
-        // all at depth 0, so `↑`/`↓` walk every hit and `→` has nowhere to go.
-        assert!(
-            plan.items.iter().all(|i| matches!(i, Item::Ticket { .. })),
-            "{:?}",
-            plan.items
-        );
-        assert_eq!(plan.rows().len(), 3, "done tickets stay findable by query");
-        assert!(plan.stops().iter().all(|at| at.depth == 0));
-        assert_eq!(plan.idle_hidden, 0);
+    /// A ticket with a title of its own — the sifting tests are about which
+    /// rows a query keeps, so they need titles a query can tell apart.
+    fn titled(number: u64, title: &str, open: bool, blocked_by: Vec<u64>) -> Ticket {
+        Ticket {
+            title: title.to_string(),
+            ..ticket(number, open, false, blocked_by)
+        }
+    }
+
+    /// The body as one string per line, furniture included: this is a test
+    /// about the *shape* a query leaves behind, so the shape is what it reads.
+    fn shape(plan: &Plan, m: &Map) -> Vec<String> {
+        let number = |row: &Row| m.tickets[row.index].number;
+        plan.items
+            .iter()
+            .map(|item| match item {
+                Item::Header(id) => format!("▌ {}", id.short_repo()),
+                Item::Ticket { row, prefix, .. } => format!("{prefix}#{}", number(row)),
+                Item::Context { row, prefix } => format!("{prefix}#{} dim", number(row)),
+                Item::Group {
+                    id,
+                    held,
+                    fold: Fold::Sifted { shown },
+                } => format!("{:?} {shown}/{held}", id.kind),
+                Item::Group { id, held, .. } => format!("{:?} {held}", id.kind),
+                Item::Blank => String::new(),
+            })
+            .collect()
+    }
+
+    fn sifted(query: &str) -> Screen<'_> {
+        Screen::Sifted {
+            lens: Lens::Leverage,
+            query,
+        }
     }
 
     #[test]
-    fn flattened_puts_the_better_match_first_regardless_of_cluster_order() {
-        let mut exact = ticket(6, true, false, vec![]);
-        exact.title = "breadcrumbs".to_string();
-        let mut loose = ticket(103, true, false, vec![]);
-        loose.title = "b-r-e-a-d spelled out crumbs".to_string();
-        let a = map(vec![loose]);
-        let b = map(vec![exact]);
-        let a_id = MapId::new("blooop/dotfiles", 4); // sorts before wayfinder
-        let b_id = id();
+    fn a_query_keeps_the_cluster_and_the_root_its_match_hangs_from() {
+        // #14 matches, nothing else does. The header stays (which project this
+        // is), the takeable #6 stays as context (what unlocks the match), and
+        // #7 — neither a match nor on the way to one — goes.
+        let m = map(vec![
+            titled(6, "root", true, vec![]),
+            titled(7, "sibling", true, vec![6]),
+            titled(14, "alpha", true, vec![6]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert_eq!(shape(&plan, &m), vec!["▌ wayfinder", "#6 dim", "└─#14"]);
+        // The context row is drawn but not landed on: `↑`/`↓` walk the hits,
+        // all of them depth 0, exactly as they did over the flat list.
+        assert_eq!(nav(&plan, &m), vec![("#14".to_string(), 0)]);
+        assert_eq!(plan.rows().len(), 1, "context rows are not matches");
+    }
+
+    #[test]
+    fn an_unmatched_link_with_one_surviving_child_elides() {
+        // #7 is on the way to the match and nothing else: it is chain length,
+        // and the `⋯` on #14's link is all that is left of it.
+        let m = map(vec![
+            titled(6, "root", true, vec![]),
+            titled(7, "link", true, vec![6]),
+            titled(14, "alpha", true, vec![7]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert_eq!(shape(&plan, &m), vec!["▌ wayfinder", "#6 dim", "└⋯#14"]);
+    }
+
+    #[test]
+    fn an_unmatched_link_that_forks_is_drawn() {
+        // Two matches hang off #7, so #7 earns its line: without it the two
+        // would read as siblings under #6, which is a different tree.
+        let m = map(vec![
+            titled(6, "root", true, vec![]),
+            titled(7, "link", true, vec![6]),
+            titled(12, "alpha", true, vec![7]),
+            titled(13, "alpha", true, vec![7]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert_eq!(
+            shape(&plan, &m),
+            vec!["▌ wayfinder", "#6 dim", "└─#7 dim", "  ├─#12", "  └─#13"]
+        );
+    }
+
+    #[test]
+    fn the_branch_holding_the_best_match_leads_its_cluster() {
+        // #20's title is the query exactly; #14 spells it out scattered. The
+        // branch that holds the better hit comes first, so a query still walks
+        // best-first even though the rows are back in a tree.
+        let m = map(vec![
+            titled(6, "root", true, vec![]),
+            titled(14, "a-l-p-h-a spelled out", true, vec![6]),
+            titled(9, "other root", true, vec![]),
+            titled(20, "alpha", true, vec![9]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert_eq!(
+            shape(&plan, &m),
+            vec!["▌ wayfinder", "#9 dim", "└─#20", "#6 dim", "└─#14"]
+        );
+    }
+
+    #[test]
+    fn the_cluster_holding_the_best_match_leads_the_screen() {
+        // What the flat list used to give for free: score outranks the cluster
+        // order the multi-project screen is otherwise built on.
+        let loose = map(vec![titled(103, "a-l-p-h-a spelled out", true, vec![])]);
+        let exact = map(vec![titled(6, "alpha", true, vec![])]);
+        let loose_id = MapId::new("blooop/dotfiles", 4);
+        let exact_id = id();
         let plan = plan(
-            &[(&a_id, &a), (&b_id, &b)],
-            Screen::Flattened { query: "bread" },
+            &[(&loose_id, &loose), (&exact_id, &exact)],
+            sifted("alpha"),
             &nothing(),
         );
-        let first = plan.rows()[0].clone();
-        assert_eq!(first.map, b_id, "score outranks cluster order");
+        assert_eq!(
+            plan.items.first(),
+            Some(&Item::Header(exact_id)),
+            "{:?}",
+            plan.items
+        );
+    }
+
+    #[test]
+    fn a_cluster_with_nothing_matching_leaves_the_body() {
+        let hit = map(vec![titled(6, "alpha", true, vec![])]);
+        let miss = map(vec![titled(103, "nothing like it", true, vec![])]);
+        let hit_id = id();
+        let miss_id = MapId::new("blooop/dotfiles", 4);
+        let plan = plan(
+            &[(&miss_id, &miss), (&hit_id, &hit)],
+            sifted("alpha"),
+            &nothing(),
+        );
+        assert_eq!(
+            plan.items,
+            vec![
+                Item::Header(hit_id.clone()),
+                Item::Ticket {
+                    row: Row {
+                        map: hit_id,
+                        index: 0
+                    },
+                    depth: 0,
+                    prefix: String::new(),
+                    also_needs: vec![],
+                    branch: Branch::Plain,
+                },
+            ],
+            "no header, no spacer, no trace of the cluster that missed"
+        );
+    }
+
+    #[test]
+    fn a_query_opens_a_group_onto_its_matches_and_says_how_many_of_how_many() {
+        // Done work stays findable by typing (it did when a query flattened
+        // the body, and it has to still). The group line stays too, because
+        // showing one of five done tickets and saying "done" would be a lie.
+        let m = map(vec![
+            titled(2, "alpha", false, vec![]),
+            titled(4, "unrelated", false, vec![]),
+            titled(6, "root", true, vec![]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert_eq!(shape(&plan, &m), vec!["▌ wayfinder", "Done 1/2", "└─#2"]);
+        // The group is a heading here, not a fold: only the match is a stop.
+        assert_eq!(nav(&plan, &m), vec![("#2".to_string(), 0)]);
+    }
+
+    #[test]
+    fn a_query_reaches_into_a_map_the_leverage_screen_drops() {
+        // A map with nothing takeable is not on the leverage screen at all —
+        // but its finished work is exactly as findable by typing as anyone
+        // else's, so the sieve gets to look before the map is dropped.
+        let m = map(vec![titled(2, "alpha", false, vec![])]);
+        let binding = id();
+        let idle = plan(
+            &[(&binding, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        assert_eq!(idle.idle_hidden, 1, "the premise: nothing takeable here");
+        assert!(idle.items.is_empty());
+
+        let found = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert_eq!(shape(&found, &m), vec!["▌ wayfinder", "Done 1/1", "└─#2"]);
+        assert_eq!(
+            found.idle_hidden, 0,
+            "the map is on screen, so there is nothing to say it is hidden"
+        );
+    }
+
+    #[test]
+    fn sifting_the_forest_prunes_the_forest() {
+        // The lens the query sifts is whichever one is toggled: on the forest
+        // the tree parent is the blocker, and done rows are in place rather
+        // than behind a group — so the same match hangs from a different row.
+        let m = map(vec![
+            titled(2, "finished", false, vec![]),
+            titled(6, "root", true, vec![]),
+            titled(14, "alpha", true, vec![6]),
+        ]);
+        let binding = id();
+        let plan = plan(
+            &[(&binding, &m)],
+            Screen::Sifted {
+                lens: Lens::Forest,
+                query: "alpha",
+            },
+            &nothing(),
+        );
+        assert_eq!(shape(&plan, &m), vec!["▌ wayfinder", "#6 dim", "└─#14"]);
+    }
+
+    #[test]
+    fn a_sifted_screen_carries_no_rollups() {
+        // A rollup says what a row heads. On a sifted screen a row heads its
+        // matches, not its subtree, so the honest rollup is no rollup: #6
+        // unblocks two tickets here and only one of them survived the query.
+        let m = map(vec![
+            titled(6, "root", true, vec![]),
+            titled(7, "sibling", true, vec![6]),
+            titled(14, "alpha", true, vec![6]),
+        ]);
+        let binding = id();
+        let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
+        assert!(
+            plan.items.iter().all(|item| !matches!(
+                item,
+                Item::Ticket {
+                    branch: Branch::Root { .. },
+                    ..
+                }
+            )),
+            "{:?}",
+            plan.items
+        );
     }
 }


### PR DESCRIPTION
Typing used to replace the body with one flat score-ordered list. That threw away the two things a hit cannot say about itself — which project it is in, and which takeable ticket unlocks it — at exactly the moment they are hardest to reconstruct, because everything around them has just gone. A query now prunes whichever lens `tab` had toggled rather than replacing it: same tree, fewer rows.

```
▌ wayfinder · Map: deep  ○2  ⊘6
    ○ #6 the takeable root [task]        ← dim, not a cursor stop
    ├⋯▶ ⊘ #20 zebra crossing [task]      ← #7→#8 elided
    └─  ⊘ #9 a fork [task]               ← dim, kept: two matches hang from it
      ├─  ⊘ #21 zebra stripes [task]
      └─  ⊘ #22 zebra herd [task]
```

Nine rows became five, and the two that stayed are the two carrying information.

## How much tree survives

A cluster keeps its header and a match keeps its branch root. Everything between them is chain length and elides, leaving `⋯` in the next row's furniture where levels went missing. An unmatched row that *forks* keeps its line, because two matches need something to hang from.

The prune reads the flat item list and rebuilds the nodes from it, the same way `attach_rollups` does and for the same reason: the rendered tree *is* that list, so both lenses get one implementation, and a DAG diamond — one ticket drawn under two roots — prunes per occurrence rather than per ticket.

Rows kept only to place a match are `Item::Context`: drawn, dimmed, never a cursor stop. A flag on `Item::Ticket` would have left "a match that cannot be selected" and "a context row that counts as a hit" both representable, and the count line and the cursor would each have had to remember to check it. `Item::stop_at` is now the single rule the stop list and the drawn `▶` share.

Navigation is deliberately unchanged: every match is a depth-0 stop, so `↓ ↓ enter` walks the hits and nothing else, exactly as it did over the flat list. Ordering is unchanged in effect too — siblings, branches and clusters all sort by the best score inside them, so the branch holding the top hit still leads.

Groups get `Fold::Sifted`, showing their matches alone and saying `1 of 5 done`. It is not a fold anyone can toggle — clearing the query is what puts the group back — so it is no more a cursor stop than a header is, and the cursor cannot land on a line where no key does anything. Leverage also stops dropping idle maps while a query is live: their finished work was findable by typing before this and had to stay so.

## Underlining what matched

A sifted screen says which rows matched but not why, and on a fuzzy match that is not always obvious. The matched characters are now underlined, from the same `Pattern` that scored the row rather than a second search over the drawn text — a highlight that disagrees with the match is worse than none.

The haystack spans two strings drawn in different places: the repo name appears once in the cluster header, the rest on the row. `Hit` reports the two halves in the coordinates each is drawn in. The header underlines its half for a reason visible the moment it does not: typing `dotf` sifts the screen to one project while landing on no character any row draws.

Bold+underline, deliberately not a colour. Every colour here already means something — cyan a cluster, green/yellow/red a stage, magenta a PR, orange the cursor and nothing else, dim finished — and a match is not a kind of thing, it is a property any of them can have.

## Tight matching

Underlining made a pre-existing problem visible. Nucleo, like fzf, matches a query as a subsequence of very nearly anything: over 30 real wayfinder tickets, `tree` kept **23 of 30 rows**, including "**T**he stage lattice: de**r**iving stag**e** from PR stat**e**".

On a ranked flat list that is harmless, which is why fzf can afford it — junk sorts to the bottom and nobody scrolls that far. A sifted tree draws every row that matched with its branch root and cluster header around it, so one junk match costs three lines and a cursor stop. Sifting made recall expensive, so the matcher now buys precision with it: **every character a query lands on has to start a word or sit against another matched character.** `tree` keeps 3 rows.

The rule keeps what fuzzy matching is good for. A letter that starts a word is how acronyms are typed, so `map` still finds "the **m**anager-**a**gent **p**rotocol"; a run is how words are typed, so `tree` still matches inside "sub**tree**". Only the mid-word single letter goes.

**Behaviour change worth knowing:** abbreviations that skip inside a word stop matching — `stgawr` for "stage-aware", and `wf` for "wayfinder". `wayf` is the shortest thing that finds the repo now. Pinned in a test rather than left to be discovered.

| query | before | after |
|---|---|---|
| `tree` | 23 | 3 |
| `stage` | 11 | 6 |
| `launch` | 6 | 5 |
| `cursor` | 5 | 3 |
| `map` | 4 | 4 |

## Also

`AGENTS.md`, documenting the `wf-next` build — the working tree installed beside the released `wf` rather than over it, so both are on PATH and running the wrong one is not possible by accident — plus the four CI checks and why the `live_*` tests sit outside them.

## Checks

All four CI checks pass locally: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --locked`, `cargo test --locked --lib --bins --examples` (187 tests), `cargo doc --no-deps --all-features --locked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Change live query behaviour from flattening the ticket list to sifting the existing trees, preserving structure while pruning to matches and adding tight fuzzy matching with inline highlighting; update UI, navigation, tests, and documentation accordingly.

New Features:
- Introduce a sifted screen mode that prunes the leverage and forest views to matched rows while keeping cluster headers and branch roots.
- Add inline match highlighting for queries on both cluster headers and ticket rows driven by shared fuzzy pattern data.

Enhancements:
- Refactor view planning to use a sieve-based tree pruning mechanism with context rows, ensuring cursor stops only land on actionable matches.
- Adjust group handling so queries open groups onto matching tickets only and report counts as "n of m" while excluding non-matching clusters from the body.
- Remove rollups from sifted screens so branch summaries accurately reflect only unsifted trees.
- Tighten fuzzy matching rules to require matches at word starts or contiguous runs, reducing noisy subsequence hits and aligning sieve and highlighting behaviour.
- Rework navigation and stop computation to rely on a unified Item::stop_at API and maintain depth-0 stops for all matches.

Documentation:
- Document the new sifting behaviour, tight fuzzy matching rules, and match underlining in README, replacing references to flattened views.
- Add AGENTS.md with guidance for agents on wf vs wf-next binaries, local build and deployment practices, CI checks, and house style.

Tests:
- Add extensive tests covering sifted tree shapes, context rows, group sifting behaviour, match ordering across clusters, and absence of rollups on sifted screens.
- Add tests for fuzzy matching tightness, hit index reporting, repo vs row highlighting, and consistency between scoring and hit reporting.
- Extend UI tests to assert sifting behaviour, match underlining, cluster header highlighting, and group count display under queries.