### PR TITLE
The search prompt leads the screen, and enter opens a launch picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ and the rows themselves are right there. Both are ordinary cursor stops: put
 the cursor on one and `→` opens it in place (`▾`), listing what it held as rows
 you can select and launch, and `←` shuts it again — so nothing is ever merely a
 number you cannot reach. A map with nothing takeable
-leaves the body entirely, counted on the bottom line as `· N idle maps hidden`.
+leaves the body entirely, counted on the count line as `· N idle maps hidden`.
 
 **A row that heads a branch carries the same rollup of what is beneath it**,
 written `(beneath) ⊘2` at the end of the line — so a takeable ticket says the
@@ -226,7 +226,10 @@ blocker; edges the tree cannot show are annotated `⤷ also needs #n`.
 
 **Typing sifts**: a live query prunes whichever screen `tab` had toggled down to
 the rows that matched, keeping the tree they sit in; clearing it restores that
-screen whole. Matching is fuzzy but **tight** — every character the query lands
+screen whole. The `>` prompt sits at the **top**, directly under the title, with
+the count line under it and the rows beneath both — you type at the top of the
+screen and watch the tree sift below it, as `fzf --reverse` does. Only the key
+hints stay anchored to the bottom. Matching is fuzzy but **tight** — every character the query lands
 on has to start a word or sit against another matched one, so `map` finds "the
 **m**anager-**a**gent **p**rotocol" and sub`tree` matches mid-word, while
 letters picked out of the middles of three unrelated words do not: `tree`

