### PR TITLE
Select a map, and launch it: cluster headers become cursor stops, `defer` becomes `auto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ the process you started. A checkout that declares a devcontainer runs that same
 agent inside it — see
 [Isolation](#isolation-the-agent-runs-in-the-repos-devcontainer).
 
-**Launching is two steps.** `enter` on the cursor's ticket does not launch: it
+**Launching is two steps.** `enter` on the cursor's node does not launch: it
 opens the **launch line** where the count line was, showing where `enter` will
 go — `→ /tdd · #65 Author the /tdd skill`. What you type lands on that line, not
 in the query, and *is* the mode:
@@ -233,35 +233,50 @@ in the query, and *is* the mode:
 | the line says | what launches |
 | --- | --- |
 | *(empty)* | interactive — the default |
-| `defer` | the subtree, resolved unattended |
-| `defer <text>` | deferred, with `<text>` as the steering prompt |
+| `auto` | the agent decides alone and drives the rest of the lifecycle unattended |
+| `auto <text>` | the same, with `<text>` as the steering prompt |
 | *anything else* | interactive, with what you typed as the steering prompt |
 
-`esc` backs out to the list with your query and cursor exactly as they were.
-`enter` on a **done** or **blocked** node opens nothing — it says why on the
-count line instead.
+The line re-resolves as you type, so `auto` visibly flips the skill it names
+before you commit to it. `esc` backs out to the list with your query and cursor
+exactly as they were. `enter` on a **done** or **blocked** node opens nothing —
+it says why on the count line instead.
 
-**Which skill is a fact about the ticket**, from its type and its stage:
+**The cursor lands on cluster headers too**, so a whole map is a thing you can
+launch: `enter` on one runs the wayfinder skill on the map itself rather than on
+any one ticket — interactively to chart it with you, or under `auto` to have the
+agent take the map from open questions to merged work on its own judgement. The
+default cursor position still skips headers and lands on the first row, so
+opening `wf` and pressing `enter` picks a ticket exactly as it always did;
+headers are one `↑` away.
 
-| type | stage | launches |
-| --- | --- | --- |
-| `wayfinder:build` | ready · building · needs attention | `claude "/tdd <n>"` |
-| `wayfinder:build` | in review | `claude "/review <n>"` |
-| research · prototype · grilling · task | any unfinished stage | `claude "/wayfinder <map> <n>"` |
-| any | done | nothing — not launchable |
+**Which skill runs is a fact about what you picked and who decides:**
 
-The mode rides whichever route you got, as ` defer`, ` defer: <text>` or
-` steer: <text>` on the end of the prompt.
+| picked | stage | mode | launches |
+| --- | --- | --- | --- |
+| a cluster header | — | interactive | `claude "/wayfinder <map>"` |
+| `wayfinder:build` | ready · building · needs attention | interactive | `claude "/tdd <n>"` |
+| `wayfinder:build` | in review | interactive | `claude "/review <n>"` |
+| research · prototype · grilling · task | any unfinished stage | interactive | `claude "/wayfinder <map> <n>"` |
+| anything | any unfinished stage | `auto` | `claude "/wayfinder-auto <map> [<n>]"` |
+| a ticket | done | — | nothing — not launchable |
+
+`auto` collapses the ticket rows on purpose: the launched session is a
+*manager*, and what it manages is the node's whole remaining lifecycle — `/tdd`,
+the gate, then a fresh-context `/review` — so it is the manager skill that runs,
+not the one skill that stage would have called. Steering text rides whichever
+route you got, as ` steer: <text>` on the end of the prompt; the mode itself
+never does, because it has already chosen the skill.
 
 | key | what it does |
 | --- | --- |
 | *type anything* | fuzzy-filter: the tree is pruned to the matches, best-first, with the rows that place them dimmed; clearing restores it |
 | `tab` | toggle the leverage view ⇄ the structure forest |
-| `↑`/`↓`, `ctrl-j`/`ctrl-k` | move between siblings at the cursor's depth — on the default screen, the tickets you can take (cluster headers are never a stop) |
+| `↑`/`↓`, `ctrl-j`/`ctrl-k` | move between siblings at the cursor's depth — on the default screen, the tickets you can take, plus each cluster's header above them |
 | `→` | reveal: open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
