### PR TITLE
Release 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.7.1"
+  version: "0.8.0"
 
 package:
   name: wf


### PR DESCRIPTION
Version bump only — Cargo.toml, Cargo.lock, recipe/recipe.yaml.

**Minor, not patch.** Since 0.7.1, `wf` gained a subcommand and the package gained a directory:

- `wf skills` reports which prompt file each route would actually exec, and where it resolved from (`$WF_SKILLS_DIR`, the installed bundle, or the checkout).
- `wf skills install` symlinks the bundled prompts into `~/.claude/skills`.
- The package now ships `share/wf/skills` beside the binary — the five prompts `launch::route` names literally.

That last one is what makes this release worth cutting rather than waiting. Until it is on a machine, `wf`'s routing table and the prompts it execs live in two repos on two cadences with nothing able to notice a disagreement — and [blooop/dotfiles#11](https://github.com/blooop/dotfiles/pull/11), which deletes this repo's copies from chezmoi, has nothing to put in their place.

Merge, then tag `v0.8.0` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the project version to 0.8.0 in Cargo manifest, lockfile, and recipe metadata to prepare the 0.8.0 release.

Build:
- Update Cargo.toml and Cargo.lock to set the package version to 0.8.0.

CI:
- Align recipe.yaml context version with Cargo.toml at 0.8.0 to keep CI version checks passing.