### PR TITLE
wf reap: remove the workspaces whose tickets are closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Then link the skills it launches into `~/.claude/skills`:
 wf skills install
 ```
 
-`wf --version`, `wf --help` and `wf skills [install]` are the only arguments;
-everything else is keys in the TUI.
+`wf --version`, `wf --help`, `wf skills [install]` and
+[`wf reap [-y] [-f]`](#wf-reap--clearing-away-finished-tickets) are the only
+arguments; everything else is keys in the TUI.
 
 ## The skills ship with the binary
 
@@ -430,12 +431,49 @@ choosing among variants would be `wf` picking a container shape, and it has no
 basis to pick. Host access, GPU passthrough and the rest are the repo's
 declarations to make — `wf` injects no `runArgs`.
 
-Container lifecycle is entirely `dl`'s: `wf` never stops, removes or rebuilds
-one, and could not — it `exec`s and is gone, so there is no `wf` left to observe
-an agent exiting. `dl <ws> stop`, `dl <ws> rm` and `dl --ls` are the tools, and
-they are yours to run. With a workspace per ticket they accumulate faster than
-they used to: a merged ticket's workspace has no further use, and reaping it is
-manual — `dl --ls` shows what exists, `dl <ws> rm` removes one.
+Container lifecycle is `dl`'s: `wf` never stops or rebuilds one, and could not
+during a session — it `exec`s and is gone, so there is no `wf` left to observe
+an agent exiting. `dl <ws> stop`, `dl <ws> rm` and `dl --ls` are yours to run.
+
+### `wf reap` — clearing away finished tickets
+
+A workspace per ticket means workspaces accumulate as fast as tickets are
+worked. `wf reap` removes the ones whose tickets are **closed**:
+
+```
+$ wf reap
+  keep  devlaunch-wayfinder-devlaunch-131-a  (devlaunch#131 is still open)
+  keep  wayfinder-wayfinder-wayfinder-42-b   (still running — stop it first)
+  reap  devlaunch-wayfinder-devlaunch-127-c  (devlaunch#127 is closed)
+
+delete 1 workspace(s)? [y/N]
+```
+
+This is the same division of labour the launch draws: **`dl` owns the
+containers, `wf` owns the tickets.** `dl` deliberately does not decide what is
+finished — that is a fact about a ticket, and inferring it from the branch
+cannot tell a squash-merged branch from an abandoned one — so it publishes what
+it knows (`dl --ls --json`) and refuses to destroy work that exists nowhere
+else, while `wf`, which minted those branch names from its own ticket numbers,
+decides. Needs `dl` **0.0.21 or newer** for the JSON listing.
+
+Kept, always: workspaces `dl` did not create (they are not `wf`'s, whatever
+their branch looks like), branches that are not `wayfinder/<repo>-<n>` for that
+repo, tickets still open, and anything **running** — a ticket closing is no
+evidence that the session in the container ended.
+
+Kept by default but waivable: a workspace whose clone holds uncommitted or
+unpushed work. `-f` reaps those too, and the plan says what it is discarding:
+
+```
+  reap  devlaunch-…-127-c  (devlaunch#127 is closed, discarding 1 uncommitted change(s) (pixi.lock))
+```
+
+`-f` exists for a case that is not hypothetical: a devcontainer whose
+`postCreateCommand` installs packages leaves a tracked lockfile modified in
+*every* workspace it builds, so without it those are unreapable forever. It
+waives the unsaved-work guard only — a running container is still kept, because
+that is a session in progress rather than bytes on disk. `-y` skips the prompt.
 
 **This container is not a security boundary, and is not trying to be.** It is
 for reproducible dependencies. Your host `~/.claude` is bind-mounted into it

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.10.0"
+  version: "0.11.0"
 
 package:
   name: wf

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod filter;
 pub mod launch;
 pub mod model;
 pub mod projects;
+pub mod reap;
 pub mod refresh;
 pub mod skills;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use ratatui::crossterm::event::{self, Event, KeyEventKind};
 use ratatui::DefaultTerminal;
 use tokio::signal::unix::{signal, SignalKind};
@@ -30,6 +30,7 @@ use wf::app::{App, Outcome, Scope};
 use wf::launch::Launch;
 use wf::model::{Map, MapId};
 use wf::projects::{self, ProjectsCache};
+use wf::reap;
 use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup};
 use wf::skills;
 
@@ -48,6 +49,14 @@ enum Invocation {
     SkillsReport,
     /// Link the bundled skills into Claude Code's personal skills directory.
     SkillsInstall,
+    /// Remove the workspaces whose tickets are closed. `yes` skips the prompt;
+    /// `insist` also reaps workspaces holding work that is not pushed anywhere,
+    /// which is what a devcontainer that dirties its own checkout on every
+    /// build leaves behind.
+    Reap {
+        yes: bool,
+        insist: bool,
+    },
     /// Print to stdout, exit 0.
     Print(String),
     /// Print to stderr, exit 2.
@@ -59,6 +68,7 @@ wf — the multi-project wayfinder ticket selector
 
 usage: wf [--version | --help]
        wf skills [install]
+       wf reap [-y] [-f]
 
 With no arguments: opens the picker over every mapped project, focused on the
 checkout you are standing in. enter runs an agent on the picked ticket, in that
@@ -67,6 +77,10 @@ ctrl-g narrow and widen the scope, ctrl-r refetches, esc quits.
 
 wf skills          report which prompt each route would actually run
 wf skills install  link this build's skills into ~/.claude/skills
+wf reap            remove the workspaces whose tickets are closed (-y to skip
+                   the prompt). Keeps anything running or holding work that is
+                   not pushed anywhere; -f reaps the unpushed ones too, naming
+                   what it discards. Needs dl 0.0.21 or newer.
 
 The skills wf execs ship in this package, so they update with it. `install`
 links rather than copies, which is what keeps them in step afterwards. Set
@@ -94,6 +108,10 @@ fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Invocation {
             "--version" | "-V" => Invocation::Print(format!("wf {}", env!("CARGO_PKG_VERSION"))),
             "--help" | "-h" => Invocation::Print(USAGE.to_string()),
             "skills" => Invocation::SkillsReport,
+            "reap" => Invocation::Reap {
+                yes: false,
+                insist: false,
+            },
             other => Invocation::Reject(format!("wf: unknown argument {other:?}\n{USAGE}")),
         },
         [first, second] if first == "skills" => match second.as_str() {
@@ -102,10 +120,36 @@ fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Invocation {
                 "wf: unknown skills subcommand {other:?} (expected `install`)\n{USAGE}"
             )),
         },
+        [first, rest @ ..] if first == "reap" => parse_reap(rest),
         [_, second, ..] => Invocation::Reject(format!(
             "wf: too many arguments (unexpected {second:?})\n{USAGE}"
         )),
     }
+}
+
+/// Parse `wf reap`'s flags, which unlike every other `wf` argument may be
+/// combined and given in any order.
+///
+/// Rejecting an unknown flag rather than ignoring it matters more here than
+/// anywhere else in this parser: the two flags waive a confirmation and a
+/// safety guard, so a typo that were quietly dropped would leave someone
+/// believing they had asked for something they had not — and a mistyped `-y`
+/// that silently opened a prompt is a much better outcome than a mistyped `-f`
+/// that silently did nothing.
+fn parse_reap(flags: &[String]) -> Invocation {
+    let (mut yes, mut insist) = (false, false);
+    for flag in flags {
+        match flag.as_str() {
+            "-y" | "--yes" => yes = true,
+            "-f" | "--force" => insist = true,
+            other => {
+                return Invocation::Reject(format!(
+                    "wf: unknown reap argument {other:?} (expected `-y` or `-f`)\n{USAGE}"
+                ))
+            }
+        }
+    }
+    Invocation::Reap { yes, insist }
 }
 
 /// `wf skills` and `wf skills install`. Both resolve the bundle and the target
@@ -169,6 +213,81 @@ fn run_skills(install: bool) -> Result<()> {
     Ok(())
 }
 
+/// `wf reap`: remove the workspaces whose tickets are closed.
+///
+/// The division of labour is the one the launch already draws — `dl` owns the
+/// containers, `wf` owns the tickets — so this asks `dl` what exists, asks the
+/// tracker which of those nodes are closed, prints the plan, and hands the
+/// finished ones back to `dl`. No terminal is taken: this is a stream command
+/// like `wf skills`, not a second TUI.
+///
+/// The plan is printed **before** the prompt and includes what is being kept,
+/// because a workspace someone expected to go and that stayed is the thing they
+/// most need told about, and a reason they disagree with ("still running" when
+/// they thought they had stopped it) is only actionable while no is an answer.
+async fn run_reap(yes: bool, insist: bool) -> Result<()> {
+    use std::collections::BTreeSet;
+    use std::fmt::Write;
+    use std::io::Write as _;
+
+    let workspaces = reap::workspaces().await?;
+    let nodes: BTreeSet<reap::Node> = workspaces.iter().filter_map(reap::node_of).collect();
+    if nodes.is_empty() {
+        emit("no wayfinder workspaces on this machine — nothing to reap\n");
+        return Ok(());
+    }
+    let finished = reap::finished_nodes(&nodes).await?;
+    let verdicts = reap::plan(&workspaces, &finished, insist);
+
+    let (doomed, kept): (Vec<_>, Vec<_>) = verdicts
+        .iter()
+        .partition(|v| matches!(v, reap::Verdict::Reap { .. }));
+    let mut out = String::new();
+    for verdict in &kept {
+        let _ = writeln!(out, "  keep  {}  ({})", verdict.id(), verdict.reason());
+    }
+    for verdict in &doomed {
+        let _ = writeln!(out, "  reap  {}  ({})", verdict.id(), verdict.reason());
+    }
+    emit(&out);
+    if doomed.is_empty() {
+        emit("nothing to reap\n");
+        return Ok(());
+    }
+
+    if !yes {
+        emit(&format!("\ndelete {} workspace(s)? [y/N] ", doomed.len()));
+        let _ = std::io::stdout().flush();
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("cannot read the answer")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            emit("aborted\n");
+            return Ok(());
+        }
+    }
+
+    // One at a time, reporting each: `dl <ws> rm` tears down a container, and a
+    // failure part-way through leaves a set the next run has to be able to make
+    // sense of. Failures are collected rather than propagated at the first one,
+    // so a single wedged workspace does not strand the rest.
+    let mut failed = Vec::new();
+    for verdict in &doomed {
+        match reap::remove(verdict.id(), insist).await {
+            Ok(()) => emit(&format!("removed {}\n", verdict.id())),
+            Err(e) => {
+                emit(&format!("could not remove {}: {e}\n", verdict.id()));
+                failed.push(verdict.id().to_string());
+            }
+        }
+    }
+    if !failed.is_empty() {
+        bail!("{} workspace(s) could not be removed", failed.len());
+    }
+    Ok(())
+}
+
 /// Write a whole report to stdout, tolerating a reader that has gone away.
 ///
 /// `println!` panics on a closed pipe: Rust ignores `SIGPIPE`, so the write
@@ -202,6 +321,10 @@ async fn main() -> Result<()> {
         }
         Invocation::SkillsInstall => {
             run_skills(true)?;
+            return Ok(());
+        }
+        Invocation::Reap { yes, insist } => {
+            run_reap(yes, insist).await?;
             return Ok(());
         }
         Invocation::Tui => {}
@@ -496,6 +619,58 @@ mod tests {
             parse_args(argv(&["--help"])),
             Invocation::Print(USAGE.to_string())
         );
+    }
+
+    #[test]
+    fn reap_takes_its_two_flags_in_any_order_or_neither() {
+        assert_eq!(
+            parse_args(argv(&["reap"])),
+            Invocation::Reap {
+                yes: false,
+                insist: false
+            }
+        );
+        assert_eq!(
+            parse_args(argv(&["reap", "-y"])),
+            Invocation::Reap {
+                yes: true,
+                insist: false
+            }
+        );
+        assert_eq!(
+            parse_args(argv(&["reap", "-f"])),
+            Invocation::Reap {
+                yes: false,
+                insist: true
+            }
+        );
+        // Both, either way round, long or short: these waive a prompt and a
+        // safety guard, so the shapes someone will actually type all have to
+        // mean what they look like.
+        for both in [
+            vec!["reap", "-y", "-f"],
+            vec!["reap", "-f", "-y"],
+            vec!["reap", "--yes", "--force"],
+        ] {
+            assert_eq!(
+                parse_args(argv(&both)),
+                Invocation::Reap {
+                    yes: true,
+                    insist: true
+                },
+                "{both:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mistyped_reap_flag_is_rejected_rather_than_dropped() {
+        // Silently dropping it would leave someone believing they had waived a
+        // guard they had not — or, worse, that they had not waived one they had.
+        match parse_args(argv(&["reap", "--forse"])) {
+            Invocation::Reject(message) => assert!(message.contains("--forse")),
+            other => panic!("expected a rejection, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -1,0 +1,548 @@
+//! Reaping: remove the workspaces whose tickets are finished.
+//!
+//! A workspace per ticket (#106) means workspaces accumulate as fast as tickets
+//! are worked, and something has to clear the finished ones away. That
+//! something is `wf`, and the division of labour is the same one the launch
+//! already draws: **`dl` owns the containers, `wf` owns the tickets.**
+//!
+//! `dl` deliberately does not decide what is finished, and could not — it knows
+//! about clones and containers, and "this work is over" is a fact about a
+//! ticket. It infers nothing from the branch either; a squash-merged branch and
+//! an abandoned one look identical from there. So it publishes what it knows
+//! (`dl --ls --json`) and refuses to destroy work that exists nowhere else
+//! (`dl <ws> rm`), and `wf` — which named those branches after its own tickets,
+//! and knows which tickets are closed — decides.
+//!
+//! Which makes this module's job small and its shape strict: match workspaces
+//! to nodes by the branch `wf` itself minted, ask the tracker which of those
+//! nodes are closed, and hand the finished ones back to `dl`. Everything a
+//! workspace holds that says "not yet" — unsaved work, a running container — is
+//! `dl`'s fact, read here rather than argued with.
+
+use std::collections::BTreeSet;
+use std::process::Stdio;
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use tokio::process::Command;
+
+/// The branch prefix `wf` mints its workspaces under (#106): the full branch is
+/// `wayfinder/<short-repo>-<n>`, which is also the branch `/wf-tdd` works on.
+const BRANCH_PREFIX: &str = "wayfinder/";
+
+/// One workspace as `dl --ls --json` reports it.
+///
+/// Only the fields `wf` acts on are declared; serde ignores the rest, so a
+/// newer `dl` adding fields does not break this and an older one missing the
+/// optional ones still parses.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Workspace {
+    pub id: String,
+    /// Whether `dl` created it. Anything else is not `wf`'s to touch, whatever
+    /// its branch looks like.
+    #[serde(default)]
+    pub devlaunch: bool,
+    /// `owner/name`, from the record `dl` wrote when it made the clone.
+    #[serde(default)]
+    pub repo: Option<String>,
+    /// The branch the workspace was made for.
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// devpod's state: `Running`, `Stopped`, …
+    #[serde(default)]
+    pub state: Option<String>,
+    /// What deleting would destroy, in `dl`'s words, or `None`.
+    #[serde(default)]
+    pub unsaved: Option<String>,
+}
+
+/// What `wf` decided about one workspace. Two arms, both carrying a reason,
+/// because the plan is printed before anything is deleted and a reason the
+/// reader disagrees with is only useful while saying no is still possible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    Reap { id: String, reason: String },
+    Keep { id: String, reason: String },
+}
+
+impl Verdict {
+    pub fn id(&self) -> &str {
+        match self {
+            Verdict::Reap { id, .. } | Verdict::Keep { id, .. } => id,
+        }
+    }
+
+    pub fn reason(&self) -> &str {
+        match self {
+            Verdict::Reap { reason, .. } | Verdict::Keep { reason, .. } => reason,
+        }
+    }
+}
+
+/// The node a workspace belongs to: the repo it is in and the ticket number its
+/// branch names. Only workspaces `wf` minted have one.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Node {
+    pub repo: String,
+    pub number: u64,
+}
+
+/// Which node a workspace is for, or `None` if it is not one of `wf`'s.
+///
+/// Strict on purpose, and every clause is a way for this to be someone else's
+/// workspace: `dl` must have made it (so the branch means what `wf` thinks),
+/// the branch must carry the prefix, and the tail must be
+/// `<short-repo>-<number>` for *this* workspace's repo — `wayfinder/hotfix-3`
+/// in `blooop/devlaunch` is a hand-made branch that happens to sit under the
+/// prefix, not ticket 3. A parse that guessed would delete a stranger's
+/// container.
+pub fn node_of(workspace: &Workspace) -> Option<Node> {
+    if !workspace.devlaunch {
+        return None;
+    }
+    let repo = workspace.repo.as_ref()?;
+    let branch = workspace.branch.as_ref()?;
+    let short = repo.split('/').next_back()?;
+    let number = branch
+        .strip_prefix(BRANCH_PREFIX)?
+        .strip_prefix(short)?
+        .strip_prefix('-')?
+        .parse()
+        .ok()?;
+    Some(Node {
+        repo: repo.clone(),
+        number,
+    })
+}
+
+/// Decide every workspace's fate, in listing order.
+///
+/// `finished` is the set of nodes the tracker says are closed — gathered once,
+/// [`finished_nodes`], because that is one network call for the lot rather than
+/// one per workspace.
+///
+/// The guards run before the reason to delete, and their order is the safety
+/// argument: work that would be lost outranks a closed ticket, and a live
+/// container outranks it too. Neither is `wf`'s judgement — the first is `dl`'s
+/// fact and the second is devpod's — which is exactly why they are read here
+/// instead of being left for `dl` to refuse on: a caller that argues with a
+/// refusal it could have anticipated is a caller that will one day pass
+/// `--force` to shut it up.
+///
+/// `insist` is that override, made explicit and given to the human instead. It
+/// exists because of a case that is not hypothetical: a devcontainer whose
+/// `postCreateCommand` installs packages leaves a tracked lockfile modified in
+/// **every** workspace it builds, so without it those workspaces are unreapable
+/// forever. It waives the unsaved-work guard **only** — a running container is
+/// still kept, because that guard is about a session in progress rather than
+/// about bytes on disk. The plan names what is being overridden either way, so
+/// the waiver is read before it is granted, and `dl` gets `--force` only for the
+/// workspaces the human just saw described.
+pub fn plan(workspaces: &[Workspace], finished: &BTreeSet<Node>, insist: bool) -> Vec<Verdict> {
+    let mut verdicts = Vec::new();
+    for workspace in workspaces {
+        let Some(node) = node_of(workspace) else {
+            // Not one of ours. Not reported either: a listing full of "not
+            // mine" lines buries the two rows that matter.
+            continue;
+        };
+        let id = workspace.id.clone();
+        if let (Some(unsaved), false) = (&workspace.unsaved, insist) {
+            verdicts.push(Verdict::Keep {
+                id,
+                reason: format!("holds {unsaved}"),
+            });
+        } else if workspace.state.as_deref() == Some("Running") {
+            verdicts.push(Verdict::Keep {
+                id,
+                reason: "still running — stop it first".to_string(),
+            });
+        } else if finished.contains(&node) {
+            let node_name = format!("{}#{} is closed", short_repo(&node.repo), node.number);
+            verdicts.push(Verdict::Reap {
+                id,
+                // Naming the waived work in the reap line, not only in the
+                // keep line it replaced: this is the row the human is about to
+                // approve, and "and discarding …" is the part they might stop
+                // at.
+                reason: match (&workspace.unsaved, insist) {
+                    (Some(unsaved), true) => format!("{node_name}, discarding {unsaved}"),
+                    _ => node_name,
+                },
+            });
+        } else {
+            verdicts.push(Verdict::Keep {
+                id,
+                reason: format!("{}#{} is still open", short_repo(&node.repo), node.number),
+            });
+        }
+    }
+    verdicts
+}
+
+fn short_repo(slug: &str) -> &str {
+    slug.split('/').next_back().unwrap_or(slug)
+}
+
+/// Ask `dl` what workspaces exist and what they hold.
+///
+/// # Errors
+///
+/// No `dl` on PATH, a `dl` too old to know `--ls --json`, or output that does
+/// not parse. All three mean the same thing to the caller — `wf` cannot see the
+/// workspaces, so it must not delete any.
+pub async fn workspaces() -> Result<Vec<Workspace>> {
+    let output = Command::new("dl")
+        .args(["--ls", "--json"])
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to run `dl` — is devlaunch installed and on PATH?")?;
+    if !output.status.success() {
+        bail!(
+            "`dl --ls --json` failed: {}\n\
+             (needs devlaunch 0.0.21 or newer, which is where --json arrived)",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    parse_workspaces(&output.stdout)
+}
+
+/// The parse boundary for `dl`'s listing, kept apart from the process call so
+/// it is testable without devlaunch installed.
+fn parse_workspaces(body: &[u8]) -> Result<Vec<Workspace>> {
+    serde_json::from_slice(body).context("unparseable workspace listing from `dl --ls --json`")
+}
+
+/// Which of `nodes` the tracker says are closed.
+///
+/// One `gh` search per repo rather than one call per ticket: the numbers are
+/// asked about together, so ten workspaces of one repo cost one round trip.
+///
+/// # Errors
+///
+/// A `gh` that is missing, unauthenticated or refused. Never partial: a repo
+/// whose state could not be read makes the whole call fail, because the
+/// alternative is treating "could not ask" as "not closed" for some workspaces
+/// and deleting the rest — a half-answered question is the one shape this must
+/// not act on.
+pub async fn finished_nodes(nodes: &BTreeSet<Node>) -> Result<BTreeSet<Node>> {
+    let mut finished = BTreeSet::new();
+    let mut repos: BTreeSet<&str> = BTreeSet::new();
+    for node in nodes {
+        repos.insert(node.repo.as_str());
+    }
+    for repo in repos {
+        let wanted: Vec<u64> = nodes
+            .iter()
+            .filter(|n| n.repo == repo)
+            .map(|n| n.number)
+            .collect();
+        for number in wanted {
+            if issue_is_closed(repo, number).await? {
+                finished.insert(Node {
+                    repo: repo.to_string(),
+                    number,
+                });
+            }
+        }
+    }
+    Ok(finished)
+}
+
+/// Whether one issue is closed. `gh api` rather than a search, because search
+/// indexes lag and a stale "still open" only ever costs a workspace that stays.
+async fn issue_is_closed(repo: &str, number: u64) -> Result<bool> {
+    let output = Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/{repo}/issues/{number}"),
+            "--jq",
+            ".state",
+        ])
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to run `gh` — is the GitHub CLI installed and on PATH?")?;
+    if !output.status.success() {
+        bail!(
+            "could not read {repo}#{number}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim() == "closed")
+}
+
+/// Hand one finished workspace back to `dl`.
+///
+/// `insist` passes `dl`'s own `--force`, and is only ever the human's `-f`
+/// reaching this far: without it, `dl` refuses when a clone holds work that
+/// exists nowhere else, and that refusal is load-bearing — [`plan`] already
+/// skipped those, so a refusal here means the clone changed under us between
+/// the listing and now, which is precisely the moment to stop rather than
+/// insist. With it, the human has read the plan naming what would be discarded.
+///
+/// # Errors
+///
+/// No `dl` on PATH, or a `dl <ws> rm` that failed — including the refusal
+/// above, which is a failure `wf` reports rather than quietly overrides.
+pub async fn remove(id: &str, insist: bool) -> Result<()> {
+    let mut args = vec![id, "rm"];
+    if insist {
+        args.push("--force");
+    }
+    let output = Command::new("dl")
+        .args(&args)
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to run `dl`")?;
+    if !output.status.success() {
+        bail!(
+            "`dl {id} rm` failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace(id: &str, repo: &str, branch: &str) -> Workspace {
+        Workspace {
+            id: id.to_string(),
+            devlaunch: true,
+            repo: Some(repo.to_string()),
+            branch: Some(branch.to_string()),
+            state: Some("Stopped".to_string()),
+            unsaved: None,
+        }
+    }
+
+    fn node(repo: &str, number: u64) -> Node {
+        Node {
+            repo: repo.to_string(),
+            number,
+        }
+    }
+
+    #[test]
+    fn a_workspace_wf_minted_names_its_node() {
+        assert_eq!(
+            node_of(&workspace(
+                "ws",
+                "blooop/devlaunch",
+                "wayfinder/devlaunch-80"
+            )),
+            Some(node("blooop/devlaunch", 80))
+        );
+        // The short name is the repo's, so a repo whose name repeats inside the
+        // branch still parses to the right number.
+        assert_eq!(
+            node_of(&workspace(
+                "ws",
+                "blooop/wayfinder",
+                "wayfinder/wayfinder-42"
+            )),
+            Some(node("blooop/wayfinder", 42))
+        );
+    }
+
+    #[test]
+    fn anything_wf_did_not_mint_names_no_node_and_is_never_touched() {
+        // A workspace dl did not create: its branch means whatever its author
+        // meant, and wf has no business reading it.
+        let mut foreign = workspace("ws", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        foreign.devlaunch = false;
+        assert_eq!(node_of(&foreign), None);
+        // Under the prefix, but not <short-repo>-<n>: a hand-made branch, not
+        // ticket 3.
+        assert_eq!(
+            node_of(&workspace("ws", "blooop/devlaunch", "wayfinder/hotfix-3")),
+            None
+        );
+        // The right shape for a *different* repo's tickets.
+        assert_eq!(
+            node_of(&workspace("ws", "blooop/devlaunch", "wayfinder/bencher-3")),
+            None
+        );
+        // Ordinary branches.
+        assert_eq!(node_of(&workspace("ws", "blooop/devlaunch", "main")), None);
+        assert_eq!(
+            node_of(&workspace("ws", "blooop/devlaunch", "feat/something")),
+            None
+        );
+        // A trailing non-number, which `parse` must refuse rather than round.
+        assert_eq!(
+            node_of(&workspace(
+                "ws",
+                "blooop/devlaunch",
+                "wayfinder/devlaunch-80-retry"
+            )),
+            None
+        );
+        // No record at all: dl could not say what it was for.
+        let mut unrecorded = workspace("ws", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        unrecorded.branch = None;
+        assert_eq!(node_of(&unrecorded), None);
+    }
+
+    #[test]
+    fn a_closed_ticket_is_reaped_and_an_open_one_is_kept() {
+        let listing = vec![
+            workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80"),
+            workspace("open", "blooop/devlaunch", "wayfinder/devlaunch-81"),
+        ];
+        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        let verdicts = plan(&listing, &finished, false);
+        assert_eq!(
+            verdicts,
+            vec![
+                Verdict::Reap {
+                    id: "done".to_string(),
+                    reason: "devlaunch#80 is closed".to_string()
+                },
+                Verdict::Keep {
+                    id: "open".to_string(),
+                    reason: "devlaunch#81 is still open".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn unsaved_work_keeps_a_workspace_whose_ticket_is_closed() {
+        // dl's fact, read rather than argued with: dl would refuse this delete,
+        // and a caller that walks into a refusal it could have anticipated is
+        // one that eventually learns to pass --force.
+        let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.unsaved = Some("2 uncommitted change(s)".to_string());
+        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        let verdicts = plan(&[ws], &finished, false);
+        assert_eq!(
+            verdicts,
+            vec![Verdict::Keep {
+                id: "done".to_string(),
+                reason: "holds 2 uncommitted change(s)".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn a_running_workspace_is_kept_even_when_its_ticket_is_closed() {
+        // The ticket closing does not mean the session in the container ended.
+        let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.state = Some("Running".to_string());
+        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        assert_eq!(
+            plan(&[ws], &finished, false),
+            vec![Verdict::Keep {
+                id: "done".to_string(),
+                reason: "still running — stop it first".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn unsaved_work_outranks_a_running_container_so_the_worse_news_is_the_one_shown() {
+        let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.state = Some("Running".to_string());
+        ws.unsaved = Some("1 unpushed commit(s)".to_string());
+        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        assert!(plan(&[ws], &finished, false)[0]
+            .reason()
+            .contains("unpushed"));
+    }
+
+    #[test]
+    fn workspaces_that_are_not_wfs_are_left_out_of_the_plan_entirely() {
+        // Not "kept with a reason": a plan padded with everything wf does not
+        // manage buries the rows that matter.
+        let mut foreign = workspace("theirs", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        foreign.devlaunch = false;
+        let listing = vec![
+            foreign,
+            workspace("mine", "blooop/devlaunch", "wayfinder/devlaunch-81"),
+            workspace("plain", "blooop/devlaunch", "main"),
+        ];
+        let verdicts = plan(&listing, &BTreeSet::new(), false);
+        assert_eq!(verdicts.len(), 1);
+        assert_eq!(verdicts[0].id(), "mine");
+    }
+
+    #[test]
+    fn the_listing_parses_what_dl_prints_and_tolerates_fields_it_does_not_know() {
+        let body = br#"[
+          {"id": "a", "devlaunch": true, "repo": "blooop/devlaunch",
+           "branch": "wayfinder/devlaunch-80", "checkedOut": "wayfinder/devlaunch-80",
+           "path": "/cache/x", "state": "Stopped",
+           "lastUsed": "2026-08-08T11:43:27Z", "unsaved": null},
+          {"id": "b", "devlaunch": false, "repo": null, "branch": null,
+           "checkedOut": null, "path": null, "state": null,
+           "lastUsed": "", "unsaved": null, "somethingNewer": 7}
+        ]"#;
+        let parsed = parse_workspaces(body).expect("dl's listing parses");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(node_of(&parsed[0]), Some(node("blooop/devlaunch", 80)));
+        assert_eq!(node_of(&parsed[1]), None);
+    }
+
+    #[test]
+    fn insisting_waives_the_unsaved_guard_and_says_what_it_is_discarding() {
+        // The case this exists for: a devcontainer that installs packages in
+        // its postCreateCommand leaves a tracked lockfile modified in every
+        // workspace it builds, so without an override those are unreapable
+        // forever. The reap line has to name what is being thrown away, since
+        // that is the row being approved.
+        let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        assert_eq!(
+            plan(std::slice::from_ref(&ws), &finished, true),
+            vec![Verdict::Reap {
+                id: "done".to_string(),
+                reason: "devlaunch#80 is closed, discarding 1 uncommitted change(s) (pixi.lock)"
+                    .to_string()
+            }]
+        );
+        // And it is only ever a waiver of *that* guard: an open ticket is still
+        // an open ticket.
+        assert!(matches!(
+            plan(&[ws], &BTreeSet::new(), true).as_slice(),
+            [Verdict::Keep { .. }]
+        ));
+    }
+
+    #[test]
+    fn insisting_never_reaps_a_running_container() {
+        // The unsaved guard is about bytes on disk and can be waived by someone
+        // who has read what they are discarding. A running container is a
+        // session in progress -- a different question, and not one `-f` was
+        // given an answer to.
+        let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.state = Some("Running".to_string());
+        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        assert_eq!(
+            plan(&[ws], &finished, true),
+            vec![Verdict::Keep {
+                id: "done".to_string(),
+                reason: "still running — stop it first".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn an_unreadable_listing_is_an_error_rather_than_an_empty_plan() {
+        // Empty would mean "nothing to reap", which is indistinguishable from
+        // success and would hide a broken or too-old `dl`.
+        assert!(parse_workspaces(b"not json").is_err());
+        assert!(parse_workspaces(b"").is_err());
+    }
+}


### PR DESCRIPTION
A workspace per ticket (#106) means workspaces accumulate as fast as tickets are worked. `wf reap` clears the finished ones.

## Why this is wf's job

The same division the launch already draws: **`dl` owns the containers, `wf` owns the tickets.** `dl` cannot know what is finished — that is a fact about a ticket, and a branch-shaped inference cannot tell a squash-merged branch from an abandoned one. So `dl` publishes what it knows (`dl --ls --json`, new in devlaunch 0.0.21) and refuses to destroy work that exists nowhere else; `wf`, which minted those branch names from its own ticket numbers, decides.

```
$ wf reap
  keep  devlaunch-…-131  (devlaunch#131 is still open)
  keep  wayfinder-…-42   (still running — stop it first)
  reap  devlaunch-…-127  (devlaunch#127 is closed)

delete 1 workspace(s)? [y/N]
```

**Kept always**: workspaces `dl` did not create, branches that are not `wayfinder/<repo>-<n>` *for that repo* (`wayfinder/hotfix-3` is not ticket 3), open tickets, and anything **running** — a ticket closing is no evidence the session ended.

**Kept by default, waived by `-f`**: a clone holding uncommitted or unpushed work. That flag is not a convenience — a devcontainer whose `postCreateCommand` installs packages leaves a tracked lockfile modified in *every* workspace it builds (this repo's own does), so without it those are unreapable forever. The plan names what `-f` discards, and `-f` never waives the running guard.

## Verification

Ran against the real workspace list throughout, which is how both of the session's real bugs were found (the second one in devlaunch: `git status --porcelain`'s leading space meant `pixi.lock` was reported as `ixi.lock` — blooop/devlaunch#135). End to end with a real closed ticket: `wf reap -f` correctly proposed reaping devlaunch#127's stopped workspace and left three others alone with accurate reasons.

11 new tests; 217 lib tests pass; fmt/clippy/doc clean under `-D warnings`. Version 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a `wf reap` command to clean up devlaunch-created workspaces whose tickets are closed, with safety guards around running containers and unsaved work, and document the new workflow.

New Features:
- Introduce the `wf reap` CLI subcommand to list and remove wayfinder workspaces whose associated tickets are closed, with optional `-y` and `-f` flags for non-interactive and forced cleanup.

Enhancements:
- Implement ticket-to-workspace mapping and planning logic that consults devlaunch and GitHub to determine which workspaces are safe to delete, and surface clear keep/reap reasons to the user.

Build:
- Bump the crate and recipe version from 0.10.0 to 0.11.0 to release the new functionality.

Documentation:
- Extend the README with a dedicated section explaining `wf reap`, its flags, required devlaunch version, and how workspace cleanup works with closed tickets.

Tests:
- Add unit tests for the new reap module covering workspace parsing, node detection, planning behavior, and insist/force semantics, plus argument parsing tests for `wf reap` flags.