### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.5.1"
+  version: "0.6.0"
 
 package:
   name: wf


### PR DESCRIPTION
Cuts 0.6.0 from the three changes on `main` since v0.5.1:

- the agent launches inside the repo's devcontainer, via `dl` (#80)
- a query sifts the tree instead of flattening it — structure kept, matched characters underlined, tighter match rule (#93)
- the `~/.config/gh` mount is gone; gh auth arrives as `GH_TOKEN` (#41)

A minor bump rather than a patch, since both of the first two are user-visible features.

`Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` move together — the package job fails if the recipe and the crate disagree, and rejects a tag that does not match `Cargo.toml`. Tagging `v0.6.0` after this merges builds the release and publishes to prefix.dev/blooop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the crate and packaging metadata to version 0.6.0 for the new release.

Build:
- Update recipe metadata to reference version 0.6.0 in sync with Cargo.toml.

Chores:
- Update Cargo.toml and Cargo.lock package version to 0.6.0.