### PR TITLE
Release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.6.0"
+  version: "0.7.0"
 
 package:
   name: wf


### PR DESCRIPTION
Cargo.toml, Cargo.lock and `recipe/recipe.yaml` move together: CI fails the build if the recipe and the crate disagree, and a tag that does not match Cargo.toml is rejected before anything is published.

A **minor** bump rather than a patch. Since 0.6.0:

- **A cluster header is a cursor stop**, so a whole map launches as one node — `/wayfinder <map>` to chart it with you, `/wayfinder-auto <map>` to have the agent drive it alone ([#99](https://github.com/blooop/wayfinder/pull/99), closing [#96](https://github.com/blooop/wayfinder/issues/96)).
- **The launch line's mode word is `auto`**, routing to `/wayfinder-auto`; `defer` retired to ordinary steering text. Under `auto` every node routes to the manager skill, which drives the node's whole remaining lifecycle rather than the one stage it sits at.
- **Maps are looked up live** instead of naming `#1`, which could always close ([#97](https://github.com/blooop/wayfinder/pull/97)).

The default cursor position is unchanged from 0.6.0 — it skips cluster headers and lands on the first row, so opening `wf` and pressing `enter` still picks a ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update Cargo.toml, Cargo.lock, and recipe.yaml versions to 0.7.0 for the new release.