-| `←` | close: shut an open group, else back out to the parent, else one stop back |
-| `enter` | open the launch line on the cursor's ticket; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
-| *type, then `enter`* | on the launch line: the mode (`defer`, `defer <text>`, or steering text) — `esc` backs out with the query and cursor intact |
+| `←` | close: shut an open group, else back out to the parent, else one stop back — which, from a cluster's first row, is that cluster's header |
+| `enter` | open the launch line on the cursor's ticket, or on its map when the cursor is on a cluster header; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
+| *type, then `enter`* | on the launch line: the mode (`auto`, `auto <text>`, or steering text) — `esc` backs out with the query and cursor intact |
 | `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |
 | `ctrl-g` | widen back to every project |
 | `ctrl-r` | refetch every map in place, keeping your query, scope and cursor |

--- a/examples/preview_screen.rs
+++ b/examples/preview_screen.rs
@@ -25,6 +25,10 @@ fn press(app: &mut App, name: &str) {
         "left" => KeyCode::Left,
         "right" => KeyCode::Right,
         "tab" => KeyCode::Tab,
+        // Named so the launch line (#62/#96) is reachable from `$KEYS` —
+        // without them `enter` would send a bare `e` into the query.
+        "enter" => KeyCode::Enter,
+        "esc" => KeyCode::Esc,
         other => KeyCode::Char(other.chars().next().expect("a key")),
     };
     app.handle_key(KeyEvent::new(code, mods));
@@ -67,6 +71,7 @@ async fn main() {
     let stops = app.stops();
     let pos = app.cursor_pos();
     let label = |at: &wf::view::StopAt| match &at.stop {
+        wf::view::Stop::Map(id) => format!("map #{}", id.number),
         wf::view::Stop::Ticket(row) => format!("#{}", app.ticket(row).number),
         wf::view::Stop::Group(g) => format!("{:?}", g.kind),
     };

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,11 +46,12 @@ pub enum Outcome {
 pub enum Overlay {
     None,
     /// The launch line — enter on a launchable node staged this launch, and
-    /// the line now collects its mode: empty is interactive, `defer [text]`
-    /// defers, anything else steers ([`LaunchMode::parse`]). The route is
-    /// already resolved from (type, stage), so the line can *show* where enter
-    /// goes — and a line for an unlaunchable node is unrepresentable, because
-    /// no `Route` exists to put in it.
+    /// the line now collects its mode: empty is interactive, `auto [text]`
+    /// hands it to the manager, anything else steers ([`LaunchMode::parse`]).
+    /// The line resolves the route from the staged node and the mode typed so
+    /// far, so it *shows* where enter goes and changes as `auto` is typed — and
+    /// a line for an unlaunchable node is unrepresentable, because
+    /// [`launch::Launchable`] refused it before anything was staged.
     ///
     /// The staged launch is index-free ([`Staged`]) for the same reason the
     /// picker's candidates are complete `Launch`es: a background map arrival
@@ -100,6 +101,7 @@ pub struct RowKey {
 /// [`GroupId`] already names a map and a kind rather than any index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StopKey {
+    Map(MapId),
     Ticket(RowKey),
     Group(GroupId),
 }
@@ -325,10 +327,11 @@ impl App {
         }
     }
 
-    /// A stop's durable identity: a ticket by (map, number), a group by its
-    /// own id — which already names no indices.
+    /// A stop's durable identity: a ticket by (map, number), a map or a group
+    /// by its own id — both of which already name no indices.
     fn stop_key(&self, stop: &Stop) -> StopKey {
         match stop {
+            Stop::Map(id) => StopKey::Map(id.clone()),
             Stop::Ticket(row) => StopKey::Ticket(self.row_key(row)),
             Stop::Group(id) => StopKey::Group(id.clone()),
         }
@@ -337,9 +340,22 @@ impl App {
     /// Cursor position clamped into the stop list. An untouched cursor is not a
     /// remembered position but a *rule* — the top of the list — so it is
     /// answered from the stops on screen now rather than from anything stored.
+    ///
+    /// "The top" skips cluster headers, and only those. #88 settled that the
+    /// default is the first stop **literally**, not the first *takeable* one —
+    /// a blocked or claimed row still gets the cursor. A header is not a row
+    /// competing for that place, though: it is the container the rows sit in,
+    /// and defaulting onto one would make `enter` on a freshly filtered screen
+    /// launch the whole map rather than the row that was filtered to. So the
+    /// #96 stops are reachable by `↑` from the row below them, and never by
+    /// arriving.
     pub fn cursor_pos(&self) -> usize {
         match self.cursor {
-            Cursor::Untouched => 0,
+            Cursor::Untouched => self
+                .stops()
+                .iter()
+                .position(|at| !matches!(at.stop, Stop::Map(_)))
+                .unwrap_or(0),
             Cursor::Chosen(pos) => pos.min(self.stops().len().saturating_sub(1)),
         }
     }
@@ -351,12 +367,12 @@ impl App {
             .map(|at| at.stop.clone())
     }
 
-    /// The row under the cursor — `None` when the cursor is on a group line,
-    /// which is exactly why the two are different types.
+    /// The row under the cursor — `None` when the cursor is on a header or a
+    /// group line, which is exactly why they are different types.
     pub fn cursor_row(&self) -> Option<Row> {
         match self.cursor_stop() {
             Some(Stop::Ticket(row)) => Some(row),
-            Some(Stop::Group(_)) | None => None,
+            Some(Stop::Map(_) | Stop::Group(_)) | None => None,
         }
     }
 
@@ -373,6 +389,7 @@ impl App {
     /// wherever the cursor can be at all.
     pub fn cursor_map(&self) -> Option<MapId> {
         match self.cursor_stop()? {
+            Stop::Map(id) => Some(id),
             Stop::Ticket(row) => Some(row.map),
             Stop::Group(id) => Some(id.map),
         }
@@ -547,27 +564,48 @@ impl App {
         }
     }
 
-    /// The first enter (#62): stage a launch of the cursor's ticket by opening
-    /// the launch line — or refuse, with a count-line notice, the two things
-    /// that cannot launch. Blocked is refused on *status* (its stage is
-    /// unactionable, whatever it is); done is refused by [`launch::route`]
-    /// returning no route — stage, not ticket state, so a merged PR on a
-    /// still-open ticket refuses too.
+    /// The first enter (#62): stage a launch of whatever the cursor is on by
+    /// opening the launch line — a ticket, or since #96 the cluster header,
+    /// which stages the **map** as one node.
+    ///
+    /// Two things still refuse, with a count-line notice, and both are
+    /// ticket-only. Blocked is refused on *status* (its stage is unactionable,
+    /// whatever it is); done is refused by [`launch::Launchable::parse`]
+    /// finding no launchable stage — stage, not ticket state, so a merged PR
+    /// on a still-open ticket refuses too. Neither can arise on a map: a map
+    /// has no blockers and no stage, and a finished one is not drawn.
     fn request_launch(&mut self) -> Outcome {
-        // On a group line there is no agent to run, and exactly one thing the
-        // key could plausibly mean — so `enter` opens or shuts it rather than
-        // reporting that nothing is selected when something plainly is.
-        if let Some(Stop::Group(id)) = self.cursor_stop() {
-            if !self.expanded.remove(&id) {
-                self.expanded.insert(id);
+        match self.cursor_stop() {
+            // On a group line there is no agent to run, and exactly one thing
+            // the key could plausibly mean — so `enter` opens or shuts it
+            // rather than reporting that nothing is selected when something
+            // plainly is.
+            Some(Stop::Group(id)) => {
+                if !self.expanded.remove(&id) {
+                    self.expanded.insert(id);
+                }
+                Outcome::Continue
             }
-            return Outcome::Continue;
+            Some(Stop::Map(id)) => {
+                let title = self.clusters[&id].title.clone();
+                self.overlay = Overlay::LaunchLine {
+                    staged: Staged::map(&id, &title),
+                    text: String::new(),
+                };
+                Outcome::Continue
+            }
+            Some(Stop::Ticket(row)) => self.request_ticket_launch(&row),
+            None => {
+                self.notice = Some("nothing selected".to_string());
+                Outcome::Continue
+            }
         }
-        let Some(row) = self.cursor_row() else {
-            self.notice = Some("nothing selected".to_string());
-            return Outcome::Continue;
-        };
-        let ticket = self.ticket(&row);
+    }
+
+    /// The ticket half of [`App::request_launch`], split out so the two
+    /// refusals sit together and the stop match above stays readable.
+    fn request_ticket_launch(&mut self, row: &Row) -> Outcome {
+        let ticket = self.ticket(row);
         if let Status::Blocked { needs } = &ticket.status {
             let needs: Vec<String> = needs.iter().map(|n| format!("#{n}")).collect();
             self.notice = Some(format!(
@@ -577,14 +615,14 @@ impl App {
             ));
             return Outcome::Continue;
         }
-        match launch::route(ticket.ticket_type, stage(&ticket.prs, &ticket.status)) {
+        match Staged::ticket(ticket, row.map.number, stage(&ticket.prs, &ticket.status)) {
             None => {
                 self.notice = Some(format!("#{} is done — nothing to launch", ticket.number));
                 Outcome::Continue
             }
-            Some(route) => {
+            Some(staged) => {
                 self.overlay = Overlay::LaunchLine {
-                    staged: Staged::new(ticket, row.map.number, route),
+                    staged,
                     text: String::new(),
                 };
                 Outcome::Continue
@@ -615,10 +653,7 @@ impl App {
                 Outcome::Launch(launch)
             }
             Targets::Many(launches) => {
-                self.notice = Some(format!(
-                    "{}#{}: which checkout?",
-                    staged.repo, staged.ticket
-                ));
+                self.notice = Some(format!("{}{}: which checkout?", staged.repo, staged.key()));
                 self.overlay = Overlay::PickCheckout {
                     launches,
                     cursor: 0,
@@ -823,7 +858,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::launch::Route;
+    use crate::launch::{Mode, Route};
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
@@ -991,7 +1026,7 @@ mod tests {
             Some("2026-08-01T00:00:00Z"),
             true,
         )]));
-        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_pos(), 1, "past the header");
 
         let mut both = BTreeMap::new();
         both.extend([cluster(
@@ -1009,11 +1044,12 @@ mod tests {
         app.replace_clusters(both);
 
         // the fresher map now renders first
-        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_pos(), 1);
     }
 
     /// Two live maps, the second of them older, so a map fresher than both sorts
-    /// above the pair and pushes every existing row down by one.
+    /// above the pair and pushes every existing stop down by two — its header
+    /// and its row (#96).
     fn streaming_pair() -> BTreeMap<MapId, Map> {
         [
             cluster("blooop/slow", 1, Some("2026-08-01T00:00:00Z"), true),
@@ -1023,8 +1059,8 @@ mod tests {
         .collect()
     }
 
-    /// The pair with a fresher map added — it renders first, so both original
-    /// rows move down one.
+    /// The pair with a fresher map added — it renders first, so every original
+    /// stop moves down two.
     fn streaming_trio() -> BTreeMap<MapId, Map> {
         let mut all = streaming_pair();
         all.extend([cluster(
@@ -1042,13 +1078,15 @@ mod tests {
         // is pinned by identity, so an arriving map slides it down the screen
         // rather than stealing the selection.
         let mut app = App::new(streaming_pair());
-        app.handle_key(key(KeyCode::Down));
-        assert_eq!(app.cursor_pos(), 1);
+        for _ in 0..3 {
+            app.handle_key(key(KeyCode::Down)); // past slow's header and row, onto older's
+        }
+        assert_eq!(app.cursor_pos(), 3);
         assert_eq!(app.cursor_map(), Some(MapId::new("blooop/older", 3)));
 
         app.replace_clusters(streaming_trio());
 
-        assert_eq!(app.cursor_pos(), 2, "the fresher map pushed the row down");
+        assert_eq!(app.cursor_pos(), 5, "the fresher map pushed the row down");
         assert_eq!(
             app.cursor_map(),
             Some(MapId::new("blooop/older", 3)),
@@ -1058,14 +1096,15 @@ mod tests {
 
     #[test]
     fn choosing_the_top_row_pins_it_rather_than_re_defaulting_to_the_top() {
-        // The case a sentinel cannot serve. This cursor is at position 0 exactly
-        // like a fresh one, and must behave like the *opposite* of a fresh one:
-        // the human put it there, so a map arriving above carries it down. Read
-        // `cursor == 0` as "untouched" and this test lands on blooop/fresh.
+        // The case a sentinel cannot serve. This cursor sits on exactly the stop
+        // a fresh one resolves to, and must behave like the *opposite* of a
+        // fresh one: the human put it there, so a map arriving above carries it
+        // down. Read the position as "untouched" and this test lands on
+        // blooop/fresh.
         let mut app = App::new(streaming_pair());
         app.handle_key(key(KeyCode::Down));
         app.handle_key(key(KeyCode::Up)); // deliberately back on the top row
-        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_pos(), 1);
         assert_eq!(app.cursor_map(), Some(MapId::new("blooop/slow", 1)));
 
         app.replace_clusters(streaming_trio());
@@ -1073,9 +1112,9 @@ mod tests {
         assert_eq!(
             app.cursor_map(),
             Some(MapId::new("blooop/slow", 1)),
-            "their row, not whatever is on top now"
+            "their stop, not whatever is on top now"
         );
-        assert_eq!(app.cursor_pos(), 1);
+        assert_eq!(app.cursor_pos(), 3);
     }
 
     #[test]
@@ -1089,7 +1128,7 @@ mod tests {
 
         app.replace_clusters(streaming_trio());
 
-        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_pos(), 1);
         assert_eq!(app.cursor_map(), Some(MapId::new("blooop/fresh", 2)));
     }
 
@@ -1120,11 +1159,9 @@ mod tests {
         // down as a choice, the one state `Cursor` exists to forbid. The symptom is
         // #88's own: the next map to sort above drags the cursor off the top row.
         let mut app = App::new(map_with_a_done_group());
-        app.handle_key(key(KeyCode::Down));
-        assert!(
-            matches!(app.cursor_stop(), Some(Stop::Group(_))),
-            "the leverage lens shows blooop/slow's Done group"
-        );
+        while !matches!(app.cursor_stop(), Some(Stop::Group(_))) {
+            app.handle_key(key(KeyCode::Down));
+        }
 
         app.handle_key(key(KeyCode::Tab)); // the forest has no group line to keep
 
@@ -1137,7 +1174,7 @@ mod tests {
         )]);
         app.replace_clusters(fresher);
 
-        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_pos(), 1);
         assert_eq!(
             app.cursor_map(),
             Some(MapId::new("blooop/fresh", 2)),
@@ -1160,27 +1197,49 @@ mod tests {
         let visible = app.visible();
         assert_eq!(visible.len(), 1);
         assert_eq!(app.cursor_ticket().unwrap().number, 6);
-        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_pos(), 1);
     }
 
-    /// What the cursor is on, as a short label: a ticket by number, a group by
-    /// kind. Reads like the screen does.
+    /// What the cursor is on, as a short label: a ticket by number, a map by
+    /// `map #n`, a group by kind. Reads like the screen does.
     fn at(app: &App) -> String {
         match app.cursor_stop() {
+            Some(Stop::Map(id)) => format!("map #{}", id.number),
             Some(Stop::Ticket(row)) => format!("#{}", app.ticket(&row).number),
             Some(Stop::Group(g)) => format!("{:?}", g.kind),
             None => "nothing".to_string(),
         }
     }
 
+    /// Walk the cursor down to the stop [`at`] labels `label`.
+    ///
+    /// Tests that only need to *be somewhere* say where with this rather than
+    /// counting `Down` presses: a count is a claim about the whole stop list,
+    /// so every change to what counts as a stop — cluster headers becoming one
+    /// (#96), the group lines of #57 before them — silently invalidates every
+    /// such count at once. The tests that are genuinely *about* navigation
+    /// still press the keys.
+    fn go_to(app: &mut App, label: &str) {
+        for _ in 0..=app.stops().len() {
+            if at(app) == label {
+                return;
+            }
+            app.handle_key(key(KeyCode::Down));
+        }
+        panic!("no stop labelled {label} on this screen");
+    }
+
     #[test]
     fn down_walks_the_takeable_tickets_and_steps_over_their_context() {
         // Clusters order by (repo, number): dotfiles#4 before wayfinder#1.
-        // The depth-0 axis is dotfiles #103, then wayfinder's takeable #6 and
-        // #9, then its Done group — #7 hangs under #6 as context and is *not*
-        // on this axis, which is the whole point of #57.
+        // The depth-0 axis is each cluster's header (#96), then its rows:
+        // dotfiles #103, then wayfinder's takeable #6 and #9, then its Done
+        // group — #7 hangs under #6 as context and is *not* on this axis,
+        // which is the whole point of #57.
         let mut app = fixture_app();
-        assert_eq!(at(&app), "#103");
+        assert_eq!(at(&app), "#103", "the default skips the header above it");
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(at(&app), "map #1");
         app.handle_key(key(KeyCode::Down));
         assert_eq!(at(&app), "#6");
         app.handle_key(ctrl('j'));
@@ -1198,7 +1257,7 @@ mod tests {
         }
         assert_eq!(
             at(&app),
-            "#103",
+            "map #4",
             "clamped at the first stop, across clusters"
         );
     }
@@ -1206,8 +1265,7 @@ mod tests {
     #[test]
     fn right_descends_into_the_subtree_and_left_comes_back() {
         let mut app = fixture_app();
-        app.handle_key(key(KeyCode::Down)); // wayfinder #6
-        assert_eq!(at(&app), "#6");
+        go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Right));
         assert_eq!(at(&app), "#7", "→ steps into what #6 unblocks");
         // #7 is an only child, so there is no sibling to walk to — and ↓ must
@@ -1223,9 +1281,10 @@ mod tests {
         app.handle_key(key(KeyCode::Left));
         assert_eq!(at(&app), "#6", "← returns to the parent");
         // At depth 0 there is no parent to climb to, so ← keeps its promise the
-        // only way left: one stop back.
+        // only way left: one stop back — which, from a cluster's first row, is
+        // that cluster's own header.
         app.handle_key(key(KeyCode::Left));
-        assert_eq!(at(&app), "#103");
+        assert_eq!(at(&app), "map #1");
     }
 
     #[test]
