### PR TITLE
Say why the live tests failed when the reason is a missing GH_TOKEN

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,8 +63,15 @@
   // for the interactive path `wf` actually uses. The last two are per-session,
   // so a postCreateCommand cannot see the token at all on the path that matters,
   // and a false alarm on every create would be worse than the silence it
-  // replaced. (That the token survives the ssh transport is measured, not
-  // assumed: devpod's ssh server honours SendEnv, with no AcceptEnv gate.)
+  // replaced.
+  //
+  // That the token survives the ssh transport was worth checking rather than
+  // assuming, because `SendEnv` is only a *request* — a stock sshd drops any
+  // variable not named in its `AcceptEnv`, and devlaunch's tests assert that
+  // the flag is built, never that the variable arrives. Probed on 2026-08-08
+  // against a running devpod workspace with fake values, over plain
+  // `ssh -o SendEnv=...` (the transport dl 0.0.13 uses): they arrive. devpod's
+  // ssh server is its own Go implementation and does not gate on AcceptEnv.
   //
   // `~/.ssh` is deliberately absent — devpod forwards git credentials and can
   // forward an ssh agent, which lends the *use* of a key without handing over

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,10 +51,16 @@
   //
   // The cost of dropping it, said plainly: brought up by something *other* than
   // `dl` — plain `devpod up`, or the devcontainer CLI from an editor — this
-  // container has no `gh` login, and tests/live_fetch.rs will fail. `dl` is this
+  // container has no `gh` login, and the live tests will fail. `dl` is this
   // repo's front door (blooop/wayfinder#36) and `wf` itself now launches through
   // it (blooop/wayfinder#80), so that is the supported path; export `GH_TOKEN`
-  // yourself for the others.
+  // yourself for the others. The failure at least explains itself now:
+  // tests/common/mod.rs names a missing GH_TOKEN as the cause when it is one,
+  // rather than surfacing `gh`'s error alone (raised by the review of #94).
+  // Deliberately not a create-time check: `dl` delivers the token as devpod
+  // *workspace env*, so whether it is visible to a postCreateCommand depends on
+  // ordering nobody here has verified, and a false alarm on every create would
+  // be worse than the silence it replaced.
   //
   // `~/.ssh` is deliberately absent — devpod forwards git credentials and can
   // forward an ssh agent, which lends the *use* of a key without handing over

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,10 +57,14 @@
   // yourself for the others. The failure at least explains itself now:
   // tests/common/mod.rs names a missing GH_TOKEN as the cause when it is one,
   // rather than surfacing `gh`'s error alone (raised by the review of #94).
-  // Deliberately not a create-time check: `dl` delivers the token as devpod
-  // *workspace env*, so whether it is visible to a postCreateCommand depends on
-  // ordering nobody here has verified, and a false alarm on every create would
-  // be worse than the silence it replaced.
+  // Deliberately not a create-time check. `dl` delivers the token by whichever
+  // transport carries the payload — devpod *workspace env* on `up`, `devpod ssh
+  // --send-env` when attaching, and since dl 0.0.13 `ssh -o SendEnv=GH_TOKEN`
+  // for the interactive path `wf` actually uses. The last two are per-session,
+  // so a postCreateCommand cannot see the token at all on the path that matters,
+  // and a false alarm on every create would be worse than the silence it
+  // replaced. (That the token survives the ssh transport is measured, not
+  // assumed: devpod's ssh server honours SendEnv, with no AcceptEnv gate.)
   //
   // `~/.ssh` is deliberately absent — devpod forwards git credentials and can
   // forward an ssh agent, which lends the *use* of a key without handing over

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,18 @@ jobs:
       - name: Unit tests
         run: cargo test --locked --lib --bins --examples
 
