### PR TITLE
Install the skills where a devcontainer can read them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,18 @@ Three consequences for anyone editing here:
   names are in `BUNDLED` — that list is the only thing sweep can tell "ours, and
   no longer shipped" from "someone else's" by.
 
-To work on a skill against a released `wf`, link the checkout instead of the
+- **They reach the agent as a copy, not as a link into this tree.**
+  `wf skills install` writes `~/.claude/wf-skills/<name>` and links
+  `~/.claude/skills/<name> -> ../wf-skills/<name>`, because an isolated launch
+  mounts `~/.claude` into the devcontainer and nothing else — a link into the
+  pixi prefix dangles in there, and the symptom is `Unknown command: /wf-tdd`
+  after the launch rather than an error anywhere near the install. The copy
+  records the bundle it came from and every launch re-copies from it, so it
+  cannot fall behind the tree you are editing.
+
+To work on a skill against a released `wf`, install the checkout instead of the
 package — `WF_SKILLS_DIR=$PWD/skills wf skills install` — and the edit is live
-in the next session.
+in the next session, however you launch.
 
 ## Checks
 

--- a/README.md
+++ b/README.md
@@ -53,27 +53,45 @@ older `wf` left under its old names, and touches nothing else — it removes a
 link only when the link points into a `wf` bundle, so a skill of yours can never
 match however dead it looks.
 