@@ -1247,6 +1306,7 @@ mod tests {
             },
         );
         let mut app = App::new(clusters);
+        go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Right));
         assert_eq!(at(&app), "#7");
         app.handle_key(key(KeyCode::Down));
@@ -1351,6 +1411,11 @@ mod tests {
         // its end rather than looping or stalling part-way. `→` is the one that
         // visits *every* stop, since it steps one at a time.
         let mut app = knotty_app();
+        // From the very first stop, not the default one — the default skips
+        // the cluster header (#96), and `→` only ever moves forward, so
+        // starting there would leave one stop unvisited for a reason that has
+        // nothing to do with the property being measured.
+        app.handle_key(key(KeyCode::Up));
         let mut seen = vec![app.cursor_pos()];
         for _ in 0..40 {
             app.handle_key(key(KeyCode::Right));
@@ -1422,6 +1487,7 @@ mod tests {
             },
         );
         let mut app = App::new(clusters);
+        go_to(&mut app, "#1069");
         app.handle_key(key(KeyCode::Right)); // into #1070
         assert_eq!(at(&app), "#1070");
 
@@ -1441,6 +1507,9 @@ mod tests {
 
         // Every stop is reachable by ↓ alone — the property that was broken.
         let total = app.stops().len();
+        for _ in 0..total {
+            app.handle_key(key(KeyCode::Up)); // back to the very first stop
+        }
         let mut seen = vec![at(&app)];
         for _ in 1..total {
             app.handle_key(key(KeyCode::Down));
@@ -1448,7 +1517,7 @@ mod tests {
         }
         assert_eq!(
             seen,
-            vec!["#1069", "#1070", "#1071", "#1072"],
+            vec!["map #1064", "#1069", "#1070", "#1071", "#1072"],
             "↓ walked the whole tree"
         );
     }
@@ -1511,7 +1580,7 @@ mod tests {
     #[test]
     fn tab_toggles_the_lens_and_the_cursor_stays_on_its_ticket() {
         let mut app = fixture_app();
-        app.handle_key(key(KeyCode::Down)); // wayfinder #6
+        go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Right)); // into its subtree: #7
         assert_eq!(at(&app), "#7");
         assert_eq!(app.screen(), Screen::Structured(Lens::Leverage));
@@ -1522,7 +1591,11 @@ mod tests {
         // its ticket, not its old position.
         assert_eq!(at(&app), "#7");
         assert_eq!(app.visible().len(), 5, "the forest is total");
-        assert_eq!(app.stops().len(), 5, "and holds nothing back to open");
+        assert_eq!(
+            app.stops().len(),
+            7,
+            "and holds nothing back to open — the two extra stops are the headers"
+        );
 
         app.handle_key(key(KeyCode::Tab));
         assert_eq!(app.screen(), Screen::Structured(Lens::Leverage));
@@ -1589,13 +1662,17 @@ mod tests {
         // The two-step (#62): the first enter stages the launch — nothing
         // execs yet — and an empty line's enter is the interactive default.
         let mut app = launchable_app();
-        // Move to wayfinder#6, whose repo has one checkout.
-        app.handle_key(key(KeyCode::Down));
+        // wayfinder#6, whose repo has one checkout.
+        go_to(&mut app, "#6");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
             Overlay::LaunchLine { staged, text } => {
-                assert_eq!(staged.route, Route::Wayfinder, "a task is a decision node");
-                assert_eq!(staged.ticket, 6);
+                assert_eq!(
+                    staged.route(Mode::Interactive),
+                    Route::Wayfinder,
+                    "a task is a decision node"
+                );
+                assert_eq!(staged.key(), "#6");
                 assert_eq!(staged.title, "Re-entry breadcrumbs", "the line names it");
                 assert_eq!(text, "", "the line opens empty");
             }
@@ -1643,8 +1720,9 @@ mod tests {
             path: std::path::PathBuf::from("/data/proj/wayfinder"),
             repo: "blooop/wayfinder".to_string(),
         }]);
-        // Row 0 is map #1's copy, row 1 is map #47's.
-        app.handle_key(key(KeyCode::Down));
+        // Both clusters hold a #6; the second one is map #47's copy.
+        go_to(&mut app, "map #47");
+        go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Enter)); // stage it
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
@@ -1666,8 +1744,9 @@ mod tests {
     #[test]
     fn several_checkouts_open_the_picker_and_enter_launches_the_pick() {
         let mut app = launchable_app();
-        // Cursor starts on dotfiles#103 — two checkouts. The first enter
-        // stages the launch; the second resolves it to the picker.
+        // dotfiles#103 — a repo with two checkouts. The first enter stages the
+        // launch; the second resolves it to the picker.
+        go_to(&mut app, "#103");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
@@ -1695,6 +1774,7 @@ mod tests {
     #[test]
     fn the_picker_clamps_and_esc_cancels_it() {
         let mut app = launchable_app();
+        go_to(&mut app, "#103");
         app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage the launch
         app.handle_key(key(KeyCode::Enter)); // resolve — two checkouts: picker
         for _ in 0..5 {
@@ -1761,40 +1841,38 @@ mod tests {
     }
 
     #[test]
-    fn defer_text_on_the_launch_line_launches_deferred_with_steering() {
-        // The acceptance shape: enter → `defer something` → enter produces a
-        // command carrying `defer: something`.
+    fn auto_text_on_the_launch_line_launches_the_manager_with_steering() {
+        // The acceptance shape (#96): enter → `auto something` → enter
+        // produces the manager skill carrying `steer: something`.
         let mut app = launchable_app();
-        app.handle_key(key(KeyCode::Down)); // wayfinder#6, one checkout
+        go_to(&mut app, "#6"); // wayfinder#6, one checkout
         app.handle_key(key(KeyCode::Enter));
-        type_str(&mut app, "defer something");
+        type_str(&mut app, "auto something");
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(
             launch.agent_argv().last().unwrap(),
-            "/wayfinder 1 6 defer: something"
+            "/wayfinder-auto 1 6 steer: something"
         );
     }
 
     #[test]
     fn the_typed_mode_survives_the_checkout_picker() {
         // Two checkouts of dotfiles: the mode is settled on the line, the
-        // picker only answers *where* — the pick must not lose the defer.
+        // picker only answers *where* — the pick must not lose the `auto`.
         let mut app = launchable_app();
+        go_to(&mut app, "#103");
         app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage
-        type_str(&mut app, "defer");
+        type_str(&mut app, "auto");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert!(matches!(app.overlay, Overlay::PickCheckout { .. }));
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(
-            launch.agent_argv().last().unwrap(),
-            "/wayfinder 4 103 defer"
-        );
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder-auto 4 103");
     }
 
     #[test]
@@ -1805,14 +1883,14 @@ mod tests {
         // — the ticket it was opened on, wherever that ticket now sits.
         let staged = || {
             let mut app = launchable_app();
-            app.handle_key(key(KeyCode::Down)); // wayfinder#6, at index 1
+            go_to(&mut app, "#6");
             app.handle_key(key(KeyCode::Enter));
-            type_str(&mut app, "defer");
+            type_str(&mut app, "auto");
             app
         };
         let wf = MapId::new("blooop/wayfinder", 1);
 
-        // Reordered: index 1 now names #9, not #6.
+        // Reordered: #6's old index now names #9.
         let mut app = staged();
         let mut reordered = app.clusters.clone();
         reordered.get_mut(&wf).expect("the map").tickets = vec![
@@ -1840,7 +1918,7 @@ mod tests {
         };
         assert_eq!(
             launch.agent_argv().last().unwrap(),
-            "/wayfinder 1 6 defer",
+            "/wayfinder-auto 1 6",
             "the staged ticket, not whatever landed at its old index"
         );
 
@@ -1858,21 +1936,57 @@ mod tests {
         );
         app.replace_clusters(shrunk);
         match &app.overlay {
-            Overlay::LaunchLine { staged, .. } => assert_eq!(staged.ticket, 6),
+            Overlay::LaunchLine { staged, .. } => assert_eq!(staged.key(), "#6"),
             other => panic!("expected the launch line, got {other:?}"),
         }
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 1 6 defer");
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder-auto 1 6");
+    }
+
+    #[test]
+    fn enter_on_a_cluster_header_stages_the_whole_map() {
+        // #96's headline: the cursor can land on a map, and launching one runs
+        // the wayfinder skill on the map alone — no ticket argument, because
+        // there is no ticket. Interactive charts it with the human; `auto`
+        // hands the whole map to the manager.
+        let mut app = launchable_app();
+        go_to(&mut app, "map #1");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::LaunchLine { staged, .. } => {
+                assert_eq!(staged.key(), "#1");
+                assert_eq!(staged.title, "Map: wf", "the line names the map");
+                assert_eq!(staged.route(Mode::Interactive), Route::Wayfinder);
+                assert_eq!(staged.route(Mode::Auto), Route::WayfinderAuto);
+            }
+            other => panic!("expected the launch line, got {other:?}"),
+        }
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.key(), "wayfinder#1");
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder 1");
+
+        let mut app = launchable_app();
+        go_to(&mut app, "map #1");
+        app.handle_key(key(KeyCode::Enter));
+        type_str(&mut app, "auto");
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wayfinder-auto 1");
     }
 
     #[test]
     fn enter_on_a_done_or_blocked_node_is_a_notice_not_a_launch_line() {
         let mut app = launchable_app();
         // Blocked: #7 hangs under #6 as context.
-        app.handle_key(key(KeyCode::Down)); // #6
+        go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Right)); // into #7
         assert_eq!(at(&app), "#7");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
@@ -1930,20 +2044,12 @@ mod tests {
 
         let mut ready = build_app(vec![]);
         ready.handle_key(key(KeyCode::Enter));
-        assert!(
-            matches!(
-                &ready.overlay,
-                Overlay::LaunchLine {
-                    staged: Staged {
-                        route: Route::Tdd,
-                        ..
-                    },
-                    ..
-                }
-            ),
-            "{:?}",
-            ready.overlay
-        );
+        match &ready.overlay {
+            Overlay::LaunchLine { staged, .. } => {
+                assert_eq!(staged.route(Mode::Interactive), Route::Tdd);
+            }
+            other => panic!("expected the launch line, got {other:?}"),
+        }
         let launch = match ready.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -1959,20 +2065,12 @@ mod tests {
             },
         }]);
         in_review.handle_key(key(KeyCode::Enter));
-        assert!(
-            matches!(
-                &in_review.overlay,
-                Overlay::LaunchLine {
-                    staged: Staged {
-                        route: Route::Review,
-                        ..
-                    },
-                    ..
-                }
-            ),
-            "{:?}",
-            in_review.overlay
-        );
+        match &in_review.overlay {
+            Overlay::LaunchLine { staged, .. } => {
+                assert_eq!(staged.route(Mode::Interactive), Route::Review);
+            }
+            other => panic!("expected the launch line, got {other:?}"),
+        }
         let launch = match in_review.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -2003,7 +2101,7 @@ mod tests {
     #[test]
     fn ctrl_f_focuses_cursor_rows_project_and_ctrl_g_widens() {
         let mut app = fixture_app();
-        app.handle_key(key(KeyCode::Down)); // cursor on wayfinder #6
+        go_to(&mut app, "#6");
         app.handle_key(ctrl('f'));
         assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
         assert_eq!(
@@ -2060,7 +2158,7 @@ mod tests {
     fn ctrl_r_requests_refresh_and_replace_clusters_keeps_anchor() {
         let mut app = fixture_app();
         assert_eq!(app.handle_key(ctrl('r')), Outcome::Refresh);
-        app.handle_key(key(KeyCode::Down)); // cursor on wayfinder#6
+        go_to(&mut app, "#6");
         let same = app.clusters.clone();
         app.replace_clusters(same);
         assert_eq!(app.cursor_ticket().unwrap().number, 6);
@@ -2069,7 +2167,7 @@ mod tests {
     #[test]
     fn replace_clusters_does_not_teleport_when_cursor_ticket_vanishes() {
         let mut app = fixture_app();
-        app.handle_key(key(KeyCode::Down)); // cursor on wayfinder#6, position 1
+        go_to(&mut app, "#6"); // position 3: two stops per cluster ahead of it
         let mut smaller = app.clusters.clone();
         smaller
             .get_mut(&MapId::new("blooop/wayfinder", 1))
@@ -2078,7 +2176,7 @@ mod tests {
             .retain(|t| t.number != 6);
         app.replace_clusters(smaller);
         // Identity gone: cursor stays at the same position, clamped.
-        assert_eq!(app.cursor_pos(), 1);
+        assert_eq!(app.cursor_pos(), 3);
         assert_eq!(app.cursor_ticket().unwrap().number, 9);
     }
 
@@ -2105,8 +2203,9 @@ mod tests {
             );
         }
         let mut app = App::new(clusters);
-        app.handle_key(key(KeyCode::Down)); // cursor on upstream/dotfiles#5
-        assert_eq!(app.cursor_ticket().unwrap().repo, "upstream/dotfiles");
+        while app.cursor_ticket().map(|t| t.repo.as_str()) != Some("upstream/dotfiles") {
+            app.handle_key(key(KeyCode::Down));
+        }
         app.handle_key(ctrl('f'));
         assert_eq!(app.scope, Scope::Project("upstream/dotfiles".to_string()));
         assert_eq!(

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1,13 +1,14 @@
 //! The launch: a picked ticket becomes the agent, running right here.
 //!
 //! `wf` is a selector (#26/#34). There is no multiplexer, no tab, no session
-//! and no supervision: the picked ticket resolves to a checkout, `wf` gives the
+//! and no supervision: the picked node resolves to a checkout, `wf` gives the
 //! terminal back, and its own process image is replaced by
 //! `claude --dangerously-skip-permissions "<skill> …"` in that checkout
-//! ([`Launch::exec`]) — which skill is the (type, stage) [`route`], and the
-//! launch line's mode rides the prompt as a suffix (#61/#62). Unattended work
-//! is still not supervised here — a deferred launch is the same exec with
-//! ` defer` in the prompt, watched from another terminal or not at all.
+//! ([`Launch::exec`]) — which skill is [`route`]'s answer to what was picked
+//! ([`Aim`]) and who decides ([`Mode`]), and any steering text rides the
+//! prompt as a suffix (#61/#62/#96). Unattended work is still not supervised
+//! here — an `auto` launch is the same exec of `/wayfinder-auto`, watched from
+//! another terminal or not at all.
 //!
 //! A checkout that declares a devcontainer runs that same agent *inside* it,
 //! by way of `dl` ([`Isolation`], #80): `wf` owns which ticket, which checkout,
@@ -26,11 +27,11 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::model::{Stage, Ticket, TicketType};
+use crate::model::{MapId, Stage, Ticket, TicketType};
 use crate::projects::Checkout;
 
-/// Which skill the launched agent runs — the (type, stage) → skill table,
-/// hardcoded in `wf` (#61): not per-ticket config, not a Notes-parsed table.
+/// Which skill the launched agent runs — the (aim, mode) → skill table,
+/// hardcoded in `wf` (#61/#96): not per-ticket config, not a Notes-parsed table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Route {
     /// `/tdd <n>` — build work: ready, resuming, or acting on red checks and
@@ -38,8 +39,13 @@ pub enum Route {
     Tdd,
     /// `/review <n>` — a build whose PR awaits its independent look.
     Review,
-    /// `/wayfinder <map> <n>` — every decision session.
+    /// `/wayfinder <map> [<n>]` — a decision session with the human in it,
+    /// on one ticket or on the map itself.
     Wayfinder,
+    /// `/wayfinder-auto <map> [<n>]` — the same map with nobody in the loop:
+    /// decisions settled against the skill's guiding principles, and the whole
+    /// remaining lifecycle driven unattended (#96).
+    WayfinderAuto,
 }
 
 impl Route {
@@ -49,86 +55,169 @@ impl Route {
             Route::Tdd => "/tdd",
             Route::Review => "/review",
             Route::Wayfinder => "/wayfinder",
+            Route::WayfinderAuto => "/wayfinder-auto",
         }
     }
+}
+
+/// Who resolves the launched node — the axis #96 added to routing, orthogonal
+/// to what the cursor was standing on.
+///
+/// Not a flag on the skill: the two modes are *different skills* (`/wayfinder`
+/// and `/wayfinder-auto`), so the mode is an input to [`route`] rather than
+/// something the prompt carries. That is why nothing about "auto" survives
+/// into the exec'd prompt's steering suffix — by then it has already been spent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// The default: the human is in the loop, and the session grills them.
+    Interactive,
+    /// The word `auto`: the agent decides alone, under `/wayfinder-auto`'s
+    /// declared principles, and drives the node's remaining lifecycle
+    /// unattended. Replaced `defer`, which routed to `/wayfinder`'s own
+    /// deferred mode before that skill existed (#63 → #96).
+    Auto,
 }
 
 /// What the launch line's typed text meant — parsed once at the second enter
-/// (parse, don't validate: the exec never re-reads a string). The four
-/// meanings of #62's staged prompt step.
+/// (parse, don't validate: the exec never re-reads a string).
+///
+/// Two independent axes, so genuinely a product and not a four-armed sum: the
+/// leading `auto` picks *who decides*, and whatever follows steers them. Every
+/// combination is meaningful, which is the test for a product being honest.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LaunchMode {
-    /// An empty line: today's behavior, the default.
-    Interactive,
-    /// `defer` — the whole subtree, resolved unattended (#63).
-    Deferred,
-    /// `defer <text>` — deferred, with a steering prompt.
-    DeferredSteered(String),
-    /// Any other text — a steering prompt on an interactive launch.
-    Steered(String),
+pub struct LaunchMode {
+    mode: Mode,
+    /// The steering prompt, never empty — [`LaunchMode::parse`] trims, and an
+    /// empty steer is spelt `None` rather than `Some("")`.
+    steer: Option<String>,
 }
 
 impl LaunchMode {
-    /// Parse the launch line. Total: every string means one of the four
-    /// things. `defer` is matched as a *word* — `deferred work` is steering
-    /// text that happens to start with the same letters, not a mode.
+    /// Parse the launch line. Total: every string means exactly one launch.
+    /// `auto` is matched as a *word* — `automate the release` is steering text
+    /// that happens to start with the same letters, not a mode.
     pub fn parse(text: &str) -> LaunchMode {
         let text = text.trim();
-        if text.is_empty() {
-            return LaunchMode::Interactive;
-        }
-        match text.strip_prefix("defer") {
-            Some("") => LaunchMode::Deferred,
-            Some(rest) if rest.starts_with(char::is_whitespace) => {
-                LaunchMode::DeferredSteered(rest.trim_start().to_string())
-            }
-            _ => LaunchMode::Steered(text.to_string()),
+        let (mode, steer) = match text.strip_prefix("auto") {
+            Some("") => (Mode::Auto, ""),
+            Some(rest) if rest.starts_with(char::is_whitespace) => (Mode::Auto, rest.trim_start()),
+            _ => (Mode::Interactive, text),
+        };
+        LaunchMode {
+            mode,
+            steer: (!steer.is_empty()).then(|| steer.to_string()),
         }
     }
 
-    /// The suffix appended to the exec'd slash command (#62/#63): nothing,
-    /// ` defer`, ` defer: <text>`, or ` steer: <text>`.
+    /// Which skill this line resolves to, given what the cursor was on.
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// The suffix appended to the exec'd slash command: nothing, or
+    /// ` steer: <text>`. The mode is *not* here — it chose the skill.
     fn suffix(&self) -> String {
-        match self {
-            LaunchMode::Interactive => String::new(),
-            LaunchMode::Deferred => " defer".to_string(),
-            LaunchMode::DeferredSteered(text) => format!(" defer: {text}"),
-            LaunchMode::Steered(text) => format!(" steer: {text}"),
+        match &self.steer {
+            None => String::new(),
+            Some(text) => format!(" steer: {text}"),
         }
     }
 }
 
-/// Resolve which skill a (type, stage) launches. Total, with `None` as the
-/// one honest refusal: done is not launchable, whatever the type. Blocked is
-/// refused *before* this is consulted — blocked is [`crate::model::Status`],
-/// not a stage, so an illegal blocked route is unrepresentable here.
+/// A stage a launch can act on: [`Stage`] minus [`Stage::Done`], which has no
+/// work left to hand an agent.
 ///
-/// Every arm is named on both axes: adding a stage or a type without deciding
-/// its route is a compile error, not a silent fall-through.
-pub fn route(ticket_type: TicketType, stage: Stage) -> Option<Route> {
-    match stage {
-        Stage::Done => None,
-        // Build rows of the #61 table: in-review hands off to the fresh-eyes
-        // reviewer; everything else on a build node is code work.
-        Stage::InReview => match ticket_type {
-            TicketType::Build => Some(Route::Review),
-            TicketType::Research
-            | TicketType::Task
-            | TicketType::Grilling
-            | TicketType::Prototype
-            | TicketType::Untyped => Some(Route::Wayfinder),
-        },
-        Stage::Ready | Stage::Building | Stage::NeedsAttention => match ticket_type {
-            TicketType::Build => Some(Route::Tdd),
-            // Decision types (untyped riding along, as it always launched):
-            // /wayfinder at every unfinished stage — PR-dominant derivation
-            // can put a decision node past "in progress" (a prototype's PR
-            // counts), and the skill owns its node's PR state.
-            TicketType::Research
-            | TicketType::Task
-            | TicketType::Grilling
-            | TicketType::Prototype
-            | TicketType::Untyped => Some(Route::Wayfinder),
+/// Parsed once, at the first enter ([`Launchable::parse`]), so that a staged
+/// launch of a finished node is unrepresentable and [`route`] is **total** —
+/// no `Option` for the three later steps to carry, wonder about and re-refuse.
+/// Blocked never reaches here at all: blocked is [`crate::model::Status`], not
+/// a stage, and the picker refuses it before anything is staged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Launchable {
+    Ready,
+    Building,
+    InReview,
+    NeedsAttention,
+}
+
+impl Launchable {
+    /// Narrow a derived stage to one an agent can be launched on. Exhaustive
+    /// on [`Stage`]: a new stage must decide whether it is launchable, or this
+    /// stops compiling.
+    pub fn parse(stage: Stage) -> Option<Launchable> {
+        match stage {
+            Stage::Ready => Some(Launchable::Ready),
+            Stage::Building => Some(Launchable::Building),
+            Stage::InReview => Some(Launchable::InReview),
+            Stage::NeedsAttention => Some(Launchable::NeedsAttention),
+            Stage::Done => None,
+        }
+    }
+}
+
+/// What a launch is aimed at: a whole map, or one ticket in it (#96).
+///
+/// The cursor can land on a cluster header now, and a map is not a ticket with
+/// a missing number — it has no type and no stage, because stage is derived
+/// from a node's PRs and a map has none. So the two are arms of one sum rather
+/// than a ticket struct with optional fields, and every consumer that needs a
+/// ticket number has to say which case it is answering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Aim {
+    /// The cluster header: the map itself, charted or driven as a whole.
+    Map,
+    /// One ticket in the map, carrying the pair its route turns on.
+    Ticket {
+        number: u64,
+        ticket_type: TicketType,
+        stage: Launchable,
+    },
+}
+
+/// Resolve which skill a launch runs, from what it is aimed at and who is
+/// deciding. Total on every axis (#96): adding a stage, a type or a mode
+/// without saying where it routes is a compile error, not a fall-through.
+///
+/// The mode axis collapses the ticket table wherever it is `Auto`, and that is
+/// the point rather than a shortcut: under `Auto` the launched session is a
+/// **manager**, and what it manages is the node's whole remaining lifecycle —
+/// `/tdd`, the gate, then fresh-context `/review` — so it is `/wayfinder-auto`
+/// that gets launched at every stage, not the stage's own skill.
+pub fn route(aim: &Aim, mode: Mode) -> Route {
+    match (aim, mode) {
+        (Aim::Map, Mode::Interactive) => Route::Wayfinder,
+        (Aim::Map | Aim::Ticket { .. }, Mode::Auto) => Route::WayfinderAuto,
+        (
+            Aim::Ticket {
+                ticket_type, stage, ..
+            },
+            Mode::Interactive,
+        ) => match stage {
+            // Build rows of the #61 table: in-review hands off to the fresh-eyes
+            // reviewer; everything else on a build node is code work.
+            Launchable::InReview => match ticket_type {
+                TicketType::Build => Route::Review,
+                TicketType::Research
+                | TicketType::Task
+                | TicketType::Grilling
+                | TicketType::Prototype
+                | TicketType::Untyped => Route::Wayfinder,
+            },
+            Launchable::Ready | Launchable::Building | Launchable::NeedsAttention => {
+                match ticket_type {
+                    TicketType::Build => Route::Tdd,
+                    // Decision types (untyped riding along, as it always
+                    // launched): /wayfinder at every unfinished stage —
+                    // PR-dominant derivation can put a decision node past "in
+                    // progress" (a prototype's PR counts), and the skill owns
+                    // its node's PR state.
+                    TicketType::Research
+                    | TicketType::Task
+                    | TicketType::Grilling
+                    | TicketType::Prototype
+                    | TicketType::Untyped => Route::Wayfinder,
+                }
+            }
         },
     }
 }
@@ -146,31 +235,60 @@ pub fn route(ticket_type: TicketType, stage: Stage) -> Option<Route> {
 /// [`Launch`]es rather than a choice to re-resolve later.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Staged {
-    /// The ticket's repo, full slug (`owner/name`) — what the checkout cache
+    /// The node's repo, full slug (`owner/name`) — what the checkout cache
     /// is matched on (#15).
     pub repo: String,
-    /// The ticket the launch line names.
-    pub ticket: u64,
+    /// What the launch line names: the map, or one ticket in it.
+    pub aim: Aim,
     /// Its title as it read when the line opened — the line is showing the
     /// human what they picked, not re-reporting a row that may have moved.
     pub title: String,
     /// The map issue of the cluster the row was picked in (#50) — which map a
-    /// ticket listed twice was launched from.
+    /// ticket listed twice was launched from, and the launch target itself
+    /// when the cursor was on the cluster header.
     pub map_issue: u64,
-    /// Resolved from (type, stage) by [`route`] at the first enter, which is
-    /// also where an unlaunchable node was refused: no `Route`, no `Staged`.
-    pub route: Route,
 }
 
 impl Staged {
     /// Stage a launch of `ticket`, picked in the cluster of `map_issue`.
-    pub fn new(ticket: &Ticket, map_issue: u64, route: Route) -> Staged {
-        Staged {
+    /// `None` for a finished ticket, which has no launchable stage — the one
+    /// refusal, made here so that everything downstream is total.
+    pub fn ticket(ticket: &Ticket, map_issue: u64, stage: Stage) -> Option<Staged> {
+        Some(Staged {
             repo: ticket.repo.clone(),
-            ticket: ticket.number,
+            aim: Aim::Ticket {
+                number: ticket.number,
+                ticket_type: ticket.ticket_type,
+                stage: Launchable::parse(stage)?,
+            },
             title: ticket.title.clone(),
             map_issue,
-            route,
+        })
+    }
+
+    /// Stage a launch of a whole map — the cursor was on its cluster header.
+    /// Total, unlike the ticket case: a map has no stage to be finished at,
+    /// and a finished map is not on screen to put the cursor on.
+    pub fn map(id: &MapId, title: &str) -> Staged {
+        Staged {
+            repo: id.repo.clone(),
+            aim: Aim::Map,
+            title: title.to_string(),
+            map_issue: id.number,
+        }
+    }
+
+    /// Which skill this launch would run in `mode` — what the launch line
+    /// echoes as the mode word is typed, and what [`plan`] resolves with.
+    pub fn route(&self, mode: Mode) -> Route {
+        route(&self.aim, mode)
+    }
+
+    /// How the staged node reads: `#<n>`, the ticket's number or the map's.
+    pub fn key(&self) -> String {
+        match &self.aim {
+            Aim::Map => format!("#{}", self.map_issue),
+            Aim::Ticket { number, .. } => format!("#{number}"),
         }
     }
 }
@@ -270,18 +388,20 @@ fn shell_quote(arg: &str) -> String {
 /// `Route` for it exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Launch {
-    /// The ticket's repo, full slug (`owner/name`) — the identity half, kept
+    /// The node's repo, full slug (`owner/name`) — the identity half, kept
     /// whole because a fork and its upstream share a short name (#15).
     repo: String,
-    /// The ticket being worked.
-    ticket: u64,
-    /// The repo's map issue — `/wayfinder`'s first argument.
+    /// What is being worked: the map, or one ticket in it.
+    aim: Aim,
+    /// The map issue — `/wayfinder`'s first argument, and its only one when
+    /// the aim is the map itself.
     map_issue: u64,
     /// The checkout the agent works in: the process's working directory.
     cwd: PathBuf,
     /// The skill this launch execs, resolved from (type, stage).
     route: Route,
-    /// What the launch line said: interactive, deferred, steered.
+    /// What the launch line said. The mode half already picked `route`; what
+    /// is left to spend here is the steering text.
     mode: LaunchMode,
     /// Host or container, decided from the checkout at [`plan`] time (#80).
     isolation: Isolation,
@@ -297,10 +417,15 @@ impl Launch {
         &self.cwd
     }
 
-    /// How this ticket reads on screen: `<short_repo>#<number>`, the same
-    /// identity the picker's rows show.
+    /// How this node reads on screen: `<short_repo>#<number>`, the same
+    /// identity the picker's rows show — the ticket's number, or the map's
+    /// when the whole map is what was picked.
     pub fn key(&self) -> String {
-        format!("{}#{}", short_repo(&self.repo), self.ticket)
+        let number = match &self.aim {
+            Aim::Map => self.map_issue,
+            Aim::Ticket { number, .. } => *number,
+        };
+        format!("{}#{}", short_repo(&self.repo), number)
     }
 
     /// Where this launch's agent runs.
@@ -320,13 +445,23 @@ impl Launch {
     }
 
     /// The agent itself. `claude` takes a single positional prompt, so the
-    /// slash command, its arguments and the mode suffix are one argv entry,
-    /// not several. Only `/wayfinder` takes the map argument — `/tdd` and
-    /// `/review` resolve the repo from the checkout they run in.
+    /// slash command, its arguments and the steering suffix are one argv
+    /// entry, not several. Only the wayfinder skills take the map argument —
+    /// `/tdd` and `/review` resolve the repo from the checkout they run in.
+    ///
+    /// The map aim is matched first because it is the arm that needs no
+    /// second thought: [`route`] hands a cluster header nothing but a
+    /// wayfinder skill, and a wayfinder skill on a map is the map's number
+    /// alone. The ticket arm is where the two argument shapes live.
     fn claude_argv(&self) -> Vec<String> {
-        let prompt = match self.route {
-            Route::Tdd | Route::Review => format!("{} {}", self.route.label(), self.ticket),
-            Route::Wayfinder => format!("/wayfinder {} {}", self.map_issue, self.ticket),
+        let prompt = match &self.aim {
+            Aim::Map => format!("{} {}", self.route.label(), self.map_issue),
+            Aim::Ticket { number, .. } => match self.route {
+                Route::Tdd | Route::Review => format!("{} {number}", self.route.label()),
+                Route::Wayfinder | Route::WayfinderAuto => {
+                    format!("{} {} {number}", self.route.label(), self.map_issue)
+                }
+            },
         };
         vec![
             "claude".to_string(),
@@ -478,8 +613,8 @@ pub enum Targets {
 }
 
 /// Resolve a launch request against the projects cache. Zero or one candidate
-/// never prompts. The route and mode arrive already settled — this function
-/// only answers *where* the agent can run.
+/// never prompts. The aim and mode arrive already settled — this function
+/// answers *where* the agent can run, and resolves the route the mode picked.
 ///
 /// Isolation is decided **here**, per candidate, rather than at the exec: a
 /// checkout that has a devcontainer and one that does not can both be
@@ -492,14 +627,15 @@ pub enum Targets {
 /// Never: the `expect` in the one-candidate arm is guarded by the `match` on
 /// the length immediately above it.
 pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
+    let route = staged.route(mode.mode());
     let launches: Vec<Launch> = candidate_checkouts(checkouts, &staged.repo)
         .into_iter()
         .map(|c| Launch {
             repo: staged.repo.clone(),
-            ticket: staged.ticket,
+            aim: staged.aim.clone(),
             map_issue: staged.map_issue,
             cwd: c.path.clone(),
-            route: staged.route,
+            route,
             mode: mode.clone(),
             isolation: Isolation::detect(&c.path),
         })
@@ -541,8 +677,8 @@ mod tests {
     fn plan_wf(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets {
         plan(
             checkouts,
-            &Staged::new(ticket, map_issue, Route::Wayfinder),
-            &LaunchMode::Interactive,
+            &Staged::ticket(ticket, map_issue, Stage::Ready).expect("ready is launchable"),
+            &LaunchMode::parse(""),
         )
     }
 
@@ -580,7 +716,7 @@ mod tests {
                 assert_eq!(launch.cwd(), Path::new("/data/proj/wayfinder"));
                 assert_eq!(launch.key(), "wayfinder#16");
                 assert_eq!(launch.map_issue, 1);
-                assert_eq!(launch.ticket, 16);
+                assert!(matches!(launch.aim, Aim::Ticket { number: 16, .. }));
             }
             other => panic!("expected One, got {other:?}"),
         }
@@ -629,64 +765,114 @@ mod tests {
     }
 
     #[test]
-    fn the_launch_line_text_parses_to_its_mode() {
-        // The four meanings of the typed line (#62): empty is the interactive
-        // default, `defer` alone is the deferred subtree, `defer <text>` adds
-        // steering to it, anything else steers an interactive launch.
-        assert_eq!(LaunchMode::parse(""), LaunchMode::Interactive);
-        assert_eq!(LaunchMode::parse("   "), LaunchMode::Interactive);
-        assert_eq!(LaunchMode::parse("defer"), LaunchMode::Deferred);
-        assert_eq!(LaunchMode::parse("defer "), LaunchMode::Deferred);
+    fn the_launch_line_text_parses_to_a_mode_and_a_steer() {
+        // The two axes of the typed line (#62/#96): a leading `auto` picks who
+        // decides, whatever follows steers them, and either may be absent.
+        let parse = |text: &str| {
+            let mode = LaunchMode::parse(text);
+            (mode.mode, mode.steer)
+        };
+        assert_eq!(parse(""), (Mode::Interactive, None));
+        assert_eq!(parse("   "), (Mode::Interactive, None));
+        assert_eq!(parse("auto"), (Mode::Auto, None));
+        assert_eq!(parse("auto "), (Mode::Auto, None));
         assert_eq!(
-            LaunchMode::parse("defer skip the flaky suite"),
-            LaunchMode::DeferredSteered("skip the flaky suite".to_string())
+            parse("auto skip the flaky suite"),
+            (Mode::Auto, Some("skip the flaky suite".to_string()))
         );
         assert_eq!(
-            LaunchMode::parse("try the other approach"),
-            LaunchMode::Steered("try the other approach".to_string())
+            parse("try the other approach"),
+            (
+                Mode::Interactive,
+                Some("try the other approach".to_string())
+            )
         );
-        // `defer` is a word, not a prefix: no fuzzy matching.
+        // `auto` is a word, not a prefix: no fuzzy matching.
         assert_eq!(
-            LaunchMode::parse("deferred work first"),
-            LaunchMode::Steered("deferred work first".to_string())
+            parse("automate the release"),
+            (Mode::Interactive, Some("automate the release".to_string()))
+        );
+        // `defer` retired with #96: it is ordinary steering text now, not a
+        // mode word that quietly still means something.
+        assert_eq!(
+            parse("defer"),
+            (Mode::Interactive, Some("defer".to_string()))
+        );
+    }
+
+    /// The prompt a node of this (type, stage) is launched with, for a launch
+    /// line reading `text`.
+    fn ticket_prompt(ticket_type: TicketType, stage: Stage, text: &str) -> String {
+        let mut node = ticket("blooop/wayfinder", 16);
+        node.ticket_type = ticket_type;
+        let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
+        match plan(&cache(), &staged, &LaunchMode::parse(text)) {
+            Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    /// The same, for a launch aimed at the whole map.
+    fn map_prompt(text: &str) -> String {
+        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        match plan(&cache(), &staged, &LaunchMode::parse(text)) {
+            Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_agent_command_is_the_route_plus_the_steering_suffix() {
+        // The route picks the skill; only the wayfinder skills take the map
+        // argument. The mode is *not* in the suffix — it chose the skill.
+        assert_eq!(
+            ticket_prompt(TicketType::Build, Stage::Ready, ""),
+            "/tdd 16"
+        );
+        assert_eq!(
+            ticket_prompt(TicketType::Build, Stage::InReview, ""),
+            "/review 16"
+        );
+        assert_eq!(
+            ticket_prompt(TicketType::Grilling, Stage::Ready, ""),
+            "/wayfinder 1 16"
+        );
+        assert_eq!(
+            ticket_prompt(TicketType::Grilling, Stage::Ready, "auto"),
+            "/wayfinder-auto 1 16"
+        );
+        // Steering rides as a suffix, whatever the route.
+        assert_eq!(
+            ticket_prompt(
+                TicketType::Grilling,
+                Stage::Ready,
+                "auto skip the flaky suite"
+            ),
+            "/wayfinder-auto 1 16 steer: skip the flaky suite"
+        );
+        assert_eq!(
+            ticket_prompt(TicketType::Build, Stage::Ready, "try the other approach"),
+            "/tdd 16 steer: try the other approach"
         );
     }
 
     #[test]
-    fn the_agent_command_is_the_route_plus_the_mode_suffix() {
-        let launch = |route: Route, mode: LaunchMode| -> String {
-            let staged = Staged::new(&ticket("blooop/wayfinder", 16), 1, route);
-            match plan(&cache(), &staged, &mode) {
-                Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
-                other => panic!("{other:?}"),
-            }
-        };
-        // The route picks the skill; only /wayfinder takes the map argument.
-        assert_eq!(launch(Route::Tdd, LaunchMode::Interactive), "/tdd 16");
-        assert_eq!(launch(Route::Review, LaunchMode::Interactive), "/review 16");
+    fn a_map_launch_is_the_skill_and_the_map_number_alone() {
+        // No ticket argument exists to pass, so none is passed — the map aim
+        // is the whole subject (#96).
+        assert_eq!(map_prompt(""), "/wayfinder 59");
+        assert_eq!(map_prompt("auto"), "/wayfinder-auto 59");
         assert_eq!(
-            launch(Route::Wayfinder, LaunchMode::Interactive),
-            "/wayfinder 1 16"
+            map_prompt("auto merge when green"),
+            "/wayfinder-auto 59 steer: merge when green"
         );
-        // The mode rides as a suffix, whatever the route (#62/#63).
-        assert_eq!(
-            launch(Route::Wayfinder, LaunchMode::Deferred),
-            "/wayfinder 1 16 defer"
-        );
-        assert_eq!(
-            launch(
-                Route::Wayfinder,
-                LaunchMode::DeferredSteered("skip the flaky suite".to_string())
-            ),
-            "/wayfinder 1 16 defer: skip the flaky suite"
-        );
-        assert_eq!(
-            launch(
-                Route::Tdd,
-                LaunchMode::Steered("try the other approach".to_string())
-            ),
-            "/tdd 16 steer: try the other approach"
-        );
+        // A map's key is its own issue number, not a ticket's.
+        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        assert_eq!(staged.key(), "#59");
+        match plan(&cache(), &staged, &LaunchMode::parse("")) {
+            Targets::One(l) => assert_eq!(l.key(), "wayfinder#59"),
+            other => panic!("{other:?}"),
+        }
     }
 
     #[test]
@@ -720,20 +906,40 @@ mod tests {
         assert_eq!(short_repo("wayfinder"), "wayfinder");
     }
 
+    /// Every decision type, and every stage a launch can act on — the two
+    /// axes the routing table is swept across.
+    const DECISION_TYPES: [TicketType; 5] = [
+        TicketType::Research,
+        TicketType::Task,
+        TicketType::Grilling,
+        TicketType::Prototype,
+        TicketType::Untyped,
+    ];
+    const LAUNCHABLE: [Launchable; 4] = [
+        Launchable::Ready,
+        Launchable::Building,
+        Launchable::InReview,
+        Launchable::NeedsAttention,
+    ];
+
+    /// A ticket aim, for asking [`route`] about one cell of the table.
+    fn aim(ticket_type: TicketType, stage: Launchable) -> Aim {
+        Aim::Ticket {
+            number: 16,
+            ticket_type,
+            stage,
+        }
+    }
+
     #[test]
     fn build_nodes_route_to_tdd_except_in_review_which_routes_to_review() {
         // The #61 routing table's build rows: failing checks and requested
         // changes are code work, so needs-attention goes back to /tdd.
-        assert_eq!(route(TicketType::Build, Stage::Ready), Some(Route::Tdd));
-        assert_eq!(route(TicketType::Build, Stage::Building), Some(Route::Tdd));
-        assert_eq!(
-            route(TicketType::Build, Stage::NeedsAttention),
-            Some(Route::Tdd)
-        );
-        assert_eq!(
-            route(TicketType::Build, Stage::InReview),
-            Some(Route::Review)
-        );
+        let build = |stage| route(&aim(TicketType::Build, stage), Mode::Interactive);
+        assert_eq!(build(Launchable::Ready), Route::Tdd);
+        assert_eq!(build(Launchable::Building), Route::Tdd);
+        assert_eq!(build(Launchable::NeedsAttention), Route::Tdd);
+        assert_eq!(build(Launchable::InReview), Route::Review);
     }
 
     #[test]
@@ -743,22 +949,11 @@ mod tests {
         // prototype's PR counts) — the skill owns its node's PR state, so the
         // route stays /wayfinder at every stage short of done. Untyped rides
         // along: launching untyped tickets is today's behavior, kept.
-        for ticket_type in [
-            TicketType::Research,
-            TicketType::Task,
-            TicketType::Grilling,
-            TicketType::Prototype,
-            TicketType::Untyped,
-        ] {
-            for stage in [
-                Stage::Ready,
-                Stage::Building,
-                Stage::InReview,
-                Stage::NeedsAttention,
-            ] {
+        for ticket_type in DECISION_TYPES {
+            for stage in LAUNCHABLE {
                 assert_eq!(
-                    route(ticket_type, stage),
-                    Some(Route::Wayfinder),
+                    route(&aim(ticket_type, stage), Mode::Interactive),
+                    Route::Wayfinder,
                     "{ticket_type:?} at {stage:?}"
                 );
             }
@@ -766,16 +961,37 @@ mod tests {
     }
 
     #[test]
+    fn auto_routes_every_node_to_wayfinder_auto() {
+        // The mode axis collapses the table (#96): under `auto` the launched
+        // session manages the node's whole remaining lifecycle, so it is the
+        // manager skill that runs — never the stage's own skill, which would
+        // do one stage and stop.
+        for ticket_type in DECISION_TYPES.into_iter().chain([TicketType::Build]) {
+            for stage in LAUNCHABLE {
+                assert_eq!(
+                    route(&aim(ticket_type, stage), Mode::Auto),
+                    Route::WayfinderAuto,
+                    "{ticket_type:?} at {stage:?}"
+                );
+            }
+        }
+        assert_eq!(route(&Aim::Map, Mode::Auto), Route::WayfinderAuto);
+        assert_eq!(route(&Aim::Map, Mode::Interactive), Route::Wayfinder);
+    }
+
+    #[test]
     fn done_is_not_launchable_whatever_the_type() {
-        for ticket_type in [
-            TicketType::Build,
-            TicketType::Research,
-            TicketType::Task,
-            TicketType::Grilling,
-            TicketType::Prototype,
-            TicketType::Untyped,
-        ] {
-            assert_eq!(route(ticket_type, Stage::Done), None, "{ticket_type:?}");
+        // The refusal moved off `route` and onto the parse that builds the
+        // aim, so it is made once and cannot be forgotten by a caller.
+        assert_eq!(Launchable::parse(Stage::Done), None);
+        for ticket_type in DECISION_TYPES.into_iter().chain([TicketType::Build]) {
+            let mut node = ticket("blooop/wayfinder", 16);
+            node.ticket_type = ticket_type;
+            assert_eq!(
+                Staged::ticket(&node, 1, Stage::Done),
+                None,
+                "{ticket_type:?}"
+            );
         }
     }
 
@@ -853,14 +1069,18 @@ mod tests {
     /// The same launch, forced into a container — the fields are private and
     /// `plan` reads the real filesystem, so a test that wants the isolated
     /// shape builds it here rather than arranging a `dl` on PATH.
-    fn isolated(route: Route, mode: LaunchMode) -> Launch {
+    fn isolated(route: Route, text: &str) -> Launch {
         Launch {
             repo: "blooop/wayfinder".to_string(),
-            ticket: 80,
+            aim: Aim::Ticket {
+                number: 80,
+                ticket_type: TicketType::Task,
+                stage: Launchable::Ready,
+            },
             map_issue: 67,
             cwd: PathBuf::from("/data/proj/wayfinder"),
             route,
-            mode,
+            mode: LaunchMode::parse(text),
             isolation: Isolation::Devlaunch,
         }
     }
@@ -873,7 +1093,7 @@ mod tests {
         // not quoted — and it is a path, never `owner/repo@branch`, which would
         // send `dl` off to clone a second tree.
         assert_eq!(
-            isolated(Route::Wayfinder, LaunchMode::Interactive).agent_argv(),
+            isolated(Route::Wayfinder, "").agent_argv(),
             vec![
                 "dl".to_string(),
                 "/data/proj/wayfinder".to_string(),
@@ -881,10 +1101,10 @@ mod tests {
                 "'claude' '--dangerously-skip-permissions' '/wayfinder 67 80'".to_string(),
             ]
         );
-        // The mode suffix rides inside the same quoted argument.
+        // The steering suffix rides inside the same quoted argument.
         assert_eq!(
-            isolated(Route::Wayfinder, LaunchMode::Deferred).agent_argv()[3],
-            "'claude' '--dangerously-skip-permissions' '/wayfinder 67 80 defer'"
+            isolated(Route::WayfinderAuto, "auto merge when green").agent_argv()[3],
+            "'claude' '--dangerously-skip-permissions' '/wayfinder-auto 67 80 steer: merge when green'"
         );
     }
 
@@ -892,10 +1112,7 @@ mod tests {
     fn steering_text_cannot_break_out_of_the_shell_command() {
         // The one string a user types that reaches a shell. A single quote
         // closes, escapes, reopens — the argument stays one argument.
-        let launch = isolated(
-            Route::Tdd,
-            LaunchMode::Steered("don't touch the CI; rm -rf /".to_string()),
-        );
+        let launch = isolated(Route::Tdd, "don't touch the CI; rm -rf /");
         assert_eq!(
             launch.agent_argv()[3],
             r"'claude' '--dangerously-skip-permissions' '/tdd 80 steer: don'\''t touch the CI; rm -rf /'"
@@ -908,7 +1125,7 @@ mod tests {
     #[test]
     fn the_notice_names_the_container_when_there_is_one_and_stays_quiet_otherwise() {
         assert_eq!(
-            isolated(Route::Wayfinder, LaunchMode::Interactive).describe(),
+            isolated(Route::Wayfinder, "").describe(),
             "wayfinder#80 in /data/proj/wayfinder (devlaunch)"
         );
         match plan_wf(&cache(), &ticket("blooop/wayfinder", 80), 67) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,7 @@ use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
 use crate::filter;
-use crate::launch::Launch;
+use crate::launch::{Launch, LaunchMode};
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
 use crate::view::{Branch, Fold, GroupKind, Item, Plan};
 
@@ -50,9 +50,12 @@ fn glyph_style(glyph: RowGlyph) -> Style {
 /// half of what a ticket is matched against and the rows below do not draw it:
 /// typing a project name would otherwise sift the whole screen down to one
 /// cluster while underlining nothing anywhere.
-fn cluster_header(id: &MapId, map: &Map, lit: &[usize]) -> Line<'static> {
+fn cluster_header(id: &MapId, map: &Map, lit: &[usize], under_cursor: bool) -> Line<'static> {
     let cyan = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
-    let mut spans = vec![Span::styled("▌ ", cyan)];
+    // The cursor rides *before* the `▌`, not after it: the bar is the cluster's
+    // left edge and every row below hangs off it, so a marker inside it would
+    // read as belonging to the first row rather than to the header (#96).
+    let mut spans = vec![cursor_span(under_cursor), Span::styled("▌ ", cyan)];
     spans.extend(lit_spans(id.short_repo(), lit, cyan));
     spans.push(Span::styled(format!(" · {}", map.title), cyan));
     for (glyph, count) in map.tally() {
@@ -369,7 +372,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
             Item::Header(id) => {
                 let map = &app.clusters[id];
                 let lit = query.as_mut().map(|q| q.in_repo(map)).unwrap_or_default();
-                lines.push(cluster_header(id, map, &lit));
+                lines.push(cluster_header(id, map, &lit, under_cursor));
             }
             Item::Ticket {
                 row,
@@ -589,16 +592,22 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     frame.render_widget(body, body_area);
 
     // The count line's slot is shared: while a launch is staged (#62) the
-    // launch line lives there instead — the resolved route, the ticket it
+    // launch line lives there instead — the resolved route, the node it
     // launches, and the mode text as it is typed.
+    //
+    // The route is resolved *per frame* from the text, not read off the staged
+    // launch, because since #96 the mode picks the skill: typing `auto` has to
+    // flip the echoed command from `/wayfinder` to `/wayfinder-auto` as you
+    // type it. Showing a stale route would be showing the wrong skill.
     if let Overlay::LaunchLine { staged, text } = &app.overlay {
+        let route = staged.route(LaunchMode::parse(text).mode());
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled(
-                    format!("  → {}", staged.route.label()),
+                    format!("  → {}", route.label()),
                     Style::new().fg(Color::Cyan),
                 ),
-                Span::raw(format!(" · #{} {}  {text}", staged.ticket, staged.title)),
+                Span::raw(format!(" · {} {}  {text}", staged.key(), staged.title)),
                 Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
             ])),
             count_area,
@@ -1265,7 +1274,7 @@ mod tests {
         let body = lit_body(&app);
         assert!(
             body.iter()
-                .any(|l| l.starts_with("▌ «wayf»inder · Map: wf")),
+                .any(|l| l.starts_with("  ▌ «wayf»inder · Map: wf")),
             "{body:?}"
         );
         assert!(
@@ -1321,8 +1330,8 @@ mod tests {
         );
         assert_eq!(
             app.cursor_pos(),
-            0,
-            "typing snaps the cursor to the best hit"
+            1,
+            "typing snaps the cursor to the best hit, past its cluster header"
         );
     }
 
@@ -1403,10 +1412,16 @@ mod tests {
             "the count line is replaced: {screen}"
         );
 
-        // The typed mode shows on the line as it accumulates.
-        type_str(&mut app, "defer something");
+        // The typed mode shows on the line as it accumulates — and re-routes
+        // it live, because since #96 the mode word picks the skill and a line
+        // still echoing `/wayfinder` would be naming the wrong one.
+        type_str(&mut app, "auto something");
         let screen = render(&app);
-        assert!(screen.contains("defer something"), "{screen}");
+        assert!(screen.contains("auto something"), "{screen}");
+        assert!(
+            screen.contains("→ /wayfinder-auto · #6 Re-entry breadcrumbs"),
+            "{screen}"
+        );
 
         // Esc gives the count line back.
         app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -1556,12 +1571,14 @@ mod tests {
         assert_eq!(app.cursor_ticket().unwrap().number, 50);
         let screen = render(&app);
         assert!(screen.contains("▶ ○ #50 Build: clusters"), "{screen}");
-        // And with the cursor back at the top, the top is what shows.
+        // And with the cursor back at the top — the first cluster's header,
+        // since #96 — the top is what shows.
         for _ in 0..40 {
             app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
         }
         let screen = render(&app);
-        assert!(screen.contains("▶ ○ #1 Open 1"), "{screen}");
+        assert!(screen.contains("▶ ▌ wayfinder · Map: wf"), "{screen}");
+        assert!(screen.contains("○ #1 Open 1"), "{screen}");
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -112,9 +112,12 @@ pub type Expanded = BTreeSet<GroupId>;
 
 /// What the cursor is on. Since #57 that is no longer always a ticket: a
 /// collapsed group is a stop too, because opening one is an action the cursor
-/// has to be able to name.
+/// has to be able to name — and since #96 so is a cluster header, because a
+/// map is a thing you can launch an agent at.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Stop {
+    /// A cluster header: the whole map, launched as one.
+    Map(MapId),
     Ticket(Row),
     Group(GroupId),
 }
@@ -126,8 +129,9 @@ pub struct StopAt {
     pub depth: usize,
 }
 
-/// One line of the body. [`Item::Ticket`] and [`Item::Group`] are cursor stops;
-/// headers, spacers and context rows are not — [`Item::stop_at`] is the rule.
+/// One line of the body. [`Item::Header`], [`Item::Ticket`] and [`Item::Group`]
+/// are cursor stops; spacers and context rows are not — [`Item::stop_at`] is
+/// the rule.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Item {
     /// A cluster header — the map this and the following lines belong to.
@@ -174,16 +178,23 @@ impl Item {
                 stop: Stop::Ticket(row.clone()),
                 depth: *depth,
             }),
+            // A header sits at depth 0 alongside the cluster's top-level rows
+            // rather than above them, because the depth axis is what `←`/`→`
+            // walk and a header is not something you descend *into* — `←` from
+            // a top-level row already steps back to it as the previous stop.
+            Item::Header(id) => Some(StopAt {
+                stop: Stop::Map(id.clone()),
+                depth: 0,
+            }),
             // Nothing to land on. A sifted group leads this arm because it is
             // the narrower pattern: it is a heading the query wrote, not a fold
             // anyone can toggle — clearing the query is what puts the group
-            // back — so it is no more a stop than a header is.
+            // back — so there is no action for the cursor to name on it.
             Item::Group {
                 fold: Fold::Sifted { .. },
                 ..
             }
             | Item::Context { .. }
-            | Item::Header(_)
             | Item::Blank => None,
             Item::Group { id, .. } => Some(StopAt {
                 stop: Stop::Group(id.clone()),
@@ -987,13 +998,21 @@ mod tests {
             .collect()
     }
 
-    /// Every cursor stop as (what it is, depth) — tickets by number, groups by
-    /// kind. This is the navigation surface, so it is what the tests assert on.
+    /// Every cursor stop as (what it is, depth) — tickets by number, maps by
+    /// `map #n`, groups by kind. This is the navigation surface, so it is what
+    /// the tests assert on.
+    /// The cluster header's stop, which every plan below opens with since #96.
+    /// Named once so the assertions stay about the rows under it.
+    fn header() -> (String, usize) {
+        ("map #47".to_string(), 0)
+    }
+
     fn nav(plan: &Plan, m: &Map) -> Vec<(String, usize)> {
         plan.stops()
             .into_iter()
             .map(|at| {
                 let label = match at.stop {
+                    Stop::Map(id) => format!("map #{}", id.number),
                     Stop::Ticket(row) => format!("#{}", m.tickets[row.index].number),
                     Stop::Group(g) => format!("{:?}", g.kind),
                 };
@@ -1049,6 +1068,7 @@ mod tests {
         assert_eq!(
             nav(&plan, &m),
             vec![
+                header(),
                 ("#6".to_string(), 0),
                 ("#7".to_string(), 1),
                 ("#8".to_string(), 1),
@@ -1079,7 +1099,7 @@ mod tests {
             .filter(|(_, depth)| *depth == 0)
             .map(|(label, _)| label)
             .collect();
-        assert_eq!(top, vec!["#6", "#9", "Done"]);
+        assert_eq!(top, vec!["map #47", "#6", "#9", "Done"]);
     }
 
     #[test]
@@ -1105,7 +1125,7 @@ mod tests {
         );
         assert_eq!(
             nav(&collapsed, &m),
-            vec![("#6".to_string(), 0), ("Done".to_string(), 0)]
+            vec![header(), ("#6".to_string(), 0), ("Done".to_string(), 0)]
         );
         assert!(collapsed.items.iter().any(|i| matches!(
             i,
@@ -1122,6 +1142,7 @@ mod tests {
         assert_eq!(
             nav(&expanded, &m),
             vec![
+                header(),
                 ("#6".to_string(), 0),
                 ("Done".to_string(), 0),
                 ("#2".to_string(), 1),
@@ -1135,6 +1156,39 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn every_cluster_opens_with_its_header_as_a_stop() {
+        // #96: a map is a thing you can launch an agent at, so the cursor has
+        // to be able to name it. One stop per cluster, at the front of it and
+        // at depth 0 — context rows and spacers stay unreachable.
+        let m = map(vec![ticket(6, true, false, vec![])]);
+        let other = MapId::new("blooop/dotfiles", 4);
+        let binding = id();
+        let plan = plan(
+            &[(&binding, &m), (&other, &m)],
+            Screen::Structured(Lens::Leverage),
+            &nothing(),
+        );
+        let headers: Vec<MapId> = plan
+            .stops()
+            .into_iter()
+            .filter_map(|at| match at.stop {
+                Stop::Map(id) => Some(id),
+                Stop::Ticket(_) | Stop::Group(_) => None,
+            })
+            .collect();
+        assert_eq!(
+            headers,
+            vec![binding, other],
+            "one per cluster, in render order"
+        );
+        assert_eq!(
+            plan.stops().first().map(|at| at.depth),
+            Some(0),
+            "a header sits alongside its top-level rows, not above them"
+        );
     }
 
     #[test]
@@ -1420,7 +1474,11 @@ mod tests {
         );
         assert_eq!(
             nav(&plan, &m),
-            vec![("#6".to_string(), 0), ("BlockedDeeper".to_string(), 0)]
+            vec![
+                header(),
+                ("#6".to_string(), 0),
+                ("BlockedDeeper".to_string(), 0)
+            ]
         );
     }
 
@@ -1464,6 +1522,7 @@ mod tests {
         assert_eq!(
             nav(&plan, &m),
             vec![
+                header(),
                 ("#6".to_string(), 0),
                 ("#9".to_string(), 1),
                 ("#9".to_string(), 0),
@@ -1490,6 +1549,7 @@ mod tests {
         assert_eq!(
             nav(&plan, &m),
             vec![
+                header(),
                 ("#6".to_string(), 0),
                 ("#7".to_string(), 1),
                 ("#8".to_string(), 2),
@@ -1529,6 +1589,7 @@ mod tests {
         assert_eq!(
             nav(&plan, &m),
             vec![
+                header(),
                 ("#2".to_string(), 0),
                 ("#6".to_string(), 0),
                 ("#14".to_string(), 1),
@@ -1648,7 +1709,7 @@ mod tests {
         assert_eq!(shape(&plan, &m), vec!["▌ wayfinder", "#6 dim", "└─#14"]);
         // The context row is drawn but not landed on: `↑`/`↓` walk the hits,
         // all of them depth 0, exactly as they did over the flat list.
-        assert_eq!(nav(&plan, &m), vec![("#14".to_string(), 0)]);
+        assert_eq!(nav(&plan, &m), vec![header(), ("#14".to_string(), 0)]);
         assert_eq!(plan.rows().len(), 1, "context rows are not matches");
     }
 
@@ -1768,7 +1829,7 @@ mod tests {
         let plan = plan(&[(&binding, &m)], sifted("alpha"), &nothing());
         assert_eq!(shape(&plan, &m), vec!["▌ wayfinder", "Done 1/2", "└─#2"]);
         // The group is a heading here, not a fold: only the match is a stop.
-        assert_eq!(nav(&plan, &m), vec![("#2".to_string(), 0)]);
+        assert_eq!(nav(&plan, &m), vec![header(), ("#2".to_string(), 0)]);
     }
 
     #[test]

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -351,9 +351,11 @@ fn enter_execs_the_agent_in_the_checkout_and_leaves_no_wf_behind() {
     assert_eq!(skip, "--dangerously-skip-permissions");
     // This repo keeps several maps open (#50), and which cluster — and which
     // ticket, at which stage — the cursor landed on is the live tracker's
-    // business. So only the prompt's shape is asserted: one of the three
-    // routes (#61), with its numeric arguments and no mode suffix (the line
-    // was empty — interactive).
+    // business. So only the prompt's shape is asserted: one of the interactive
+    // routes (#61), with its numeric arguments and no steering suffix (the
+    // line was empty). `/wayfinder-auto` cannot appear — that needs the word
+    // `auto` typed — and neither can a bare map launch, since the default
+    // cursor skips cluster headers (#96).
     let (skill, numbers) = prompt.split_once(' ').expect("a skill and arguments");
     let halves: Vec<&str> = match skill {
         "/wayfinder" => numbers.splitn(2, ' ').collect(),


### PR DESCRIPTION
Resolves both halves of [Three skills, one launch word #96](https://github.com/blooop/wayfinder/issues/96), on [Map: the general dev-process tree #59](https://github.com/blooop/wayfinder/issues/59).

`wf` could only ever put the cursor on a ticket, so the one thing a map is — a whole effort, with fog in it — was the one thing you could not hand to an agent. Two changes; everything else falls out of them.

## A cluster header is a cursor stop

`Stop::Map(MapId)`, and `Item::Header` answers `stop_at` at depth 0 — alongside its top-level rows rather than above them, since a header is not something you descend *into* and `←` from a top-level row already steps back to it.

`enter` on one stages the **map**, and the prompt is the skill plus the map number alone:

```
▌ wayfinder · Map: the general dev-process tree   ○2  ●11

→ /wayfinder · #59 Map: the general dev-process tree
→ /wayfinder-auto · #59 …                             (after typing `auto`)
```

`Aim::{Map, Ticket { number, ticket_type, stage }}` is a sum, not a ticket struct with an absent number: a map has no type and no stage, because stage is derived from a node’s PRs and a map has none.

## Routing grows a mode axis

`route` is now `(&Aim, Mode) -> Route`, total on all three axes — a new stage, type or mode is a compile error. The typed word is **`auto`** and it routes to `/wayfinder-auto`; **`defer` retires**, since `/wayfinder`’s deferred-mode section (#63) was superseded by that skill.

| picked | stage | mode | launches |
| --- | --- | --- | --- |
| cluster header | — | interactive | `/wayfinder <map>` |
| `wayfinder:build` | ready · building · attention | interactive | `/tdd <n>` |
| `wayfinder:build` | in review | interactive | `/review <n>` |
| decision types | any unfinished | interactive | `/wayfinder <map> <n>` |
| anything | any unfinished | `auto` | `/wayfinder-auto <map> [<n>]` |

`auto` collapses the ticket rows deliberately: the launched session is a **manager**, and what it manages is the node’s whole remaining lifecycle — `/tdd`, the gate, fresh-context `/review` — so the manager skill runs, not the one skill that stage would have called.

## Two supporting shapes

- **`Launchable`** is `Stage` minus `Done`, parsed at the first enter. The refusal is made once, so `route` returns a `Route` rather than an `Option` that three later steps carry and re-refuse.
- **`LaunchMode`** becomes a product of mode and steering text, because that is what it honestly is — the four-armed sum was a 2×2 written out. The mode no longer rides the prompt as a suffix (it has already chosen the skill), and the launch line re-resolves **per frame**, so typing `auto` visibly flips the command it names before you commit to it.

## The default cursor skips headers — and only headers

[#88](https://github.com/blooop/wayfinder/issues/88) settled that the top is the first stop *literally*, not the first *takeable* one. That stands for rows: a blocked or claimed row still gets the cursor. A header is not a row competing for that place, though — it is the container — and defaulting onto one would make `enter` on a freshly filtered screen launch the whole map instead of the row you filtered to. So opening `wf` and pressing `enter` picks a ticket exactly as it did in 0.6.0; headers are one `↑` away.

## Notes for the reviewer

- Tests that only needed to *be somewhere* now say where with `go_to(&mut app, "#6")` rather than counting `Down` presses. A count is a claim about the whole stop list, which is precisely what this change invalidated in 43 places at once. Tests genuinely *about* navigation still press the keys, and now assert the header stops explicitly.
- `holding_a_direction_key_walks_all_the_way_to_the_end` presses `↑` first: `→` only moves forward, so starting from the header-skipping default would leave one stop unvisited for a reason unrelated to the property.
- `examples/preview_screen.rs` learned `enter`/`esc` so the launch line is reachable from `$KEYS`.
- All four CI checks pass locally with `RUSTFLAGS=-D warnings RUSTDOCFLAGS=-D warnings`: fmt, clippy, 201 tests, doc.
- **Not in this PR:** the dotfiles-side edits #96 also calls for — deleting `/wayfinder`'s superseded deferred-mode section — and the question of whether `/wayfinder-one` is reachable from `wf` at all. Those belong on blooop/dotfiles and in a separate ticket respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow launching either a ticket or an entire map, introduce an `auto` manager mode that routes to `/wayfinder-auto`, and refactor launch routing and cursor behavior to support map headers as first-class cursor stops.

New Features:
- Support launching a whole map by treating cluster headers as selectable cursor stops.
- Introduce an `auto` launch mode that drives the node’s remaining lifecycle via `/wayfinder-auto` instead of the old `defer` mode.

Enhancements:
- Refactor routing to be total over aim, stage and mode using new `Aim`, `Launchable`, `Mode` and `LaunchMode` shapes.
- Stage launches against tickets or maps via updated `Staged`/`Launch` structures, with prompts and keys derived from the aimed node.
- Adjust cursor defaults and navigation so headers are selectable but skipped by the initial cursor position, preserving ticket-first behavior.
- Update UI rendering of cluster headers and the launch line so the echoed command re-resolves live as the mode is typed.

Documentation:
- Refresh README to describe map-level launches, the `auto` manager mode and the updated routing table.

Tests:
- Extend and adapt navigation, routing and launch-line tests to cover map headers as stops, the `auto` mode and the new routing/refactor shapes.