### PR TITLE
Release 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.11.0"
+  version: "0.12.0"
 
 package:
   name: wf


### PR DESCRIPTION
Version bump only — `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` in step,
which CI checks for drift.

Releases the two commits sitting on `main` past `v0.11.0`:

- **#109** — `enter` opens a launch picker instead of a launch line, so the mode
  is a row you select rather than a word (`auto`, and `defer` before it) you had
  to already know; anything typed in the overlay is steering text. The chords are
  unchanged. The search prompt and count line also move to the top of the screen.
- **#110** — `wf skills install` writes a copy under `~/.claude/wf-skills/` and
  links to it, so skills resolve inside an isolated launch's devcontainer rather
  than dangling into the pixi prefix.

The upgrade note for an 0.11.0 user is that typing `auto` no longer means
unattended. It is steering text now, and unattended is a row you move to.

Tagging `v0.12.0` after this merges is what actually publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump project version metadata to 0.12.0 across Cargo and recipe configuration files to prepare the 0.12.0 release.