-`wf skills install` **symlinks** rather than copies, which is the whole point:
-updating the package updates the prompts, with no second command to remember
-and no copy to go stale in between. `wf skills` reports which prompt each route
-would actually run:
+`wf skills install` **symlinks**, so a name under `~/.claude/skills` is `wf`'s
+only when `wf` put it there and a real directory can go on meaning *somebody
+else owns this*. What the link points at is the part worth knowing:
+`~/.claude/wf-skills`, a **copy** of the package's bundle kept beside the links,
+reached *relatively* — `wf-tdd -> ../wf-skills/wf-tdd`.
+
+That indirection exists for the containers. An isolated launch
+([Isolation](#isolation-the-agent-runs-in-the-repos-devcontainer)) mounts your
+`~/.claude` into the devcontainer and nothing else: no pixi prefix, and your home
+at a different path inside (`/home/vscode`) than out. A link into
+`~/.pixi/envs/wf/share/wf/skills` is a fine link on the host and a dangling one
+in there — and a dangling skill does not report itself, it comes back as
+`Unknown command: /wf-tdd` seconds after a launch. A relative link into a copy
+that rides the same mount resolves on both sides.
+
+The copy is then the thing that could go stale, so it is not left to trust:
+`wf skills install` rewrites it, **every launch brings it back in step** before
+exec'ing the agent, and `wf skills` reports a copy that is not this build's
+rather than running a release behind:
 
 ```
 bundle  /home/you/.pixi/envs/wf/share/wf/skills (installed beside the binary)
-target  /home/you/.claude/skills
+links   /home/you/.claude/skills
+copy    /home/you/.claude/wf-skills (what the links point at, so a devcontainer can read them too)
 
   wf              ok
   wf-auto         ok
-  wf-one          ok
+  wf-one          outdated — the copy is not this build's
   wf-tdd          stale — links to /home/you/projects/wayfinder/skills
   wf-review       not a link — another tool owns this one
 ```
 
 `wf` never deletes a real directory it did not create — if chezmoi or a
 hand-edit owns one, it says so and leaves it, and the other four still install.
-Set `WF_SKILLS_DIR` to link a checkout instead of the package, which is what
-you want while you are editing the prompts: the link points at your working
-tree, so an edit is live in the next session with nothing to reinstall.
+Set `WF_SKILLS_DIR` to install a checkout's prompts instead of the package's,
+which is what you want while you are editing them: the copy **remembers where it
+was made from**, so every launch re-copies from your working tree and an edit is
+live in the next session — and an ordinary launch by the released `wf` refreshes
+your checkout's prompts rather than quietly replacing them with its own.
 
 The skills stay ordinary installed skills rather than text `wf` injects at exec
 time, because `wf` is not their only caller: `LIFECYCLE.md` has the manager
@@ -437,9 +455,16 @@ they are yours to run. With a workspace per ticket they accumulate faster than
 they used to: a merged ticket's workspace has no further use, and reaping it is
 manual — `dl --ls` shows what exists, `dl <ws> rm` removes one.
 
+Your host `~/.claude` is bind-mounted in, which is how the agent arrives already
+logged in — and is the reason `wf skills install` keeps the prompts *inside* that
+directory and links to them relatively. `~/.pixi` is not mounted and your home is
+at a different path in there, so a link into the package prefix dangles and the
+launch answers `Unknown command: /wf-tdd`. See
+[the skills](#the-skills-ship-with-the-binary).
+
 **This container is not a security boundary, and is not trying to be.** It is
-for reproducible dependencies. Your host `~/.claude` is bind-mounted into it
-read-write and your `gh` login is forwarded as `GH_TOKEN`, so everything running
+for reproducible dependencies. That `~/.claude` mount is read-write and your
+`gh` login is forwarded as `GH_TOKEN`, so everything running
 in a repo's devcontainer — including a `postCreateCommand` you did not write —
 gets both. That is a deliberate trade for zero-friction auth, taken with eyes
 open ([#73](https://github.com/blooop/wayfinder/issues/73)); the repos this

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,10 @@ wf skills          report which prompt each route would actually run
 wf skills install  link this build's skills into ~/.claude/skills
 
 The skills wf execs ship in this package, so they update with it. `install`
-links rather than copies, which is what keeps them in step afterwards. Set
-WF_SKILLS_DIR to link a checkout instead, while you are editing them.";
+links ~/.claude/skills at a copy of them kept beside it, which is the only
+place a launch inside a devcontainer can read them from; every launch brings
+that copy back in step. Set WF_SKILLS_DIR to install a checkout's skills
+instead, while you are editing them.";
 
 /// Parse argv (without the program name). `wf` takes at most one argument, and
 /// anything it does not recognise is rejected rather than ignored, so a typo
@@ -119,7 +121,7 @@ fn run_skills(install: bool) -> Result<()> {
     use std::fmt::Write;
 
     let bundle = skills::Bundle::resolve()?;
-    let target = skills::claude_skills_dir()?;
+    let target = skills::Target::resolve()?;
     if !install {
         emit(&skills::report(&bundle, &target));
         return Ok(());
@@ -142,6 +144,9 @@ fn run_skills(install: bool) -> Result<()> {
     for (name, outcome) in &done {
         let line = match outcome {
             skills::Outcome::AlreadyCurrent => "already current".to_string(),
+            skills::Outcome::Refreshed => {
+                "refreshed — the prompt behind the link is now this build's".to_string()
+            }
             skills::Outcome::Linked { was: None } => "linked".to_string(),
             skills::Outcome::Linked { was: Some(old) } => {
                 format!("relinked (was {})", old.display())
@@ -149,7 +154,7 @@ fn run_skills(install: bool) -> Result<()> {
             skills::Outcome::Blocked => format!(
                 "BLOCKED — {} is a real directory, not a link. Remove it \
                  (chezmoi may own it) and run this again",
-                target.join(name).display()
+                target.links().join(name).display()
             ),
             skills::Outcome::NotInBundle => {
                 "NOT IN BUNDLE — this build shipped without it".to_string()
@@ -278,8 +283,36 @@ async fn main() -> Result<()> {
     ratatui::restore();
     match ending? {
         Ending::Quit => Ok(()),
-        // Only ever returns an error: on success this process *is* the agent.
-        Ending::Handover(launch) => Err(launch.exec()),
+        Ending::Handover(launch) => {
+            // The prompts the agent is about to run. `wf skills install` links
+            // `~/.claude/skills` at a *copy* of the bundle, because that is the
+            // only place a devcontainer can read them from, and a copy is a
+            // thing that can fall behind a `pixi global update wf`. This is
+            // where it cannot: the process that refreshes it is the same one
+            // that then execs the prompt, so no launch ever gets ahead by even
+            // one release.
+            refresh_skills();
+            // Only ever returns an error: on success this process *is* the agent.
+            Err(launch.exec())
+        }
+    }
+}
+
+/// Bring the installed skill copies back in step with the bundle they were
+/// installed from.
+///
+/// Best-effort, and deliberately silent when there is nothing to do: a machine
+/// with no home directory to resolve, and one that never ran
+/// `wf skills install`, are not worth a word on the way into an agent. A copy
+/// that could not be *written* is different — the agent is about to run a
+/// prompt that is not the one that was installed — so that one is said out
+/// loud.
+fn refresh_skills() {
+    let Ok(target) = skills::Target::resolve() else {
+        return;
+    };
+    if let Err(err) = skills::refresh(&target) {
+        eprintln!("wf: could not refresh the installed skills: {err:#}");
     }
 }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -12,10 +12,30 @@
 //! one version, one `pixi global update wf`.
 //!
 //! What this module does *not* do is teach the agent where to look. Claude Code
-//! reads `~/.claude/skills`, so the last step is a **symlink** from there into
-//! this build's bundle ([`install`]) — a link rather than a copy precisely so
-//! that updating the package updates the prompts, with no second command to
-//! remember and no copy to go stale in between.
+//! reads `~/.claude/skills`, so the last step is a **symlink** from there
+//! ([`install`]) — a link rather than a copy, so that a name is `wf`'s only
+//! when `wf` put it there, and a real directory can go on meaning *somebody
+//! else owns this*.
+//!
+//! **What the link points at is the part that is not obvious.** Not the package
+//! bundle: an isolated launch ([`crate::launch::Isolation`], #80) runs the agent
+//! in a container with the host's `~/.claude` bind-mounted and nothing else —
+//! no pixi prefix, and the home directory at a different absolute path
+//! (`/home/you` outside, `/home/vscode` inside). A link into
+//! `~/.pixi/envs/wf/share/wf/skills` is a perfectly good link on the host and a
+//! dangling one in there, and a dangling skill is not an error anyone reports:
+//! it is `Unknown command: /wf-tdd`, seconds after a launch, with nothing to say
+//! why (#107).
+//!
+//! So [`install`] puts a **copy of the bundle beside the links** —
+//! `<config>/wf-skills`, inside the tree that is mounted — and links to it
+//! *relatively* (`../wf-skills/wf-tdd`), which is the whole reason the same link
+//! resolves under both home directories. The copy is then the thing this module
+//! has to keep honest, and it does that in three places rather than trusting it:
+//! [`install`] rewrites it and records where it came from, [`refresh`] brings it
+//! back in step with *that* source at every launch, and [`status`] reports it as
+//! [`State::Outdated`] when it has drifted — so a stale copy is something that
+//! gets *seen*, rather than a prompt that quietly runs a release behind.
 
 use std::path::{Path, PathBuf};
 
@@ -45,6 +65,19 @@ pub const BUNDLE_ENV: &str = "WF_SKILLS_DIR";
 /// Claude Code's own config-directory override, honoured so that `wf` installs
 /// where the agent will actually read from rather than where it usually does.
 const CLAUDE_CONFIG_ENV: &str = "CLAUDE_CONFIG_DIR";
+
+/// The copy of the bundle the links point at, as a name inside Claude Code's
+/// config directory (`~/.claude/wf-skills`).
+///
+/// A sibling of `skills/` rather than a directory inside it, because Claude Code
+/// reads *every* directory under `skills/` — a copy in there would register five
+/// more skills under a second set of names.
+pub const MIRROR: &str = "wf-skills";
+
+/// Where the copy came from, recorded inside it: the bundle directory the last
+/// [`install`] copied. A file rather than an inference, because the answer
+/// outlives the process that knew it — see [`installed_from`].
+const SOURCE: &str = ".source";
 
 /// Where this build's skills are, and how that was decided — carried together
 /// because the answer is only actionable with the reason attached: "no bundle"
@@ -148,18 +181,88 @@ pub fn claude_skills_dir() -> Result<PathBuf> {
     Ok(home.join(".claude").join("skills"))
 }
 
-/// What is at `~/.claude/skills/<name>` right now.
+/// Where an install goes: the directory Claude Code reads, and the copy of the
+/// bundle that sits beside it.
 ///
-/// A sum rather than a bool pair, because the three failures want three
-/// different sentences and only one of them is safe to fix by overwriting.
+/// One type rather than two paths passed around together, because they are not
+/// independent. The links are relative — `../wf-skills/<name>` — so the copy is
+/// a **sibling** of the links directory or the links resolve to nothing at all,
+/// and that relationship is the only reason a link written on the host still
+/// works inside a container that mounted the tree somewhere else.
+/// [`Target::beside`] is the only constructor, so the pair cannot be built
+/// disagreeing.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum State {
-    /// A symlink into this build's bundle: the prompt that runs is the one
-    /// this `wf` shipped.
+pub struct Target {
+    links: PathBuf,
+    mirror: PathBuf,
+}
+
+impl Target {
+    /// The pair formed around a links directory.
+    ///
+    /// # Errors
+    ///
+    /// When `links` has no parent to put the copy in — a bare relative name, or
+    /// the filesystem root. There is then no sibling for `..` to reach.
+    pub fn beside(links: &Path) -> Result<Target> {
+        let parent = links
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .with_context(|| {
+                format!(
+                    "{} has no parent directory to keep the skills copy in",
+                    links.display()
+                )
+            })?;
+        Ok(Target {
+            links: links.to_path_buf(),
+            mirror: parent.join(MIRROR),
+        })
+    }
+
+    /// The pair `wf` actually installs into on this machine.
+    ///
+    /// # Errors
+    ///
+    /// When [`claude_skills_dir`] cannot be resolved.
+    pub fn resolve() -> Result<Target> {
+        Target::beside(&claude_skills_dir()?)
+    }
+
+    /// The directory Claude Code reads.
+    pub fn links(&self) -> &Path {
+        &self.links
+    }
+
+    /// The copy those links point at.
+    pub fn mirror(&self) -> &Path {
+        &self.mirror
+    }
+
+    /// The exact link [`install`] writes for `name`. Relative, and one `..`
+    /// deep, which is the whole portability argument: nothing in it names a
+    /// home directory, so the host and the container read the same link and
+    /// both find the copy.
+    fn link_target(name: &str) -> PathBuf {
+        Path::new("..").join(MIRROR).join(name)
+    }
+}
+
+/// What sits at `<links>/<name>` — a fact about the link alone, settled before
+/// anything has been read about what it points at.
+///
+/// Separate from [`State`] on purpose: [`State::Outdated`] is a statement about
+/// *content*, so it cannot be an answer this function is able to give, and
+/// keeping the two apart is what lets [`install`] match exhaustively without an
+/// arm for a case that cannot reach it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Link {
+    /// The link `wf` writes, character for character.
     Current,
-    /// A symlink, but into some other bundle — an older prefix, or a checkout
-    /// you pointed at once and forgot. Relinking is safe: nothing but a link
-    /// is lost.
+    /// A symlink, but not that one — an older `wf`'s link into a package
+    /// prefix, a checkout someone pointed at once, or an absolute path into the
+    /// copy that would dangle in a container. Relinking is safe: nothing but a
+    /// link is lost.
     Stale(PathBuf),
     /// A real directory. Somebody else owns this — chezmoi, a hand-edit, a
     /// plugin — so `wf` reports it and does not touch it. Deleting a directory
@@ -169,8 +272,45 @@ pub enum State {
     Missing,
 }
 
+impl Link {
+    /// The link's state, plus what was found behind it: a link that is right
+    /// still runs the wrong prompt if the copy it points at is not this
+    /// build's.
+    fn with_copy(self, copy_is_current: bool, copied_from: Option<PathBuf>) -> State {
+        match self {
+            Link::Current if copy_is_current => State::Current,
+            Link::Current => State::Outdated { copied_from },
+            Link::Stale(target) => State::Stale(target),
+            Link::Unmanaged => State::Unmanaged,
+            Link::Missing => State::Missing,
+        }
+    }
+}
+
+/// What `~/.claude/skills/<name>` amounts to right now — the link and the
+/// prompt behind it, together, because "which prompt is going to run" is the
+/// only question worth answering and neither half settles it alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum State {
+    /// The link is `wf`'s and the copy behind it is this build's bundle.
+    Current,
+    /// The link is right, but the copy it points at is not this build's — a
+    /// `pixi global update wf` since the last install, or an install made from
+    /// somewhere else entirely. The prompt that runs is a real one, just not
+    /// this one, so the answer is only useful with the *where* attached:
+    /// `copied_from` is what [`install`] recorded, and `None` means a copy old
+    /// enough to predate the record.
+    Outdated { copied_from: Option<PathBuf> },
+    /// A symlink pointing somewhere else entirely.
+    Stale(PathBuf),
+    /// A real directory another tool owns.
+    Unmanaged,
+    /// Nothing there.
+    Missing,
+}
+
 impl State {
-    /// Whether this state means the bundled prompt is what would run.
+    /// Whether this state means this build's prompt is what would run.
     fn is_current(&self) -> bool {
         matches!(self, State::Current)
     }
@@ -183,50 +323,152 @@ pub struct Status {
     pub state: State,
 }
 
-/// Inspect every bundled skill against `into`.
-pub fn status(bundle: &Bundle, into: &Path) -> Vec<Status> {
+/// Inspect every bundled skill against `target`.
+pub fn status(bundle: &Bundle, target: &Target) -> Vec<Status> {
+    let copied_from = installed_from(target);
     BUNDLED
         .iter()
         .map(|name| Status {
             name: (*name).to_string(),
-            state: state_of(&bundle.path.join(name), &into.join(name)),
+            state: link_state(name, &target.links.join(name)).with_copy(
+                same_tree(&bundle.path.join(name), &target.mirror.join(name)),
+                copied_from.clone(),
+            ),
         })
         .collect()
 }
 
-/// Classify one link target. `symlink_metadata` rather than `metadata`, so a
-/// link is seen as a link instead of as whatever it points at — the whole
-/// distinction this function exists to draw.
-fn state_of(want: &Path, link: &Path) -> State {
+/// The directory the copy was last made from, as [`install`] recorded it.
+///
+/// The record is what keeps [`refresh`] from being a bully. The copy has one
+/// source — the bundle of whichever `wf` installed it, which is the package's
+/// for everyone and a checkout's for anyone who set `$WF_SKILLS_DIR` — and a
+/// launch by a *different* `wf` has no business overwriting it with its own
+/// prompts. Without the record, `wf skills install` from a checkout would be
+/// undone by the first ordinary launch, silently.
+///
+/// `None` when nothing was ever installed here, or when the record is from a
+/// `wf` old enough not to have written one.
+pub fn installed_from(target: &Target) -> Option<PathBuf> {
+    let recorded = std::fs::read_to_string(target.mirror.join(SOURCE)).ok()?;
+    let recorded = recorded.trim();
+    (!recorded.is_empty()).then(|| PathBuf::from(recorded))
+}
+
+/// Classify one link. `symlink_metadata` rather than `metadata`, so a link is
+/// seen as a link instead of as whatever it points at — the whole distinction
+/// this function exists to draw.
+///
+/// The target is compared *literally* against the one path [`install`] writes,
+/// rather than canonically. Canonically was right while the link named a bundle
+/// that could be reached by more than one route; it is wrong now, because an
+/// absolute link into the copy canonicalises to the same place on this machine
+/// and dangles in the container — which is exactly the state this shape exists
+/// to stop calling healthy.
+fn link_state(name: &str, link: &Path) -> Link {
     let Ok(meta) = std::fs::symlink_metadata(link) else {
-        return State::Missing;
+        return Link::Missing;
     };
     if !meta.file_type().is_symlink() {
-        return State::Unmanaged;
+        return Link::Unmanaged;
     }
     match std::fs::read_link(link) {
-        // Compared canonically: `~/.pixi/envs/wf/...` and a path reached
-        // through a symlinked prefix are the same bundle, and a textual
-        // comparison would call that stale on every run.
-        Ok(target) => {
-            let same = target.canonicalize().ok() == want.canonicalize().ok()
-                && want.canonicalize().is_ok();
-            if same {
-                State::Current
-            } else {
-                State::Stale(target)
-            }
-        }
-        Err(_) => State::Stale(PathBuf::new()),
+        Ok(target) if target == Target::link_target(name) => Link::Current,
+        Ok(target) => Link::Stale(target),
+        Err(_) => Link::Stale(PathBuf::new()),
     }
+}
+
+/// Whether two directory trees hold the same names and the same bytes.
+///
+/// The copy is a copy, so "is the prompt that will run this build's?" is a
+/// content question, and no stat answers it: `pixi global update wf` rewrites
+/// the bundle in the prefix without touching anything under `~/.claude`. The
+/// trees are a handful of small markdown files, so comparing bytes is cheaper
+/// than being clever about it, and an unreadable side answers `false` — "not
+/// known to match" is the only safe direction, and it costs one re-copy.
+fn same_tree(a: &Path, b: &Path) -> bool {
+    let (Ok(mut left), Ok(mut right)) = (listing(a), listing(b)) else {
+        return false;
+    };
+    left.sort();
+    right.sort();
+    if left != right {
+        return false;
+    }
+    left.iter().all(|name| {
+        let (a, b) = (a.join(name), b.join(name));
+        if a.is_dir() {
+            same_tree(&a, &b)
+        } else {
+            matches!((std::fs::read(&a), std::fs::read(&b)), (Ok(x), Ok(y)) if x == y)
+        }
+    })
+}
+
+/// The names directly inside `dir`.
+fn listing(dir: &Path) -> std::io::Result<Vec<std::ffi::OsString>> {
+    std::fs::read_dir(dir)?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect()
+}
+
+/// Copy `src` over `dst`, replacing whatever was there.
+///
+/// Whole-directory rather than file-by-file: a prompt the bundle *dropped* must
+/// not survive in the copy, and a mirror that only ever grows would eventually
+/// hold a file no build ships.
+fn recopy(src: &Path, dst: &Path) -> Result<()> {
+    clear(dst)?;
+    copy_tree(src, dst)
+}
+
+/// Remove `path`, whatever it is, and say nothing if it was not there.
+/// `symlink_metadata` so that a link is removed as a link rather than followed.
+fn clear(path: &Path) -> Result<()> {
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return Ok(());
+    };
+    if meta.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+    .with_context(|| format!("cannot replace {}", path.display()))
+}
+
+/// Copy a tree of directories and regular files. The bundle is exactly that —
+/// markdown beside markdown — so there is no symlink or special file case to
+/// get right, and one appearing would be a packaging fault worth an error.
+fn copy_tree(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst).with_context(|| format!("cannot create {}", dst.display()))?;
+    for entry in std::fs::read_dir(src).with_context(|| format!("cannot read {}", src.display()))? {
+        let entry = entry.with_context(|| format!("cannot read {}", src.display()))?;
+        let (from, to) = (entry.path(), dst.join(entry.file_name()));
+        let kind = entry
+            .file_type()
+            .with_context(|| format!("cannot stat {}", from.display()))?;
+        if kind.is_dir() {
+            copy_tree(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)
+                .with_context(|| format!("cannot copy {} → {}", from.display(), to.display()))?;
+        }
+    }
+    Ok(())
 }
 
 /// What one skill's installation did — reported rather than printed, so the
 /// caller owns the wording and the tests can assert on the outcome.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome {
-    /// It already pointed at this build's bundle.
+    /// It already pointed here, and the copy behind it was already this
+    /// build's.
     AlreadyCurrent,
+    /// The link was already right; the copy behind it was rewritten from this
+    /// build's bundle. What a `pixi global update wf` leaves for the next
+    /// install to pick up.
+    Refreshed,
     /// A link was created, or repointed from `was`.
     Linked { was: Option<PathBuf> },
     /// A real directory is in the way; nothing was touched.
@@ -236,66 +478,164 @@ pub enum Outcome {
     NotInBundle,
 }
 
-/// Link every bundled skill into `into`, creating it if needed.
+/// Copy every bundled skill beside `target`'s links and link each one to its
+/// copy, creating both directories if needed.
 ///
-/// Idempotent by construction: the only thing ever removed is a symlink `wf`
-/// would have created itself, and a skill already pointing at this bundle is
-/// left alone rather than relinked, so running it twice is indistinguishable
-/// from running it once.
+/// Idempotent by construction: a link already pointing at its copy is left
+/// alone rather than rewritten, and a copy that already matches the bundle is
+/// not re-copied, so running it twice is indistinguishable from running it once.
 ///
 /// # Errors
 ///
-/// When `into` cannot be created, or a link cannot be written. A skill that is
-/// merely *blocked* or absent from the bundle is not an error — it is an
-/// [`Outcome`], so one bad skill never costs the other four their install.
-pub fn install(bundle: &Bundle, into: &Path) -> Result<Vec<(String, Outcome)>> {
-    std::fs::create_dir_all(into).with_context(|| format!("cannot create {}", into.display()))?;
+/// When a directory cannot be created, a copy cannot be written, or a link
+/// cannot be replaced. A skill that is merely *blocked* or absent from the
+/// bundle is not an error — it is an [`Outcome`], so one bad skill never costs
+/// the other four their install.
+pub fn install(bundle: &Bundle, target: &Target) -> Result<Vec<(String, Outcome)>> {
+    for dir in [&target.links, &target.mirror] {
+        std::fs::create_dir_all(dir).with_context(|| format!("cannot create {}", dir.display()))?;
+    }
     let mut done = Vec::new();
     for name in BUNDLED {
         let source = bundle.path.join(name);
-        let link = into.join(name);
+        let link = target.links.join(name);
+        let copy = target.mirror.join(name);
         if !source.is_dir() {
             done.push((name.to_string(), Outcome::NotInBundle));
             continue;
         }
-        let outcome = match state_of(&source, &link) {
-            State::Current => Outcome::AlreadyCurrent,
-            State::Unmanaged => Outcome::Blocked,
+        let state = link_state(name, &link);
+        // A blocked skill's copy is never read, so it is never written: the
+        // whole point of stopping here is to touch nothing on this skill's
+        // behalf.
+        if state == Link::Unmanaged {
+            done.push((name.to_string(), Outcome::Blocked));
+            continue;
+        }
+        let recopied = !same_tree(&source, &copy);
+        if recopied {
+            recopy(&source, &copy)?;
+        }
+        let outcome = match state {
+            Link::Current if recopied => Outcome::Refreshed,
+            Link::Current => Outcome::AlreadyCurrent,
+            Link::Unmanaged => unreachable!("handled above"),
             state => {
                 let was = match state {
-                    State::Stale(target) => Some(target),
+                    Link::Stale(target) => Some(target),
                     _ => None,
                 };
                 if was.is_some() {
                     std::fs::remove_file(&link)
                         .with_context(|| format!("cannot replace the link {}", link.display()))?;
                 }
-                std::os::unix::fs::symlink(&source, &link).with_context(|| {
-                    format!("cannot link {} → {}", link.display(), source.display())
-                })?;
+                std::os::unix::fs::symlink(Target::link_target(name), &link).with_context(
+                    || format!("cannot link {} → {}", link.display(), copy.display()),
+                )?;
                 Outcome::Linked { was }
             }
         };
         done.push((name.to_string(), outcome));
     }
+    prune_mirror(&target.mirror)?;
+    // Written last, and unconditionally: from here on, *this* is the bundle the
+    // copy tracks, and the launches that follow refresh it from there.
+    let record = target.mirror.join(SOURCE);
+    std::fs::write(&record, format!("{}\n", bundle.path.display()))
+        .with_context(|| format!("cannot record the skills source in {}", record.display()))?;
     Ok(done)
 }
 
-/// Whether `target` names a directory inside some `wf` bundle — this build's,
-/// or one belonging to a prefix that has since been replaced.
+/// Bring the copies back in step with the bundle they were installed from, and
+/// name the ones that moved.
+///
+/// This is what keeps "a copy" from meaning "a copy that goes stale". `wf` is
+/// the thing that launches the agent, so the copy is rewritten by the very
+/// process that is about to exec the prompt — a `pixi global update wf` cannot
+/// get a launch ahead of it, and an edit to a checkout's `skills/` is live in
+/// the next session exactly as it was when the link pointed at the checkout
+/// itself.
+///
+/// Its source is [`installed_from`] and **not** this build's bundle, which is
+/// the difference between refreshing and overwriting: a `WF_SKILLS_DIR` install
+/// is a choice about which prompts run, and an ordinary launch has no standing
+/// to undo it.
+///
+/// Nothing is touched unless there is something to keep in step: a machine that
+/// never ran `wf skills install`, a link chezmoi owns, or a recorded source that
+/// has since been deleted all leave the copy exactly as it is — a prompt one
+/// release behind still beats no prompt at all.
+///
+/// # Errors
+///
+/// When a copy cannot be rewritten.
+pub fn refresh(target: &Target) -> Result<Vec<String>> {
+    let Some(bundle) = installed_from(target).filter(|source| source.is_dir()) else {
+        return Ok(Vec::new());
+    };
+    let mut refreshed = Vec::new();
+    for name in BUNDLED {
+        let source = bundle.join(name);
+        let copy = target.mirror.join(name);
+        if !source.is_dir() || link_state(name, &target.links.join(name)) != Link::Current {
+            continue;
+        }
+        if same_tree(&source, &copy) {
+            continue;
+        }
+        recopy(&source, &copy)?;
+        refreshed.push(name.to_string());
+    }
+    Ok(refreshed)
+}
+
+/// Drop copies of skills this build no longer ships, leaving the source record.
+///
+/// Unlike [`sweep`], which has to *prove* a link is `wf`'s before removing it,
+/// everything in here is `wf`'s by construction: the mirror is a directory `wf`
+/// creates, fills and owns, and nothing else has a reason to write to it.
+///
+/// # Errors
+///
+/// When a copy cannot be removed. A missing mirror is not an error.
+fn prune_mirror(mirror: &Path) -> Result<Vec<PathBuf>> {
+    let Ok(entries) = std::fs::read_dir(mirror) else {
+        return Ok(Vec::new());
+    };
+    let mut pruned = Vec::new();
+    for entry in entries {
+        let entry = entry.with_context(|| format!("cannot read {}", mirror.display()))?;
+        let name = entry.file_name();
+        if name == std::ffi::OsStr::new(SOURCE)
+            || BUNDLED.iter().any(|b| std::ffi::OsStr::new(b) == name)
+        {
+            continue;
+        }
+        clear(&entry.path())?;
+        pruned.push(entry.path());
+    }
+    Ok(pruned)
+}
+
+/// Whether `target` is a link `wf` wrote — this build's, or one of the shapes an
+/// older `wf` left behind.
 ///
 /// This is the whole safety argument for [`sweep`]. A link is removed only when
-/// it points *into a bundle*, which is a place nothing but `wf` ever links to,
-/// so a skill the user wrote, a plugin's, or a link some other tool left behind
-/// can never match however dead it looks.
-fn points_into_a_bundle(target: &Path, bundle: &Path) -> bool {
+/// it points at a place nothing but `wf` ever links to, so a skill the user
+/// wrote, a plugin's, or a link some other tool left behind can never match
+/// however dead it looks.
+fn is_ours(target: &Path, bundle: &Path) -> bool {
     let Some(parent) = target.parent() else {
         return false;
     };
-    // The current bundle covers `$WF_SKILLS_DIR` pointing at a checkout, whose
-    // path ends in `skills` and not in `share/wf/skills`. The suffix covers
-    // every installed prefix, including the older ones this is here to clear.
-    parent == bundle || parent.ends_with("share/wf/skills")
+    // What this build writes: relative, into the copy beside the links.
+    parent == Path::new("..").join(MIRROR)
+        // What older builds wrote: straight into a bundle. The first covers
+        // `$WF_SKILLS_DIR` pointing at a checkout, whose path ends in `skills`
+        // and not in `share/wf/skills`; the suffix covers every installed
+        // prefix, including the older ones this is here to clear.
+        || parent == bundle
+        || parent.ends_with("share/wf/skills")
 }
 
 /// Remove links `wf` wrote for skills it no longer ships.
@@ -313,15 +653,15 @@ fn points_into_a_bundle(target: &Path, bundle: &Path) -> bool {
 ///
 /// # Errors
 ///
-/// When `into` cannot be read, or a link cannot be removed. A missing `into` is
-/// not an error — there is nothing to sweep.
-pub fn sweep(bundle: &Bundle, into: &Path) -> Result<Vec<PathBuf>> {
-    let Ok(entries) = std::fs::read_dir(into) else {
+/// When the links directory cannot be read, or a link cannot be removed. A
+/// missing directory is not an error — there is nothing to sweep.
+pub fn sweep(bundle: &Bundle, target: &Target) -> Result<Vec<PathBuf>> {
+    let Ok(entries) = std::fs::read_dir(&target.links) else {
         return Ok(Vec::new());
     };
     let mut swept = Vec::new();
     for entry in entries {
-        let entry = entry.with_context(|| format!("cannot read {}", into.display()))?;
+        let entry = entry.with_context(|| format!("cannot read {}", target.links.display()))?;
         let link = entry.path();
         let name = entry.file_name();
         if BUNDLED.iter().any(|b| std::ffi::OsStr::new(b) == name) {
@@ -333,10 +673,10 @@ pub fn sweep(bundle: &Bundle, into: &Path) -> Result<Vec<PathBuf>> {
         if !meta.file_type().is_symlink() {
             continue;
         }
-        let Ok(target) = std::fs::read_link(&link) else {
+        let Ok(points_at) = std::fs::read_link(&link) else {
             continue;
         };
-        if !points_into_a_bundle(&target, &bundle.path) {
+        if !is_ours(&points_at, &bundle.path) {
             continue;
         }
         std::fs::remove_file(&link)
@@ -346,9 +686,10 @@ pub fn sweep(bundle: &Bundle, into: &Path) -> Result<Vec<PathBuf>> {
     Ok(swept)
 }
 
-/// The `wf skills` report: where the bundle is, where the links go, and the
-/// state of each — the answer to "which prompt is actually going to run".
-pub fn report(bundle: &Bundle, into: &Path) -> String {
+/// The `wf skills` report: where the bundle is, where the links and the copy
+/// they point at are, and the state of each — the answer to "which prompt is
+/// actually going to run".
+pub fn report(bundle: &Bundle, target: &Target) -> String {
     use std::fmt::Write;
     let source = match bundle.found_by {
         FoundBy::Env => BUNDLE_ENV,
@@ -356,18 +697,30 @@ pub fn report(bundle: &Bundle, into: &Path) -> String {
         FoundBy::Checkout => "this checkout",
     };
     let mut out = format!(
-        "bundle  {} ({source})\ntarget  {}\n\n",
+        "bundle  {} ({source})\nlinks   {}\ncopy    {} (what the links point at, \
+         so a devcontainer can read them too)\n\n",
         bundle.path.display(),
-        into.display()
+        target.links.display(),
+        target.mirror.display()
     );
     // Inspected once and reported from that, rather than asked twice: the two
     // answers would be a stat apart, and a report whose list and whose verdict
     // disagreed would be the worst possible output for this command.
-    let statuses = status(bundle, into);
+    let statuses = status(bundle, target);
     for Status { name, state } in &statuses {
         let line = match state {
             State::Current => "ok".to_string(),
-            State::Stale(target) => format!("stale — links to {}", target.display()),
+            // Where from, when that is known and is not where this build's
+            // bundle is: "outdated" alone leaves you guessing between a package
+            // update you have not launched since and a checkout you installed
+            // from months ago, and the fix is different.
+            State::Outdated { copied_from } => match copied_from {
+                Some(source) if *source != bundle.path => {
+                    format!("outdated — the copy came from {}", source.display())
+                }
+                _ => "outdated — the copy is not this build's".to_string(),
+            },
+            State::Stale(points_at) => format!("stale — links to {}", points_at.display()),
             State::Unmanaged => "not a link — another tool owns this one".to_string(),
             State::Missing => "missing".to_string(),
         };
@@ -385,16 +738,17 @@ pub fn report(bundle: &Bundle, into: &Path) -> String {
 mod tests {
     use super::*;
 
-    /// A scratch tree with a bundle and an empty target, removed on drop. No
-    /// `tempfile` dependency for a handful of tests that need real paths —
-    /// and these need *real* paths, because symlinks are what is under test.
+    /// A scratch tree with a bundle and an empty config directory, removed on
+    /// drop. No `tempfile` dependency for a handful of tests that need real
+    /// paths — and these need *real* paths, because symlinks are what is under
+    /// test.
     struct Scratch(PathBuf);
 
     impl Scratch {
         fn new(name: &str) -> Scratch {
             let dir = std::env::temp_dir().join(format!("wf-skills-{}-{name}", std::process::id()));
             let _ = std::fs::remove_dir_all(&dir);
-            std::fs::create_dir_all(dir.join("target")).expect("scratch");
+            std::fs::create_dir_all(dir.join("config/skills")).expect("scratch");
             Scratch(dir)
         }
 
@@ -405,9 +759,7 @@ mod tests {
                 if omit.contains(&name) {
                     continue;
                 }
-                let dir = path.join(name);
-                std::fs::create_dir_all(&dir).expect("bundle skill");
-                std::fs::write(dir.join("SKILL.md"), "---\n---\n").expect("SKILL.md");
+                write_skill(&path, name, "---\n---\n");
             }
             std::fs::create_dir_all(&path).expect("bundle");
             Bundle {
@@ -416,8 +768,10 @@ mod tests {
             }
         }
 
-        fn target(&self) -> PathBuf {
-            self.0.join("target")
+        /// The config directory Claude Code would read: `skills/` and the copy
+        /// beside it.
+        fn target(&self) -> Target {
+            Target::beside(&self.0.join("config/skills")).expect("a target")
         }
     }
 
@@ -427,42 +781,31 @@ mod tests {
         }
     }
 
-    #[test]
-    fn sweep_clears_links_a_rename_orphaned_and_nothing_else() {
-        let scratch = Scratch::new("sweep");
-        let bundle = scratch.bundle(&[]);
-        let target = scratch.target();
-        install(&bundle, &target).expect("install");
+    /// Write one skill into a bundle — the way a package update rewrites one.
+    fn write_skill(bundle: &Path, name: &str, body: &str) {
+        let dir = bundle.join(name);
+        std::fs::create_dir_all(&dir).expect("bundle skill");
+        std::fs::write(dir.join("SKILL.md"), body).expect("SKILL.md");
+    }
 
-        // What #104's rename left behind: a link named for a skill no longer in
-        // BUNDLED, pointing into a prefix whose bundle is already gone. Nothing
-        // that iterates BUNDLED can see it, and it dangles.
-        let dead = scratch.0.join("old-prefix/share/wf/skills/wayfinder");
-        std::os::unix::fs::symlink(&dead, target.join("wayfinder")).expect("orphan");
-        assert!(target.join("wayfinder").symlink_metadata().is_ok());
-
-        // Two things sweep must not touch, and the reason it can tell: neither
-        // target is inside a bundle.
-        let mine = target.join("grill-me");
-        std::fs::create_dir_all(&mine).expect("a skill of the user's own");
-        let elsewhere = scratch.0.join("somewhere-else");
-        std::fs::create_dir_all(&elsewhere).expect("another tool's tree");
-        std::os::unix::fs::symlink(&elsewhere, target.join("other-tool")).expect("other link");
-
-        let swept = sweep(&bundle, &target).expect("sweep");
-
-        assert_eq!(swept, vec![target.join("wayfinder")]);
-        assert!(target.join("wayfinder").symlink_metadata().is_err());
-        assert!(mine.is_dir(), "a real directory is never swept");
-        assert!(
-            target.join("other-tool").symlink_metadata().is_ok(),
-            "a link pointing outside any bundle is never swept"
-        );
-        // The skills this build does ship are untouched: they are in BUNDLED,
-        // so sweep skips them before it ever looks at where they point.
-        assert!(status(&bundle, &target)
-            .iter()
-            .all(|s| s.state == State::Current));
+    /// Copy a tree the way a bind mount presents one: at a different absolute
+    /// path, with symlinks carried across as symlinks rather than followed.
+    /// This is how the container is reproduced in a unit test.
+    fn remount(from: &Path, to: &Path) {
+        std::fs::create_dir_all(to).expect("mount point");
+        for entry in std::fs::read_dir(from).expect("read") {
+            let entry = entry.expect("entry");
+            let (src, dst) = (entry.path(), to.join(entry.file_name()));
+            let kind = entry.file_type().expect("file type");
+            if kind.is_symlink() {
+                let points_at = std::fs::read_link(&src).expect("link");
+                std::os::unix::fs::symlink(points_at, &dst).expect("relink");
+            } else if kind.is_dir() {
+                remount(&src, &dst);
+            } else {
+                std::fs::copy(&src, &dst).expect("copy");
+            }
+        }
     }
 
     #[test]
@@ -482,8 +825,8 @@ mod tests {
             .iter()
             .all(|s| s.state == State::Current));
 
-        // Twice is once: nothing is relinked, so a link is never briefly
-        // absent and no run reports work it did not do.
+        // Twice is once: nothing is relinked and nothing is re-copied, so a
+        // link is never briefly absent and no run reports work it did not do.
         let second = install(&bundle, &target).expect("reinstall");
         assert!(
             second.iter().all(|(_, o)| *o == Outcome::AlreadyCurrent),
@@ -492,26 +835,167 @@ mod tests {
     }
 
     #[test]
-    fn a_link_into_another_bundle_is_stale_and_gets_repointed() {
-        // The case that matters after `pixi global update wf`: the link is
-        // ours, it is just aimed at the previous prefix.
+    fn the_links_are_relative_into_a_copy_that_survives_being_mounted_elsewhere() {
+        // The #107 regression. A link into the package prefix is a good link on
+        // the host and a dangling one inside the devcontainer, which mounts
+        // `~/.claude` and nothing else, under a different home directory. So the
+        // link names neither a prefix nor a home: one `..` into the copy beside
+        // it, which rides the same mount.
+        let scratch = Scratch::new("mounted");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        install(&bundle, &target).expect("install");
+
+        for name in BUNDLED {
+            assert_eq!(
+                std::fs::read_link(target.links().join(name)).expect("a link"),
+                PathBuf::from(format!("../{MIRROR}/{name}")),
+                "{name} must be linked relatively"
+            );
+        }
+        // Now be the container: the whole config directory appears at another
+        // absolute path, with no bundle and no prefix anywhere in sight.
+        let container = scratch.0.join("container-home/.claude");
+        remount(&scratch.0.join("config"), &container);
+        std::fs::remove_dir_all(&bundle.path).expect("no bundle in the container");
+        for name in BUNDLED {
+            let skill = container.join("skills").join(name).join("SKILL.md");
+            assert!(
+                skill.is_file(),
+                "{} must resolve after the mount — this is the launch that says \
+                 `Unknown command: /{name}` when it does not",
+                skill.display()
+            );
+        }
+    }
+
+    #[test]
+    fn a_link_into_the_package_bundle_is_stale_and_gets_repointed() {
+        // What every `wf` up to this one wrote, and what is on every machine
+        // that has run `wf skills install`: an absolute link into the prefix.
+        // It resolves here, so nothing but the shape itself says it is wrong.
         let scratch = Scratch::new("stale");
         let bundle = scratch.bundle(&[]);
         let target = scratch.target();
-        let old = scratch.0.join("old-prefix").join("wf");
-        std::fs::create_dir_all(&old).expect("old bundle");
-        std::os::unix::fs::symlink(&old, target.join("wf")).expect("old link");
+        let old = bundle.path.join("wf");
+        std::os::unix::fs::symlink(&old, target.links().join("wf")).expect("old link");
 
         assert_eq!(
-            state_of(&bundle.path.join("wf"), &target.join("wf")),
-            State::Stale(old.clone())
+            link_state("wf", &target.links().join("wf")),
+            Link::Stale(old.clone())
         );
         let done = install(&bundle, &target).expect("install");
         let wf_skill = done.iter().find(|(n, _)| n == "wf").expect("entry");
         assert_eq!(wf_skill.1, Outcome::Linked { was: Some(old) });
+        assert_eq!(link_state("wf", &target.links().join("wf")), Link::Current);
+    }
+
+    #[test]
+    fn a_package_update_is_picked_up_by_install_and_by_refresh() {
+        // The copy is the thing that can go stale, so it is the thing that gets
+        // checked. A bundle rewritten under a running install (which is what
+        // `pixi global update wf` is) must not leave a prompt a release behind.
+        let scratch = Scratch::new("update");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        install(&bundle, &target).expect("install");
+
+        write_skill(&bundle.path, "wf-tdd", "---\n---\nthe new prompt\n");
         assert_eq!(
-            state_of(&bundle.path.join("wf"), &target.join("wf")),
-            State::Current
+            status(&bundle, &target)
+                .iter()
+                .find(|s| s.name == "wf-tdd")
+                .map(|s| s.state.clone()),
+            Some(State::Outdated {
+                copied_from: Some(bundle.path.clone())
+            }),
+            "a copy that is not this build's is reported, not assumed fresh"
+        );
+
+        // `refresh` is what the launch path calls: it moves the copy and
+        // nothing else.
+        assert_eq!(refresh(&target).expect("refresh"), vec!["wf-tdd"]);
+        assert_eq!(
+            std::fs::read_to_string(target.mirror().join("wf-tdd/SKILL.md")).expect("the copy"),
+            "---\n---\nthe new prompt\n"
+        );
+        assert!(status(&bundle, &target)
+            .iter()
+            .all(|s| s.state == State::Current));
+        assert!(
+            refresh(&target).expect("refresh").is_empty(),
+            "a copy already in step is not rewritten"
+        );
+
+        // And `install` says so rather than reporting a no-op.
+        write_skill(&bundle.path, "wf-tdd", "---\n---\nnewer still\n");
+        let done = install(&bundle, &target).expect("install");
+        assert_eq!(
+            done.iter().find(|(n, _)| n == "wf-tdd").expect("entry").1,
+            Outcome::Refreshed
+        );
+    }
+
+    #[test]
+    fn refresh_touches_nothing_it_was_not_asked_to_own() {
+        // A machine that never installed, and one where another tool owns the
+        // directory: neither gets files written behind its back by a launch.
+        let scratch = Scratch::new("untouched");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        assert!(refresh(&target).expect("refresh").is_empty());
+        assert!(!target.mirror().exists(), "no links, so nothing to serve");
+
+        std::fs::create_dir_all(target.links().join("wf-tdd")).expect("another tool's directory");
+        install(&bundle, &target).expect("install");
+        write_skill(&bundle.path, "wf-tdd", "---\n---\nnot yours to place\n");
+        assert!(refresh(&target).expect("refresh").is_empty());
+        assert!(!target.mirror().join("wf-tdd").exists());
+    }
+
+    #[test]
+    fn a_launch_refreshes_the_prompts_that_were_installed_not_its_own() {
+        // The `$WF_SKILLS_DIR` workflow, which the copy would otherwise break:
+        // you install a checkout's prompts to edit them, and then launch with
+        // the *released* `wf`, whose bundle is the package's. Overwriting the
+        // copy with its own prompts would undo your install silently on the
+        // next enter — so the copy tracks the bundle it was installed from, and
+        // an edit to that checkout is live in the next session exactly as it
+        // was when the link pointed straight at it.
+        let scratch = Scratch::new("checkout");
+        let checkout = scratch.bundle(&[]);
+        let target = scratch.target();
+        install(&checkout, &target).expect("install from the checkout");
+        assert_eq!(installed_from(&target).as_deref(), Some(&*checkout.path));
+
+        let released = Bundle {
+            path: scratch.0.join("prefix/share/wf/skills"),
+            found_by: FoundBy::Installed,
+        };
+        for name in BUNDLED {
+            write_skill(&released.path, name, "---\n---\nthe released prompt\n");
+        }
+        write_skill(
+            &checkout.path,
+            "wf-tdd",
+            "---\n---\nthe prompt being edited\n",
+        );
+
+        // The released `wf` launching: it refreshes from the checkout, because
+        // that is what was installed.
+        assert_eq!(refresh(&target).expect("refresh"), vec!["wf-tdd"]);
+        assert_eq!(
+            std::fs::read_to_string(target.mirror().join("wf-tdd/SKILL.md")).expect("the copy"),
+            "---\n---\nthe prompt being edited\n"
+        );
+        // And says whose prompts those are, rather than a bare "outdated".
+        assert!(
+            report(&released, &target).contains(&format!(
+                "outdated — the copy came from {}",
+                checkout.path.display()
+            )),
+            "{}",
+            report(&released, &target)
         );
     }
 
@@ -523,7 +1007,7 @@ mod tests {
         let scratch = Scratch::new("unmanaged");
         let bundle = scratch.bundle(&[]);
         let target = scratch.target();
-        let real = target.join("wf-tdd");
+        let real = target.links().join("wf-tdd");
         std::fs::create_dir_all(&real).expect("real dir");
         std::fs::write(real.join("SKILL.md"), "someone else's").expect("write");
 
@@ -531,6 +1015,10 @@ mod tests {
         let tdd = done.iter().find(|(n, _)| n == "wf-tdd").expect("entry");
         assert_eq!(tdd.1, Outcome::Blocked);
         assert!(real.join("SKILL.md").is_file(), "the file must survive");
+        assert!(
+            !target.mirror().join("wf-tdd").exists(),
+            "a blocked skill's copy is never read, so it is never written"
+        );
         assert!(
             done.iter()
                 .filter(|(n, _)| n != "wf-tdd")
@@ -550,7 +1038,7 @@ mod tests {
         let done = install(&bundle, &target).expect("install");
         let review = done.iter().find(|(n, _)| n == "wf-review").expect("entry");
         assert_eq!(review.1, Outcome::NotInBundle);
-        assert!(!target.join("wf-review").exists());
+        assert!(!target.links().join("wf-review").exists());
         assert_eq!(
             status(&bundle, &target)
                 .iter()
@@ -561,7 +1049,72 @@ mod tests {
     }
 
     #[test]
-    fn the_report_names_the_bundle_the_target_and_every_skill() {
+    fn sweep_clears_links_a_rename_orphaned_and_nothing_else() {
+        let scratch = Scratch::new("sweep");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        install(&bundle, &target).expect("install");
+
+        // What #104's rename left behind: a link named for a skill no longer in
+        // BUNDLED, pointing into a prefix whose bundle is already gone. Nothing
+        // that iterates BUNDLED can see it, and it dangles. Both the old shape
+        // and the one this build writes have to be recognised, or the next
+        // rename leaves residue of its own.
+        let dead = scratch.0.join("old-prefix/share/wf/skills/wayfinder");
+        std::os::unix::fs::symlink(&dead, target.links().join("wayfinder")).expect("orphan");
+        std::os::unix::fs::symlink(Target::link_target("wf-old"), target.links().join("wf-old"))
+            .expect("orphan copy link");
+
+        // Two things sweep must not touch, and the reason it can tell: neither
+        // target is one `wf` writes.
+        let mine = target.links().join("grill-me");
+        std::fs::create_dir_all(&mine).expect("a skill of the user's own");
+        let elsewhere = scratch.0.join("somewhere-else");
+        std::fs::create_dir_all(&elsewhere).expect("another tool's tree");
+        std::os::unix::fs::symlink(&elsewhere, target.links().join("other-tool"))
+            .expect("other link");
+
+        let mut swept = sweep(&bundle, &target).expect("sweep");
+        swept.sort();
+
+        assert_eq!(
+            swept,
+            vec![
+                target.links().join("wayfinder"),
+                target.links().join("wf-old")
+            ]
+        );
+        assert!(mine.is_dir(), "a real directory is never swept");
+        assert!(
+            target.links().join("other-tool").symlink_metadata().is_ok(),
+            "a link pointing where wf never links is never swept"
+        );
+        // The skills this build does ship are untouched: they are in BUNDLED,
+        // so sweep skips them before it ever looks at where they point.
+        assert!(status(&bundle, &target)
+            .iter()
+            .all(|s| s.state == State::Current));
+    }
+
+    #[test]
+    fn the_copy_drops_what_this_build_no_longer_ships() {
+        // The mirror is wf's own directory, so a rename's residue in there is
+        // wf's to clear — and it must be, or a copy outlives every build that
+        // shipped it.
+        let scratch = Scratch::new("prune");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        install(&bundle, &target).expect("install");
+        let orphan = target.mirror().join("wayfinder");
+        std::fs::create_dir_all(&orphan).expect("an older build's copy");
+
+        install(&bundle, &target).expect("reinstall");
+        assert!(!orphan.exists());
+        assert!(target.mirror().join("wf-tdd").is_dir(), "and only that");
+    }
+
+    #[test]
+    fn the_report_names_the_bundle_the_links_the_copy_and_every_skill() {
         let scratch = Scratch::new("report");
         let bundle = scratch.bundle(&[]);
         let target = scratch.target();
@@ -574,8 +1127,32 @@ mod tests {
         for name in BUNDLED {
             assert!(after.contains(name), "{name} missing from {after}");
         }
+        // Where the prompts actually live is half the answer to "which prompt
+        // runs", so the report says it rather than leaving it to be guessed.
+        assert!(
+            after.contains(&target.mirror().display().to_string()),
+            "{after}"
+        );
         assert!(!after.contains("missing"), "{after}");
         assert!(after.contains("this build's own"), "{after}");
+
+        write_skill(&bundle.path, "wf", "---\n---\nchanged\n");
+        assert!(report(&bundle, &target).contains("outdated"));
+    }
+
+    #[test]
+    fn a_links_directory_with_no_parent_has_nowhere_to_keep_the_copy() {
+        // Total rather than papered over: the copy is a sibling or the links do
+        // not resolve, so a path that has no sibling is refused at the
+        // constructor instead of producing links that dangle.
+        assert!(Target::beside(Path::new("skills")).is_err());
+        assert!(Target::beside(Path::new("/")).is_err());
+        assert_eq!(
+            Target::beside(Path::new("/home/you/.claude/skills"))
+                .expect("a target")
+                .mirror(),
+            Path::new("/home/you/.claude/wf-skills")
+        );
     }
 
     #[test]

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -88,6 +88,14 @@ impl Scratch {
         self.0.join("cache")
     }
 
+    /// A Claude Code config directory of this test's own. Not a nicety: the
+    /// launch path refreshes the installed skill copies on its way to the exec,
+    /// and a test that let it find the real `~/.claude` would be rewriting the
+    /// user's prompts as a side effect of running.
+    fn claude(&self) -> PathBuf {
+        self.0.join("claude")
+    }
+
     fn report(&self) -> PathBuf {
         self.0.join("report.txt")
     }
@@ -251,6 +259,18 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     scratch.write_shims();
     let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
 
+    // Claim 4's setup: this repo's skills, installed into a config directory of
+    // the test's own, with one copied prompt then vandalised. What the launch
+    // does about that is checked after the exec.
+    let target = wf::skills::Target::beside(&scratch.claude().join("skills")).expect("a target");
+    let bundle = wf::skills::Bundle {
+        path: repo.join("skills"),
+        found_by: wf::skills::FoundBy::Checkout,
+    };
+    wf::skills::install(&bundle, &target).expect("install the skills");
+    let copied_prompt = target.mirror().join("wf-tdd/SKILL.md");
+    std::fs::write(&copied_prompt, "a prompt from an older release\n").expect("vandalise the copy");
+
     let (master, slave) = openpty_sized(40, 120);
     let path = format!(
         "{}:{}",
@@ -265,6 +285,7 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
             // Keep the user's real projects cache out of it: this run
             // registers a checkout and writes a map seed.
             .env("XDG_CACHE_HOME", scratch.cache())
+            .env("CLAUDE_CONFIG_DIR", scratch.claude())
             .env("TERM", "xterm-256color")
             .stdin(Stdio::from(slave.try_clone().expect("dup slave")))
             .stdout(Stdio::from(slave.try_clone().expect("dup slave")))
@@ -426,5 +447,25 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
         contains(handover, b"\x1b[?25h"),
         "wf never made the cursor visible again before handing over — \
          the agent inherits an invisible cursor"
+    );
+
+    // Claim 4: the agent can actually *run* the skill it was just handed. The
+    // prompt is a slash command, so a link the agent cannot resolve is not an
+    // error anywhere near here — it is `Unknown command: /wf-tdd` inside the
+    // session (#107). Two halves, both only observable on a real launch: the
+    // link is relative, so it still resolves after `dl` mounts `~/.claude` into
+    // the container at another path; and the copy behind it was brought back in
+    // step with this build's `skills/` on the way past, which is what stops a
+    // copy from being a thing that goes stale.
+    assert_eq!(
+        std::fs::read_link(target.links().join("wf-tdd")).ok(),
+        Some(PathBuf::from("../wf-skills/wf-tdd")),
+        "the installed link must name no home directory, or the container's \
+         copy of it dangles"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&copied_prompt).ok(),
+        std::fs::read_to_string(repo.join("skills/wf-tdd/SKILL.md")).ok(),
+        "the launch must refresh the prompt it is about to exec"
     );
 }


### PR DESCRIPTION
## Summary

- `enter` in a repo with a devcontainer launched an agent that answered `Unknown command: /wf-tdd`. `wf skills install` wrote **absolute** links into the pixi prefix — `~/.claude/skills/wf-tdd -> ~/.pixi/envs/wf/share/wf/skills/wf-tdd` — and `dl` mounts `~/.claude` into the container and nothing else, under a different home path (`/home/vscode` in, `/home/you` out). Every link dangles in there, and a dangling skill reports itself nowhere near the install: it is one line inside the session, seconds after the launch.
- The links now point at a **copy kept inside the mounted tree** (`~/.claude/wf-skills`), and point at it **relatively** (`wf-tdd -> ../wf-skills/wf-tdd`), which is what makes one link resolve under both home directories. Cross-skill references (`../wf/GITHUB_TRACKER.md`) survive, because the whole bundle is copied as a tree.
- A copy is a thing that goes stale, so it is not trusted. `install` records the bundle it copied (`<mirror>/.source`), **every launch re-copies from that record** before exec'ing the agent, and `wf skills` reports `outdated — the copy came from <path>` instead of quietly running a release behind.
- Refreshing from the *record* rather than from the launching build's own bundle is what keeps an ordinary `wf` launch from silently undoing a `WF_SKILLS_DIR=$PWD/skills wf skills install`. Editing a checkout's prompts is still live in the next session, however you launch.
- Modelling: `Link` (a fact about the symlink) is split from `State` (what will actually run), so `State::Outdated` cannot be returned by the function that only stat'd a link, and `install` matches exhaustively with no unreachable arm. `Target` pairs the links directory with its copy, so "the copy is a sibling" — the invariant the relative link depends on — cannot be constructed false.
- `sweep` learns the new link shape (a rename's residue is still swept, a user's own skill still never is), and the copy is pruned of skills a build stopped shipping.

## Test plan

- `cargo fmt --check`, `clippy --all-targets`, `test --lib --bins --examples`, `doc` — all under `RUSTFLAGS=-D warnings` / `RUSTDOCFLAGS=-D warnings`. 212 unit tests green.
- New unit test **remounts** the config tree at a different absolute path with the bundle deleted, and asserts every skill still resolves — the container, reproduced without one.
- New unit tests cover: a package update seen by both `install` and `refresh`; a `WF_SKILLS_DIR` install *not* overwritten by a released build's launch; `refresh` touching nothing on a machine that never installed; the copy pruned on rename; a links directory with no parent refused at the constructor.
- `tests/live_launch_exec.rs` gained claim 4 — real pty, real map off the tracker, real `enter`: the installed link is relative, and the launch refreshed a deliberately vandalised copy on its way to the exec. **Verified it fails when `refresh_skills()` is removed**, so it is not vacuous.
- That live test now also gets a scratch `CLAUDE_CONFIG_DIR`. It would otherwise have rewritten the developer's real `~/.claude` as a side effect of the launch path it exercises.
- Drove the released-shape flow by hand with the built binary: install → report → package update → report says outdated → refreshed.

## Review notes

- **Existing machines need one `wf skills install` after this ships.** Their links are the old absolute kind, which `refresh` deliberately will not touch (it only keeps `wf`'s own links in step; it does not adopt or rewrite links it did not write). The install relinks and reports `relinked (was …)`. A picker-level notice when the installed links are stale would have caught this class of bug years earlier and is worth its own ticket — deliberately not in this PR.
- `install` writes `.source` even when every skill was `Blocked`, leaving a `~/.claude/wf-skills` holding nothing but the record. Harmless, and the alternative is a conditional that has to agree with the loop above it.
- `copy_tree` handles directories and regular files only. The bundle is markdown beside markdown, so a symlink appearing inside it would be a packaging fault and errors rather than being silently followed.

## Summary by Sourcery

Ensure wf-installed skills remain usable inside devcontainers by linking ~/.claude/skills to a local copy of the bundle and keeping that copy in sync across launches.

New Features:
- Track the source bundle for installed skills and expose outdated copies in wf skills status and reports.
- Automatically refresh installed skill copies on every wf launch so prompts match the recorded bundle.
- Support installing skills from an arbitrary WF_SKILLS_DIR checkout without later launches silently overwriting them.

Enhancements:
- Introduce a Target abstraction tying the Claude skills directory to its sibling mirror and refine skill state modelling to distinguish link shape from content freshness.
- Update sweep logic to recognise both old and new link shapes while preserving user-owned skills and prune mirror entries for skills no longer shipped.
- Clarify CLI help and documentation around skill installation, devcontainer behavior, and the new copy-and-refresh model.

Tests:
- Add unit tests for relative links surviving remounts, package updates being picked up by install/refresh, WF_SKILLS_DIR checkout installs remaining authoritative, mirror pruning, and invalid target paths.
- Extend live_launch_exec to use an isolated Claude config, install skills into it, and assert that launch-time refresh fixes a deliberately stale copied prompt.