+      # The one part of `tests/` that needs neither network nor `gh`: the
+      # fixture's own diagnostic, which decides what a failing live test tells
+      # you about a missing GH_TOKEN. It is split from the environment it reads
+      # precisely so it can be asserted — and an assertion no workflow runs is
+      # not an assertion. Named by filter, so the live tests around it stay
+      # compiled-not-run as below. Quoted because a plain YAML scalar may not
+      # end in a colon, and `common::` does — unquoted, this file stops parsing
+      # and the whole workflow silently never runs, which is the #84 failure
+      # mode rather than a loud one.
+      - name: The live fixture's diagnostic
+        run: "cargo test --locked --test live_fetch -- common::"
+
       # Compiled but not run: a test that no longer builds is rot, and this is
       # what catches it at the commit that caused it rather than the next time
       # somebody runs them by hand.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -187,4 +187,4 @@ jobs:
       - name: Say why nothing was published
         if: env.PIXI_TOKEN == ''
         run: |
-          echo "::notice::PIXI_TOKEN is not set on this repository, so the package was attached to the release but not published to prefix.dev/blooop. Add the secret, or publish via blooop-feedstock — see blooop/wayfinder#12."
+          echo "::notice::PIXI_TOKEN is not set on this repository, so the package was attached to the release but not published to prefix.dev/blooop. Add a prefix.dev API key with upload rights to the blooop channel as the PIXI_TOKEN secret, or publish via blooop-feedstock instead."

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 /target
 /output
+
+# Agent worktrees. Each is a full checkout with a `target/` of its own — one
+# reached 794 MB here — and they are created inside the repo rather than beside
+# it, so without this a `git add -A` in the wrong moment stages a gigabyte of
+# build output. Only the worktree directory is ignored: `.claude/` also holds
+# settings and skills, which are worth committing.
+/.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -327,6 +327,17 @@ it always has:
 1. the checkout declares one of those two configs, and
 2. `dl` is on PATH.
 
+**Use `dl` 0.0.13 or newer.** `wf` pins no version and never will — the launch
+is one `exec` of a program found on PATH — but older `dl` on devpod 0.26 hands
+the agent **no terminal**, and an agent with no terminal decides it was invoked
+non-interactively: it prints one answer and exits, so the symptom is a session
+that never starts rather than an error. Measured here on devpod 0.26.1:
+`devpod ssh --command` (what `dl` ≤ 0.0.12 uses) gives `not a tty`, `TERM=dumb`
+even from a real terminal, while 0.0.13's `ssh -t` transport gives `/dev/pts/0`,
+`TERM=xterm-256color`. The `GH_TOKEN` forwarding below survives that change of
+transport — devpod's ssh server honours OpenSSH's `SendEnv`, which is also
+measured rather than assumed.
+
 **A missing `dl` degrades rather than refuses.** Plenty of repos carry a
 `devcontainer.json` for their editor users, and refusing to launch on a machine
 that has never installed `dl` would be a regression for people who never asked

--- a/README.md
+++ b/README.md
@@ -335,8 +335,7 @@ that never starts rather than an error. Measured here on devpod 0.26.1:
 `devpod ssh --command` (what `dl` ≤ 0.0.12 uses) gives `not a tty`, `TERM=dumb`
 even from a real terminal, while 0.0.13's `ssh -t` transport gives `/dev/pts/0`,
 `TERM=xterm-256color`. The `GH_TOKEN` forwarding below survives that change of
-transport — devpod's ssh server honours OpenSSH's `SendEnv`, which is also
-measured rather than assumed.
+transport; `.devcontainer/devcontainer.json` records why.
 
 **A missing `dl` degrades rather than refuses.** Plenty of repos carry a
 `devcontainer.json` for their editor users, and refusing to launch on a machine

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ to main, in the order they are cheap to fix:
 cargo fmt --all --check
 cargo clippy --all-targets --all-features --locked
 cargo test --locked --lib --bins --examples