--- a/README.md
+++ b/README.md
@@ -292,25 +292,42 @@ agent inside it — see
 [Isolation](#isolation-the-agent-runs-in-the-repos-devcontainer).
 
 **Launching is two steps.** `enter` on the cursor's node does not launch: it
-opens the **launch line** where the count line was, showing where `enter` will
-go — `→ /wf-tdd · #65 Author the /wf-tdd skill`. What you type lands on that line, not
-in the query, and *is* the mode:
+opens the **launch picker** over the list, showing what is about to happen and
+the one thing still undecided — who resolves the node:
 
-| the line says | what launches |
-| --- | --- |
-| *(empty)* | interactive — the default |
-| `auto` | the agent decides alone and drives the rest of the lifecycle unattended |
-| `auto <text>` | the same, with `<text>` as the steering prompt |
-| *anything else* | interactive, with what you typed as the steering prompt |
+```
+┌ launch #65 Author the /wf-tdd skill ────────────────────────────┐
+│                                                                 │
+│  ▶ interactive /wf-tdd   you are in the loop; it grills you     │
+│    auto        /wf-auto  the agent decides alone and drives it  │
+│                                                                 │
+│    steer  █                                                     │
+│                                                                 │
+│  enter launch · ↑/↓ mode · type to steer · esc cancel           │
+└─────────────────────────────────────────────────────────────────┘
+```
 
-The line re-resolves as you type, so `auto` visibly flips the skill it names
-before you commit to it. `esc` backs out to the list with your query and cursor
-exactly as they were. `enter` on a **done** or **blocked** node opens nothing —
-it says why on the count line instead.
+`↑`/`↓` (or `tab`) move between the modes and `enter` runs the one you are on,
+so the common case is `enter enter`. Every mode is on screen with the skill it
+routes *this* node to, because that difference is the choice being made: the
+picker is where you see that `auto` means `/wf-auto` and will not stop to ask
+you anything.
+
+Anything you type goes into the **steer** field — a steering prompt on whichever
+mode is selected, never a mode itself. That is the difference from the launch
+*line* this replaced: the modes were words you had to already know (`defer`, then
+`auto`), typing one was indistinguishable from a typo until the agent ran, and
+`automate the release` had to be special-cased into not meaning unattended. No
+string moves the cursor now, so a launch goes unattended only because you
+selected it.
+
+`esc` backs out to the list with your query and cursor exactly as they were.
+`enter` on a **done** or **blocked** node opens nothing — it says why on the
+count line instead.
 
 **The cursor lands on cluster headers too**, so a whole map is a thing you can
 launch: `enter` on one runs the wayfinder skill on the map itself rather than on
-any one ticket — interactively to chart it with you, or under `auto` to have the
+any one ticket — interactively to chart it with you, or under auto to have the
 agent take the map from open questions to merged work on its own judgement. The
 default cursor position still skips headers and lands on the first row, so
 opening `wf` and pressing `enter` picks a ticket exactly as it always did;
@@ -324,10 +341,10 @@ headers are one `↑` away.
 | `wayfinder:build` | ready · building · needs attention | interactive | `claude "/wf-tdd <n>"` |
 | `wayfinder:build` | in review | interactive | `claude "/wf-review <n>"` |
 | research · prototype · grilling · task | any unfinished stage | interactive | `claude "/wf <map> <n>"` |
-| anything | any unfinished stage | `auto` | `claude "/wf-auto <map> [<n>]"` |
+| anything | any unfinished stage | auto | `claude "/wf-auto <map> [<n>]"` |
 | a ticket | done | — | nothing — not launchable |
 
-`auto` collapses the ticket rows on purpose: the launched session is a
+The auto mode collapses the ticket rows on purpose: the launched session is a
 *manager*, and what it manages is the node's whole remaining lifecycle — `/wf-tdd`,
 the gate, then a fresh-context `/wf-review` — so it is the manager skill that runs,
 not the one skill that stage would have called. Steering text rides whichever
@@ -341,8 +358,8 @@ never does, because it has already chosen the skill.
 | `↑`/`↓`, `ctrl-j`/`ctrl-k` | move between siblings at the cursor's depth — on the default screen, the tickets you can take, plus each cluster's header above them |
 | `→` | reveal: open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
 | `←` | close: shut an open group, else back out to the parent, else one stop back — which, from a cluster's first row, is that cluster's header |
-| `enter` | open the launch line on the cursor's ticket, or on its map when the cursor is on a cluster header; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
-| *type, then `enter`* | on the launch line: the mode (`auto`, `auto <text>`, or steering text) — `esc` backs out with the query and cursor intact |
+| `enter` | open the launch picker on the cursor's ticket, or on its map when the cursor is on a cluster header; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
+| `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick the mode, type a steering prompt, launch — `esc` backs out with the query and cursor intact |
 | `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |
 | `ctrl-g` | widen back to every project |
 | `ctrl-r` | refetch every map in place, keeping your query, scope and cursor |

--- a/examples/preview_screen.rs
+++ b/examples/preview_screen.rs
@@ -25,7 +25,7 @@ fn press(app: &mut App, name: &str) {
         "left" => KeyCode::Left,
         "right" => KeyCode::Right,
         "tab" => KeyCode::Tab,
-        // Named so the launch line (#62/#96) is reachable from `$KEYS` —
+        // Named so the launch picker (#62/#96) is reachable from `$KEYS` —
         // without them `enter` would send a bare `e` into the query.
         "enter" => KeyCode::Enter,
         "esc" => KeyCode::Esc,

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Launch, LaunchMode, Staged, Targets};
+use crate::launch::{self, Launch, LaunchMode, Mode, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
@@ -45,21 +45,22 @@ pub enum Outcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Overlay {
     None,
-    /// The launch line — enter on a launchable node staged this launch, and
-    /// the line now collects its mode: empty is interactive, `auto [text]`
-    /// hands it to the manager, anything else steers ([`LaunchMode::parse`]).
-    /// The line resolves the route from the staged node and the mode typed so
-    /// far, so it *shows* where enter goes and changes as `auto` is typed — and
-    /// a line for an unlaunchable node is unrepresentable, because
+    /// The launch picker — `enter` on a launchable node staged this launch, and
+    /// the overlay now collects the two things a launch needs beyond the node:
+    /// which [`Mode`] resolves it, picked from a list, and the steering text.
+    /// It resolves the route from the staged node and the picked mode, so it
+    /// *shows* which skill `enter` will run and re-reads as the mode moves — and
+    /// a picker for an unlaunchable node is unrepresentable, because
     /// [`launch::Launchable`] refused it before anything was staged.
     ///
     /// The staged launch is index-free ([`Staged`]) for the same reason the
     /// picker's candidates are complete `Launch`es: a background map arrival
     /// swaps the clusters underneath an open overlay, and a positional [`Row`]
     /// held across that would name a different ticket, or none at all.
-    LaunchLine {
+    PickLaunch {
         staged: Staged,
-        text: String,
+        mode: Mode,
+        steer: String,
     },
     /// Candidates are complete launches, so the pick cannot produce an
     /// inconsistent one.
@@ -67,6 +68,25 @@ pub enum Overlay {
         launches: Vec<Launch>,
         cursor: usize,
     },
+}
+
+/// The mode the launch picker moves to on `key`, wrapping both ways.
+///
+/// Derived from [`Mode::all`] rather than written as a toggle: with two modes a
+/// toggle is the same thing, but it stops being the same thing the moment a
+/// third mode exists, and this is the code that would silently keep working
+/// while skipping it.
+fn stepped(mode: Mode, key: KeyCode) -> Mode {
+    let modes = Mode::all();
+    let at = modes.iter().position(|m| *m == mode).unwrap_or(0);
+    // Backwards is a forward step of len-1: no signed arithmetic, and no
+    // underflow to reason about at index 0.
+    let delta = if key == KeyCode::Up {
+        modes.len() - 1
+    } else {
+        1
+    };
+    modes[(at + delta) % modes.len()]
 }
 
 /// One on-screen row: which map's cluster it is in, and the ticket's position
@@ -565,7 +585,7 @@ impl App {
     }
 
     /// The first enter (#62): stage a launch of whatever the cursor is on by
-    /// opening the launch line — a ticket, or since #96 the cluster header,
+    /// opening the launch picker — a ticket, or since #96 the cluster header,
     /// which stages the **map** as one node.
     ///
     /// Two things still refuse, with a count-line notice, and both are
@@ -588,9 +608,10 @@ impl App {
             }
             Some(Stop::Map(id)) => {
                 let title = self.clusters[&id].title.clone();
-                self.overlay = Overlay::LaunchLine {
+                self.overlay = Overlay::PickLaunch {
                     staged: Staged::map(&id, &title),
-                    text: String::new(),
+                    mode: Mode::default(),
+                    steer: String::new(),
                 };
                 Outcome::Continue
             }
@@ -621,9 +642,10 @@ impl App {
                 Outcome::Continue
             }
             Some(staged) => {
-                self.overlay = Overlay::LaunchLine {
+                self.overlay = Overlay::PickLaunch {
                     staged,
-                    text: String::new(),
+                    mode: Mode::default(),
+                    steer: String::new(),
                 };
                 Outcome::Continue
             }
@@ -663,38 +685,50 @@ impl App {
         }
     }
 
-    /// Keys while the launch line is up (#62). The line owns every printable
-    /// key — filtering already happened, this text is the launch's mode — and
-    /// esc backs out to the list with the query and cursor untouched (they
-    /// were never touched to begin with; the invariant is that nothing here
-    /// may touch them).
-    fn handle_launch_line_key(
+    /// Keys while the launch picker is up (#62, restaged as an overlay). It
+    /// owns every printable key — filtering already happened, and this text
+    /// steers the launch — and esc backs out to the list with the query and
+    /// cursor untouched (they were never touched to begin with; the invariant
+    /// is that nothing here may touch them).
+    ///
+    /// The arrows move the mode and the letters type: no printable key picks a
+    /// mode, so `auto` typed into the steer field steers, and `j`/`k` — which
+    /// walk the which-checkout picker, a modal with nothing to type into — are
+    /// text here.
+    fn handle_pick_launch_key(
         &mut self,
         key: KeyEvent,
         staged: Staged,
-        mut text: String,
+        mode: Mode,
+        mut steer: String,
     ) -> Outcome {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let mut mode = mode;
         match key.code {
             // Back to the list; the overlay is already None.
-            KeyCode::Esc => Outcome::Continue,
-            KeyCode::Char('c') if ctrl => Outcome::Quit,
-            KeyCode::Enter => self.resolve_launch(&staged, &LaunchMode::parse(&text)),
+            KeyCode::Esc => return Outcome::Continue,
+            KeyCode::Char('c') if ctrl => return Outcome::Quit,
+            KeyCode::Enter => {
+                return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
+            }
+            // Two modes today, so both arrows and tab are the same step — and
+            // they stay right when a third mode arrives, which a plain toggle
+            // would not.
+            KeyCode::Up | KeyCode::Down | KeyCode::Tab => mode = stepped(mode, key.code),
             KeyCode::Backspace => {
-                text.pop();
-                self.overlay = Overlay::LaunchLine { staged, text };
-                Outcome::Continue
+                steer.pop();
             }
             KeyCode::Char(c) if !ctrl && !key.modifiers.contains(KeyModifiers::ALT) => {
-                text.push(c);
-                self.overlay = Overlay::LaunchLine { staged, text };
-                Outcome::Continue
+                steer.push(c);
             }
-            _ => {
-                self.overlay = Overlay::LaunchLine { staged, text };
-                Outcome::Continue
-            }
+            _ => {}
         }
+        self.overlay = Overlay::PickLaunch {
+            staged,
+            mode,
+            steer,
+        };
+        Outcome::Continue
     }
 
     /// Keys while the checkout picker is up. The modal owns every key: no
@@ -756,8 +790,12 @@ impl App {
             Overlay::PickCheckout { launches, cursor } => {
                 return self.handle_overlay_key(key, launches, cursor);
             }
-            Overlay::LaunchLine { staged, text } => {
-                return self.handle_launch_line_key(key, staged, text);
+            Overlay::PickLaunch {
+                staged,
+                mode,
+                steer,
+            } => {
+                return self.handle_pick_launch_key(key, staged, mode, steer);
             }
             Overlay::None => {}
         }
@@ -1658,25 +1696,30 @@ mod tests {
     }
 
     #[test]
-    fn enter_opens_the_launch_line_and_a_second_enter_launches() {
+    fn enter_opens_the_launch_picker_and_a_second_enter_launches() {
         // The two-step (#62): the first enter stages the launch — nothing
-        // execs yet — and an empty line's enter is the interactive default.
+        // execs yet — and enter on the default row is the interactive launch.
         let mut app = launchable_app();
         // wayfinder#6, whose repo has one checkout.
         go_to(&mut app, "#6");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
-            Overlay::LaunchLine { staged, text } => {
+            Overlay::PickLaunch {
+                staged,
+                mode,
+                steer,
+            } => {
                 assert_eq!(
                     staged.route(Mode::Interactive),
                     Route::Wayfinder,
                     "a task is a decision node"
                 );
                 assert_eq!(staged.key(), "#6");
-                assert_eq!(staged.title, "Re-entry breadcrumbs", "the line names it");
-                assert_eq!(text, "", "the line opens empty");
+                assert_eq!(staged.title, "Re-entry breadcrumbs", "the picker names it");
+                assert_eq!(*mode, Mode::Interactive, "the picker opens on the default");
+                assert_eq!(steer, "", "with nothing steering it");
             }
-            other => panic!("expected the launch line, got {other:?}"),
+            other => panic!("expected the launch picker, got {other:?}"),
         }
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
@@ -1754,7 +1797,7 @@ mod tests {
                 assert_eq!(launches.len(), 2);
                 assert_eq!(*cursor, 0);
             }
-            other @ (Overlay::None | Overlay::LaunchLine { .. }) => {
+            other @ (Overlay::None | Overlay::PickLaunch { .. }) => {
                 panic!("expected the picker, got {other:?}")
             }
         }
@@ -1782,7 +1825,7 @@ mod tests {
         }
         match &app.overlay {
             Overlay::PickCheckout { cursor, .. } => assert_eq!(*cursor, 1),
-            other @ (Overlay::None | Overlay::LaunchLine { .. }) => {
+            other @ (Overlay::None | Overlay::PickLaunch { .. }) => {
                 panic!("expected the picker, got {other:?}")
             }
         }
@@ -1810,8 +1853,8 @@ mod tests {
     }
 
     #[test]
-    fn launch_line_typing_lands_in_the_line_and_esc_restores_the_list() {
-        // The line owns every printable key: nothing leaks into the query.
+    fn launch_picker_typing_steers_and_esc_restores_the_list() {
+        // The picker owns every printable key: nothing leaks into the query.
         // Esc backs out with the query and the cursor exactly as they were.
         let mut app = launchable_app();
         type_str(&mut app, "bread"); // flattens to wayfinder#6
@@ -1820,8 +1863,8 @@ mod tests {
         type_str(&mut app, "half a thought");
         app.handle_key(key(KeyCode::Backspace));
         match &app.overlay {
-            Overlay::LaunchLine { text, .. } => assert_eq!(text, "half a though"),
-            other => panic!("expected the launch line, got {other:?}"),
+            Overlay::PickLaunch { steer, .. } => assert_eq!(steer, "half a though"),
+            other => panic!("expected the launch picker, got {other:?}"),
         }
         assert_eq!(app.query, "bread", "typing stayed out of the query");
 
@@ -1833,7 +1876,7 @@ mod tests {
             6,
             "esc kept the cursor"
         );
-        // And esc means *back to the list*, never quit-from-the-line: the next
+        // And esc means *back to the list*, never quit-from-the-picker: the next
         // esc clears the query, the one after quits — the ordinary ladder.
         assert_eq!(app.handle_key(key(KeyCode::Esc)), Outcome::Continue);
         assert!(app.query.is_empty());
@@ -1841,13 +1884,15 @@ mod tests {
     }
 
     #[test]
-    fn auto_text_on_the_launch_line_launches_the_manager_with_steering() {
-        // The acceptance shape (#96): enter → `auto something` → enter
-        // produces the manager skill carrying `steer: something`.
+    fn picking_auto_in_the_overlay_launches_the_manager_with_steering() {
+        // The acceptance shape (#96), through the picker: enter → move to the
+        // `auto` row → type the steer → enter produces the manager skill
+        // carrying `steer: something`.
         let mut app = launchable_app();
         go_to(&mut app, "#6"); // wayfinder#6, one checkout
         app.handle_key(key(KeyCode::Enter));
-        type_str(&mut app, "auto something");
+        app.handle_key(key(KeyCode::Down));
+        type_str(&mut app, "something");
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -1859,13 +1904,14 @@ mod tests {
     }
 
     #[test]
-    fn the_typed_mode_survives_the_checkout_picker() {
-        // Two checkouts of dotfiles: the mode is settled on the line, the
-        // picker only answers *where* — the pick must not lose the `auto`.
+    fn the_picked_mode_survives_the_checkout_picker() {
+        // Two checkouts of dotfiles: the mode is settled in the launch
+        // overlay, the checkout picker only answers *where* — the pick must
+        // not lose the `auto`.
         let mut app = launchable_app();
         go_to(&mut app, "#103");
         app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage
-        type_str(&mut app, "auto");
+        app.handle_key(key(KeyCode::Down)); // to the auto row
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert!(matches!(app.overlay, Overlay::PickCheckout { .. }));
         let launch = match app.handle_key(key(KeyCode::Enter)) {
@@ -1877,15 +1923,15 @@ mod tests {
 
     #[test]
     fn a_staged_launch_survives_a_refetch_moving_its_ticket() {
-        // The line stays up while background fetches are still landing (#27),
+        // The picker stays up while background fetches are still landing (#27),
         // and each arrival swaps the clusters underneath it. A staged launch
-        // is snapshotted index-free, so the line keeps naming — and launching
+        // is snapshotted index-free, so the picker keeps naming — and launching
         // — the ticket it was opened on, wherever that ticket now sits.
         let staged = || {
             let mut app = launchable_app();
             go_to(&mut app, "#6");
             app.handle_key(key(KeyCode::Enter));
-            type_str(&mut app, "auto");
+            app.handle_key(key(KeyCode::Down)); // to the auto row
             app
         };
         let wf = MapId::new("blooop/wayfinder", 1);
@@ -1936,8 +1982,8 @@ mod tests {
         );
         app.replace_clusters(shrunk);
         match &app.overlay {
-            Overlay::LaunchLine { staged, .. } => assert_eq!(staged.key(), "#6"),
-            other => panic!("expected the launch line, got {other:?}"),
+            Overlay::PickLaunch { staged, .. } => assert_eq!(staged.key(), "#6"),
+            other => panic!("expected the launch picker, got {other:?}"),
         }
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
@@ -1956,13 +2002,13 @@ mod tests {
         go_to(&mut app, "map #1");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
-            Overlay::LaunchLine { staged, .. } => {
+            Overlay::PickLaunch { staged, .. } => {
                 assert_eq!(staged.key(), "#1");
-                assert_eq!(staged.title, "Map: wf", "the line names the map");
+                assert_eq!(staged.title, "Map: wf", "the picker names the map");
                 assert_eq!(staged.route(Mode::Interactive), Route::Wayfinder);
                 assert_eq!(staged.route(Mode::Auto), Route::WayfinderAuto);
             }
-            other => panic!("expected the launch line, got {other:?}"),
+            other => panic!("expected the launch picker, got {other:?}"),
         }
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
@@ -1974,7 +2020,7 @@ mod tests {
         let mut app = launchable_app();
         go_to(&mut app, "map #1");
         app.handle_key(key(KeyCode::Enter));
-        type_str(&mut app, "auto");
+        app.handle_key(key(KeyCode::Down)); // to the auto row
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -1983,14 +2029,14 @@ mod tests {
     }
 
     #[test]
-    fn enter_on_a_done_or_blocked_node_is_a_notice_not_a_launch_line() {
+    fn enter_on_a_done_or_blocked_node_is_a_notice_not_a_launch_picker() {
         let mut app = launchable_app();
         // Blocked: #7 hangs under #6 as context.
         go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Right)); // into #7
         assert_eq!(at(&app), "#7");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
-        assert_eq!(app.overlay, Overlay::None, "no line on a blocked node");
+        assert_eq!(app.overlay, Overlay::None, "no picker on a blocked node");
         assert!(
             app.notice.as_deref().unwrap().contains("blocked"),
             "{:?}",
@@ -2004,7 +2050,7 @@ mod tests {
         app.handle_key(key(KeyCode::Right)); // onto #2
         assert_eq!(at(&app), "#2");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
-        assert_eq!(app.overlay, Overlay::None, "no line on a done node");
+        assert_eq!(app.overlay, Overlay::None, "no picker on a done node");
         assert!(
             app.notice.as_deref().unwrap().contains("done"),
             "{:?}",
@@ -2045,10 +2091,10 @@ mod tests {
         let mut ready = build_app(vec![]);
         ready.handle_key(key(KeyCode::Enter));
         match &ready.overlay {
-            Overlay::LaunchLine { staged, .. } => {
+            Overlay::PickLaunch { staged, .. } => {
                 assert_eq!(staged.route(Mode::Interactive), Route::Tdd);
             }
-            other => panic!("expected the launch line, got {other:?}"),
+            other => panic!("expected the launch picker, got {other:?}"),
         }
         let launch = match ready.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
@@ -2066,10 +2112,10 @@ mod tests {
         }]);
         in_review.handle_key(key(KeyCode::Enter));
         match &in_review.overlay {
-            Overlay::LaunchLine { staged, .. } => {
+            Overlay::PickLaunch { staged, .. } => {
                 assert_eq!(staged.route(Mode::Interactive), Route::Review);
             }
-            other => panic!("expected the launch line, got {other:?}"),
+            other => panic!("expected the launch picker, got {other:?}"),
         }
         let launch = match in_review.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,22 +70,29 @@ pub enum Overlay {
     },
 }
 
-/// The mode the launch picker moves to on `key`, wrapping both ways.
+/// The mode after `mode` in the launch picker, wrapping.
 ///
 /// Derived from [`Mode::all`] rather than written as a toggle: with two modes a
 /// toggle is the same thing, but it stops being the same thing the moment a
 /// third mode exists, and this is the code that would silently keep working
 /// while skipping it.
-fn stepped(mode: Mode, key: KeyCode) -> Mode {
+fn next_mode(mode: Mode) -> Mode {
+    stepped(mode, 1)
+}
+
+/// The mode before it. Backwards is a forward step of `len - 1`, so there is no
+/// signed arithmetic and no underflow to reason about at index 0.
+fn previous_mode(mode: Mode) -> Mode {
+    let modes = Mode::all();
+    stepped(mode, modes.len() - 1)
+}
+
+/// Step `delta` places along [`Mode::all`], wrapping. Takes a distance rather
+/// than a key, so which key means which direction stays in the key handler
+/// where the rest of the bindings are.
+fn stepped(mode: Mode, delta: usize) -> Mode {
     let modes = Mode::all();
     let at = modes.iter().position(|m| *m == mode).unwrap_or(0);
-    // Backwards is a forward step of len-1: no signed arithmetic, and no
-    // underflow to reason about at index 0.
-    let delta = if key == KeyCode::Up {
-        modes.len() - 1
-    } else {
-        1
-    };
     modes[(at + delta) % modes.len()]
 }
 
@@ -699,22 +706,25 @@ impl App {
         &mut self,
         key: KeyEvent,
         staged: Staged,
-        mode: Mode,
+        mut mode: Mode,
         mut steer: String,
     ) -> Outcome {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let mut mode = mode;
         match key.code {
             // Back to the list; the overlay is already None.
             KeyCode::Esc => return Outcome::Continue,
             KeyCode::Char('c') if ctrl => return Outcome::Quit,
+            // Returns *before* the overlay is put back, because resolving may
+            // have opened the which-checkout modal over this one — falling
+            // through would overwrite it with the picker the launch just left.
             KeyCode::Enter => {
                 return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
             }
-            // Two modes today, so both arrows and tab are the same step — and
-            // they stay right when a third mode arrives, which a plain toggle
-            // would not.
-            KeyCode::Up | KeyCode::Down | KeyCode::Tab => mode = stepped(mode, key.code),
+            // With two modes every step is the same step; `tab` joins the
+            // arrows because it is what the rest of the screen uses to move
+            // between two of something.
+            KeyCode::Up => mode = previous_mode(mode),
+            KeyCode::Down | KeyCode::Tab => mode = next_mode(mode),
             KeyCode::Backspace => {
                 steer.pop();
             }
@@ -1850,6 +1860,43 @@ mod tests {
             notice.contains("no registered checkout"),
             "notice: {notice}"
         );
+    }
+
+    #[test]
+    fn the_picker_walks_the_modes_both_ways_and_wraps() {
+        // Up and down are inverses and neither can fall off an end: with two
+        // modes every step lands on the other one, and the mode under the
+        // cursor is the mode `enter` will launch, so a step that went nowhere
+        // (or panicked at index 0) would launch the wrong skill.
+        let mut app = launchable_app();
+        go_to(&mut app, "#6");
+        app.handle_key(key(KeyCode::Enter));
+        let mode = |app: &App| match &app.overlay {
+            Overlay::PickLaunch { mode, .. } => *mode,
+            other => panic!("expected the launch picker, got {other:?}"),
+        };
+        assert_eq!(mode(&app), Mode::Interactive);
+        // Up from the first row wraps to the last rather than sticking.
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(mode(&app), Mode::Auto);
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(mode(&app), Mode::Interactive, "and wraps back round");
+        // Tab steps the same way down does — it is not the view toggle in here.
+        app.handle_key(key(KeyCode::Tab));
+        assert_eq!(mode(&app), Mode::Auto);
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(mode(&app), Mode::Interactive);
+        // Steering text is untouched by moving the mode: the two axes are
+        // edited independently, in one overlay.
+        type_str(&mut app, "keep me");
+        app.handle_key(key(KeyCode::Down));
+        match &app.overlay {
+            Overlay::PickLaunch { mode, steer, .. } => {
+                assert_eq!(*mode, Mode::Auto);
+                assert_eq!(steer, "keep me");
+            }
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -56,7 +56,7 @@ pub enum Route {
 }
 
 impl Route {
-    /// How the route reads on the launch line: the slash command it execs.
+    /// How the route reads in the launch picker: the slash command it execs.
     ///
     /// Every label is prefixed `wf`, because these names are claimed in a
     /// namespace `wf` does not own: `~/.claude/skills` is flat and shared with
@@ -80,49 +80,98 @@ impl Route {
 /// and `/wf-auto`), so the mode is an input to [`route`] rather than
 /// something the prompt carries. That is why nothing about "auto" survives
 /// into the exec'd prompt's steering suffix — by then it has already been spent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Mode {
     /// The default: the human is in the loop, and the session grills them.
+    #[default]
     Interactive,
-    /// The word `auto`: the agent decides alone, under `/wf-auto`'s
-    /// declared principles, and drives the node's remaining lifecycle
-    /// unattended. Replaced `defer`, which routed to `/wf`'s own
-    /// deferred mode before that skill existed (#63 → #96).
+    /// The agent decides alone, under `/wf-auto`'s declared principles, and
+    /// drives the node's remaining lifecycle unattended. Replaced `defer`,
+    /// which routed to `/wf`'s own deferred mode before that skill existed
+    /// (#63 → #96).
     Auto,
 }
 
-/// What the launch line's typed text meant — parsed once at the second enter
-/// (parse, don't validate: the exec never re-reads a string).
+impl Mode {
+    /// How the mode reads in the launch picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            Mode::Interactive => "interactive",
+            Mode::Auto => "auto",
+        }
+    }
+
+    /// What picking it means, in the words the choice actually turns on: who
+    /// decides. The picker shows this because the skill name alone (`/wf` vs
+    /// `/wf-auto`) does not say that one of them will not stop to ask you.
+    pub fn blurb(self) -> &'static str {
+        match self {
+            Mode::Interactive => "you are in the loop; it grills you",
+            Mode::Auto => "the agent decides alone and drives it to done",
+        }
+    }
+
+    /// The next mode in the picker's order, wrapping.
+    ///
+    /// Exhaustive, and the reason [`Mode::all`] is derived from it rather than
+    /// written out beside it: a new mode has to say where it sits in the cycle,
+    /// and the picker then lists it without anyone having to remember a second
+    /// place to add it.
+    fn after(self) -> Mode {
+        match self {
+            Mode::Interactive => Mode::Auto,
+            Mode::Auto => Mode::Interactive,
+        }
+    }
+
+    /// Every mode, in picker order, starting at the default. Walks
+    /// [`Mode::after`] until it comes back round — or, if a future cycle is
+    /// malformed and never does, until it repeats itself, so this cannot spin.
+    pub fn all() -> Vec<Mode> {
+        let mut modes = vec![Mode::default()];
+        while let Some(&last) = modes.last() {
+            let next = last.after();
+            if modes.contains(&next) {
+                break;
+            }
+            modes.push(next);
+        }
+        modes
+    }
+}
+
+/// What the launch picker settled on: who decides, and what steers them.
 ///
 /// Two independent axes, so genuinely a product and not a four-armed sum: the
-/// leading `auto` picks *who decides*, and whatever follows steers them. Every
-/// combination is meaningful, which is the test for a product being honest.
+/// picked [`Mode`] chooses *who decides*, and the steering text — typed in the
+/// same overlay — steers them. Every combination is meaningful, which is the
+/// test for a product being honest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LaunchMode {
     mode: Mode,
-    /// The steering prompt, never empty — [`LaunchMode::parse`] trims, and an
+    /// The steering prompt, never empty — [`LaunchMode::picked`] trims, and an
     /// empty steer is spelt `None` rather than `Some("")`.
     steer: Option<String>,
 }
 
 impl LaunchMode {
-    /// Parse the launch line. Total: every string means exactly one launch.
-    /// `auto` is matched as a *word* — `automate the release` is steering text
-    /// that happens to start with the same letters, not a mode.
-    pub fn parse(text: &str) -> LaunchMode {
-        let text = text.trim();
-        let (mode, steer) = match text.strip_prefix("auto") {
-            Some("") => (Mode::Auto, ""),
-            Some(rest) if rest.starts_with(char::is_whitespace) => (Mode::Auto, rest.trim_start()),
-            _ => (Mode::Interactive, text),
-        };
+    /// The launch the picker composed: a mode selected from a list, and
+    /// whatever steering text was typed alongside it.
+    ///
+    /// The mode is *picked*, not parsed out of the text (#62's `defer`, then
+    /// #96's `auto`, were both words at the front of one line). Nothing you can
+    /// type changes who decides, so steering text starting `auto` is steering
+    /// text — and, the other way round, an unattended launch is a thing you
+    /// selected and saw selected rather than a word you had to know.
+    pub fn picked(mode: Mode, steer: &str) -> LaunchMode {
+        let steer = steer.trim();
         LaunchMode {
             mode,
             steer: (!steer.is_empty()).then(|| steer.to_string()),
         }
     }
 
-    /// Which skill this line resolves to, given what the cursor was on.
+    /// Which skill this launch resolves to, given what the cursor was on.
     pub fn mode(&self) -> Mode {
         self.mode
     }
@@ -236,11 +285,11 @@ pub fn route(aim: &Aim, mode: Mode) -> Route {
 }
 
 /// A launch the first enter staged but the machine has not answered yet (#62):
-/// everything the launch line draws and the second enter needs, snapshotted
+/// everything the launch picker draws and the second enter needs, snapshotted
 /// **index-free**.
 ///
 /// Index-free is the whole point. `crate::app::Row` is positional — an index
-/// into a `Vec` that the next fetch replaces — and the line stays up while
+/// into a `Vec` that the next fetch replaces — and the picker stays up while
 /// background map arrivals swap the clusters underneath it (#27). A `Row` held
 /// here would draw, and then launch, whichever ticket had landed at that
 /// index; a shorter map would panic on the next frame. So the staged launch
@@ -251,9 +300,9 @@ pub struct Staged {
     /// The node's repo, full slug (`owner/name`) — what the checkout cache
     /// is matched on (#15).
     pub repo: String,
-    /// What the launch line names: the map, or one ticket in it.
+    /// What the launch picker names: the map, or one ticket in it.
     pub aim: Aim,
-    /// Its title as it read when the line opened — the line is showing the
+    /// Its title as it read when the picker opened — the picker is showing the
     /// human what they picked, not re-reporting a row that may have moved.
     pub title: String,
     /// The map issue of the cluster the row was picked in (#50) — which map a
@@ -291,7 +340,7 @@ impl Staged {
         }
     }
 
-    /// Which skill this launch would run in `mode` — what the launch line
+    /// Which skill this launch would run in `mode` — what the launch picker
     /// echoes as the mode word is typed, and what [`plan`] resolves with.
     pub fn route(&self, mode: Mode) -> Route {
         route(&self.aim, mode)
@@ -417,7 +466,7 @@ pub struct Launch {
     cwd: PathBuf,
     /// The skill this launch execs, resolved from (type, stage).
     route: Route,
-    /// What the launch line said. The mode half already picked `route`; what
+    /// What the launch picker settled on. The mode half already picked `route`; what
     /// is left to spend here is the steering text.
     mode: LaunchMode,
     /// Host or container, decided from the checkout at [`plan`] time (#80).
@@ -717,6 +766,17 @@ mod tests {
         }
     }
 
+    /// What the picker composes with the default mode row selected, steered by
+    /// whatever was typed into it.
+    fn interactive(steer: &str) -> LaunchMode {
+        LaunchMode::picked(Mode::Interactive, steer)
+    }
+
+    /// The same with the `auto` row selected.
+    fn auto(steer: &str) -> LaunchMode {
+        LaunchMode::picked(Mode::Auto, steer)
+    }
+
     /// An interactive `/wf` plan — the default launch, and the shape
     /// every checkout-resolution test wants (route and mode are orthogonal to
     /// which trees are candidates).
@@ -724,7 +784,7 @@ mod tests {
         plan(
             checkouts,
             &Staged::ticket(ticket, map_issue, Stage::Ready).expect("ready is launchable"),
-            &LaunchMode::parse(""),
+            &LaunchMode::picked(Mode::Interactive, ""),
         )
     }
 
@@ -811,57 +871,71 @@ mod tests {
     }
 
     #[test]
-    fn the_launch_line_text_parses_to_a_mode_and_a_steer() {
-        // The two axes of the typed line (#62/#96): a leading `auto` picks who
-        // decides, whatever follows steers them, and either may be absent.
-        let parse = |text: &str| {
-            let mode = LaunchMode::parse(text);
-            (mode.mode, mode.steer)
-        };
-        assert_eq!(parse(""), (Mode::Interactive, None));
-        assert_eq!(parse("   "), (Mode::Interactive, None));
-        assert_eq!(parse("auto"), (Mode::Auto, None));
-        assert_eq!(parse("auto "), (Mode::Auto, None));
+    fn a_picked_launch_keeps_who_decides_out_of_what_was_typed() {
+        // The two axes (#62/#96), now that the mode is a picked row and not a
+        // word at the front of one line: the selection decides who resolves the
+        // node, and the text only ever steers.
+        let picked = |mode: LaunchMode| (mode.mode, mode.steer);
+        assert_eq!(picked(interactive("")), (Mode::Interactive, None));
+        assert_eq!(picked(auto("")), (Mode::Auto, None));
+        // An all-whitespace field is an empty one, not a steer made of spaces.
+        assert_eq!(picked(interactive("   ")), (Mode::Interactive, None));
+        assert_eq!(picked(auto("  \t ")), (Mode::Auto, None));
         assert_eq!(
-            parse("auto skip the flaky suite"),
+            picked(auto("skip the flaky suite")),
             (Mode::Auto, Some("skip the flaky suite".to_string()))
         );
         assert_eq!(
-            parse("try the other approach"),
+            picked(interactive("try the other approach")),
             (
                 Mode::Interactive,
                 Some("try the other approach".to_string())
             )
         );
-        // `auto` is a word, not a prefix: no fuzzy matching.
-        assert_eq!(
-            parse("automate the release"),
-            (Mode::Interactive, Some("automate the release".to_string()))
-        );
-        // `defer` retired with #96: it is ordinary steering text now, not a
-        // mode word that quietly still means something.
-        assert_eq!(
-            parse("defer"),
-            (Mode::Interactive, Some("defer".to_string()))
-        );
+        // The mode words of #62 and #96 are both ordinary steering text now:
+        // no string can move the mode the human is looking at, so there is no
+        // longer such a thing as a launch that went unattended because of what
+        // it happened to start with.
+        for typed in ["auto", "auto merge when green", "automate it", "defer"] {
+            assert_eq!(
+                picked(interactive(typed)),
+                (Mode::Interactive, Some(typed.to_string())),
+                "{typed:?} steers an interactive launch"
+            );
+        }
     }
 
-    /// The prompt a node of this (type, stage) is launched with, for a launch
-    /// line reading `text`.
-    fn ticket_prompt(ticket_type: TicketType, stage: Stage, text: &str) -> String {
+    #[test]
+    fn every_mode_is_in_the_picker_and_the_default_leads_it() {
+        // The picker lists `Mode::all`, so a mode missing from it would be a
+        // mode nothing on screen can reach.
+        assert_eq!(Mode::all(), vec![Mode::Interactive, Mode::Auto]);
+        assert_eq!(
+            Mode::all().first(),
+            Some(&Mode::default()),
+            "enter opens on the default"
+        );
+        // Derived from the `after` cycle: every mode appears exactly once.
+        let mut seen = Mode::all();
+        seen.dedup();
+        assert_eq!(seen.len(), Mode::all().len());
+    }
+
+    /// The prompt a node of this (type, stage) is launched with, under `mode`.
+    fn ticket_prompt(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> String {
         let mut node = ticket("blooop/wayfinder", 16);
         node.ticket_type = ticket_type;
         let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
-        match plan(&cache(), &staged, &LaunchMode::parse(text)) {
+        match plan(&cache(), &staged, mode) {
             Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
             other => panic!("{other:?}"),
         }
     }
 
     /// The same, for a launch aimed at the whole map.
-    fn map_prompt(text: &str) -> String {
+    fn map_prompt(mode: &LaunchMode) -> String {
         let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
-        match plan(&cache(), &staged, &LaunchMode::parse(text)) {
+        match plan(&cache(), &staged, mode) {
             Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
             other => panic!("{other:?}"),
         }
@@ -872,19 +946,19 @@ mod tests {
         // The route picks the skill; only the wayfinder skills take the map
         // argument. The mode is *not* in the suffix — it chose the skill.
         assert_eq!(
-            ticket_prompt(TicketType::Build, Stage::Ready, ""),
+            ticket_prompt(TicketType::Build, Stage::Ready, &interactive("")),
             "/wf-tdd 16"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Build, Stage::InReview, ""),
+            ticket_prompt(TicketType::Build, Stage::InReview, &interactive("")),
             "/wf-review 16"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Grilling, Stage::Ready, ""),
+            ticket_prompt(TicketType::Grilling, Stage::Ready, &interactive("")),
             "/wf 1 16"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Grilling, Stage::Ready, "auto"),
+            ticket_prompt(TicketType::Grilling, Stage::Ready, &auto("")),
             "/wf-auto 1 16"
         );
         // Steering rides as a suffix, whatever the route.
@@ -892,12 +966,16 @@ mod tests {
             ticket_prompt(
                 TicketType::Grilling,
                 Stage::Ready,
-                "auto skip the flaky suite"
+                &auto("skip the flaky suite")
             ),
             "/wf-auto 1 16 steer: skip the flaky suite"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Build, Stage::Ready, "try the other approach"),
+            ticket_prompt(
+                TicketType::Build,
+                Stage::Ready,
+                &interactive("try the other approach")
+            ),
             "/wf-tdd 16 steer: try the other approach"
         );
     }
@@ -906,16 +984,16 @@ mod tests {
     fn a_map_launch_is_the_skill_and_the_map_number_alone() {
         // No ticket argument exists to pass, so none is passed — the map aim
         // is the whole subject (#96).
-        assert_eq!(map_prompt(""), "/wf 59");
-        assert_eq!(map_prompt("auto"), "/wf-auto 59");
+        assert_eq!(map_prompt(&interactive("")), "/wf 59");
+        assert_eq!(map_prompt(&auto("")), "/wf-auto 59");
         assert_eq!(
-            map_prompt("auto merge when green"),
+            map_prompt(&auto("merge when green")),
             "/wf-auto 59 steer: merge when green"
         );
         // A map's key is its own issue number, not a ticket's.
         let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
         assert_eq!(staged.key(), "#59");
-        match plan(&cache(), &staged, &LaunchMode::parse("")) {
+        match plan(&cache(), &staged, &interactive("")) {
             Targets::One(l) => assert_eq!(l.key(), "wayfinder#59"),
             other => panic!("{other:?}"),
         }
@@ -1115,11 +1193,11 @@ mod tests {
     /// The same launch, forced into a container — the fields are private and
     /// `plan` reads the real filesystem, so a test that wants the isolated
     /// shape builds it here rather than arranging a `dl` on PATH.
-    fn isolated(route: Route, text: &str) -> Launch {
-        isolated_ticket(80, route, text)
+    fn isolated(route: Route, mode: LaunchMode) -> Launch {
+        isolated_ticket(80, route, mode)
     }
 
-    fn isolated_ticket(number: u64, route: Route, text: &str) -> Launch {
+    fn isolated_ticket(number: u64, route: Route, mode: LaunchMode) -> Launch {
         Launch {
             repo: "blooop/wayfinder".to_string(),
             aim: Aim::Ticket {
@@ -1130,7 +1208,7 @@ mod tests {
             map_issue: 67,
             cwd: PathBuf::from("/data/proj/wayfinder"),
             route,
-            mode: LaunchMode::parse(text),
+            mode,
             isolation: Isolation::Devlaunch,
         }
     }
@@ -1144,7 +1222,7 @@ mod tests {
         // prompt has to arrive already quoted or it lands as three arguments;
         // the workspace spec is a plain argv entry and is not quoted.
         assert_eq!(
-            isolated(Route::Wayfinder, "").agent_argv(),
+            isolated(Route::Wayfinder, interactive("")).agent_argv(),
             vec![
                 "dl".to_string(),
                 "blooop/wayfinder@wayfinder/wayfinder-80".to_string(),
@@ -1154,7 +1232,7 @@ mod tests {
         );
         // The steering suffix rides inside the same quoted argument.
         assert_eq!(
-            isolated(Route::WayfinderAuto, "auto merge when green").agent_argv()[3],
+            isolated(Route::WayfinderAuto, auto("merge when green")).agent_argv()[3],
             "'claude' '--dangerously-skip-permissions' '/wf-auto 67 80 steer: merge when green'"
         );
     }
@@ -1165,9 +1243,9 @@ mod tests {
         // tickets launched at once must not share a tree or a container, and
         // the same ticket launched twice must land in the same workspace
         // (that is `dl` reattaching, not a second clone).
-        let a = isolated_ticket(80, Route::Tdd, "").agent_argv()[1].clone();
-        let b = isolated_ticket(81, Route::Tdd, "").agent_argv()[1].clone();
-        let a_again = isolated_ticket(80, Route::Review, "").agent_argv()[1].clone();
+        let a = isolated_ticket(80, Route::Tdd, interactive("")).agent_argv()[1].clone();
+        let b = isolated_ticket(81, Route::Tdd, interactive("")).agent_argv()[1].clone();
+        let a_again = isolated_ticket(80, Route::Review, interactive("")).agent_argv()[1].clone();
         assert_ne!(a, b);
         assert_eq!(a, a_again);
         // The branch is the one `/wf-tdd` is told to work on, so a build agent
@@ -1185,7 +1263,7 @@ mod tests {
             map_issue: 67,
             cwd: PathBuf::from("/data/proj/wayfinder"),
             route: Route::WayfinderAuto,
-            mode: LaunchMode::parse("auto"),
+            mode: auto(""),
             isolation: Isolation::Devlaunch,
         };
         assert_eq!(
@@ -1203,7 +1281,7 @@ mod tests {
     fn steering_text_cannot_break_out_of_the_shell_command() {
         // The one string a user types that reaches a shell. A single quote
         // closes, escapes, reopens — the argument stays one argument.
-        let launch = isolated(Route::Tdd, "don't touch the CI; rm -rf /");
+        let launch = isolated(Route::Tdd, interactive("don't touch the CI; rm -rf /"));
         assert_eq!(
             launch.agent_argv()[3],
             r"'claude' '--dangerously-skip-permissions' '/wf-tdd 80 steer: don'\''t touch the CI; rm -rf /'"
@@ -1218,7 +1296,7 @@ mod tests {
         // An isolated launch works in its workspace, not in the checkout —
         // so the workspace is what the notice names.
         assert_eq!(
-            isolated(Route::Wayfinder, "").describe(),
+            isolated(Route::Wayfinder, interactive("")).describe(),
             "wayfinder#80 in blooop/wayfinder@wayfinder/wayfinder-80 (devlaunch)"
         );
         match plan_wf(&cache(), &ticket("blooop/wayfinder", 80), 67) {

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -124,8 +124,8 @@ impl Mode {
         }
     }
 
-    /// Every mode, in picker order, starting at the default. Walks
-    /// [`Mode::after`] until it comes back round — or, if a future cycle is
+    /// Every mode, in picker order, starting at the default. Walks the private
+    /// `after` cycle until it comes back round — or, if a future cycle is
     /// malformed and never does, until it repeats itself, so this cannot spin.
     pub fn all() -> Vec<Mode> {
         let mut modes = vec![Mode::default()];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -552,9 +552,12 @@ fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
     );
 }
 
-/// Draw the full screen: bordered frame with the scope in the title, the
-/// clusters, then the anchored bottom chrome — the match-count line (with the
-/// load hint and any one-shot notice), the fzf-style prompt, and the key hints.
+/// Draw the full screen: bordered frame with the scope in the title, then the
+/// search chrome anchored at the *top* — the fzf-style prompt and, under it, the
+/// match-count line (with the load hint and any one-shot notice) — the clusters
+/// filling what is left, and the key hints on the last line. The prompt leads
+/// because it is what you type into: `fzf --reverse`'s order, and it keeps the
+/// count line against the query whose matches it counts.
 /// The which-checkout picker, when open, floats over all of it.
 pub fn draw(frame: &mut Frame<'_>, app: &App) {
     let mut block = match &app.scope {
@@ -569,13 +572,22 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     let inner = block.inner(frame.area());
     frame.render_widget(block, frame.area());
 
-    let [body_area, count_area, prompt_area, hint_area] = Layout::vertical([
+    let [prompt_area, count_area, body_area, hint_area] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
         Constraint::Min(0),
-        Constraint::Length(1),
-        Constraint::Length(1),
         Constraint::Length(1),
     ])
     .areas(inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  > ", Style::new().fg(Color::Cyan)),
+            Span::raw(app.query.clone()),
+            Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
+        ])),
+        prompt_area,
+    );
 
     // Scroll only as far as it takes to keep the cursor's line on screen —
     // several clusters can be taller than the body area (#50), and a cursor
@@ -637,14 +649,6 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
         frame.render_widget(Paragraph::new(Line::from(count_spans)), count_area);
     }
 
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("  > ", Style::new().fg(Color::Cyan)),
-            Span::raw(app.query.clone()),
-            Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
-        ])),
-        prompt_area,
-    );
     frame.render_widget(
         Paragraph::new(KEY_HINTS).style(Style::new().add_modifier(Modifier::DIM)),
         hint_area,
@@ -1171,7 +1175,7 @@ mod tests {
     }
 
     #[test]
-    fn bottom_chrome_has_count_prompt_and_hint_lines() {
+    fn the_chrome_has_count_prompt_and_hint_lines() {
         let screen = render(&fixture_app());
         assert!(screen.contains("5/5"));
         assert!(screen.contains("> █"));
@@ -1180,6 +1184,30 @@ mod tests {
         assert!(screen.contains("ctrl-r refresh"));
         assert!(screen.contains("esc quit"));
         assert!(screen.contains("wf · blooop/wayfinder"));
+    }
+
+    #[test]
+    fn the_search_prompt_leads_the_screen_with_the_count_under_it() {
+        // The prompt is the first line inside the border and the count line the
+        // second, so both sit against the title rather than drifting to
+        // wherever the body happens to end. Only the hints stay anchored to the
+        // bottom.
+        let screen = render(&fixture_app());
+        let lines: Vec<&str> = screen.lines().collect();
+        assert!(lines[0].contains("wf · blooop/wayfinder"), "{screen}");
+        assert!(lines[1].contains("> █"), "{screen}");
+        assert!(lines[2].contains("5/5"), "{screen}");
+        // The body follows, still opening on its own blank spacer line — which
+        // now reads as the gap between the chrome and the first cluster.
+        let header = lines
+            .iter()
+            .position(|l| l.contains("▌ wayfinder · Map: wf"))
+            .expect("cluster header on screen");
+        assert_eq!(header, 4, "{screen}");
+        assert!(
+            lines[lines.len() - 2].contains("enter launch"),
+            "hints stay on the last line: {screen}"
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,7 @@ use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
 use crate::filter;
-use crate::launch::{Launch, LaunchMode};
+use crate::launch::{Launch, Mode, Staged};
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
 use crate::view::{Branch, Fold, GroupKind, Item, Plan};
 
@@ -497,6 +497,70 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
     area
 }
 
+/// The launch picker: what `enter` on a node opens, and everything that launch
+/// still needs decided.
+///
+/// A modal rather than #62's one-line prompt, because the line could only *echo*
+/// what you typed — the modes were words you had to already know (`defer`, then
+/// `auto`), and an unattended launch looked exactly like a typo until it ran. The
+/// options are rows now: each one names its mode, the skill that mode routes the
+/// staged node to, and who ends up deciding. Which is also why the route is
+/// drawn per option rather than once for the cursor's — the difference between
+/// `/wf` and `/wf-auto` *is* the choice being made, so both are on screen.
+fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, mode: Mode, steer: &str) {
+    let mut lines = vec![Line::default()];
+    for option in Mode::all() {
+        let picked = option == mode;
+        let marker = if picked { '▶' } else { ' ' };
+        // The cursor's row is the one that will run, so it is the one that reads
+        // as bold; the others stay dim enough to scan past.
+        let emphasis = if picked {
+            Style::new().add_modifier(Modifier::BOLD)
+        } else {
+            Style::new().add_modifier(Modifier::DIM)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {marker} {:<12}", option.label()), emphasis),
+            Span::styled(
+                format!("{:<10}", staged.route(option).label()),
+                Style::new().fg(Color::Cyan),
+            ),
+            Span::styled(option.blurb(), Style::new().add_modifier(Modifier::DIM)),
+        ]));
+    }
+    lines.push(Line::default());
+    // The steer field is always shown, empty or not: it is the other half of
+    // what enter will do, and a field that appears only once you have typed
+    // into it cannot tell you that you may.
+    lines.push(Line::from(vec![
+        Span::styled("    steer  ", Style::new().add_modifier(Modifier::DIM)),
+        Span::raw(steer.to_string()),
+        Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
+    ]));
+    lines.push(Line::default());
+    lines.push(Line::styled(
+        "  enter launch · ↑/↓ mode · type to steer · esc cancel",
+        Style::new().add_modifier(Modifier::DIM),
+    ));
+    let title = format!(" launch {} {} ", staged.key(), staged.title);
+    let width = lines
+        .iter()
+        .map(|l| l.width() as u16 + 4)
+        .chain(std::iter::once(title.chars().count() as u16 + 4))
+        .max()
+        .unwrap_or(40);
+    let area = centered(frame.area(), width, lines.len() as u16 + 2);
+    frame.render_widget(Clear, area);
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::bordered()
+                .title(title)
+                .border_style(Style::new().fg(Color::Cyan)),
+        ),
+        area,
+    );
+}
+
 /// The which-checkout modal: one row per registered checkout of the repo.
 ///
 /// The one prompt `wf` still has, and the reason it survived the Build 7
@@ -505,9 +569,20 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
 /// distinguishes the candidates, and with no session to name there is nothing
 /// shorter to show alongside it.
 fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
-    let Overlay::PickCheckout { launches, cursor } = &app.overlay else {
-        return;
-    };
+    let launches;
+    let cursor;
+    match &app.overlay {
+        Overlay::None => return,
+        Overlay::PickLaunch {
+            staged,
+            mode,
+            steer,
+        } => return draw_launch_picker(frame, staged, *mode, steer),
+        Overlay::PickCheckout {
+            launches: l,
+            cursor: c,
+        } => (launches, cursor) = (l, c),
+    }
     let mut lines = vec![Line::default()];
     for (i, launch) in launches.iter().enumerate() {
         let marker = if i == *cursor { '▶' } else { ' ' };
@@ -603,51 +678,31 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     }
     frame.render_widget(body, body_area);
 
-    // The count line's slot is shared: while a launch is staged (#62) the
-    // launch line lives there instead — the resolved route, the node it
-    // launches, and the mode text as it is typed.
-    //
-    // The route is resolved *per frame* from the text, not read off the staged
-    // launch, because since #96 the mode picks the skill: typing `auto` has to
-    // flip the echoed command from `/wf` to `/wf-auto` as you
-    // type it. Showing a stale route would be showing the wrong skill.
-    if let Overlay::LaunchLine { staged, text } = &app.overlay {
-        let route = staged.route(LaunchMode::parse(text).mode());
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled(
-                    format!("  → {}", route.label()),
-                    Style::new().fg(Color::Cyan),
-                ),
-                Span::raw(format!(" · {} {}  {text}", staged.key(), staged.title)),
-                Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
-            ])),
-            count_area,
-        );
-    } else {
-        // The load hint, the failure note, and the idle count share one dim
-        // segment, and any of them can be live at once; empty ones drop out
-        // rather than leaving gaps.
-        let status = [app.startup.hint(), failure_note(app), idle_note(&plan)]
-            .into_iter()
-            .filter(|part| !part.is_empty())
-            .collect::<Vec<_>>()
-            .join(" ");
-        let mut count_spans = vec![
-            Span::raw(format!("  {}/{}", app.visible().len(), app.scoped().len())),
-            Span::styled(
-                format!("  {status}"),
-                Style::new().add_modifier(Modifier::DIM),
-            ),
-        ];
-        if let Some(notice) = &app.notice {
-            count_spans.push(Span::styled(
-                format!("   {notice}"),
-                Style::new().add_modifier(Modifier::DIM),
-            ));
-        }
-        frame.render_widget(Paragraph::new(Line::from(count_spans)), count_area);
+    // The load hint, the failure note, and the idle count share one dim
+    // segment, and any of them can be live at once; empty ones drop out
+    // rather than leaving gaps. The count line keeps its slot while a launch is
+    // staged — the staged launch is a modal now (#62's line became
+    // [`draw_launch_picker`]), and a modal does not need the row it covers to
+    // move out of its way.
+    let status = [app.startup.hint(), failure_note(app), idle_note(&plan)]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut count_spans = vec![
+        Span::raw(format!("  {}/{}", app.visible().len(), app.scoped().len())),
+        Span::styled(
+            format!("  {status}"),
+            Style::new().add_modifier(Modifier::DIM),
+        ),
+    ];
+    if let Some(notice) = &app.notice {
+        count_spans.push(Span::styled(
+            format!("   {notice}"),
+            Style::new().add_modifier(Modifier::DIM),
+        ));
     }
+    frame.render_widget(Paragraph::new(Line::from(count_spans)), count_area);
 
     frame.render_widget(
         Paragraph::new(KEY_HINTS).style(Style::new().add_modifier(Modifier::DIM)),
@@ -1422,40 +1477,50 @@ mod tests {
     }
 
     #[test]
-    fn the_launch_line_replaces_the_count_line_and_shows_the_route() {
+    fn enter_opens_the_launch_picker_over_the_screen_with_every_mode_on_it() {
         let mut app = fixture_app();
-        let screen = render(&app);
-        assert!(screen.contains("5/5"), "{screen}");
 
-        // Enter on #6 (a task at ready): the line opens where the count was,
-        // naming the resolved route and the ticket it launches.
+        // Enter on #6 (a task at ready): the picker floats over the list,
+        // titled with the node it launches.
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         let screen = render(&app);
         assert!(
-            screen.contains("→ /wf · #6 Re-entry breadcrumbs"),
+            screen.contains("launch #6 Re-entry breadcrumbs"),
             "{screen}"
         );
-        assert!(
-            !screen.contains("5/5"),
-            "the count line is replaced: {screen}"
-        );
+        // Both modes are on screen with the skill each one would run, because
+        // that difference *is* the choice being offered — and the cursor sits
+        // on the interactive default.
+        assert!(screen.contains("▶ interactive"), "{screen}");
+        assert!(screen.contains("/wf "), "{screen}");
+        assert!(screen.contains("auto"), "{screen}");
+        assert!(screen.contains("/wf-auto"), "{screen}");
+        assert!(screen.contains("steer"), "{screen}");
+        assert!(screen.contains("esc cancel"), "{screen}");
 
-        // The typed mode shows on the line as it accumulates — and re-routes
-        // it live, because since #96 the mode word picks the skill and a line
-        // still echoing `/wf` would be naming the wrong one.
-        type_str(&mut app, "auto something");
+        // Down moves the pick; the marker moves with it and nothing about the
+        // route line is stale, since each row draws its own.
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let screen = render(&app);
-        assert!(screen.contains("auto something"), "{screen}");
-        assert!(
-            screen.contains("→ /wf-auto · #6 Re-entry breadcrumbs"),
-            "{screen}"
-        );
+        assert!(screen.contains("▶ auto"), "{screen}");
+        assert!(!screen.contains("▶ interactive"), "{screen}");
 
-        // Esc gives the count line back.
+        // Typing steers rather than picking: the text lands in the field, and
+        // the mode stays where the cursor put it.
+        type_str(&mut app, "merge when green");
+        let screen = render(&app);
+        assert!(screen.contains("merge when green"), "{screen}");
+        assert!(screen.contains("▶ auto"), "{screen}");
+
+        // The count line was never taken away — the picker covers the rows, not
+        // the chrome that says how many there are.
+        assert!(screen.contains("5/5"), "{screen}");
+
+        // Esc closes it and gives the whole screen back.
         app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         let screen = render(&app);
+        assert!(!screen.contains("launch #6"), "{screen}");
         assert!(screen.contains("5/5"), "{screen}");
-        assert!(!screen.contains("→ /wf"), "{screen}");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -561,6 +561,23 @@ fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, mode: Mode, steer:
     );
 }
 
+/// Whichever modal is up, over the screen the rest of [`draw`] already drew.
+/// Exhaustive on the overlay, so a third modal cannot be added without being
+/// given something to draw.
+fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
+    match &app.overlay {
+        Overlay::None => {}
+        Overlay::PickLaunch {
+            staged,
+            mode,
+            steer,
+        } => draw_launch_picker(frame, staged, *mode, steer),
+        Overlay::PickCheckout { launches, cursor } => {
+            draw_checkout_picker(frame, launches, *cursor);
+        }
+    }
+}
+
 /// The which-checkout modal: one row per registered checkout of the repo.
 ///
 /// The one prompt `wf` still has, and the reason it survived the Build 7
@@ -568,24 +585,10 @@ fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, mode: Mode, steer:
 /// exactly one, and `wf` cannot guess which. The path *is* the row — it is what
 /// distinguishes the candidates, and with no session to name there is nothing
 /// shorter to show alongside it.
-fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
-    let launches;
-    let cursor;
-    match &app.overlay {
-        Overlay::None => return,
-        Overlay::PickLaunch {
-            staged,
-            mode,
-            steer,
-        } => return draw_launch_picker(frame, staged, *mode, steer),
-        Overlay::PickCheckout {
-            launches: l,
-            cursor: c,
-        } => (launches, cursor) = (l, c),
-    }
+fn draw_checkout_picker(frame: &mut Frame<'_>, launches: &[Launch], cursor: usize) {
     let mut lines = vec![Line::default()];
     for (i, launch) in launches.iter().enumerate() {
-        let marker = if i == *cursor { '▶' } else { ' ' };
+        let marker = if i == cursor { '▶' } else { ' ' };
         // Two trees of one repo can differ in what the agent will run in —
         // one carrying a devcontainer and one not — so the choice has to say
         // so here, where it is being made, not only in the notice after (#80).

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -24,7 +24,8 @@
 //!    prompt would arrive at `claude` as three arguments and every assertion
 //!    in claim 1 would fail.
 //! 1. **`enter` execs the agent.** Two enters since the two-step launch (#62):
-//!    the first stages the launch line, the second launches it interactive.
+//!    the first opens the launch picker, the second launches the mode it
+//!    opened on — interactive.
 //!    `claude` is shimmed to a script that records its argv and cwd, so the
 //!    assertion is on what `wf` actually handed the agent —
 //!    `--dangerously-skip-permissions "<skill> …"` — rather than on what it
@@ -294,12 +295,17 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     // Generous, because a cold cache pays for the map search before the fetch.
     wait_for(&seen, "▶", Duration::from_secs(60), "the map to load");
 
-    // First enter stages the launch: the line shows the resolved route where
-    // the count line was. The second enter, on an empty line, launches
-    // interactive — today's default.
+    // First enter stages the launch: the picker opens over the list, titled
+    // with the node and cursored on the interactive row. The second enter
+    // takes that row — today's default.
     keys.write_all(b"\r").expect("send enter");
     keys.flush().expect("flush enter");
-    wait_for(&seen, "→ /", Duration::from_secs(10), "the launch line");
+    wait_for(
+        &seen,
+        "▶ interactive",
+        Duration::from_secs(10),
+        "the launch picker",
+    );
     keys.write_all(b"\r").expect("send the second enter");
     keys.flush().expect("flush the second enter");
 


### PR DESCRIPTION
Two screen changes, driven by using it: the thing you type into was at the far
end of the screen from the title, and the launch it stages was a word you had to
already know.

## The search prompt leads the screen

The `>` prompt and its count line were the last two lines before the key hints,
so typing happened at the bottom while the rows re-sifted upward, away from the
cursor. Both move above the body — prompt on the first line inside the border,
count under it, tree beneath, hints still anchored to the bottom. `fzf
--reverse`'s order, and the count line stays against the query whose matches it
counts. The body's own leading blank became the gap between the chrome and the
first cluster, so nothing needed inserting.

## `enter` opens a launch picker

#62 staged the launch on a one-line prompt and #96 gave that line a mode axis,
which made the modes *words*: first `defer`, then `auto`, typed blind at the
front of the line. Three problems. The words were undiscoverable — nothing on
screen said `auto` existed, or that it meant nobody would be asked anything.
Typing one looked exactly like a typo until an unattended agent started. And the
grammar had to defend itself against ordinary English: `automate the release`
was special-cased into *not* meaning unattended.

So `enter` opens a centred overlay instead:

```
┌ launch #42 Make cargo test pass inside the container ────────────────────┐
│                                                                          │
│  ▶ interactive /wf       you are in the loop; it grills you              │
│    auto        /wf-auto  the agent decides alone and drives it to done    │
│                                                                          │
│    steer  █                                                              │
│                                                                          │
│  enter launch · ↑/↓ mode · type to steer · esc cancel                    │
└──────────────────────────────────────────────────────────────────────────┘
```

Every mode is a row naming the skill it routes *this* node to and who ends up
deciding — the difference between `/wf` and `/wf-auto` is the choice being made,
so both are on screen rather than one being echoed back after the fact. Arrows
or tab move; `enter` runs the row you are on, so the common case is still `enter
enter`. Anything typed lands in an always-visible steer field and steers
whichever mode is selected.

**No string can move the selection**, so a launch is unattended only because you
selected it — and steering text starting `auto` needs no special case, because
it was never a mode.

### What that changes in the code

- `Overlay::LaunchLine { staged, text }` → `PickLaunch { staged, mode, steer }`:
  the mode is state, not a re-parse of the text on every frame.
- `LaunchMode::parse` → `LaunchMode::picked(mode, steer)`. Still the same
  product of two axes; the mode half just arrives already decided.
- The picker lists `Mode::all()`, derived from an exhaustive `Mode::after`
  cycle, so a third mode joins the overlay without a second place to edit.
- The count line keeps its slot — a modal covers the rows, and does not need the
  chrome under it to move out of the way.

### The ruling this revisits

#96 settled two halves: `auto` → `/wf-auto` (routing), and `auto` as the word on
the launch line (input). **The routing half is untouched** — `route` is still
`(&Aim, Mode) -> Route`, total on every axis. Only the input half changes: the
mode is picked, not typed. #62's chords are otherwise intact; `enter` still
stages and a second `enter` still launches.

## Testing

208 unit + 18 integration tests green, including `live_launch_exec`, which
drives a real PTY and actually execs an agent — updated to wait for the picker
instead of the old `→ /wf` line. Driven for real via `wf-next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rework the launch flow to use a modal launch picker and move the search prompt to the top of the screen.

New Features:
- Introduce a launch picker overlay that lets users choose the launch mode and steering text before running an agent.

Enhancements:
- Anchor the search prompt and match-count line at the top of the screen so typing happens at the top while results sift below.
- Make launch modes explicit `Mode` values with labels and blurbs, and derive the picker options from an exhaustive mode cycle.
- Ensure launch mode selection is driven by cursor movement rather than parsing typed text, so steering input can no longer implicitly change who decides.

Tests:
- Extend unit, integration, and live PTY tests to cover the new launch picker behaviour and the repositioned search chrome.