### PR TITLE
Look a live map up instead of naming #1, which could always close

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,29 @@
+//! Shared fixture for the live integration tests.
+//!
+//! **Never name a map by number.** Every live test here used to pin
+//! `blooop/wayfinder` map `#1`, which quietly assumed that a map reaching its
+//! destination would never happen — and when #1 was closed, six tests across
+//! three files failed at once, none of them for a reason connected to what
+//! they test. `fetch_map` refusing a closed map is *correct* (#28: a moved or
+//! finished map must render nothing rather than the wrong issue), so the
+//! failure was the fixture's fault, not the code's.
+
+use wf::model::MapId;
+
+pub const THIS_REPO: &str = "blooop/wayfinder";
+
+/// This repo's lowest-numbered open map, looked up live.
+///
+/// Lowest-numbered rather than arbitrary so a run is reproducible against a
+/// tracker that is not moving, and looked up rather than named so the fixture
+/// survives any individual map being finished. The only precondition left is
+/// that the project has *a* map at all, which is the weakest one a test of the
+/// map machinery can have.
+pub async fn a_live_map() -> MapId {
+    let maps = wf::fetch::find_maps(&[THIS_REPO.to_string()])
+        .await
+        .expect("map label search");
+    maps.into_iter()
+        .min_by_key(|id| id.number)
+        .expect("blooop/wayfinder must have at least one open wayfinder:map issue")
+}

