### PR TITLE
Release 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.8.0"
+  version: "0.9.0"
 
 package:
   name: wf
@@ -59,8 +59,8 @@ build:
           - cargo build --release --locked --bin wf
           - install -Dm755 target/release/wf "$PREFIX/bin/wf"
           # The prompts `wf` execs travel in the same package as the binary
-          # that execs them. `wf` hardcodes `/tdd`, `/review`, `/wayfinder` and
-          # `/wayfinder-auto` in its routing table, so the skill files are part
+          # that execs them. `wf` hardcodes `/wf-tdd`, `/wf-review`, `/wf` and
+          # `/wf-auto` in its routing table, so the skill files are part
           # of its interface — and an interface split across two repos on two
           # release cadences drifts silently, which is exactly what happened
           # before this (blooop/wayfinder#96).


### PR DESCRIPTION
Version bump — Cargo.toml, Cargo.lock, recipe/recipe.yaml.

**Minor, not patch.** [#104](https://github.com/blooop/wayfinder/pull/104) renamed all five skills under a `wf` prefix, so every label `wf` execs changed:

| now | after |
| --- | --- |
| `/wayfinder` | `/wf` |
| `/wayfinder-auto` | `/wf-auto` |
| `/tdd` | `/wf-tdd` |
| `/review` | `/wf-review` |

`wayfinder-one` → `wf-one` alongside them.

Installing this **breaks the links 0.8.0 wrote** — their targets no longer exist under the old names. `wf skills install` sweeps them and writes the new set; that sweep is scoped to links pointing into a `wf` bundle, so it cannot reach a skill of yours.

Also carries a one-line comment fix in the recipe that still named the old four — missed in #104, and stale the moment it merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update recipe comment to reflect the new wf-prefixed skill route names instead of the legacy ones.