### PR TITLE
Launch every node into its own dl workspace: one branch, one container per ticket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ A checkout that carries a **`.devcontainer/devcontainer.json`** (or a top-level
 [`dl`](https://github.com/blooop/devlaunch):
 
 ```
-dl <the checkout> -- 'claude' '--dangerously-skip-permissions' '/wf 67 80'
+dl owner/repo@wayfinder/repo-80 -- 'claude' '--dangerously-skip-permissions' '/wf 67 80'
 ```
 
 `wf` owns which ticket, which checkout, which skill and which prompt. `dl` owns
@@ -380,9 +380,22 @@ keeping an editor from opening over the terminal. `wf` builds no flags, reads no
 `devcontainer.json` and writes none: **the repo's own config is the entire
 opt-in**, and there is nothing to configure on the `wf` side.
 
-The checkout reaches `dl` as a **path**, never as `owner/repo@branch`. Given a
-repo spec `dl` would clone a second copy into its own cache and run the agent
-there — abandoning the tree you picked in the checkout picker.
+Each launched node gets a **workspace of its own**:
+`owner/repo@wayfinder/<repo>-<n>`, where `n` is the ticket's number (the map's,
+for a whole-map session). `dl` creates that branch off the default branch if it
+is new, clones it into its own cache, and runs the agent in a container per
+branch — so launching five tickets is five branches in five containers,
+colliding nowhere, and relaunching a ticket reattaches to the workspace it
+already has. The branch is the same `wayfinder/<repo>-<n>` that `/wf-tdd` does
+ticket `n`'s work on, so a build agent wakes up already on its work branch and a
+review launch opens on the branch the PR was pushed from.
+
+The tree you picked in the checkout picker is **not** the agent's working tree:
+its jobs are declaring the devcontainer and hosting non-isolated launches. No
+agent mutates your checkout, checks out its branches, or fights a second agent
+over its index. (Isolated launches used to run in the picked tree itself, which
+meant every launch of a repo shared one tree and one container — serial by
+construction.)
 
 Two things have to be true, and otherwise the agent runs on the host exactly as
 it always has:
@@ -415,8 +428,10 @@ declarations to make — `wf` injects no `runArgs`.
 
 Container lifecycle is entirely `dl`'s: `wf` never stops, removes or rebuilds
 one, and could not — it `exec`s and is gone, so there is no `wf` left to observe
-an agent exiting. `dl <ws> stop`, `dl <ws> reset` and `dl --prune-worktrees` are
-the tools, and they are yours to run. Containers accumulate until you do.
+an agent exiting. `dl <ws> stop`, `dl <ws> rm` and `dl --ls` are the tools, and
+they are yours to run. With a workspace per ticket they accumulate faster than
+they used to: a merged ticket's workspace has no further use, and reaping it is
+manual — `dl --ls` shows what exists, `dl <ws> rm` removes one.
 
 **This container is not a security boundary, and is not trying to be.** It is
 for reproducible dependencies. Your host `~/.claude` is bind-mounted into it

--- a/README.md
+++ b/README.md
@@ -403,7 +403,11 @@ it always has:
 1. the checkout declares one of those two configs, and
 2. `dl` is on PATH.
 
-**Use `dl` 0.0.13 or newer.** `wf` pins no version and never will — the launch
+**Use `dl` 0.0.20 or newer.** Launching several tickets at once means several
+`dl` processes preparing the same repo's cache at the same moment; 0.0.20 is
+where those runs serialize over a per-repo lock instead of racing (the loser
+of the old race could delete the winner's half-written clone). The older floor
+still matters too: `wf` pins no version and never will — the launch
 is one `exec` of a program found on PATH — but older `dl` on devpod 0.26 hands
 the agent **no terminal**, and an agent with no terminal decides it was invoked
 non-interactively: it prints one answer and exits, so the symptom is a session

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.9.0"
+  version: "0.10.0"
 
 package:
   name: wf

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -10,12 +10,19 @@
 //! here — an `auto` launch is the same exec of `/wf-auto`, watched from
 //! another terminal or not at all.
 //!
-//! A checkout that declares a devcontainer runs that same agent *inside* it,
-//! by way of `dl` ([`Isolation`], #80): `wf` owns which ticket, which checkout,
-//! which skill and which prompt, and `dl` owns the container, its lifecycle and
-//! its credentials. The seam is the checkout **path** — never `owner/repo@branch`,
-//! which would send `dl` off to clone a second tree and abandon the one the
-//! human picked.
+//! A checkout that declares a devcontainer runs that same agent *inside* a
+//! container, by way of `dl` ([`Isolation`], #80): `wf` owns which ticket,
+//! which checkout, which skill and which prompt, and `dl` owns the container,
+//! its lifecycle and its credentials. The seam is a **per-node workspace**,
+//! `owner/repo@wayfinder/<repo>-<n>` ([`Launch::agent_argv`]): every launched
+//! node gets its own branch, its own clone under `dl`'s cache and its own
+//! container, so any number of tickets run at once without colliding — and
+//! the tree the human picked in the checkout picker stays theirs, never
+//! mutated by an agent. (#80 originally handed `dl` the checkout path so the
+//! agent worked the picked tree; that seam made every launch of a repo share
+//! one tree and one container, which is exactly the collision this replaces.)
+//! The checkout keeps two jobs: declaring the devcontainer, and hosting
+//! host-mode launches.
 //!
 //! The one thing that can go wrong is ordering: the terminal must be restored
 //! *before* the image is replaced, because after that there is no `wf` left to
@@ -310,8 +317,9 @@ pub enum Isolation {
     /// No devcontainer in the checkout, or no `dl` on PATH: `claude` runs in
     /// the checkout directly.
     Host,
-    /// `dl <checkout> -- claude …`: the agent runs in the container the repo's
-    /// own `devcontainer.json` describes.
+    /// `dl owner/repo@wayfinder/<repo>-<n> -- claude …`: the agent runs in the
+    /// container the repo's own `devcontainer.json` describes, in a workspace
+    /// of its own — one branch, one clone, one container per node.
     Devlaunch,
 }
 
@@ -402,7 +410,10 @@ pub struct Launch {
     /// The map issue — `/wf`'s first argument, and its only one when
     /// the aim is the map itself.
     map_issue: u64,
-    /// The checkout the agent works in: the process's working directory.
+    /// The picked checkout: the process's working directory, and the agent's
+    /// working tree on the host. An isolated launch works in its own `dl`
+    /// workspace instead — the checkout's remaining job there is having
+    /// declared the devcontainer.
     cwd: PathBuf,
     /// The skill this launch execs, resolved from (type, stage).
     route: Route,
@@ -423,15 +434,39 @@ impl Launch {
         &self.cwd
     }
 
+    /// The issue number this launch is about: the ticket's, or the map's own
+    /// when the whole map is the subject.
+    fn number(&self) -> u64 {
+        match &self.aim {
+            Aim::Map => self.map_issue,
+            Aim::Ticket { number, .. } => *number,
+        }
+    }
+
     /// How this node reads on screen: `<short_repo>#<number>`, the same
     /// identity the picker's rows show — the ticket's number, or the map's
     /// when the whole map is what was picked.
     pub fn key(&self) -> String {
-        let number = match &self.aim {
-            Aim::Map => self.map_issue,
-            Aim::Ticket { number, .. } => *number,
-        };
-        format!("{}#{}", short_repo(&self.repo), number)
+        format!("{}#{}", short_repo(&self.repo), self.number())
+    }
+
+    /// The `dl` workspace an isolated launch runs in:
+    /// `owner/repo@wayfinder/<repo>-<n>` — one branch per node, so parallel
+    /// launches never share a tree or a container, and relaunching a node
+    /// reattaches to the workspace it already has.
+    ///
+    /// The branch name is not `wf`'s invention: `wayfinder/<repo>-<n>` is the
+    /// branch `/wf-tdd` is instructed to do ticket `n`'s work on. `dl` creates
+    /// it (locally, off the default branch) when it does not exist yet, so a
+    /// build agent wakes up already on its work branch, and a reviewer's
+    /// workspace opens on the branch the PR was pushed from.
+    fn workspace(&self) -> String {
+        format!(
+            "{}@wayfinder/{}-{}",
+            self.repo,
+            short_repo(&self.repo),
+            self.number()
+        )
     }
 
     /// Where this launch's agent runs.
@@ -440,14 +475,15 @@ impl Launch {
     }
 
     /// One-line description for the notice: what is being launched, where, and
-    /// — when it is not the host default — in what.
+    /// — when it is not the host default — in what. "Where" is where the agent
+    /// actually works: the checkout on the host, the per-node workspace in a
+    /// container.
     pub fn describe(&self) -> String {
-        format!(
-            "{} in {}{}",
-            self.key(),
-            self.cwd.display(),
-            self.isolation.suffix()
-        )
+        let place = match self.isolation {
+            Isolation::Host => self.cwd.display().to_string(),
+            Isolation::Devlaunch => self.workspace(),
+        };
+        format!("{} in {}{}", self.key(), place, self.isolation.suffix())
     }
 
     /// The agent itself. `claude` takes a single positional prompt, so the
@@ -479,20 +515,24 @@ impl Launch {
     /// What `wf` becomes: the agent, or `dl` carrying the agent into the
     /// container.
     ///
-    /// The isolated form hands `dl` the checkout **path** — the tree the human
-    /// picked — rather than `owner/repo@branch`, which `dl` would answer by
-    /// cloning a second copy under its own cache and running the agent in
-    /// *that*. The path is a plain argv entry to `dl` and needs no quoting; the
-    /// agent command that follows `--` does, because `dl` runs it through a
-    /// shell (every argument is single-quoted), and it is one entry rather than several
-    /// because "a shell command" is exactly what `dl` documents it to be.
+    /// The isolated form hands `dl` the per-node workspace
+    /// — `owner/repo@branch` — which `dl` answers by cloning that branch under
+    /// its own cache (creating it off the default branch if it is new) and
+    /// running the agent in a container of its own. That second tree is the
+    /// point: N launched nodes are N branches in N containers, colliding
+    /// nowhere, and the human's checkout is not one of them. The workspace
+    /// spec is a plain argv entry to `dl` and needs no quoting; the agent
+    /// command that follows `--` does, because `dl` runs it through a shell
+    /// (every argument is single-quoted), and it is one entry rather than
+    /// several because "a shell command" is exactly what `dl` documents it
+    /// to be.
     pub fn agent_argv(&self) -> Vec<String> {
         let agent = self.claude_argv();
         match self.isolation {
             Isolation::Host => agent,
             Isolation::Devlaunch => vec![
                 DEVLAUNCH.to_string(),
-                self.cwd.display().to_string(),
+                self.workspace(),
                 "--".to_string(),
                 agent
                     .iter()
@@ -1076,10 +1116,14 @@ mod tests {
     /// `plan` reads the real filesystem, so a test that wants the isolated
     /// shape builds it here rather than arranging a `dl` on PATH.
     fn isolated(route: Route, text: &str) -> Launch {
+        isolated_ticket(80, route, text)
+    }
+
+    fn isolated_ticket(number: u64, route: Route, text: &str) -> Launch {
         Launch {
             repo: "blooop/wayfinder".to_string(),
             aim: Aim::Ticket {
-                number: 80,
+                number,
                 ticket_type: TicketType::Task,
                 stage: Launchable::Ready,
             },
@@ -1092,17 +1136,18 @@ mod tests {
     }
 
     #[test]
-    fn an_isolated_launch_hands_dl_the_checkout_path_and_a_quoted_shell_command() {
-        // `dl` joins everything after `--` and runs it through a shell in the
-        // container, so the prompt has to arrive already quoted or it lands as
-        // three arguments. The path is a plain argv entry to `dl` itself and is
-        // not quoted — and it is a path, never `owner/repo@branch`, which would
-        // send `dl` off to clone a second tree.
+    fn an_isolated_launch_hands_dl_a_per_node_workspace_and_a_quoted_shell_command() {
+        // The workspace is `owner/repo@wayfinder/<repo>-<n>`: `dl` clones that
+        // branch into a tree and container of the node's own, so the human's
+        // checkout is never the agent's working tree. `dl` joins everything
+        // after `--` and runs it through a shell in the container, so the
+        // prompt has to arrive already quoted or it lands as three arguments;
+        // the workspace spec is a plain argv entry and is not quoted.
         assert_eq!(
             isolated(Route::Wayfinder, "").agent_argv(),
             vec![
                 "dl".to_string(),
-                "/data/proj/wayfinder".to_string(),
+                "blooop/wayfinder@wayfinder/wayfinder-80".to_string(),
                 "--".to_string(),
                 "'claude' '--dangerously-skip-permissions' '/wf 67 80'".to_string(),
             ]
@@ -1111,6 +1156,46 @@ mod tests {
         assert_eq!(
             isolated(Route::WayfinderAuto, "auto merge when green").agent_argv()[3],
             "'claude' '--dangerously-skip-permissions' '/wf-auto 67 80 steer: merge when green'"
+        );
+    }
+
+    #[test]
+    fn parallel_nodes_get_distinct_workspaces_and_a_relaunch_gets_its_own_back() {
+        // The reason the seam is a branch and not the checkout path: two
+        // tickets launched at once must not share a tree or a container, and
+        // the same ticket launched twice must land in the same workspace
+        // (that is `dl` reattaching, not a second clone).
+        let a = isolated_ticket(80, Route::Tdd, "").agent_argv()[1].clone();
+        let b = isolated_ticket(81, Route::Tdd, "").agent_argv()[1].clone();
+        let a_again = isolated_ticket(80, Route::Review, "").agent_argv()[1].clone();
+        assert_ne!(a, b);
+        assert_eq!(a, a_again);
+        // The branch is the one `/wf-tdd` is told to work on, so a build agent
+        // wakes up already on its work branch.
+        assert_eq!(a, "blooop/wayfinder@wayfinder/wayfinder-80");
+    }
+
+    #[test]
+    fn a_map_launch_gets_a_workspace_named_by_the_map_issue() {
+        // A whole-map session is a node like any other: its own branch, its
+        // own container, keyed by the map issue since there is no ticket.
+        let launch = Launch {
+            repo: "blooop/wayfinder".to_string(),
+            aim: Aim::Map,
+            map_issue: 67,
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            route: Route::WayfinderAuto,
+            mode: LaunchMode::parse("auto"),
+            isolation: Isolation::Devlaunch,
+        };
+        assert_eq!(
+            launch.agent_argv(),
+            vec![
+                "dl".to_string(),
+                "blooop/wayfinder@wayfinder/wayfinder-67".to_string(),
+                "--".to_string(),
+                "'claude' '--dangerously-skip-permissions' '/wf-auto 67'".to_string(),
+            ]
         );
     }
 
@@ -1130,9 +1215,11 @@ mod tests {
 
     #[test]
     fn the_notice_names_the_container_when_there_is_one_and_stays_quiet_otherwise() {
+        // An isolated launch works in its workspace, not in the checkout —
+        // so the workspace is what the notice names.
         assert_eq!(
             isolated(Route::Wayfinder, "").describe(),
-            "wayfinder#80 in /data/proj/wayfinder (devlaunch)"
+            "wayfinder#80 in blooop/wayfinder@wayfinder/wayfinder-80 (devlaunch)"
         );
         match plan_wf(&cache(), &ticket("blooop/wayfinder", 80), 67) {
             Targets::One(launch) => {


### PR DESCRIPTION
## What

The `dl` seam changes from the **checkout path** to a **per-node workspace**: `owner/repo@wayfinder/<repo>-<n>` (`n` = ticket number, or the map issue for a whole-map session). `dl` creates the branch off the default branch when it is new, clones it under its own cache, and runs the agent in a container per branch.

## Why

With the path seam, every isolated launch of a repo shared one tree and one container — serial by construction — and the agent worked in the very tree the human was editing. Now any number of tickets launch in parallel without colliding, relaunching a ticket reattaches to the workspace it already has, and the picked checkout is never an agent's working tree again (its jobs: declaring the devcontainer, hosting host-mode launches).

The branch name is `/wf-tdd`'s own convention (`wayfinder/<repo>-<n>`), so a build agent wakes up already on its work branch and a review launch opens on the branch its PR was pushed from.

This is the effort map #35 set aside as "how wf itself launches agents into devpod workspaces", and it reverses #80's path seam deliberately — the second tree `dl` clones is the point, not a defect.

## Verified on metal

Against `blooop/devlaunch` with released `dl` 0.0.20: two simultaneous launches of fresh fake-ticket branches → two containers (`1ce4d813a20a` / `58efed93f588`), branches auto-created (`wayfinder/devlaunch-9998`/`-9999`), separate trees, no marker-file crossover; a relaunch of 9998 reattached to the same container with its marker intact. Requires dl ≥ 0.0.20 for race-free simultaneous cold launches (the README already says ≥ 0.0.13 for the pty fix; 0.0.20 is what's released).

`cargo fmt --check`, `clippy -Dwarnings`, `cargo test` (206 lib tests), `cargo doc -Dwarnings` all green. Version bumped to 0.10.0 for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Change isolated agent launches from operating directly in the picked checkout to running in a per-node dl workspace branch, so each ticket/map session gets its own clone and container and relaunches reattach to the same workspace.

New Features:
- Introduce per-node dl workspaces keyed by ticket or map issue (owner/repo@wayfinder/<repo>-<n>) for isolated launches, ensuring one branch, one clone and one container per node.

Enhancements:
- Adjust launch descriptions and isolation behavior to report the actual dl workspace for isolated containers instead of the host checkout path.
- Refine internal launch helpers to derive workspace names from ticket or map numbers and reuse them across routes for consistent agent targeting.

Build:
- Bump crate version to 0.10.0 for the new workspace-based isolation behavior.

Documentation:
- Update README to describe per-ticket dl workspaces, revised dl invocation syntax and updated container lifecycle commands, including guidance on pruning unused workspaces.

Tests:
- Expand tests to cover workspace naming for tickets and map sessions, enforce distinct workspaces for parallel nodes and stable reuse on relaunch, and validate notices reference the workspace for isolated launches.