### PR TITLE
A plain launch mode: enter a node with a bare claude session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,10 +71,13 @@ Three consequences for anyone editing here:
   it. `skills/wf-one/SKILL.md` and `wf-auto` link
   `../wf/GITHUB_TRACKER.md` and `../wf/LIFECYCLE.md` by relative
   path, so the five move as a set and the layout under `skills/` is load-bearing.
-- **Adding a `Route` means adding a skill.** `skills::BUNDLED` lists what ships
-  and a unit test asserts every `Route::label()` is in it, so a route pointing
+- **Adding a `Route` means saying which skill it invokes — or that it invokes
+  none.** `skills::BUNDLED` lists what ships and `Route::bundled_skill()` is the
+  exhaustive answer to which of them a route names; a unit test sweeps
+  `Route::all()` and asserts every `Some` is in the bundle, so a route pointing
   at a prompt the package does not carry fails the build rather than an agent
-  launch.
+  launch. `Route::Plain` (#112) is the one `None`: it execs the agent with no
+  slash command, so there is no prompt for the package to be missing.
 - **Renaming one leaves residue on every machine that had the old name.**
   `status` and `install` both iterate `BUNDLED`, so a link named for a skill
   that left the list is invisible to them while staying on disk, dangling.

--- a/README.md
+++ b/README.md
@@ -315,15 +315,16 @@ opens the **launch picker** over the list, showing what is about to happen and
 the one thing still undecided — who resolves the node:
 
 ```
-┌ launch #65 Author the /wf-tdd skill ────────────────────────────┐
-│                                                                 │
-│  ▶ interactive /wf-tdd   you are in the loop; it grills you     │
-│    auto        /wf-auto  the agent decides alone and drives it  │
-│                                                                 │
-│    steer  █                                                     │
-│                                                                 │
-│  enter launch · ↑/↓ mode · type to steer · esc cancel           │
-└─────────────────────────────────────────────────────────────────┘
+┌ launch #65 Author the /wf-tdd skill ──────────────────────────────────┐
+│                                                                       │
+│  ▶ interactive /wf-tdd   you are in the loop; it grills you           │
+│    auto        /wf-auto  the agent decides alone and drives it to done│
+│    plain       claude    no skill; a bare session on the node's branch│
+│                                                                       │
+│    steer  █                                                           │
+│                                                                       │
+│  enter launch · ↑/↓ mode · type to steer · esc cancel                 │
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
 `↑`/`↓` (or `tab`) move between the modes and `enter` runs the one you are on,
@@ -361,6 +362,7 @@ headers are one `↑` away.
 | `wayfinder:build` | in review | interactive | `claude "/wf-review <n>"` |
 | research · prototype · grilling · task | any unfinished stage | interactive | `claude "/wf <map> <n>"` |
 | anything | any unfinished stage | auto | `claude "/wf-auto <map> [<n>]"` |
+| anything | any unfinished stage | plain | `claude` — no skill, no arguments |
 | a ticket | done | — | nothing — not launchable |
 
 The auto mode collapses the ticket rows on purpose: the launched session is a
@@ -369,6 +371,17 @@ the gate, then a fresh-context `/wf-review` — so it is the manager skill that 
 not the one skill that stage would have called. Steering text rides whichever
 route you got, as ` steer: <text>` on the end of the prompt; the mode itself
 never does, because it has already chosen the skill.
+
+**The plain mode collapses them for the opposite reason: it runs no skill at
+all.** Everything else about the launch is unchanged — same checkout, same
+per-node branch, same clone and container — so it is the way to get `wf`'s
+workspace without a skill's opinion about what to do in it: reading the code a
+ticket is about, a quick fix too small to be a node's lifecycle, or picking up
+after an agent that stopped somewhere awkward. There being no skill in front of
+it is also why steering text is handled differently here: a ` steer: <text>`
+suffix would be addressed to nobody, so whatever you type is simply the
+session's opening prompt, and typing nothing passes no prompt at all rather than
+an empty one.
 
 | key | what it does |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ headers are one `↑` away.
 | `wayfinder:build` | in review | interactive | `claude "/wf-review <n>"` |
 | research · prototype · grilling · task | any unfinished stage | interactive | `claude "/wf <map> <n>"` |
 | anything | any unfinished stage | auto | `claude "/wf-auto <map> [<n>]"` |
-| anything | any unfinished stage | plain | `claude` — no skill, no arguments |
+| anything | any unfinished stage | plain | `claude` — no skill; anything typed is the whole prompt |
 | a ticket | done | — | nothing — not launchable |
 
 The auto mode collapses the ticket rows on purpose: the launched session is a

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,10 +72,9 @@ pub enum Overlay {
 
 /// The mode after `mode` in the launch picker, wrapping.
 ///
-/// Derived from [`Mode::all`] rather than written as a toggle: with two modes a
-/// toggle is the same thing, but it stops being the same thing the moment a
-/// third mode exists, and this is the code that would silently keep working
-/// while skipping it.
+/// Derived from [`Mode::all`] rather than written as a toggle. With two modes a
+/// toggle was the same thing; #112's third mode is exactly the change that
+/// would have left a toggle silently working and skipping the new one.
 fn next_mode(mode: Mode) -> Mode {
     stepped(mode, 1)
 }
@@ -720,9 +719,10 @@ impl App {
             KeyCode::Enter => {
                 return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
             }
-            // With two modes every step is the same step; `tab` joins the
-            // arrows because it is what the rest of the screen uses to move
-            // between two of something.
+            // The two directions are genuinely different steps now that there
+            // is a third mode (#112); `tab` joins the arrows because it is what
+            // the rest of the screen uses to move through a list, and it steps
+            // the way `down` does rather than toggling.
             KeyCode::Up => mode = previous_mode(mode),
             KeyCode::Down | KeyCode::Tab => mode = next_mode(mode),
             KeyCode::Backspace => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1864,10 +1864,11 @@ mod tests {
 
     #[test]
     fn the_picker_walks_the_modes_both_ways_and_wraps() {
-        // Up and down are inverses and neither can fall off an end: with two
-        // modes every step lands on the other one, and the mode under the
-        // cursor is the mode `enter` will launch, so a step that went nowhere
-        // (or panicked at index 0) would launch the wrong skill.
+        // Up and down are inverses and neither can fall off an end, and the
+        // mode under the cursor is the mode `enter` will launch — so a step
+        // that went nowhere (or panicked at index 0) would launch the wrong
+        // skill. With a third mode (#112) the two directions are no longer the
+        // same step, so each is walked the whole way round.
         let mut app = launchable_app();
         go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Enter));
@@ -1876,7 +1877,10 @@ mod tests {
             other => panic!("expected the launch picker, got {other:?}"),
         };
         assert_eq!(mode(&app), Mode::Interactive);
-        // Up from the first row wraps to the last rather than sticking.
+        // Up from the first row wraps to the last rather than sticking, and
+        // keeps climbing back to the top.
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(mode(&app), Mode::Plain);
         app.handle_key(key(KeyCode::Up));
         assert_eq!(mode(&app), Mode::Auto);
         app.handle_key(key(KeyCode::Up));
@@ -1884,6 +1888,8 @@ mod tests {
         // Tab steps the same way down does — it is not the view toggle in here.
         app.handle_key(key(KeyCode::Tab));
         assert_eq!(mode(&app), Mode::Auto);
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(mode(&app), Mode::Plain, "down reaches the third mode too");
         app.handle_key(key(KeyCode::Down));
         assert_eq!(mode(&app), Mode::Interactive);
         // Steering text is untouched by moving the mode: the two axes are

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -8,7 +8,10 @@
 //! ([`Aim`]) and who decides ([`Mode`]), and any steering text rides the
 //! prompt as a suffix (#61/#62/#96). Unattended work is still not supervised
 //! here — an `auto` launch is the same exec of `/wf-auto`, watched from
-//! another terminal or not at all.
+//! another terminal or not at all. One mode invokes no skill at all
+//! ([`Mode::Plain`], #112): the same exec, in the same workspace, with the
+//! prompt left to the human — so `wf` remains the thing that resolves a node
+//! to a place to work even when nothing is going to be run in it.
 //!
 //! A checkout that declares a devcontainer runs that same agent *inside* a
 //! container, by way of `dl` ([`Isolation`], #80): `wf` owns which ticket,
@@ -81,10 +84,11 @@ impl Route {
 /// Who resolves the launched node — the axis #96 added to routing, orthogonal
 /// to what the cursor was standing on.
 ///
-/// Not a flag on the skill: the two modes are *different skills* (`/wf`
-/// and `/wf-auto`), so the mode is an input to [`route`] rather than
-/// something the prompt carries. That is why nothing about "auto" survives
-/// into the exec'd prompt's steering suffix — by then it has already been spent.
+/// Not a flag on the skill: the modes are *different skills* (`/wf` and
+/// `/wf-auto`) — or, in [`Mode::Plain`]'s case, no skill at all — so the mode
+/// is an input to [`route`] rather than something the prompt carries. That is
+/// why nothing about "auto" survives into the exec'd prompt's steering suffix:
+/// by then it has already been spent.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Mode {
     /// The default: the human is in the loop, and the session grills them.
@@ -963,7 +967,10 @@ mod tests {
     fn every_mode_is_in_the_picker_and_the_default_leads_it() {
         // The picker lists `Mode::all`, so a mode missing from it would be a
         // mode nothing on screen can reach.
-        assert_eq!(Mode::all(), vec![Mode::Interactive, Mode::Auto, Mode::Plain]);
+        assert_eq!(
+            Mode::all(),
+            vec![Mode::Interactive, Mode::Auto, Mode::Plain]
+        );
         assert_eq!(
             Mode::all().first(),
             Some(&Mode::default()),

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -63,13 +63,14 @@ pub enum Route {
 
 impl Route {
     /// How the route reads in the launch picker: the slash command it execs,
-    /// or the bare agent when it execs no slash command at all.
+    /// or — for the one route that execs none — the agent's own name.
     ///
-    /// Every label is prefixed `wf`, because these names are claimed in a
-    /// namespace `wf` does not own: `~/.claude/skills` is flat and shared with
+    /// Every *skill* label is prefixed `wf`, because those names are claimed in
+    /// a namespace `wf` does not own: `~/.claude/skills` is flat and shared with
     /// every other source of skills the user has. Unprefixed `tdd` and `review`
     /// are names someone else will plausibly want — and while `wf` holds them,
-    /// nobody else can have them (#104).
+    /// nobody else can have them (#104). [`Route::Plain`] is outside that
+    /// argument entirely: it claims no name, because it invokes nothing.
     pub fn label(self) -> &'static str {
         match self {
             Route::Tdd => "/wf-tdd",
@@ -78,6 +79,53 @@ impl Route {
             Route::WayfinderAuto => "/wf-auto",
             Route::Plain => "claude",
         }
+    }
+
+    /// The bundled skill this route invokes, named as
+    /// [`crate::skills::BUNDLED`] spells it — `None` for the one route that
+    /// invokes no skill.
+    ///
+    /// The typed form of "adding a `Route` means adding a skill": a new route
+    /// has to say which bundled prompt it names, or that it names none, and
+    /// cannot quietly point at one the package does not ship. Exhaustive, so
+    /// the answer is given at the point the route is added rather than
+    /// discovered at an agent launch.
+    pub fn bundled_skill(self) -> Option<&'static str> {
+        match self {
+            Route::Tdd | Route::Review | Route::Wayfinder | Route::WayfinderAuto => {
+                Some(self.label().trim_start_matches('/'))
+            }
+            Route::Plain => None,
+        }
+    }
+
+    /// The next route, wrapping — private, and existing only so [`Route::all`]
+    /// can be derived rather than written out. Same device as [`Mode::after`],
+    /// for the same reason: a list written beside the enum is a second place to
+    /// remember, and the bundle invariant is exactly what forgetting it breaks.
+    fn after(self) -> Route {
+        match self {
+            Route::Tdd => Route::Review,
+            Route::Review => Route::Wayfinder,
+            Route::Wayfinder => Route::WayfinderAuto,
+            Route::WayfinderAuto => Route::Plain,
+            Route::Plain => Route::Tdd,
+        }
+    }
+
+    /// Every route there is. Walks the `after` cycle until it comes back round
+    /// — or, if a future cycle is malformed and never does, until it repeats
+    /// itself, so this cannot spin.
+    pub fn all() -> Vec<Route> {
+        let mut routes = vec![Route::Tdd];
+        while let Some(&last) = routes.last() {
+            let next = last.after();
+            if routes.contains(&next) {
+                break;
+            }
+            routes.push(next);
+        }
+        routes
     }
 }
 
@@ -193,12 +241,21 @@ impl LaunchMode {
         self.mode
     }
 
-    /// The suffix appended to the exec'd slash command: nothing, or
-    /// ` steer: <text>`. The mode is *not* here — it chose the skill.
-    fn suffix(&self) -> String {
-        match &self.steer {
-            None => String::new(),
-            Some(text) => format!(" steer: {text}"),
+    /// What the agent is opened on, given the skill invocation the route
+    /// resolved to — `None` when there is nothing to say to it at all.
+    ///
+    /// Both halves of the steering axis are answered here rather than half of
+    /// them at the call site, because the typed text means something different
+    /// depending on whether anything is in front of it: with a skill it is a
+    /// ` steer: <text>` suffix *on* that skill, and with none there is nobody
+    /// for a suffix to be addressed to, so it is simply the whole prompt. The
+    /// mode itself is in neither — it has already been spent choosing the
+    /// route.
+    fn opening_prompt(&self, skill: Option<String>) -> Option<String> {
+        match (skill, &self.steer) {
+            (Some(skill), None) => Some(skill),
+            (Some(skill), Some(text)) => Some(format!("{skill} steer: {text}")),
+            (None, steer) => steer.clone(),
         }
     }
 }
@@ -558,34 +615,24 @@ impl Launch {
 
     /// The agent itself. `claude` takes a single positional prompt, so the
     /// slash command, its arguments and the steering suffix are one argv
-    /// entry, not several. Only the wayfinder skills take the map argument —
-    /// `/wf-tdd` and `/wf-review` resolve the repo from the checkout they run in.
-    ///
-    /// The map aim is matched first because it is the arm that needs no
-    /// second thought: [`route`] hands a cluster header nothing but a
-    /// wayfinder skill, and a wayfinder skill on a map is the map's number
-    /// alone. The ticket arm is where the two argument shapes live.
+    /// entry, not several — and, when there is nothing to say to it at all, no
+    /// entry rather than an empty one (`claude ""` is a prompt, and an empty
+    /// one).
     fn claude_argv(&self) -> Vec<String> {
         let mut argv = vec!["claude".to_string(), SKIP_PERMISSIONS.to_string()];
-        argv.extend(self.prompt());
+        argv.extend(self.mode.opening_prompt(self.skill_invocation()));
         argv
-    }
-
-    /// The single positional argument `claude` is opened on — `None` when
-    /// there is nothing to say to it, which is a shorter argv rather than an
-    /// empty argument (`claude ""` is a prompt, and an empty one).
-    fn prompt(&self) -> Option<String> {
-        match self.skill_invocation() {
-            Some(skill) => Some(format!("{skill}{}", self.mode.suffix())),
-            // No skill in front of it for a ` steer: …` suffix to steer, so
-            // the typed text is not steering anything — it is the whole of
-            // what the session is opened on.
-            None => self.mode.steer.clone(),
-        }
     }
 
     /// The slash command and its arguments, for the routes that invoke a
     /// skill. `None` is [`Route::Plain`]: no skill, so nothing to invoke.
+    ///
+    /// [`Route::Plain`] is absorbed first because it is the arm that needs no
+    /// second thought — it has no arguments to shape, whatever it was aimed at.
+    /// The map aim comes next for the same reason: a skill on a map is the
+    /// map's number alone. The ticket arm is where the two argument shapes
+    /// live — only the wayfinder skills take the map argument, since `/wf-tdd`
+    /// and `/wf-review` resolve the repo from the checkout they run in.
     fn skill_invocation(&self) -> Option<String> {
         let skill = self.route.label();
         match (self.route, &self.aim) {
@@ -822,19 +869,6 @@ mod tests {
         LaunchMode::picked(Mode::Plain, steer)
     }
 
-    /// The whole argv a node of this (type, stage) is launched with, under
-    /// `mode`. Whole rather than its last entry, because a plain session's
-    /// argv may have no prompt entry to take the last of.
-    fn ticket_argv(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> Vec<String> {
-        let mut node = ticket("blooop/wayfinder", 16);
-        node.ticket_type = ticket_type;
-        let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
-        match plan(&cache(), &staged, mode) {
-            Targets::One(l) => l.agent_argv(),
-            other => panic!("{other:?}"),
-        }
-    }
-
     /// An interactive `/wf` plan — the default launch, and the shape
     /// every checkout-resolution test wants (route and mode are orthogonal to
     /// which trees are candidates).
@@ -982,15 +1016,26 @@ mod tests {
         assert_eq!(seen.len(), Mode::all().len());
     }
 
-    /// The prompt a node of this (type, stage) is launched with, under `mode`.
-    fn ticket_prompt(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> String {
+    /// The whole argv a node of this (type, stage) is launched with, under
+    /// `mode`. Whole rather than its last entry, because a plain session's
+    /// argv may have no prompt entry to take the last of.
+    fn ticket_argv(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> Vec<String> {
         let mut node = ticket("blooop/wayfinder", 16);
         node.ticket_type = ticket_type;
         let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
         match plan(&cache(), &staged, mode) {
-            Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+            Targets::One(l) => l.agent_argv(),
             other => panic!("{other:?}"),
         }
+    }
+
+    /// The prompt of that launch — for the tests about *what is said* to a
+    /// skill, where the argv's shape is not the question.
+    fn ticket_prompt(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> String {
+        ticket_argv(ticket_type, stage, mode)
+            .last()
+            .expect("a prompt")
+            .clone()
     }
 
     /// The whole argv of a launch aimed at the whole map.
@@ -1002,13 +1047,9 @@ mod tests {
         }
     }
 
-    /// The same, for a launch aimed at the whole map.
+    /// The same, reduced to the prompt.
     fn map_prompt(mode: &LaunchMode) -> String {
-        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
-        match plan(&cache(), &staged, mode) {
-            Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
-            other => panic!("{other:?}"),
-        }
+        map_argv(mode).last().expect("a prompt").clone()
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -571,8 +571,13 @@ impl Launch {
     /// there is nothing to say to it, which is a shorter argv rather than an
     /// empty argument (`claude ""` is a prompt, and an empty one).
     fn prompt(&self) -> Option<String> {
-        let skill = self.skill_invocation()?;
-        Some(format!("{skill}{}", self.mode.suffix()))
+        match self.skill_invocation() {
+            Some(skill) => Some(format!("{skill}{}", self.mode.suffix())),
+            // No skill in front of it for a ` steer: …` suffix to steer, so
+            // the typed text is not steering anything — it is the whole of
+            // what the session is opened on.
+            None => self.mode.steer.clone(),
+        }
     }
 
     /// The slash command and its arguments, for the routes that invoke a
@@ -981,6 +986,15 @@ mod tests {
         }
     }
 
+    /// The whole argv of a launch aimed at the whole map.
+    fn map_argv(mode: &LaunchMode) -> Vec<String> {
+        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        match plan(&cache(), &staged, mode) {
+            Targets::One(l) => l.agent_argv(),
+            other => panic!("{other:?}"),
+        }
+    }
+
     /// The same, for a launch aimed at the whole map.
     fn map_prompt(mode: &LaunchMode) -> String {
         let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
@@ -1172,6 +1186,35 @@ mod tests {
         // and no prompt argument at all rather than an empty one.
         assert_eq!(
             ticket_argv(TicketType::Build, Stage::Ready, &plain("")),
+            vec!["claude".to_string(), SKIP_PERMISSIONS.to_string()]
+        );
+    }
+
+    #[test]
+    fn a_plain_session_opens_on_what_was_typed_and_nothing_else() {
+        // Steering rides as ` steer: …` because there is a skill in front of
+        // it to steer. With no skill the same suffix would be addressed to
+        // nobody, so the text is simply the session's first message — and the
+        // map number, which is an argument to a skill and not to `claude`,
+        // does not appear either.
+        assert_eq!(
+            ticket_argv(TicketType::Build, Stage::Ready, &plain("rebase onto main")),
+            vec![
+                "claude".to_string(),
+                SKIP_PERMISSIONS.to_string(),
+                "rebase onto main".to_string()
+            ]
+        );
+        assert_eq!(
+            map_argv(&plain("what is actually left in here?")),
+            vec![
+                "claude".to_string(),
+                SKIP_PERMISSIONS.to_string(),
+                "what is actually left in here?".to_string()
+            ]
+        );
+        assert_eq!(
+            map_argv(&plain("")),
             vec!["claude".to_string(), SKIP_PERMISSIONS.to_string()]
         );
     }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -53,10 +53,14 @@ pub enum Route {
     /// decisions settled against the skill's guiding principles, and the whole
     /// remaining lifecycle driven unattended (#96).
     WayfinderAuto,
+    /// `claude` — no skill at all (#112). The only route that invokes nothing:
+    /// the session opens in the node's workspace and the human drives it.
+    Plain,
 }
 
 impl Route {
-    /// How the route reads in the launch picker: the slash command it execs.
+    /// How the route reads in the launch picker: the slash command it execs,
+    /// or the bare agent when it execs no slash command at all.
     ///
     /// Every label is prefixed `wf`, because these names are claimed in a
     /// namespace `wf` does not own: `~/.claude/skills` is flat and shared with
@@ -69,6 +73,7 @@ impl Route {
             Route::Review => "/wf-review",
             Route::Wayfinder => "/wf",
             Route::WayfinderAuto => "/wf-auto",
+            Route::Plain => "claude",
         }
     }
 }
@@ -90,6 +95,11 @@ pub enum Mode {
     /// which routed to `/wf`'s own deferred mode before that skill existed
     /// (#63 → #96).
     Auto,
+    /// Nobody: no skill is invoked and no lifecycle is driven. The session
+    /// opens on the node's workspace and the human types the first thing it
+    /// hears (#112) — the answer to wanting `wf`'s branch, clone and container
+    /// without wanting a skill's opinion about what to do in them.
+    Plain,
 }
 
 impl Mode {
@@ -98,6 +108,7 @@ impl Mode {
         match self {
             Mode::Interactive => "interactive",
             Mode::Auto => "auto",
+            Mode::Plain => "plain",
         }
     }
 
@@ -108,6 +119,7 @@ impl Mode {
         match self {
             Mode::Interactive => "you are in the loop; it grills you",
             Mode::Auto => "the agent decides alone and drives it to done",
+            Mode::Plain => "no skill; a bare session on the node's branch",
         }
     }
 
@@ -120,7 +132,8 @@ impl Mode {
     fn after(self) -> Mode {
         match self {
             Mode::Interactive => Mode::Auto,
-            Mode::Auto => Mode::Interactive,
+            Mode::Auto => Mode::Plain,
+            Mode::Plain => Mode::Interactive,
         }
     }
 
@@ -249,6 +262,10 @@ pub fn route(aim: &Aim, mode: Mode) -> Route {
     match (aim, mode) {
         (Aim::Map, Mode::Interactive) => Route::Wayfinder,
         (Aim::Map | Aim::Ticket { .. }, Mode::Auto) => Route::WayfinderAuto,
+        // `Plain` collapses the table for the opposite reason `Auto` does:
+        // `Auto` picks one skill for every node, `Plain` picks none, and
+        // neither the aim nor the stage can change that.
+        (Aim::Map | Aim::Ticket { .. }, Mode::Plain) => Route::Plain,
         (
             Aim::Ticket {
                 ticket_type, stage, ..
@@ -545,20 +562,33 @@ impl Launch {
     /// wayfinder skill, and a wayfinder skill on a map is the map's number
     /// alone. The ticket arm is where the two argument shapes live.
     fn claude_argv(&self) -> Vec<String> {
-        let prompt = match &self.aim {
-            Aim::Map => format!("{} {}", self.route.label(), self.map_issue),
-            Aim::Ticket { number, .. } => match self.route {
-                Route::Tdd | Route::Review => format!("{} {number}", self.route.label()),
-                Route::Wayfinder | Route::WayfinderAuto => {
-                    format!("{} {} {number}", self.route.label(), self.map_issue)
-                }
-            },
-        };
-        vec![
-            "claude".to_string(),
-            SKIP_PERMISSIONS.to_string(),
-            format!("{prompt}{}", self.mode.suffix()),
-        ]
+        let mut argv = vec!["claude".to_string(), SKIP_PERMISSIONS.to_string()];
+        argv.extend(self.prompt());
+        argv
+    }
+
+    /// The single positional argument `claude` is opened on — `None` when
+    /// there is nothing to say to it, which is a shorter argv rather than an
+    /// empty argument (`claude ""` is a prompt, and an empty one).
+    fn prompt(&self) -> Option<String> {
+        let skill = self.skill_invocation()?;
+        Some(format!("{skill}{}", self.mode.suffix()))
+    }
+
+    /// The slash command and its arguments, for the routes that invoke a
+    /// skill. `None` is [`Route::Plain`]: no skill, so nothing to invoke.
+    fn skill_invocation(&self) -> Option<String> {
+        let skill = self.route.label();
+        match (self.route, &self.aim) {
+            (Route::Plain, _) => None,
+            (_, Aim::Map) => Some(format!("{skill} {}", self.map_issue)),
+            (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => {
+                Some(format!("{skill} {number}"))
+            }
+            (Route::Wayfinder | Route::WayfinderAuto, Aim::Ticket { number, .. }) => {
+                Some(format!("{skill} {} {number}", self.map_issue))
+            }
+        }
     }
 
     /// What `wf` becomes: the agent, or `dl` carrying the agent into the
@@ -777,6 +807,25 @@ mod tests {
         LaunchMode::picked(Mode::Auto, steer)
     }
 
+    /// The same with the `plain` row selected — the launch that hands the
+    /// session no skill at all.
+    fn plain(steer: &str) -> LaunchMode {
+        LaunchMode::picked(Mode::Plain, steer)
+    }
+
+    /// The whole argv a node of this (type, stage) is launched with, under
+    /// `mode`. Whole rather than its last entry, because a plain session's
+    /// argv may have no prompt entry to take the last of.
+    fn ticket_argv(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> Vec<String> {
+        let mut node = ticket("blooop/wayfinder", 16);
+        node.ticket_type = ticket_type;
+        let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
+        match plan(&cache(), &staged, mode) {
+            Targets::One(l) => l.agent_argv(),
+            other => panic!("{other:?}"),
+        }
+    }
+
     /// An interactive `/wf` plan — the default launch, and the shape
     /// every checkout-resolution test wants (route and mode are orthogonal to
     /// which trees are candidates).
@@ -909,7 +958,7 @@ mod tests {
     fn every_mode_is_in_the_picker_and_the_default_leads_it() {
         // The picker lists `Mode::all`, so a mode missing from it would be a
         // mode nothing on screen can reach.
-        assert_eq!(Mode::all(), vec![Mode::Interactive, Mode::Auto]);
+        assert_eq!(Mode::all(), vec![Mode::Interactive, Mode::Auto, Mode::Plain]);
         assert_eq!(
             Mode::all().first(),
             Some(&Mode::default()),
@@ -1101,6 +1150,30 @@ mod tests {
         }
         assert_eq!(route(&Aim::Map, Mode::Auto), Route::WayfinderAuto);
         assert_eq!(route(&Aim::Map, Mode::Interactive), Route::Wayfinder);
+    }
+
+    #[test]
+    fn plain_launches_a_session_with_no_skill_in_it() {
+        // The third mode collapses the table the way `auto` does, and for the
+        // opposite reason: `auto` picks one skill for every node, `plain` picks
+        // none. Which node it was aimed at cannot change that, so every cell
+        // answers the same.
+        for ticket_type in DECISION_TYPES.into_iter().chain([TicketType::Build]) {
+            for stage in LAUNCHABLE {
+                assert_eq!(
+                    route(&aim(ticket_type, stage), Mode::Plain),
+                    Route::Plain,
+                    "{ticket_type:?} at {stage:?}"
+                );
+            }
+        }
+        assert_eq!(route(&Aim::Map, Mode::Plain), Route::Plain);
+        // And the exec is `claude` with nothing said to it: no slash command,
+        // and no prompt argument at all rather than an empty one.
+        assert_eq!(
+            ticket_argv(TicketType::Build, Stage::Ready, &plain("")),
+            vec!["claude".to_string(), SKIP_PERMISSIONS.to_string()]
+        );
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1354,6 +1354,28 @@ mod tests {
     }
 
     #[test]
+    fn an_isolated_plain_session_gets_the_nodes_workspace_like_any_other_launch() {
+        // The point of the mode: the branch, the clone and the container are
+        // exactly what a skill launch would have got — `wf` still did all of
+        // that — and the only difference is that nothing is invoked inside it.
+        assert_eq!(
+            isolated(Route::Plain, plain("")).agent_argv(),
+            vec![
+                "dl".to_string(),
+                "blooop/wayfinder@wayfinder/wayfinder-80".to_string(),
+                "--".to_string(),
+                "'claude' '--dangerously-skip-permissions'".to_string(),
+            ]
+        );
+        // The typed prompt is one quoted argument here too, so a sentence
+        // arrives as a sentence rather than as several arguments.
+        assert_eq!(
+            isolated(Route::Plain, plain("check what the logs say")).agent_argv()[3],
+            "'claude' '--dangerously-skip-permissions' 'check what the logs say'"
+        );
+    }
+
+    #[test]
     fn parallel_nodes_get_distinct_workspaces_and_a_relaunch_gets_its_own_back() {
         // The reason the seam is a branch and not the checkout path: two
         // tickets launched at once must not share a tree or a container, and

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1170,21 +1170,29 @@ mod tests {
     #[test]
     fn every_route_wf_can_exec_is_in_the_bundle() {
         // The invariant the whole module exists for: `route` cannot name a
-        // skill the package does not ship. Asserted against the label, which
-        // is the string that actually reaches the agent's prompt.
+        // skill the package does not ship. Swept over `Route::all`, not a list
+        // written out here — a hand-written list is a second place to remember,
+        // and a route added without being added to it is exactly the case this
+        // is meant to catch.
         use crate::launch::Route;
-        for route in [
-            Route::Tdd,
-            Route::Review,
-            Route::Wayfinder,
-            Route::WayfinderAuto,
-        ] {
-            let skill = route.label().trim_start_matches('/');
+        for route in Route::all() {
+            // `None` is the one route that invokes no skill (#112): there is no
+            // prompt for the package to be missing.
+            let Some(skill) = route.bundled_skill() else {
+                continue;
+            };
             assert!(
                 BUNDLED.contains(&skill),
                 "{} is routable but not bundled",
                 route.label()
             );
         }
+        // …and the sweep is only worth anything if it covers everything: a
+        // route missing from the cycle would be silently skipped above.
+        assert_eq!(
+            Route::all().len(),
+            5,
+            "every route must be in the cycle `Route::all` walks"
+        );
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -506,7 +506,8 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
 /// options are rows now: each one names its mode, the skill that mode routes the
 /// staged node to, and who ends up deciding. Which is also why the route is
 /// drawn per option rather than once for the cursor's — the difference between
-/// `/wf` and `/wf-auto` *is* the choice being made, so both are on screen.
+/// `/wf`, `/wf-auto` and no skill at all (#112) *is* the choice being made, so
+/// every one of them is on screen.
 fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, mode: Mode, steer: &str) {
     let mut lines = vec![Line::default()];
     for option in Mode::all() {
@@ -1499,8 +1500,11 @@ mod tests {
         assert!(screen.contains("auto"), "{screen}");
         assert!(screen.contains("/wf-auto"), "{screen}");
         // The skill-free mode (#112) reads as what it execs — a bare `claude`,
-        // no slash command — and says what picking it costs you.
+        // no slash command — and says what picking it costs you. The route
+        // column is asserted too: it is the half of the row that says what will
+        // actually run, and it is drawn from a label nothing else reads.
         assert!(screen.contains("plain"), "{screen}");
+        assert!(screen.contains("claude"), "{screen}");
         assert!(screen.contains("no skill"), "{screen}");
         assert!(screen.contains("steer"), "{screen}");
         assert!(screen.contains("esc cancel"), "{screen}");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1491,13 +1491,17 @@ mod tests {
             screen.contains("launch #6 Re-entry breadcrumbs"),
             "{screen}"
         );
-        // Both modes are on screen with the skill each one would run, because
+        // Every mode is on screen with the skill each one would run, because
         // that difference *is* the choice being offered — and the cursor sits
         // on the interactive default.
         assert!(screen.contains("▶ interactive"), "{screen}");
         assert!(screen.contains("/wf "), "{screen}");
         assert!(screen.contains("auto"), "{screen}");
         assert!(screen.contains("/wf-auto"), "{screen}");
+        // The skill-free mode (#112) reads as what it execs — a bare `claude`,
+        // no slash command — and says what picking it costs you.
+        assert!(screen.contains("plain"), "{screen}");
+        assert!(screen.contains("no skill"), "{screen}");
         assert!(screen.contains("steer"), "{screen}");
         assert!(screen.contains("esc cancel"), "{screen}");
 
@@ -1507,6 +1511,11 @@ mod tests {
         let screen = render(&app);
         assert!(screen.contains("▶ auto"), "{screen}");
         assert!(!screen.contains("▶ interactive"), "{screen}");
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("▶ plain"), "{screen}");
+        assert!(!screen.contains("▶ auto"), "{screen}");
+        app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
 
         // Typing steers rather than picking: the text lands in the field, and
         // the mode stays where the cursor put it.


### PR DESCRIPTION
Closes #112.

A third row in the launch picker: **plain** — a session with no skill in it.

```
  ▶ interactive /wf-tdd   you are in the loop; it grills you
    auto        /wf-auto  the agent decides alone and drives it to done
    plain       claude    no skill; a bare session on the node's branch
```

`wf` already resolves a node to a place to work — a checkout, a per-node branch,
a clone and a container. Until now that work was only reachable with a skill
bolted to the front of it, so reading the code a ticket is about, or a fix too
small to be a lifecycle, meant quitting `wf` and retyping the workspace spec by
hand. `plain` is the same launch with nothing invoked in it.

## The shape

- **`Mode::Plain`** joins the picker's cycle, and `route` gains one arm:
  `(Aim::Map | Aim::Ticket { .. }, Mode::Plain) => Route::Plain`. It collapses
  the table for the opposite reason `Auto` does — `Auto` picks one skill for
  every node, `Plain` picks none — and the match stays exhaustive on all three
  axes, so a new mode, type or stage is still a compile error.
- **The prompt became an `Option`.** `claude_argv` no longer always has a third
  entry: with no skill to invoke and nothing typed there is no prompt argument
  at all, rather than an empty string (`claude ""` is a prompt, and an empty
  one). `skill_invocation` answers `None` for `Route::Plain` and the argument
  shapes stay in one exhaustive `(route, aim)` match with no unreachable arm.
- **Steering text is handled differently here, on purpose.** With a skill in
  front of it, typed text rides as ` steer: <text>`. With no skill, that suffix
  would be addressed to nobody — so the text is simply the session's opening
  prompt, verbatim.
- **Nothing else about a launch changes**: same checkout resolution, same
  `owner/repo@wayfinder/<repo>-<n>` workspace, same devcontainer detection, same
  shell-quoting through `dl`.

## Tests

Written test-first at the three seams #112 pre-agreed:

- routing — every type, every stage and both aims under `plain`, plus the exec'd
  argv being `claude` and nothing else
- the exec'd command — typed text as the whole prompt, and no prompt argument
  when nothing was typed, for a ticket aim and a map aim
- the mode list and the picker — `Mode::all` carries it, `↑`/`↓` reach it and
  wrap through it in both directions, and the rendered picker shows the row with
  what it execs

The two tests that pass over paths already covered (the container form, the
picker rendering) were **mutation-verified** rather than trusted: breaking the
prompt to `Some("")` and dropping the mode from the cycle each make them fail.

`cargo fmt --check`, `cargo clippy --all-targets --all-features` under
`-D warnings`, and 239 tests: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new plain launch mode that opens a bare claude session in the node’s workspace without invoking any skill, while keeping all existing workspace resolution behavior unchanged.

New Features:
- Introduce Mode::Plain and Route::Plain to support launching a skill-free claude session on a node’s workspace from the launch picker.

Enhancements:
- Refactor launch argument construction so claude’s prompt becomes optional and is derived from either the chosen skill route or directly from user steering text in plain mode.
- Extend the launch picker and mode cycling to include the new plain mode, ensuring consistent navigation and display across UI and app layers.

Documentation:
- Update README to document the plain launch mode, its behavior, and how it appears and is used in the launch picker.

Tests:
- Add routing, argv-shape, isolation, and UI tests to cover plain mode behavior, its inclusion in mode lists, and navigation in the launch picker.