+cargo test --locked --test live_fetch -- common::
 cargo doc --no-deps --all-features --locked
 ```
 
@@ -45,8 +46,11 @@ arguable rather than accumulating.
 
 Everything under `tests/` is a `live_*` integration test — a real `gh`, real
 network, real assertions against this project's own tracker — so CI compiles
-them but does not run them, and a moving map never breaks a build. Run them
-yourself when the fetch or launch path changes:
+them but does not run them, and a moving map never breaks a build. The one
+exception is the fourth command above: `tests/common`'s diagnostic, which
+decides what a failing live test tells you about a missing `GH_TOKEN`, is pure
+and needs no network, and an assertion nothing runs is not an assertion. Run
+the rest yourself when the fetch or launch path changes:
 
 ```
 cargo test --test live_fetch --test live_discovery

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,8 @@
 //! finished map must render nothing rather than the wrong issue), so the
 //! failure was the fixture's fault, not the code's.
 
+use std::path::Path;
+
 use wf::model::MapId;
 
 pub const THIS_REPO: &str = "blooop/wayfinder";
@@ -22,8 +24,89 @@ pub const THIS_REPO: &str = "blooop/wayfinder";
 pub async fn a_live_map() -> MapId {
     let maps = wf::fetch::find_maps(&[THIS_REPO.to_string()])
         .await
-        .expect("map label search");
+        .unwrap_or_else(|e| panic!("{}", search_failed(&format!("{e:#}"))));
     maps.into_iter()
         .min_by_key(|id| id.number)
         .expect("blooop/wayfinder must have at least one open wayfinder:map issue")
+}
+
+/// The panic message for a failed map search — with the reason it fails for
+/// most often spelled out rather than left to be deduced from `gh`'s stderr.
+///
+/// Raised by the review of #94, which dropped the `~/.config/gh` mount: a
+/// container's `gh` login now arrives as `GH_TOKEN`, forwarded by `dl`, so a
+/// container brought up any other way (`devpod up` on its own, an editor's
+/// devcontainer CLI) has no login at all — and the first thing that says so is
+/// a live test failing on a `gh` error several layers down. The fix is to say
+/// it here, where the failure surfaces, because that is where somebody is
+/// actually reading.
+///
+/// It fires only on failure, never as a precondition check. A token that is
+/// absent while everything works is not a problem worth a warning: on the host
+/// `gh` reads its own keyring, and `GH_TOKEN` being unset there is the normal
+/// case rather than a broken one.
+fn search_failed(err: &str) -> String {
+    let has_token = ["GH_TOKEN", "GITHUB_TOKEN"]
+        .iter()
+        .any(|var| std::env::var_os(var).is_some_and(|v| !v.is_empty()));
+    let in_container = Path::new("/.dockerenv").exists();
+    match advice(has_token, in_container) {
+        Some(advice) => format!("the map search failed: {err}\n\n{advice}"),
+        None => format!("the map search failed: {err}"),
+    }
+}
+
+/// What to tell somebody about a failed search, given the two facts that
+/// change the answer. Split out from the environment it reads so the advice
+/// can be asserted rather than assumed — a diagnostic nobody has seen render
+/// is exactly the kind that turns out to say the wrong thing on the one day it
+/// fires.
+fn advice(has_token: bool, in_container: bool) -> Option<&'static str> {
+    match (has_token, in_container) {
+        // A token is present, so it is not the cause; `gh`'s own error is the
+        // best thing available and adding to it would only bury it.
+        (true, _) => None,
+        // Inside a container the missing token *is* the story.
+        (false, true) => Some(
+            "GH_TOKEN is not set, and this is a container: `gh` has no login here. \
+             `dl` forwards the host's token into every workspace it starts, so bring \
+             this container up with `dl <checkout>` (see the Isolation section of \
+             README.md), or export GH_TOKEN yourself before running the tests.",
+        ),
+        // On the host it is one candidate among several, and the usual answer
+        // is a keyring `gh` can read perfectly well — so point at the check,
+        // not at a variable that is normally and correctly unset.
+        (false, false) => Some(
+            "Neither GH_TOKEN nor GITHUB_TOKEN is set. On a host that is normal — \
+             `gh` reads its own keyring — so check `gh auth status` first; these \
+             tests need an authenticated `gh` and network.",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::advice;
+
+    #[test]
+    fn a_token_that_exists_is_not_blamed() {
+        assert_eq!(advice(true, true), None);
+        assert_eq!(advice(true, false), None);
+    }
+
+    #[test]
+    fn a_tokenless_container_is_told_where_the_token_comes_from() {
+        let msg = advice(false, true).expect("a tokenless container gets advice");
+        assert!(msg.contains("dl"), "{msg}");
+    }
+
+    #[test]
+    fn a_tokenless_host_is_sent_to_gh_auth_status_instead() {
+        let msg = advice(false, false).expect("a tokenless host gets advice");
+        assert!(msg.contains("gh auth status"), "{msg}");
+        assert!(
+            !msg.contains("container"),
+            "host advice must not talk about containers: {msg}"
+        );
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,26 +8,54 @@
 //! finished map must render nothing rather than the wrong issue), so the
 //! failure was the fixture's fault, not the code's.
 
+// Each including binary uses a different part of this module, and dead-code
+// analysis runs per binary — so anything used by only one of them would warn
+// under CI's `-D warnings` in the other. The alternative is splitting the
+// module by consumer, which is more files than the problem is worth.
+#![allow(dead_code)]
+
 use std::path::Path;
 
+use tokio::sync::OnceCell;
 use wf::model::MapId;
 
 pub const THIS_REPO: &str = "blooop/wayfinder";
 
+/// Looked up once per test binary. The lookup is a ~2.5 s `gh api
+/// search/issues`, and four tests in `live_streaming_startup` want the same
+/// answer: without this they issue four concurrent searches at t=0, which is
+/// enough contention to push the warm-start timing assertion in that file past
+/// its budget about half the time. One search per binary, and the tests are
+/// measuring what they claim to measure again.
+static LIVE_MAP: OnceCell<MapId> = OnceCell::const_new();
+
 /// This repo's lowest-numbered open map, looked up live.
 ///
-/// Lowest-numbered rather than arbitrary so a run is reproducible against a
-/// tracker that is not moving, and looked up rather than named so the fixture
-/// survives any individual map being finished. The only precondition left is
-/// that the project has *a* map at all, which is the weakest one a test of the
-/// map machinery can have.
+/// Lowest-numbered rather than arbitrary because a newly charted map is always
+/// the highest-numbered one: picking the lowest means the fixture only moves
+/// when a *mature* map is finished, and the next one along has years of
+/// tickets on it too.
+///
+/// What this asks of the tracker, stated rather than implied — the callers
+/// assert against whatever comes back, so these are real preconditions:
+/// `blooop/wayfinder` has **more than one** open map (`live_discovery`,
+/// `live_streaming_startup`), and the lowest-numbered one has at least seven
+/// tickets, at least one closed, at least one blocking edge, and no ticket
+/// missing its `wayfinder:*` label. Every open map satisfies that today, and a
+/// map is charted long before it is worked, so a freshly charted one cannot
+/// become the fixture while any older map is still open.
 pub async fn a_live_map() -> MapId {
-    let maps = wf::fetch::find_maps(&[THIS_REPO.to_string()])
+    LIVE_MAP
+        .get_or_init(|| async {
+            let maps = wf::fetch::find_maps(&[THIS_REPO.to_string()])
+                .await
+                .unwrap_or_else(|e| panic!("{}", search_failed(&format!("{e:#}"))));
+            maps.into_iter()
+                .min_by_key(|id| id.number)
+                .unwrap_or_else(|| panic!("{}", nothing_found()))
+        })
         .await
-        .unwrap_or_else(|e| panic!("{}", search_failed(&format!("{e:#}"))));
-    maps.into_iter()
-        .min_by_key(|id| id.number)
-        .expect("blooop/wayfinder must have at least one open wayfinder:map issue")
+        .clone()
 }
 
 /// The panic message for a failed map search — with the reason it fails for
@@ -45,15 +73,46 @@ pub async fn a_live_map() -> MapId {
 /// absent while everything works is not a problem worth a warning: on the host
 /// `gh` reads its own keyring, and `GH_TOKEN` being unset there is the normal
 /// case rather than a broken one.
-fn search_failed(err: &str) -> String {
-    let has_token = ["GH_TOKEN", "GITHUB_TOKEN"]
-        .iter()
-        .any(|var| std::env::var_os(var).is_some_and(|v| !v.is_empty()));
-    let in_container = Path::new("/.dockerenv").exists();
-    match advice(has_token, in_container) {
+pub fn search_failed(err: &str) -> String {
+    match advice(has_token(), in_container()) {
         Some(advice) => format!("the map search failed: {err}\n\n{advice}"),
         None => format!("the map search failed: {err}"),
     }
+}
+
+/// The panic message for a search that *succeeded* and found nothing.
+///
+/// Separate from [`search_failed`] because the cause is different and so is
+/// the fix: `find_maps` returns an empty set rather than an error when the
+/// token is valid but cannot see this repo — a fine-grained PAT without access
+/// to it, or a `GITHUB_TOKEN` scoped to another repository. Blaming the
+/// tracker for having no maps would send somebody looking in exactly the wrong
+/// place.
+fn nothing_found() -> String {
+    let mut msg = format!("the map search found no open `wayfinder:map` issue on {THIS_REPO}");
+    if has_token() {
+        msg.push_str(
+            ". A token is set, so if the tracker does have open maps this is most likely \
+             a token that cannot see this repository — a fine-grained PAT without access \
+             to it, or a GITHUB_TOKEN scoped elsewhere.",
+        );
+    }
+    msg
+}
+
+fn has_token() -> bool {
+    ["GH_TOKEN", "GITHUB_TOKEN"]
+        .iter()
+        .any(|var| std::env::var_os(var).is_some_and(|v| !v.is_empty()))
+}
+
+/// Whether this is running inside a container, by the marker its runtime
+/// leaves. Docker writes `/.dockerenv`; podman and anything else built on
+/// libcontainer write `/run/.containerenv`. Checking only the first would give
+/// a podman workspace the *host* advice, which is the one piece of advice that
+/// is actively wrong there — a container has no keyring for `gh` to read.
+fn in_container() -> bool {
+    Path::new("/.dockerenv").exists() || Path::new("/run/.containerenv").exists()
 }
 
 /// What to tell somebody about a failed search, given the two facts that

--- a/tests/live_discovery.rs
+++ b/tests/live_discovery.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 
 use wf::projects::{discover_checkout, ProjectsCache};
 
+mod common;
+
 #[tokio::test]
 async fn registering_this_checkout_finds_and_fetches_its_map() {
     // Discover: this checkout's toplevel and origin-derived slug.
@@ -38,7 +40,7 @@ async fn registering_this_checkout_finds_and_fetches_its_map() {
     // survive rather than only the lowest-numbered.
     let maps = wf::fetch::find_maps(&reloaded.repos())
         .await
-        .expect("map label search");
+        .unwrap_or_else(|e| panic!("{}", common::search_failed(&format!("{e:#}"))));
     //
     // Which maps those are is deliberately not asserted: pinning this to map
     // #1 outlived the map itself, and a test that fails when a map reaches its
@@ -57,7 +59,7 @@ async fn registering_this_checkout_finds_and_fetches_its_map() {
     // Render-ready: the discovered map fetches with real tickets.
     let map = wf::fetch::fetch_map(&map_id)
         .await
-        .expect("fetch the discovered map");
+        .unwrap_or_else(|e| panic!("fetch the discovered map {map_id:?}: {e:#}"));
     assert!(
         map.tickets.len() >= 7,
         "expected the real map's tickets, got {}",

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -2,9 +2,10 @@
 //! of blooop/wayfinder's live maps through `gh api graphql`. Needs network
 //! and an authenticated `gh`.
 //!
-//! The map is **looked up, not named** (see `common`), so every assertion
-//! below is about what any live map must satisfy rather than about a
-//! particular ticket on a particular map.
+//! The map is **looked up, not named** (see `common`), so no assertion below
+//! names a ticket. They do assume a *mature* map — seven tickets, some closed,
+//! some blocking edges — which is why the lookup takes the oldest open one
+//! rather than any open one.
 
 use wf::model::{Status, TicketType};
 
@@ -15,12 +16,15 @@ async fn fetches_the_live_wayfinder_map() {
     let map_id = common::a_live_map().await;
     let map = wf::fetch::fetch_map(&map_id)
         .await
-        .unwrap_or_else(|e| panic!("live fetch of {map_id:?}: {e}"));
+        .unwrap_or_else(|e| panic!("live fetch of {map_id:?}: {e:#}"));
 
+    // Not the `Map:` title convention: nothing enforces it — issue #67 carries
+    // `wayfinder:map` without it — and the fixture no longer knows which map it
+    // has. That an issue is a map at all is checked where it can be: `fetch_map`
+    // refuses anything that is not an open `wayfinder:map` (#28).
     assert!(
-        map.title.starts_with("Map:"),
-        "map issue title: {}",
-        map.title
+        !map.title.is_empty(),
+        "the map issue's title must come back"
     );
     assert!(
         map.tickets.len() >= 7,
@@ -60,27 +64,19 @@ async fn fetches_the_live_wayfinder_map() {
 
     // #19's addition: the `labels` selection is accepted by the real API and
     // every ticket's `wayfinder:*` type comes back parsed. A query GitHub
-    // silently dropped labels from would show up as Untyped — and a map worth
-    // charting mixes types, so a single-type answer is a parse collapsing
-    // rather than a real map.
-    let mut types: Vec<TicketType> = Vec::new();
-    for ticket in &map.tickets {
-        if !types.contains(&ticket.ticket_type) {
-            types.push(ticket.ticket_type);
-        }
-    }
+    // silently dropped labels from shows up here as Untyped. Which *specific*
+    // label maps to which type is fixture-tested in `model::tests`, so this
+    // does not also demand that the live map happen to mix types.
     assert!(
-        !types.contains(&TicketType::Untyped),
+        map.tickets
+            .iter()
+            .all(|t| t.ticket_type != TicketType::Untyped),
         "every ticket on a map is labelled: {:?}",
         map.tickets
             .iter()
             .filter(|t| t.ticket_type == TicketType::Untyped)
             .map(|t| t.number)
             .collect::<Vec<_>>()
-    );
-    assert!(
-        types.len() >= 2,
-        "a real map mixes ticket types; got only {types:?}"
     );
 
     // The old `#17 is blocked only by #13, so it is Blocked while #13 is open`

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -132,10 +132,10 @@ async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
 
 #[tokio::test]
 async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
-    // A cached id that no longer names a map — here the map's own *first
-    // ticket*, an issue that exists and is a sub-issue rather than a map. The
-    // fetch must refuse it (a wrong map is worse than no map) and the search's
-    // answer must move the load onto the real id.
+    // A cached id that no longer names a map — here `#2`, a closed sub-issue
+    // that exists and is not a map, which is refused for either reason alone.
+    // The fetch must refuse it (a wrong map is worse than no map) and the
+    // search's answer must move the load onto the real id.
     let (tx, mut rx) = mpsc::unbounded_channel();
     let stale: MapSet = [MapId::new(THIS_REPO, 2)].into_iter().collect();
 


### PR DESCRIPTION
Stacked on **#97** — that is the base branch, because this touches `tests/common/mod.rs`, which #97 creates. Merge #97 first and this retargets to `main` on its own.

## The review comment

[Sourcery on #94](https://github.com/blooop/wayfinder/pull/94#pullrequestreview-4882172074), the only actionable one it has left recently (it has been rate-limited on every PR since):

> Since the container now relies on `GH_TOKEN` being injected by `dl`, consider adding a small runtime check (e.g., in `postCreateCommand` or an init script) that detects a missing token and prints a clear guidance message, instead of letting `tests/live_fetch.rs` fail in a less obvious way.

It is right about the problem. #94 dropped the `~/.config/gh` mount because it never worked — `gh` keeps its token in the keyring — so a container's login now arrives as `GH_TOKEN`, forwarded by `dl`. Bring the container up any other way (plain `devpod up`, an editor's devcontainer CLI) and there is no login at all, and the first thing that says so is a live test failing on a `gh` error several layers down.

## Where the guidance went instead, and why

**In `common::a_live_map`** — the one choke point every live test reaches `gh` through — not in a `postCreateCommand`. Two reasons, both about the message being *read*:

1. A create-time message has scrolled far out of view by the time anyone runs `cargo test`. The failure is what gets read, so the failure is where the explanation belongs.
2. `dl` delivers the token as devpod **workspace env** (`devpod up --workspace-env-file`, per `devlaunch/gh_auth.py`), not as exec-time env. Whether a `postCreateCommand` can see it therefore depends on when devpod applies that env relative to postCreate — which I have not verified, and cannot without a container build. A check that cries wolf on every create would be worse than the silence it replaced.

Both reasons are recorded in `devcontainer.json` next to the prose that already documents the cost, so the next person doesn't re-litigate it from scratch.

It **fires only on failure**, never as a precondition check. A token absent while everything works is not a problem worth warning about: on the host `gh` reads its own keyring, so `GH_TOKEN` being unset there is the normal case, not a broken one. The advice differs by environment for exactly that reason — in a container the missing token *is* the story; on a host it is one candidate and `gh auth status` is the better first move.

## Verified, not assumed

`advice(has_token, in_container)` is split from the environment it reads, so the message is asserted rather than hoped for — a diagnostic nobody has watched render is the kind that says the wrong thing on the one day it fires. Three unit tests cover the branches, and the whole path was run end to end against a `gh` that always fails, with no token in the environment:

```
thread 'fetches_the_live_wayfinder_map' panicked at tests/common/mod.rs:27:29:
the map search failed: `gh api search/issues` failed: gh: authentication required

Neither GH_TOKEN nor GITHUB_TOKEN is set. On a host that is normal — `gh` reads
its own keyring — so check `gh auth status` first; these tests need an
authenticated `gh` and network.
```

## Two loose ends, from reviewing last night's work

Each is one line of substance, which is why they are here rather than in PRs of their own:

- **The "nothing was published" notice pointed at #12**, closed since. It now says what to do rather than naming a dead issue. (Only ever printed on a repo with no `PIXI_TOKEN`, so it was cosmetic — but a dead pointer in a message whose whole job is telling you what to do next is worth one line.)
- **`.claude/worktrees/` is now gitignored.** Agent worktrees are full checkouts with a `target/` apiece — one in this repo reached **794 MB** — and they are created *inside* the repo, so without this a `git add -A` at the wrong moment stages a gigabyte of build output. Scoped to the worktree directory only: `.claude/` also holds settings and skills that are worth committing.

## Checks

`cargo test --all`: **211 passed, 0 failed**. `cargo fmt --check`, `cargo clippy --all-targets --all-features --locked` under `-D warnings`, and `cargo doc` under `-D warnings`: clean. `package.yml` and `devcontainer.json` both re-parsed after editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify failure reasons for live GitHub-backed tests when authentication tokens are missing and adjust ancillary tooling messages and ignores.

Enhancements:
- Augment live map search failures with context-aware guidance explaining missing GH/GITHUB tokens in containers vs hosts.
- Update the release workflow notice to give concrete instructions for configuring PIXI_TOKEN with a prefix.dev API key or using blooop-feedstock instead.
- Ignore Claude agent worktree directories to avoid accidentally committing large build artifacts.

CI:
- Refine the package publication workflow notice to describe how to supply a proper PIXI_TOKEN and alternative publishing route.

Tests:
- Add unit tests validating the environment-sensitive advice shown for failed live map searches in different token and container scenarios.