--- a/tests/live_discovery.rs
+++ b/tests/live_discovery.rs
@@ -39,15 +39,20 @@ async fn registering_this_checkout_finds_and_fetches_its_map() {
     let maps = wf::fetch::find_maps(&reloaded.repos())
         .await
         .expect("map label search");
-    let map_id = wf::model::MapId::new(slug.clone(), 1);
-    assert!(
-        maps.contains(&map_id),
-        "blooop/wayfinder must have wayfinder:map issue #1; found {maps:?}"
-    );
+    //
+    // Which maps those are is deliberately not asserted: pinning this to map
+    // #1 outlived the map itself, and a test that fails when a map reaches its
+    // destination is testing the tracker's contents rather than the search.
     assert!(
         maps.iter().filter(|id| id.repo == slug).count() > 1,
         "every open map must be found, not one per repo; found {maps:?}"
     );
+    let map_id = maps
+        .iter()
+        .filter(|id| id.repo == slug)
+        .min_by_key(|id| id.number)
+        .expect("the search just found this repo's maps")
+        .clone();
 
     // Render-ready: the discovered map fetches with real tickets.
     let map = wf::fetch::fetch_map(&map_id)

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -1,14 +1,21 @@
-//! Integration test for the fetch layer against the real tracker: fetches
-//! blooop/wayfinder's live map (#1) through `gh api graphql`. Needs network
+//! Integration test for the fetch layer against the real tracker: fetches one
+//! of blooop/wayfinder's live maps through `gh api graphql`. Needs network
 //! and an authenticated `gh`.
+//!
+//! The map is **looked up, not named** (see `common`), so every assertion
+//! below is about what any live map must satisfy rather than about a
+//! particular ticket on a particular map.
 
-use wf::model::{MapId, Status, TicketType};
+use wf::model::{Status, TicketType};
+
+mod common;
 
 #[tokio::test]
 async fn fetches_the_live_wayfinder_map() {
-    let map = wf::fetch::fetch_map(&MapId::new("blooop/wayfinder", 1))
+    let map_id = common::a_live_map().await;
+    let map = wf::fetch::fetch_map(&map_id)
         .await
-        .expect("live fetch of blooop/wayfinder map #1");
+        .unwrap_or_else(|e| panic!("live fetch of {map_id:?}: {e}"));
 
     assert!(
         map.title.starts_with("Map:"),
@@ -37,14 +44,14 @@ async fn fetches_the_live_wayfinder_map() {
         "the live map issue's updatedAt must parse into an Activity"
     );
 
-    // The map's charted decisions are closed tickets — DONE must be non-empty.
+    // A map's charted decisions are closed tickets — DONE must be non-empty.
     assert!(
         map.tickets.iter().any(|t| t.status == Status::Done),
         "the live map has closed tickets; none classified as done"
     );
 
-    // #50: the full edge set survives the parse. This map's builds were chained
-    // by blocking edges and are long closed, so if closed blockers were still
+    // #50: the full edge set survives the parse. A map's tickets are chained by
+    // blocking edges and the early ones close, so if closed blockers were still
     // being discarded the whole DAG would come back empty.
     assert!(
         map.tickets.iter().any(|t| !t.blocked_by.is_empty()),
@@ -52,61 +59,39 @@ async fn fetches_the_live_wayfinder_map() {
     );
 
     // #19's addition: the `labels` selection is accepted by the real API and
-    // every ticket's `wayfinder:*` type comes back parsed. This map's types are
-    // known facts — #3 is research, #19 is the build task, #18 is a grilling —
-    // so a query GitHub silently dropped labels from would show up as Untyped.
-    let typed = |n: u64| {
-        map.tickets
-            .iter()
-            .find(|t| t.number == n)
-            .map(|t| t.ticket_type)
-    };
-    assert_eq!(
-        typed(3),
-        Some(TicketType::Research),
-        "#3 is wayfinder:research"
-    );
-    assert_eq!(typed(19), Some(TicketType::Task), "#19 is wayfinder:task");
-    assert_eq!(
-        typed(18),
-        Some(TicketType::Grilling),
-        "#18 is wayfinder:grilling"
-    );
-    assert_eq!(
-        typed(9),
-        Some(TicketType::Prototype),
-        "#9 is wayfinder:prototype"
-    );
-    // The map issue itself is not a sub-issue, so nothing on the map carries
-    // `wayfinder:map`; every ticket here is one of the four real types.
+    // every ticket's `wayfinder:*` type comes back parsed. A query GitHub
+    // silently dropped labels from would show up as Untyped — and a map worth
+    // charting mixes types, so a single-type answer is a parse collapsing
+    // rather than a real map.
+    let mut types: Vec<TicketType> = Vec::new();
+    for ticket in &map.tickets {
+        if !types.contains(&ticket.ticket_type) {
+            types.push(ticket.ticket_type);
+        }
+    }
     assert!(
-        map.tickets
-            .iter()
-            .all(|t| t.ticket_type != TicketType::Untyped),
-        "every ticket on this map is labelled: {:?}",
+        !types.contains(&TicketType::Untyped),
+        "every ticket on a map is labelled: {:?}",
         map.tickets
             .iter()
             .filter(|t| t.ticket_type == TicketType::Untyped)
             .map(|t| t.number)
             .collect::<Vec<_>>()
     );
+    assert!(
+        types.len() >= 2,
+        "a real map mixes ticket types; got only {types:?}"
+    );
 
-    // Build 5 (#17) is blocked only by Build 1 (#13): while #13 is open it
-    // must classify as blocked needing #13; once #13 closes it must not.
-    if let Some(build5) = map.tickets.iter().find(|t| t.number == 17) {
-        let build1_open = map
-            .tickets
-            .iter()
-            .any(|t| t.number == 13 && t.status != Status::Done);
-        match &build5.status {
-            Status::Blocked { needs } => {
-                assert!(build1_open, "#17 blocked but #13 is closed");
-                assert!(needs.contains(&13), "#17 should need #13, needs {needs:?}");
-            }
-            other => assert!(
-                !build1_open || *other == Status::Claimed || *other == Status::Done,
-                "#13 is open and #17 unassigned, yet #17 is {other:?}"
-            ),
-        }
-    }
+    // The old `#17 is blocked only by #13, so it is Blocked while #13 is open`
+    // case is **not** carried over, and not because it was hard to generalise.
+    // Written generically it is a loop over whatever happens to be blocked
+    // today, which on the map this now picks is nothing at all — it passed
+    // vacuously the moment it was written, and a guard forcing it to be
+    // non-vacuous would only re-pin the test to the tracker's contents. The
+    // invariant itself loses nothing: classification from open blockers is
+    // fixture-tested where it belongs, in `model::tests`
+    // (`open_unassigned_with_open_blockers_is_blocked`,
+    // `closed_is_done_even_if_assigned_or_blocked`) and at the parse boundary
+    // in `fetch::tests`. What only the live API can prove is above.
 }

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -18,11 +18,9 @@ use wf::model::{MapId, MapSet};
 use wf::projects::ProjectsCache;
 use wf::refresh::{spawn_discovery, LoadEvent, Loaders, MapFetch};
 
-const THIS_REPO: &str = "blooop/wayfinder";
+mod common;
 
-fn map_1() -> MapId {
-    MapId::new(THIS_REPO, 1)
-}
+use common::THIS_REPO;
 
 /// Take the next event, failing loudly rather than hanging a CI run forever.
 async fn next(rx: &mut mpsc::UnboundedReceiver<LoadEvent>) -> LoadEvent {
@@ -59,10 +57,6 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             }
         }
     };
-    assert!(
-        found.contains(&map_1()),
-        "this repo's original map is issue #1; found {found:?}"
-    );
     assert!(
         found.len() > 1,
         "every open map is discovered, not one per repo (#50); found {found:?}"
@@ -110,7 +104,10 @@ async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
     // The #28 claim, end to end: with the map id already in hand, the map
     // itself lands in one round trip — no ~2.5s search in front of it.
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let seed: MapSet = [map_1()].into_iter().collect();
+    // Looked up *before* the clock starts, because that is what a seed is: an
+    // id already in hand when the run begins.
+    let live = common::a_live_map().await;
+    let seed: MapSet = [live.clone()].into_iter().collect();
 
     let started = Instant::now();
     let mut loaders = Loaders::new();
@@ -121,7 +118,7 @@ async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
             id,
             outcome: MapFetch::Loaded(map),
         } => {
-            assert_eq!(id, map_1());
+            assert_eq!(id, live);
             assert!(!map.tickets.is_empty());
         }
         other => panic!("the seeded loader must fetch the map, got {other:?}"),
@@ -152,7 +149,7 @@ async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
         other => panic!("a non-map must not fetch as a map, got {other:?}"),
     }
 
