### PR TITLE
Release 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.7.0"
+  version: "0.7.1"
 
 package:
   name: wf


### PR DESCRIPTION
Patch release over 0.7.0. `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` move together, as the version-agreement check in `package.yml` requires.

## What is in it

Everything merged since the v0.7.0 tag — [#97](https://github.com/blooop/wayfinder/pull/97) and [#98](https://github.com/blooop/wayfinder/pull/98), both about the live test suite and the docs around it:

- **The live tests no longer pin map #1.** Closing that map as reached (its 30 tickets are done; its last fog moved to map #47) made `fetch_map` refuse it — correctly, per #28 — and six assertions across three files went red for a reason unconnected to the code. They now look up the lowest-numbered *open* map through the same `find_maps` search the tool uses.
- **A failing live test says when a missing `GH_TOKEN` is the cause.** Raised by the review of #94, which dropped the `~/.config/gh` mount: a container's `gh` login arrives as a forwarded token now, so a container brought up without `dl` has no login and the first thing that said so was a `gh` error several layers down. The advice differs on host and in container, and fires only on failure.
- **CI runs that diagnostic.** It is pure and needs no network; an assertion nothing runs is not an assertion.
- **A `dl` version floor in the README.** On devpod 0.26 with `dl` ≤ 0.0.12 the launch hands the agent no terminal, so it prints one answer and exits — a session that never starts, with no error. Measured both transports on 0.26.1; `dl` 0.0.13 fixes it. `wf` still pins nothing.
- `.claude/worktrees/` gitignored, and the dead `#12` pointer out of the publish notice.

## Honest note on the binary

**No `src/` changed between v0.7.0 and here.** The compiled `wf` is byte-identical to 0.7.0; what this release carries is the README (including the `dl` floor, which is the one thing here a user of the package would want to read) and a test suite that is green and stays green. Worth a version so the docs on the channel are not a release behind — not worth reading a changelog for.

## Verified

`cargo test --all`: 209 passed, 0 failed. The previously flaky `a_cached_seed_fetches_the_map_without_waiting_for_the_search` ran 10/10 green after the fixture was changed to search once per binary rather than four times (a fresh-context review measured 4 failures in 9 runs before that). fmt, clippy `-D warnings`, and doc all clean; `wf --version` prints `wf 0.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Update Cargo.toml, Cargo.lock, and recipe/recipe.yaml to reflect the 0.7.1 release version.