### PR TITLE
Delete the deferred-mode residue and pin the glyph display order

### DIFF
--- a/skills/wf-auto/SKILL.md
+++ b/skills/wf-auto/SKILL.md
@@ -87,7 +87,7 @@ Per ticket:
 1. Load the map (low-res; zoom into closed tickets on demand). Claim the ticket. If it was already claimed, read its trail first — the last `### handoff`, then the breadcrumbs after it — and open with a breadcrumb noting resumption.
 2. Hand it to a fresh subagent with the ticket body, the map's Decisions-so-far, the principles, and the skill its type calls for. Build tickets run the [LIFECYCLE.md](../wf/LIFECYCLE.md) stages with gates between; everything else resolves in one subagent.
 3. Breadcrumb each decision-grade moment on the ticket — a sub-decision settling, a direction changing, a stage transition, a gate result.
-4. **Record**: a resolution comment opening `**agent-decided (<principle>):**` and carrying the reasoning that would have been the grilling; close the ticket; append its one-line gist to Decisions-so-far with an *(agent)* suffix.
+4. **Record**: a resolution comment opening `**agent-decided (<principle>):**` and carrying the reasoning that would have been the grilling; close the ticket; append its one-line gist to Decisions-so-far with an *(agent)* suffix. A human later re-opening an agent-decided ticket to re-decide it is normal, not a conflict.
 5. **Advance the map**: graduate whatever fog the answer made specifiable into fresh tickets — including slicing new `wayfinder:build` tickets — clear those fog patches, and retire tickets the answer invalidated.
 
 Then take the next unblocked ticket. The run ends when the frontier is empty, everything left is parked, or the budget runs out — and it ends with a summary: what closed, what parked, what is still open.

--- a/skills/wf/LIFECYCLE.md
+++ b/skills/wf/LIFECYCLE.md
@@ -1,6 +1,6 @@
 # The manager protocol — a node's lifecycle, one fresh subagent per stage
 
-How a launched session drives a node (or a deferred subtree of nodes) through its stages without anyone watching. This is referenced by the `wf` skill's deferred mode and honored by `/wf-tdd` and `/wf-review`; nothing launches "the manager" directly — **the launched session is the manager**. wf itself never is: it exec'd and exited.
+How a launched session drives a node (or a whole subtree of nodes) through its stages without anyone watching. This is referenced by `/wf-auto` and honored by `/wf-tdd` and `/wf-review`; nothing launches "the manager" directly — **the launched session is the manager**. wf itself never is: it exec'd and exited.
 
 ## The stage lattice (decided on blooop/wayfinder#61)
 

--- a/skills/wf/SKILL.md
+++ b/skills/wf/SKILL.md
@@ -80,7 +80,7 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 ## Ticket Types
 
-Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this). The single exception is a **deferred launch** (see [Deferred mode](#deferred-mode)), where the human has explicitly handed judgement to the agent for a subtree.
+Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this). Handing judgement to the agent wholesale is `/wf-auto`'s job, never a variant of this skill.
 
 - **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
 - **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
@@ -121,14 +121,12 @@ Resolution comments are unchanged — the answer still lands once, at close. And
 
 ## Invocation
 
-Two modes, plus a deferred variant of the second. **Never resolve more than one ticket per session** — with two exceptions: research tickets, and a **deferred launch**, which may work its named ticket's whole subtree.
+Two modes. **Never resolve more than one ticket per session** — with one exception: research tickets.
 
 The invocation grammar (what `wf`'s launch line produces):
 
-- `/wf <map> [<ticket>]` — interactive (everything below as written)
-- `/wf <map> <ticket> defer` — deferred subtree (see [Deferred mode](#deferred-mode))
-- `/wf <map> <ticket> defer: <steering>` — deferred, with a steering prompt
-- `/wf <map> <ticket> steer: <steering>` — interactive, with a steering prompt
+- `/wf <map> [<ticket>]` — everything below as written
+- `/wf <map> <ticket> steer: <steering>` — with a steering prompt
 
 ### Chart the map
 
@@ -154,17 +152,3 @@ User invokes with a map (URL or number). A ticket is **optional** — without on
 If the session ends deliberately before the resolution lands, post the `### handoff` comment on the ticket before you go — where we are, the open thread, the first move on resume.
 
 The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.
-
-### Deferred mode
-
-A **deferred launch** (`defer` in the invocation) hands judgement to the agent for the named ticket **plus everything in its rendered unblocks-subtree**, worked in dependency order. The human chose this at launch time, standing in front of the tree — that consent is what lifts the HITL rules below, and *only* for this run.
-
-**The standing default prompt** for every deferred run: decide with best judgment in the spirit of the map's Decisions-so-far; prefer the smallest decision that unblocks the subtree; record every resolution flagged `**agent-decided:**` with the reasoning that would have been the grilling. A steering prompt (`defer: <text>`) composes *after* this default — it narrows scope or states preferences; it cannot lift stop conditions.
-
-**Claiming is as-you-go**: the launch claims the root; each subtree ticket is claimed when the agent reaches it — a crash leaves only live claims stale, and concurrent sessions still see honest assignees.
-
-**HITL types under defer:** grilling → the agent answers its own questions from the map, repo, and research, flagged agent-decided (this is precisely what deferring judgement means — the self-answering ban is lifted *only* here); prototype → build the artifact and pick, recording the reaction as judgment; a task needing human hands → park it (stop condition c). Build tickets run their lifecycle under the manager protocol in [LIFECYCLE.md](LIFECYCLE.md) — fresh subagent per stage, gates between.
-
-**Stop conditions — park instead of deciding** when a resolution would: (a) redraw the Destination, (b) rule work out of scope, (c) need credentials, purchases, or human-only action, (d) contradict an existing Decisions-so-far entry. Parking = a `### handoff` comment on that ticket; the run continues with other unblocked subtree tickets and reports every park at the end.
-
-**Audit trail:** resolution comments open with `**agent-decided:**`; the map's Decisions-so-far line gets an *(agent)* suffix. A human later re-opening an agent-decided ticket to re-decide it is normal, not a conflict.

--- a/src/model.rs
+++ b/src/model.rs
@@ -1072,4 +1072,24 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn the_full_glyph_vocabulary_sorts_into_display_order() {
+        // `RowGlyph`'s derived `Ord` *is* the display order — the cluster
+        // header, shut-group rollups, and branch-root rollups all render
+        // tallies in it — so reordering the `Stage` declaration silently
+        // reorders the screen while the tallies elsewhere in the suite stay
+        // green (#86). Sorting the whole vocabulary pins the sequence.
+        let mut glyphs = [
+            RowGlyph::Blocked,
+            RowGlyph::Stage(Stage::Done),
+            RowGlyph::Stage(Stage::NeedsAttention),
+            RowGlyph::Stage(Stage::InReview),
+            RowGlyph::Stage(Stage::Building),
+            RowGlyph::Stage(Stage::Ready),
+        ];
+        glyphs.sort();
+        let sequence: String = glyphs.iter().map(|g| g.char()).collect();
+        assert_eq!(sequence, "○◐◍!●⊘");
+    }
 }


### PR DESCRIPTION
Closes #96. Closes #86.

Two small residues from this map, landed together.

## #96 — the deferred-mode residue

PR #99 retired the `defer` launch word in favour of `auto` → `/wf-auto`, leaving `/wf`'s deferred-mode section unreachable from `wf` but still in the skill. #96's breadcrumb ruled it **deleted outright**; the edit lands here rather than in dotfiles because the skill suite moved into this repo in PR #101.

- `skills/wf/SKILL.md`: the **Deferred mode** section is gone; the invocation grammar loses its two `defer` lines; the one-ticket-per-session rule loses its deferred exception; the HITL rule's exception is replaced by a pointer at `/wf-auto`, which is where handing judgement to the agent lives now.
- `skills/wf/LIFECYCLE.md`: the opener names `/wf-auto` as its referrer instead of "the `wf` skill's deferred mode".
- `skills/wf-auto/SKILL.md`: gains the one norm the deleted section carried that it lacked — *a human later re-opening an agent-decided ticket to re-decide it is normal, not a conflict*. Everything else in the deleted section (standing default prompt, as-you-go claiming, stop conditions, steering composition) was already superseded by `/wf-auto`'s own text.
- **Check**: `grep -rni defer skills/` now returns nothing — no skill offers `defer` as a word a user can type.
- Left alone as accurate history: `src/skills.rs:7`, the `Mode` doc comments in `src/launch.rs`, and the two README passages describing the era `defer` belonged to.

## #86 — pinning the glyph display order

`RowGlyph`'s derived `Ord` **is** the glyph display order, trusted by three render sites (cluster header counts, shut-group rollups, branch-root rollups), and no test failed when `Stage::Building` and `Stage::InReview` swapped places in the declaration.

Of the ticket's three candidates, this takes **the single test asserting the full six-glyph sequence** (`the_full_glyph_vocabulary_sorts_into_display_order` in `src/model.rs`): separating display order from severity order would re-add the duplication #78 deliberately collapsed — and #86 itself records that collapse as the right call — while documentation alone cannot go red on the swap. The test sorts all six `RowGlyph` values and asserts the rendered sequence `○◐◍!●⊘`, so any reorder of the declaration fails it.

**Mutation evidence** — with `Building` and `InReview` swapped in the declaration, the pin goes red:

```
---- model::tests::the_full_glyph_vocabulary_sorts_into_display_order stdout ----
thread 'model::tests::the_full_glyph_vocabulary_sorts_into_display_order' (3379) panicked at src/model.rs:1093:9:
assertion `left == right` failed
  left: "○◍◐!●⊘"
 right: "○◐◍!●⊘"
```

Swapped back, the suite is fully green: 227 lib + 10 bin unit tests, all live tests, `cargo clippy --all-targets -- -D warnings` clean, rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the deprecated deferred mode from the wf skill and pin the glyph display order with a dedicated test.

Bug Fixes:
- Add a test to assert RowGlyphs always sort into the intended display order, preventing accidental changes when Stage variants are reordered.

Enhancements:
- Clean up wf skill documentation by removing the unreachable deferred mode and clarifying that handing judgement to the agent is owned by /wf-auto.
- Update lifecycle documentation to reference /wf-auto instead of wf deferred mode and to describe subtree handling more generally.
- Carry forward the norm that re-opening agent-decided tickets is normal into the /wf-auto skill documentation.

Tests:
- Introduce a glyph ordering test that sorts the full RowGlyph vocabulary and asserts the expected display sequence.