-    let truth: MapSet = [map_1()].into_iter().collect();
+    let truth: MapSet = [common::a_live_map().await].into_iter().collect();
     loaders.reconcile(&truth, &tx);
     assert_eq!(
         loaders.targets(),
@@ -185,7 +182,8 @@ async fn restarting_the_loaders_refetches_and_cannot_be_beaten_by_the_load_it_re
     // result reaching the UI through one channel in send order is what makes
     // the newest write win, and that is what this pins.
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let seed: MapSet = [map_1()].into_iter().collect();
+    let live = common::a_live_map().await;
+    let seed: MapSet = [live.clone()].into_iter().collect();
 
     let mut loaders = Loaders::new();
     loaders.reconcile(&seed, &tx);
@@ -207,7 +205,7 @@ async fn restarting_the_loaders_refetches_and_cannot_be_beaten_by_the_load_it_re
             id,
             outcome: MapFetch::Loaded(map),
         } => {
-            assert_eq!(id, map_1());
+            assert_eq!(id, live);
             assert!(!map.tickets.is_empty());
         }
         other => panic!("ctrl-r must refetch, got {other:?}"),
@@ -229,7 +227,7 @@ async fn shutdown_leaves_nothing_in_flight() {
     // task's `Child` is dropped, which only happens if someone waits for the
     // cancellation to actually run.
     let (tx, _rx) = mpsc::unbounded_channel();
-    let seed: MapSet = [map_1()].into_iter().collect();
+    let seed: MapSet = [common::a_live_map().await].into_iter().collect();
 
     let mut loaders = Loaders::new();
     loaders.reconcile(&seed, &tx);


### PR DESCRIPTION
## What broke

[Map #1](https://github.com/blooop/wayfinder/issues/1) — *wf — the multi-project wayfinder manager TUI* — was closed today: all 30 of its tickets are closed, its destination was reached on 2026-08-06 with Build 7 (v0.3.0), and its last patch of fog ("PRs in the picture") was absorbed by [Map #47](https://github.com/blooop/wayfinder/issues/47) and shipped as the `⇄` PR badges in #52.

Closing it turned **six assertions across three live test files red at once**, because they named it by number:

```
live_fetch:             blooop/wayfinder#1 is no longer an open `wayfinder:map` issue
live_discovery:         blooop/wayfinder must have wayfinder:map issue #1; found {35, 47, 59}
live_streaming_startup: 4 of 5 tests, three by the same pin and one by timeout
```

None of that is a defect in the code. `fetch_map` refusing a closed map is the **#28 rule working**: a moved or finished map must render nothing rather than the wrong issue. The fixture was wrong — it assumed a map would never reach its destination, in a repo whose entire purpose is walking maps to their destination.

CI never caught it because `ci.yml` compiles the live tests without running them, exactly so the map moving on cannot fail a build. So this only ever shows up in a local `cargo test`, or inside the devcontainer ([#42](https://github.com/blooop/wayfinder/issues/42)).

## The fixture

`tests/common/mod.rs` — `a_live_map()`: this repo's **lowest-numbered open map**, looked up through the same `find_maps` label search the tool itself uses. Lowest-numbered so a run is reproducible against a tracker that is not moving; looked up rather than named so finishing a map is never a test failure. The only precondition left is that the project has *a* map at all, which is the weakest one a test of the map machinery can have.

## Two assertions that could not be generalised, and are not faked

- **`#3 is research, #19 is task, #18 is grilling, #9 is prototype`** → "no ticket is `Untyped`, and a real map mixes at least two types". That is what those four equalities were actually testing (#19's addition: the live `labels` selection is accepted and parses) — not that those particular issues exist.
- **`#17 is Blocked needing #13 while #13 is open`** → **dropped, not rewritten.** Written generically it is a loop over whatever happens to be blocked today, and on the map now picked that is nothing at all: it passes vacuously. I verified that by asserting non-vacuity and watching it fail — and a guard forcing it to be non-vacuous would just re-pin the test to the tracker's contents, which is the bug being fixed. The invariant loses no coverage: classification from open blockers is fixture-tested in `model::tests` (`open_unassigned_with_open_blockers_is_blocked`, `closed_is_done_even_if_assigned_or_blocked`) and at the parse boundary in `fetch::tests`.

`live_discovery` also stops asserting *which* maps the search finds and keeps the assertion that matters (#50: more than one per repo, so every open map survives).

## Verified

- `cargo test --all`: **205 passed, 0 failed** — including all six live tests against the real tracker.
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --locked` under `-D warnings`, and `cargo doc` under `-D warnings`: clean.
- The new type assertion was mutation-checked (raised to `>= 99`, watched it fail) rather than trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update live integration tests to dynamically discover a current map instead of hard-coding issue #1, so they remain valid as maps are opened and closed.

New Features:
- Introduce a shared live test fixture that discovers this repository's lowest-numbered open map via the same label search used in production.

Bug Fixes:
- Fix brittle live tests that failed once map #1 was closed by looking up an open map instead of naming a specific issue number.
- Remove a vacuous assertion about a specific blocked ticket pair and rely on existing model and fetch tests for that invariant.

Enhancements:
- Generalize live fetch and discovery assertions to express properties of any real map (ticket typing, edges, discovery breadth) rather than properties of specific ticket numbers.

Tests:
- Refactor live_fetch, live_discovery, and live_streaming_startup tests to use the shared live map fixture and avoid assumptions about specific issue IDs.