### PR TITLE
Creation candidates: new task and new map from the header picker, and the empty-state door

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -317,16 +317,16 @@ opens the **launch picker** over the list, showing what is about to happen and
 the one thing still undecided — who resolves the node:
 
 ```
-┌ launch blooop/wayfinder · #65 Author the /wf-tdd skill ────────────────┐
-│                                                                        │
-│  ▶ interactive   /wf-tdd   you are in the loop; it grills you          │
+┌ launch blooop/wayfinder · #65 Author the /wf-tdd skill ─────────────────┐
+│                                                                         │
+│  ▶ interactive   /wf-tdd   you are in the loop; it grills you           │
 │    auto          /wf-auto  the agent decides alone and drives it to done│
 │    plain         claude    no skill; a bare session on the node's branch│
-│                                                                        │
-│    steer  █                                                            │
-│                                                                        │
-│  enter launch · ↑/↓ pick · type to fill · esc cancel                   │
-└────────────────────────────────────────────────────────────────────────┘
+│                                                                         │
+│    steer  █                                                             │
+│                                                                         │
+│  enter launch · ↑/↓ pick · type to fill · esc cancel                    │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
 `↑`/`↓` (or `tab`) move between the rows and `enter` runs the one you are on,
@@ -360,19 +360,19 @@ a *repo*, so it lives where the stop is repo-level — the cluster header — an
 reached by the same `enter` as everything else. No new keys:
 
 ```
-┌ launch blooop/wayfinder · #59 Map: the dev-process tree ───────────────┐
-│                                                                        │
-│  ▶ interactive   /wf       you are in the loop; it grills you          │
+┌ launch blooop/wayfinder · #59 Map: the dev-process tree ────────────────┐
+│                                                                         │
+│  ▶ interactive   /wf       you are in the loop; it grills you           │
 │    auto          /wf-auto  the agent decides alone and drives it to done│
 │    plain         claude    no skill; a bare session on the node's branch│
-│    new task      /wf-one   one tracked ticket, built and reviewed      │
-│    new map       /wf       chart a new map in this repo, with you      │
-│    new map, auto /wf-auto  chart a new map in this repo, alone         │
-│                                                                        │
-│    task   █                                                            │
-│                                                                        │
-│  enter launch · ↑/↓ pick · type to fill · esc cancel                   │
-└────────────────────────────────────────────────────────────────────────┘
+│    new task      /wf-one   one tracked ticket, built and reviewed       │
+│    new map       /wf       chart a new map in this repo, with you       │
+│    new map, auto /wf-auto  chart a new map in this repo, alone          │
+│                                                                         │
+│    task   █                                                             │
+│                                                                         │
+│  enter launch · ↑/↓ pick · type to fill · esc cancel                    │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
 The repo comes free from wherever the cursor was standing, which is why the title

--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ open map that the last search found. Deleting it is safe — projects re-accrete
 as you open them, and the maps are re-found on the next start.
 
 Only repos with an open `wayfinder:map`-labelled issue show tickets; other
-checkouts stay cached but hidden.
+checkouts stay cached but hidden — except the one you are *focused* on, which
+renders a slim `no map` header so its first map has somewhere to be started from
+(see [Launching](#launching)).
 
 **Every open map renders as its own cluster** — a `▌ repo · map title` header
 carrying the map's **stage** counts, in the same glyph vocabulary the rows
@@ -315,31 +317,31 @@ opens the **launch picker** over the list, showing what is about to happen and
 the one thing still undecided — who resolves the node:
 
 ```
-┌ launch #65 Author the /wf-tdd skill ──────────────────────────────────┐
-│                                                                       │
-│  ▶ interactive /wf-tdd   you are in the loop; it grills you           │
-│    auto        /wf-auto  the agent decides alone and drives it to done│
-│    plain       claude    no skill; a bare session on the node's branch│
-│                                                                       │
-│    steer  █                                                           │
-│                                                                       │
-│  enter launch · ↑/↓ mode · type to steer · esc cancel                 │
-└───────────────────────────────────────────────────────────────────────┘
+┌ launch blooop/wayfinder · #65 Author the /wf-tdd skill ────────────────┐
+│                                                                        │
+│  ▶ interactive   /wf-tdd   you are in the loop; it grills you          │
+│    auto          /wf-auto  the agent decides alone and drives it to done│
+│    plain         claude    no skill; a bare session on the node's branch│
+│                                                                        │
+│    steer  █                                                            │
+│                                                                        │
+│  enter launch · ↑/↓ pick · type to fill · esc cancel                   │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
-`↑`/`↓` (or `tab`) move between the modes and `enter` runs the one you are on,
-so the common case is `enter enter`. Every mode is on screen with the skill it
+`↑`/`↓` (or `tab`) move between the rows and `enter` runs the one you are on,
+so the common case is `enter enter`. Every row is on screen with the skill it
 routes *this* node to, because that difference is the choice being made: the
 picker is where you see that `auto` means `/wf-auto` and will not stop to ask
 you anything.
 
-Anything you type goes into the **steer** field — a steering prompt on whichever
-mode is selected, never a mode itself. That is the difference from the launch
-*line* this replaced: the modes were words you had to already know (`defer`, then
-`auto`), typing one was indistinguishable from a typo until the agent ran, and
-`automate the release` had to be special-cased into not meaning unattended. No
-string moves the cursor now, so a launch goes unattended only because you
-selected it.
+Anything you type goes into the field below the rows — on a launch row that is a
+**steering prompt** on whichever mode is selected, never a mode itself. That is
+the difference from the launch *line* this replaced: the modes were words you had
+to already know (`defer`, then `auto`), typing one was indistinguishable from a
+typo until the agent ran, and `automate the release` had to be special-cased into
+not meaning unattended. No string moves the cursor now, so a launch goes
+unattended only because you selected it.
 
 `esc` backs out to the list with your query and cursor exactly as they were.
 `enter` on a **done** or **blocked** node opens nothing — it says why on the
@@ -353,6 +355,48 @@ default cursor position still skips headers and lands on the first row, so
 opening `wf` and pressing `enter` picks a ticket exactly as it always did;
 headers are one `↑` away.
 
+**Starting something new is more rows in the same picker.** Creation is an act on
+a *repo*, so it lives where the stop is repo-level — the cluster header — and is
+reached by the same `enter` as everything else. No new keys:
+
+```
+┌ launch blooop/wayfinder · #59 Map: the dev-process tree ───────────────┐
+│                                                                        │
+│  ▶ interactive   /wf       you are in the loop; it grills you          │
+│    auto          /wf-auto  the agent decides alone and drives it to done│
+│    plain         claude    no skill; a bare session on the node's branch│
+│    new task      /wf-one   one tracked ticket, built and reviewed      │
+│    new map       /wf       chart a new map in this repo, with you      │
+│    new map, auto /wf-auto  chart a new map in this repo, alone         │
+│                                                                        │
+│    task   █                                                            │
+│                                                                        │
+│  enter launch · ↑/↓ pick · type to fill · esc cancel                   │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+The repo comes free from wherever the cursor was standing, which is why the title
+names it. **Ticket pickers are unchanged** — they list the three modes and
+nothing else, so `enter` on a ticket never offers to start something instead.
+
+The text field keeps one keyboard behaviour and takes its meaning from the row,
+which is what the name beside it says: `steer` on a launch row, `task` on **new
+task** — where the text *is* the ticket, so `enter` with nothing typed refuses on
+the count line — and `seed` on the two **new map** rows, where it is an optional
+loose idea the charting session will grill you about anyway.
+
+Adding a ticket to an existing map needs no row of its own: `enter` on its
+header, type `add a ticket for X`, launch — that is `/wf <map> steer: …`, and the
+charting session files it.
+
+**A repo with no map has a door too.** Run `wf` inside a registered checkout
+whose repo has no open `wayfinder:map` and the screen used to be empty; now it
+renders that repo as one slim header, and `enter` on it opens the creation rows
+alone — nothing to launch, so no launch rows. That is where a repo's *first* map
+gets charted. It appears only on the focused empty state and only once the load
+has landed, so a still-fetching repo never flashes a creation row under `enter`,
+and the widened screen stays free of one row per project.
+
 **Which skill runs is a fact about what you picked and who decides:**
 
 | picked | stage | mode | launches |
@@ -363,7 +407,14 @@ headers are one `↑` away.
 | research · prototype · grilling · task | any unfinished stage | interactive | `claude "/wf <map> <n>"` |
 | anything | any unfinished stage | auto | `claude "/wf-auto <map> [<n>]"` |
 | anything | any unfinished stage | plain | `claude` — no skill; anything typed is the whole prompt |
+| a cluster header, or a map-less repo | — | new task | `claude "/wf-one <task>"` |
+| a cluster header, or a map-less repo | — | new map | `claude "/wf [<seed>]"` |
+| a cluster header, or a map-less repo | — | new map, auto | `claude "/wf-auto [<seed>]"` |
 | a ticket | done | — | nothing — not launchable |
+
+A creation has no issue number until the skill files one, so it has no per-node
+branch either: it runs on the repo's **default workspace**, and the launched
+skill makes its own branches from there.
 
 The auto mode collapses the ticket rows on purpose: the launched session is a
 *manager*, and what it manages is the node's whole remaining lifecycle — `/wf-tdd`,
@@ -391,7 +442,7 @@ an empty one.
 | `→` | reveal: open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
 | `←` | close: shut an open group, else back out to the parent, else one stop back — which, from a cluster's first row, is that cluster's header |
 | `enter` | open the launch picker on the cursor's ticket, or on its map when the cursor is on a cluster header; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
-| `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick the mode, type a steering prompt, launch — `esc` backs out with the query and cursor intact |
+| `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick the row, fill the field beside it (a steering prompt, a task, or a map seed), launch — `esc` backs out with the query and cursor intact |
 | `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |
 | `ctrl-g` | widen back to every project |
 | `ctrl-r` | refetch every map in place, keeping your query, scope and cursor |

--- a/examples/preview_screen.rs
+++ b/examples/preview_screen.rs
@@ -74,6 +74,7 @@ async fn main() {
         wf::view::Stop::Map(id) => format!("map #{}", id.number),
         wf::view::Stop::Ticket(row) => format!("#{}", app.ticket(row).number),
         wf::view::Stop::Group(g) => format!("{:?}", g.kind),
+        wf::view::Stop::Project(repo) => format!("project {repo}"),
     };
     println!(
         "cursor: {} of {} → {} at depth {}",

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.12.0"
+  version: "0.13.0"
 
 package:
   name: wf

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,6 +139,9 @@ pub enum StopKey {
     Map(MapId),
     Ticket(RowKey),
     Group(GroupId),
+    /// The empty-state door, by repo slug — already index-free, like the
+    /// map and group keys.
+    Project(String),
 }
 
 /// Where the cursor is, and — the part that matters — **whether anyone put it
@@ -333,7 +336,45 @@ impl App {
     /// what the draw walks and what the cursor navigates, so the two can never
     /// disagree about order.
     pub fn plan(&self) -> Plan {
-        view::plan(&self.scoped_clusters(), self.screen(), &self.expanded)
+        let mut plan = view::plan(&self.scoped_clusters(), self.screen(), &self.expanded);
+        if let Some(repo) = self.mapless_door() {
+            plan.items.push(view::Item::MaplessHeader(repo));
+        }
+        plan
+    }
+
+    /// The repo whose empty-state door this screen is showing, if it is
+    /// showing one (#114).
+    ///
+    /// Deliberately only the **focused** empty state: a registered repo with
+    /// no open map, with the scope on it and nothing rendered. That is the
+    /// case `wf` opened inside a fresh checkout lands in, and it is where the
+    /// repo's *first* map has otherwise had no way in — the picker's rows all
+    /// hang off stops, and a repo with no map renders no stop.
+    ///
+    /// A row per map-less project on the *widened* screen is the version this
+    /// is not: permanent furniture on a screen that is otherwise all signal,
+    /// one extra row every frame for an occasional act. Reaching those repos
+    /// is the project surface's job, not the tree's.
+    fn mapless_door(&self) -> Option<String> {
+        // Not until the load has landed. A focused repo whose maps are still
+        // in flight looks identical to one that has none, and drawing the door
+        // then would put a creation row under `enter` for the second or two
+        // before the clusters arrive — turning an ordinary launch into a new
+        // map. Same reason [`crate::ui::heading`] will not say "no projects"
+        // while the search is out.
+        if !self.startup.is_loaded() {
+            return None;
+        }
+        let Scope::Project(repo) = &self.scope else {
+            return None;
+        };
+        // Registered, and nothing of it on screen: a repo whose clusters are
+        // merely filtered out by a query still *has* maps, and its door would
+        // be a second answer to a question the query is already answering.
+        let registered = self.checkouts.iter().any(|c| &c.repo == repo);
+        let has_clusters = self.clusters.keys().any(|id| &id.repo == repo);
+        (registered && !has_clusters).then(|| repo.clone())
     }
 
     /// Every cursor stop with its depth, in on-screen order (#57). The cursor
@@ -369,6 +410,7 @@ impl App {
             Stop::Map(id) => StopKey::Map(id.clone()),
             Stop::Ticket(row) => StopKey::Ticket(self.row_key(row)),
             Stop::Group(id) => StopKey::Group(id.clone()),
+            Stop::Project(repo) => StopKey::Project(repo.clone()),
         }
     }
 
@@ -407,7 +449,7 @@ impl App {
     pub fn cursor_row(&self) -> Option<Row> {
         match self.cursor_stop() {
             Some(Stop::Ticket(row)) => Some(row),
-            Some(Stop::Map(_) | Stop::Group(_)) | None => None,
+            Some(Stop::Map(_) | Stop::Group(_) | Stop::Project(_)) | None => None,
         }
     }
 
@@ -420,13 +462,14 @@ impl App {
     }
 
     /// Which map the cursor is in, whichever kind of stop it is on — what
-    /// `ctrl-f` focuses. Every stop belongs to a cluster, so this is total
-    /// wherever the cursor can be at all.
+    /// `ctrl-f` focuses. `None` on the empty-state door: it names a repo that
+    /// has no map, which is the one stop that belongs to no cluster.
     pub fn cursor_map(&self) -> Option<MapId> {
         match self.cursor_stop()? {
             Stop::Map(id) => Some(id),
             Stop::Ticket(row) => Some(row.map),
             Stop::Group(id) => Some(id.map),
+            Stop::Project(_) => None,
         }
     }
 
@@ -624,6 +667,17 @@ impl App {
             Some(Stop::Map(id)) => {
                 let title = self.clusters[&id].title.clone();
                 let staged = Staged::map(&id, &title);
+                self.overlay = Overlay::PickLaunch {
+                    candidate: staged.default_candidate(),
+                    staged,
+                    steer: String::new(),
+                };
+                Outcome::Continue
+            }
+            // The empty-state door (#114): nothing to launch here, so the
+            // picker opens straight onto the creation rows.
+            Some(Stop::Project(repo)) => {
+                let staged = Staged::project(&repo);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
                     staged,
@@ -1296,6 +1350,7 @@ mod tests {
             Some(Stop::Map(id)) => format!("map #{}", id.number),
             Some(Stop::Ticket(row)) => format!("#{}", app.ticket(&row).number),
             Some(Stop::Group(g)) => format!("{:?}", g.kind),
+            Some(Stop::Project(repo)) => format!("project {repo}"),
             None => "nothing".to_string(),
         }
     }
@@ -1762,7 +1817,7 @@ mod tests {
             } => {
                 assert_eq!(
                     staged.route(Mode::Interactive),
-                    Route::Wayfinder,
+                    Some(Route::Wayfinder),
                     "a task is a decision node"
                 );
                 assert_eq!(staged.key(), "#6");
@@ -2109,8 +2164,8 @@ mod tests {
             Overlay::PickLaunch { staged, .. } => {
                 assert_eq!(staged.key(), "#1");
                 assert_eq!(staged.title, "Map: wf", "the picker names the map");
-                assert_eq!(staged.route(Mode::Interactive), Route::Wayfinder);
-                assert_eq!(staged.route(Mode::Auto), Route::WayfinderAuto);
+                assert_eq!(staged.route(Mode::Interactive), Some(Route::Wayfinder));
+                assert_eq!(staged.route(Mode::Auto), Some(Route::WayfinderAuto));
             }
             other => panic!("expected the launch picker, got {other:?}"),
         }
@@ -2130,6 +2185,90 @@ mod tests {
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto 1");
+    }
+
+    /// An app focused on a registered repo that has no open map — what `wf`
+    /// opened inside a fresh checkout is looking at.
+    fn mapless_app() -> App {
+        let mut app = App::new(BTreeMap::new()).with_checkouts(vec![Checkout {
+            path: std::path::PathBuf::from("/data/proj/newthing"),
+            repo: "blooop/newthing".to_string(),
+        }]);
+        app.scope = Scope::Project("blooop/newthing".to_string());
+        app
+    }
+
+    #[test]
+    fn a_focused_repo_with_no_map_renders_one_slim_header_to_start_from() {
+        // #114's empty-state door: this screen used to render nothing at all,
+        // which is where the first map of a repo had no way in. The header is
+        // a stop, so the cursor can name it and `enter` can act on it.
+        let app = mapless_app();
+        assert_eq!(
+            app.stops().iter().map(|at| at.stop.clone()).collect::<Vec<_>>(),
+            vec![Stop::Project("blooop/newthing".to_string())]
+        );
+        assert_eq!(app.cursor_stop(), Some(Stop::Project("blooop/newthing".to_string())));
+    }
+
+    #[test]
+    fn a_mapless_repo_offers_creation_and_nothing_to_launch() {
+        // There is no node here, so there is nothing to launch: the picker is
+        // the three creation rows alone. A launch row would name a skill with
+        // no argument to give it.
+        let mut app = mapless_app();
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::PickLaunch { staged, candidate, .. } => {
+                assert_eq!(
+                    staged.candidates(),
+                    vec![
+                        Candidate::Create(CreationKind::Task),
+                        Candidate::Create(CreationKind::Map),
+                        Candidate::Create(CreationKind::MapAuto),
+                    ]
+                );
+                assert_eq!(*candidate, Candidate::Create(CreationKind::Task));
+            }
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+        // And it charts: the first map of this repo, from the door that had
+        // nothing behind it before.
+        app.handle_key(key(KeyCode::Down)); // onto `new map`
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wf");
+        assert_eq!(launch.cwd(), std::path::Path::new("/data/proj/newthing"));
+    }
+
+    #[test]
+    fn the_door_waits_for_the_load_rather_than_flashing_up_mid_fetch() {
+        // A focused repo whose maps have not arrived *yet* looks exactly like
+        // one that has none — the same ambiguity `Startup` exists to remove
+        // for the "no projects" heading. Rendering the door on that screen
+        // would put a creation row under `enter` for the second or two before
+        // the clusters land, so an ordinary launch would start a new map.
+        let mut app = mapless_app();
+        app.startup = Startup::default();
+        assert!(app.stops().is_empty(), "no door while the search is out");
+        let found: MapSet = [MapId::new("blooop/newthing", 3)].into_iter().collect();
+        app.startup.searched(&found);
+        assert!(app.stops().is_empty(), "nor while its map is still coming");
+        // Only once the load has actually landed and left nothing behind.
+        app.startup = Startup::loaded();
+        assert_eq!(app.stops().len(), 1);
+    }
+
+    #[test]
+    fn map_less_repos_stay_off_the_widened_screen() {
+        // The door is the *focused* empty state, not a row per project on the
+        // main screen: permanent furniture for an occasional act is what #114
+        // ruled out. Widening drops it.
+        let mut app = mapless_app();
+        app.scope = Scope::All;
+        assert!(app.stops().is_empty());
     }
 
     #[test]
@@ -2315,7 +2454,7 @@ mod tests {
         ready.handle_key(key(KeyCode::Enter));
         match &ready.overlay {
             Overlay::PickLaunch { staged, .. } => {
-                assert_eq!(staged.route(Mode::Interactive), Route::Tdd);
+                assert_eq!(staged.route(Mode::Interactive), Some(Route::Tdd));
             }
             other => panic!("expected the launch picker, got {other:?}"),
         }
@@ -2336,7 +2475,7 @@ mod tests {
         in_review.handle_key(key(KeyCode::Enter));
         match &in_review.overlay {
             Overlay::PickLaunch { staged, .. } => {
-                assert_eq!(staged.route(Mode::Interactive), Route::Review);
+                assert_eq!(staged.route(Mode::Interactive), Some(Route::Review));
             }
             other => panic!("expected the launch picker, got {other:?}"),
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,12 +45,12 @@ pub enum Outcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Overlay {
     None,
-    /// The launch picker — `enter` on a launchable node staged this launch, and
-    /// the overlay now collects the two things a launch needs beyond the node:
-    /// which [`Mode`] resolves it, picked from a list, and the steering text.
-    /// It resolves the route from the staged node and the picked mode, so it
-    /// *shows* which skill `enter` will run and re-reads as the mode moves — and
-    /// a picker for an unlaunchable node is unrepresentable, because
+    /// The launch picker — `enter` on a stop staged this launch, and the
+    /// overlay now collects the two things it still needs: which [`Candidate`]
+    /// runs, picked from a list, and the text that fills that row's field.
+    /// Every candidate carries its own resolved route, so the picker *shows*
+    /// which skill `enter` will run and re-reads as the pick moves — and a
+    /// picker for an unlaunchable node is unrepresentable, because
     /// [`launch::Launchable`] refused it before anything was staged.
     ///
     /// The staged launch is index-free ([`Staged`]) for the same reason the

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Candidate, Launch, LaunchMode, Staged, Targets};
+use crate::launch::{self, Candidate, Launch, LaunchMode, Route, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
@@ -96,8 +96,9 @@ fn previous_candidate(staged: &Staged, candidate: Candidate) -> Candidate {
 ///
 /// # Panics
 ///
-/// Never: [`Staged::candidates`] always lists the three launch rows, so the
-/// modulo below is never by zero.
+/// Never: [`Staged::candidates`] is never empty — every stop offers rows, its
+/// launch rows or the map-less door's creation rows — so the modulo below is
+/// never by zero.
 fn stepped(staged: &Staged, candidate: Candidate, delta: usize) -> Candidate {
     let candidates = staged.candidates();
     let at = candidates.iter().position(|c| *c == candidate).unwrap_or(0);
@@ -336,11 +337,12 @@ impl App {
     /// what the draw walks and what the cursor navigates, so the two can never
     /// disagree about order.
     pub fn plan(&self) -> Plan {
-        let mut plan = view::plan(&self.scoped_clusters(), self.screen(), &self.expanded);
-        if let Some(repo) = self.mapless_door() {
-            plan.items.push(view::Item::MaplessHeader(repo));
-        }
-        plan
+        view::plan(
+            &self.scoped_clusters(),
+            self.screen(),
+            &self.expanded,
+            self.mapless_door().as_deref(),
+        )
     }
 
     /// The repo whose empty-state door this screen is showing, if it is
@@ -729,10 +731,12 @@ impl App {
     /// — a row without a map is unrepresentable, so the old "repo has no map"
     /// failure is gone with it.
     ///
-    /// Everything this needs came with the [`Staged`] launch, so a refetch
-    /// between the two enters cannot redirect it at another ticket.
-    fn resolve_launch(&mut self, staged: &Staged, mode: &LaunchMode) -> Outcome {
-        let targets = launch::plan(&self.checkouts, staged, mode);
+    /// Everything this needs came with the [`Staged`] launch and the picked
+    /// [`Candidate`] — including `route`, carried from the row that was drawn
+    /// rather than derived a second time — so a refetch between the two enters
+    /// cannot redirect it at another ticket or another skill.
+    fn resolve_launch(&mut self, staged: &Staged, route: Route, mode: &LaunchMode) -> Outcome {
+        let targets = launch::plan(&self.checkouts, staged, route, mode);
         self.act_on(targets, &staged.repo, &staged.key())
     }
 
@@ -799,8 +803,8 @@ impl App {
             // The one exception is the refusal below, which puts this very
             // picker back so the missing task can be typed into it.
             KeyCode::Enter => match candidate {
-                Candidate::Launch { mode, .. } => {
-                    return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
+                Candidate::Launch { mode, route } => {
+                    return self.resolve_launch(&staged, route, &LaunchMode::picked(mode, &steer))
                 }
                 Candidate::Create(kind) => match kind.with_text(&steer) {
                     Some(creation) => return self.resolve_creation(&staged.repo, &creation),

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Launch, LaunchMode, Mode, Staged, Targets};
+use crate::launch::{self, Candidate, Launch, LaunchMode, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
@@ -59,7 +59,10 @@ pub enum Overlay {
     /// held across that would name a different ticket, or none at all.
     PickLaunch {
         staged: Staged,
-        mode: Mode,
+        /// The picked row — one of [`Staged::candidates`], which is the only
+        /// list the arrows walk, so a candidate foreign to the staged stop
+        /// (creation on a ticket) is never held here (#114).
+        candidate: Candidate,
         steer: String,
     },
     /// Candidates are complete launches, so the pick cannot produce an
@@ -70,29 +73,35 @@ pub enum Overlay {
     },
 }
 
-/// The mode after `mode` in the launch picker, wrapping.
+/// The row after `candidate` in the launch picker, wrapping.
 ///
-/// Derived from [`Mode::all`] rather than written as a toggle. With two modes a
-/// toggle was the same thing; #112's third mode is exactly the change that
-/// would have left a toggle silently working and skipping the new one.
-fn next_mode(mode: Mode) -> Mode {
-    stepped(mode, 1)
+/// Walked over [`Staged::candidates`] rather than [`Mode::all`] since #114:
+/// the list is the staged stop's own, so a header's creation rows are reached
+/// by the same arrows that walk the modes, and a ticket's picker cannot step
+/// onto a row it does not draw.
+fn next_candidate(staged: &Staged, candidate: Candidate) -> Candidate {
+    stepped(staged, candidate, 1)
 }
 
-/// The mode before it. Backwards is a forward step of `len - 1`, so there is no
+/// The row before it. Backwards is a forward step of `len - 1`, so there is no
 /// signed arithmetic and no underflow to reason about at index 0.
-fn previous_mode(mode: Mode) -> Mode {
-    let modes = Mode::all();
-    stepped(mode, modes.len() - 1)
+fn previous_candidate(staged: &Staged, candidate: Candidate) -> Candidate {
+    let len = staged.candidates().len();
+    stepped(staged, candidate, len - 1)
 }
 
-/// Step `delta` places along [`Mode::all`], wrapping. Takes a distance rather
-/// than a key, so which key means which direction stays in the key handler
-/// where the rest of the bindings are.
-fn stepped(mode: Mode, delta: usize) -> Mode {
-    let modes = Mode::all();
-    let at = modes.iter().position(|m| *m == mode).unwrap_or(0);
-    modes[(at + delta) % modes.len()]
+/// Step `delta` places along the staged stop's candidates, wrapping. Takes a
+/// distance rather than a key, so which key means which direction stays in the
+/// key handler where the rest of the bindings are.
+///
+/// # Panics
+///
+/// Never: [`Staged::candidates`] always lists the three launch rows, so the
+/// modulo below is never by zero.
+fn stepped(staged: &Staged, candidate: Candidate, delta: usize) -> Candidate {
+    let candidates = staged.candidates();
+    let at = candidates.iter().position(|c| *c == candidate).unwrap_or(0);
+    candidates[(at + delta) % candidates.len()]
 }
 
 /// One on-screen row: which map's cluster it is in, and the ticket's position
@@ -614,9 +623,10 @@ impl App {
             }
             Some(Stop::Map(id)) => {
                 let title = self.clusters[&id].title.clone();
+                let staged = Staged::map(&id, &title);
                 self.overlay = Overlay::PickLaunch {
-                    staged: Staged::map(&id, &title),
-                    mode: Mode::default(),
+                    candidate: staged.default_candidate(),
+                    staged,
                     steer: String::new(),
                 };
                 Outcome::Continue
@@ -649,8 +659,8 @@ impl App {
             }
             Some(staged) => {
                 self.overlay = Overlay::PickLaunch {
+                    candidate: staged.default_candidate(),
                     staged,
-                    mode: Mode::default(),
                     steer: String::new(),
                 };
                 Outcome::Continue
@@ -668,11 +678,27 @@ impl App {
     /// Everything this needs came with the [`Staged`] launch, so a refetch
     /// between the two enters cannot redirect it at another ticket.
     fn resolve_launch(&mut self, staged: &Staged, mode: &LaunchMode) -> Outcome {
-        match launch::plan(&self.checkouts, staged, mode) {
+        let targets = launch::plan(&self.checkouts, staged, mode);
+        self.act_on(targets, &staged.repo, &staged.key())
+    }
+
+    /// The creation half: the same resolution against the same cache, for a
+    /// launch that has no node to name (#114). The creation arrives already
+    /// complete — [`launch::CreationKind::with_text`] refused the empty task
+    /// before this was called — so the only thing left to answer is *where*.
+    fn resolve_creation(&mut self, repo: &str, creation: launch::Creation) -> Outcome {
+        let targets = launch::plan_create(&self.checkouts, repo, creation);
+        self.act_on(targets, repo, "+new")
+    }
+
+    /// What a resolved [`Targets`] does to the screen: launch, prompt for the
+    /// tree, or say there is none. Shared by both resolutions so a creation
+    /// cannot drift into reporting its checkouts differently from a node.
+    fn act_on(&mut self, targets: Targets, repo: &str, key: &str) -> Outcome {
+        match targets {
             Targets::Unregistered => {
                 self.notice = Some(format!(
-                    "no registered checkout of {} on this machine — run wf inside one",
-                    staged.repo
+                    "no registered checkout of {repo} on this machine — run wf inside one"
                 ));
                 Outcome::Continue
             }
@@ -681,7 +707,7 @@ impl App {
                 Outcome::Launch(launch)
             }
             Targets::Many(launches) => {
-                self.notice = Some(format!("{}{}: which checkout?", staged.repo, staged.key()));
+                self.notice = Some(format!("{repo}{key}: which checkout?"));
                 self.overlay = Overlay::PickCheckout {
                     launches,
                     cursor: 0,
@@ -705,7 +731,7 @@ impl App {
         &mut self,
         key: KeyEvent,
         staged: Staged,
-        mut mode: Mode,
+        mut candidate: Candidate,
         mut steer: String,
     ) -> Outcome {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
@@ -716,15 +742,30 @@ impl App {
             // Returns *before* the overlay is put back, because resolving may
             // have opened the which-checkout modal over this one — falling
             // through would overwrite it with the picker the launch just left.
-            KeyCode::Enter => {
-                return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
-            }
+            // The one exception is the refusal below, which puts this very
+            // picker back so the missing task can be typed into it.
+            KeyCode::Enter => match candidate {
+                Candidate::Launch { mode, .. } => {
+                    return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
+                }
+                Candidate::Create(kind) => match kind.with_text(&steer) {
+                    Some(creation) => return self.resolve_creation(&staged.repo, creation),
+                    // The one per-row refusal (#114): `/wf-one` with no task is
+                    // meaningless, so it is refused where a done or blocked node
+                    // is — on the count line, with the picker still up.
+                    None => {
+                        self.notice =
+                            Some(format!("type the {} first", kind.field()));
+                    }
+                },
+            },
             // The two directions are genuinely different steps now that there
-            // is a third mode (#112); `tab` joins the arrows because it is what
-            // the rest of the screen uses to move through a list, and it steps
-            // the way `down` does rather than toggling.
-            KeyCode::Up => mode = previous_mode(mode),
-            KeyCode::Down | KeyCode::Tab => mode = next_mode(mode),
+            // is a third mode (#112) and the creation rows (#114); `tab` joins
+            // the arrows because it is what the rest of the screen uses to move
+            // through a list, and it steps the way `down` does rather than
+            // toggling.
+            KeyCode::Up => candidate = previous_candidate(&staged, candidate),
+            KeyCode::Down | KeyCode::Tab => candidate = next_candidate(&staged, candidate),
             KeyCode::Backspace => {
                 steer.pop();
             }
@@ -735,7 +776,7 @@ impl App {
         }
         self.overlay = Overlay::PickLaunch {
             staged,
-            mode,
+            candidate,
             steer,
         };
         Outcome::Continue
@@ -802,10 +843,10 @@ impl App {
             }
             Overlay::PickLaunch {
                 staged,
-                mode,
+                candidate,
                 steer,
             } => {
-                return self.handle_pick_launch_key(key, staged, mode, steer);
+                return self.handle_pick_launch_key(key, staged, candidate, steer);
             }
             Overlay::None => {}
         }
@@ -906,7 +947,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::launch::{Mode, Route};
+    use crate::launch::{CreationKind, Mode, Route};
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
@@ -1716,7 +1757,7 @@ mod tests {
         match &app.overlay {
             Overlay::PickLaunch {
                 staged,
-                mode,
+                candidate,
                 steer,
             } => {
                 assert_eq!(
@@ -1726,7 +1767,14 @@ mod tests {
                 );
                 assert_eq!(staged.key(), "#6");
                 assert_eq!(staged.title, "Re-entry breadcrumbs", "the picker names it");
-                assert_eq!(*mode, Mode::Interactive, "the picker opens on the default");
+                assert_eq!(
+                    *candidate,
+                    Candidate::Launch {
+                        mode: Mode::Interactive,
+                        route: Route::Wayfinder
+                    },
+                    "the picker opens on the default"
+                );
                 assert_eq!(steer, "", "with nothing steering it");
             }
             other => panic!("expected the launch picker, got {other:?}"),
@@ -1872,9 +1920,14 @@ mod tests {
         let mut app = launchable_app();
         go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Enter));
+        // A ticket's picker lists only the launch rows, so the walk is over
+        // the modes and the candidate's mode is what `enter` will launch.
         let mode = |app: &App| match &app.overlay {
-            Overlay::PickLaunch { mode, .. } => *mode,
-            other => panic!("expected the launch picker, got {other:?}"),
+            Overlay::PickLaunch {
+                candidate: Candidate::Launch { mode, .. },
+                ..
+            } => *mode,
+            other => panic!("expected a launch row, got {other:?}"),
         };
         assert_eq!(mode(&app), Mode::Interactive);
         // Up from the first row wraps to the last rather than sticking, and
@@ -1896,11 +1949,9 @@ mod tests {
         // edited independently, in one overlay.
         type_str(&mut app, "keep me");
         app.handle_key(key(KeyCode::Down));
+        assert_eq!(mode(&app), Mode::Auto);
         match &app.overlay {
-            Overlay::PickLaunch { mode, steer, .. } => {
-                assert_eq!(*mode, Mode::Auto);
-                assert_eq!(steer, "keep me");
-            }
+            Overlay::PickLaunch { steer, .. } => assert_eq!(steer, "keep me"),
             other => panic!("expected the launch picker, got {other:?}"),
         }
     }
@@ -2079,6 +2130,125 @@ mod tests {
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto 1");
+    }
+
+    #[test]
+    fn a_header_picker_reaches_the_creation_rows_and_a_ticket_picker_has_none() {
+        // #114: creation is a repo-level act, so the rows exist exactly where
+        // the stop is repo-level. On a header the walk reaches them after the
+        // launch modes; on a ticket the same walk wraps among the three modes.
+        let mut app = launchable_app();
+        go_to(&mut app, "map #1");
+        app.handle_key(key(KeyCode::Enter));
+        let picked = |app: &App| match &app.overlay {
+            Overlay::PickLaunch { candidate, .. } => *candidate,
+            other => panic!("expected the launch picker, got {other:?}"),
+        };
+        assert_eq!(
+            picked(&app),
+            Candidate::Launch {
+                mode: Mode::Interactive,
+                route: Route::Wayfinder
+            },
+            "opens on the default launch row"
+        );
+        // Down past the three modes lands on the creation rows, in order.
+        for _ in 0..3 {
+            app.handle_key(key(KeyCode::Down));
+        }
+        assert_eq!(picked(&app), Candidate::Create(CreationKind::Task));
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(picked(&app), Candidate::Create(CreationKind::Map));
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(picked(&app), Candidate::Create(CreationKind::MapAuto));
+        app.handle_key(key(KeyCode::Down));
+        assert_eq!(
+            picked(&app),
+            Candidate::Launch {
+                mode: Mode::Interactive,
+                route: Route::Wayfinder
+            },
+            "and wraps back to the top"
+        );
+        // Up from the top wraps onto the last creation row.
+        app.handle_key(key(KeyCode::Up));
+        assert_eq!(picked(&app), Candidate::Create(CreationKind::MapAuto));
+
+        // A ticket stop walks only the modes: three downs is a full lap.
+        let mut app = launchable_app();
+        go_to(&mut app, "#6");
+        app.handle_key(key(KeyCode::Enter));
+        for _ in 0..3 {
+            app.handle_key(key(KeyCode::Down));
+        }
+        assert_eq!(
+            picked(&app),
+            Candidate::Launch {
+                mode: Mode::Interactive,
+                route: Route::Wayfinder
+            },
+            "no creation rows on a ticket"
+        );
+    }
+
+    #[test]
+    fn a_new_task_launches_wf_one_and_refuses_an_empty_task() {
+        let mut app = launchable_app();
+        go_to(&mut app, "map #1");
+        app.handle_key(key(KeyCode::Enter));
+        for _ in 0..3 {
+            app.handle_key(key(KeyCode::Down)); // onto `new task`
+        }
+        // Enter with nothing typed refuses on the count line — the overlay
+        // stays up, as a done or blocked node already refuses.
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(
+            matches!(app.overlay, Overlay::PickLaunch { .. }),
+            "the picker stays up to take the task"
+        );
+        assert!(
+            app.notice.as_deref().unwrap().contains("task"),
+            "{:?}",
+            app.notice
+        );
+        // With the task typed, enter execs /wf-one with it verbatim.
+        type_str(&mut app, "wire the exporter");
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(
+            launch.agent_argv().last().unwrap(),
+            "/wf-one wire the exporter"
+        );
+    }
+
+    #[test]
+    fn a_new_map_launches_the_charting_skill_with_the_text_as_its_seed() {
+        // The seed is optional: bare `/wf` charts from nothing.
+        let mut app = launchable_app();
+        go_to(&mut app, "map #1");
+        app.handle_key(key(KeyCode::Enter));
+        for _ in 0..4 {
+            app.handle_key(key(KeyCode::Down)); // onto `new map`
+        }
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wf");
+
+        // And seeded, alone: the auto charting row takes the idea verbatim.
+        let mut app = launchable_app();
+        go_to(&mut app, "map #1");
+        app.handle_key(key(KeyCode::Enter));
+        app.handle_key(key(KeyCode::Up)); // wrap straight onto `new map, auto`
+        type_str(&mut app, "a caching layer");
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto a caching layer");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -740,7 +740,7 @@ impl App {
     /// launch that has no node to name (#114). The creation arrives already
     /// complete — [`launch::CreationKind::with_text`] refused the empty task
     /// before this was called — so the only thing left to answer is *where*.
-    fn resolve_creation(&mut self, repo: &str, creation: launch::Creation) -> Outcome {
+    fn resolve_creation(&mut self, repo: &str, creation: &launch::Creation) -> Outcome {
         let targets = launch::plan_create(&self.checkouts, repo, creation);
         self.act_on(targets, repo, "+new")
     }
@@ -803,13 +803,12 @@ impl App {
                     return self.resolve_launch(&staged, &LaunchMode::picked(mode, &steer))
                 }
                 Candidate::Create(kind) => match kind.with_text(&steer) {
-                    Some(creation) => return self.resolve_creation(&staged.repo, creation),
+                    Some(creation) => return self.resolve_creation(&staged.repo, &creation),
                     // The one per-row refusal (#114): `/wf-one` with no task is
                     // meaningless, so it is refused where a done or blocked node
                     // is — on the count line, with the picker still up.
                     None => {
-                        self.notice =
-                            Some(format!("type the {} first", kind.field()));
+                        self.notice = Some(format!("type the {} first", kind.field()));
                     }
                 },
             },
@@ -2205,10 +2204,16 @@ mod tests {
         // a stop, so the cursor can name it and `enter` can act on it.
         let app = mapless_app();
         assert_eq!(
-            app.stops().iter().map(|at| at.stop.clone()).collect::<Vec<_>>(),
+            app.stops()
+                .iter()
+                .map(|at| at.stop.clone())
+                .collect::<Vec<_>>(),
             vec![Stop::Project("blooop/newthing".to_string())]
         );
-        assert_eq!(app.cursor_stop(), Some(Stop::Project("blooop/newthing".to_string())));
+        assert_eq!(
+            app.cursor_stop(),
+            Some(Stop::Project("blooop/newthing".to_string()))
+        );
     }
 
     #[test]
@@ -2219,7 +2224,9 @@ mod tests {
         let mut app = mapless_app();
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
-            Overlay::PickLaunch { staged, candidate, .. } => {
+            Overlay::PickLaunch {
+                staged, candidate, ..
+            } => {
                 assert_eq!(
                     staged.candidates(),
                     vec![
@@ -2387,7 +2394,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto a caching layer");
+        assert_eq!(
+            launch.agent_argv().last().unwrap(),
+            "/wf-auto a caching layer"
+        );
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -273,6 +273,63 @@ impl CreationKind {
             CreationKind::Map | CreationKind::MapAuto => "seed",
         }
     }
+
+    /// Complete this kind with the typed text — parse, don't validate. `None`
+    /// is the one refusal: a task with nothing typed, because `/wf-one` with
+    /// no task is meaningless and the picker refuses it on the count line the
+    /// way a done or blocked node already refuses. A map's text is only a
+    /// seed, so absence is fine and is spelt `None` rather than `Some("")`.
+    pub fn with_text(self, text: &str) -> Option<Creation> {
+        let text = text.trim();
+        let seed = || (!text.is_empty()).then(|| text.to_string());
+        match self {
+            CreationKind::Task => (!text.is_empty()).then(|| Creation::Task {
+                task: text.to_string(),
+            }),
+            CreationKind::Map => Some(Creation::Map { seed: seed() }),
+            CreationKind::MapAuto => Some(Creation::MapAuto { seed: seed() }),
+        }
+    }
+}
+
+/// A creation, completed: the kind plus the text that makes it launchable
+/// (#114). Built only by [`CreationKind::with_text`], so a task without its
+/// text is unrepresentable — the refusal happened at the parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Creation {
+    /// `/wf-one <task>` — the task text, never empty.
+    Task { task: String },
+    /// `/wf [<seed>]` — charting with the human; the seed is the loose idea.
+    Map { seed: Option<String> },
+    /// `/wf-auto [<seed>]` — charting alone.
+    MapAuto { seed: Option<String> },
+}
+
+impl Creation {
+    /// The kind this creation completes — for the labels the notice reuses.
+    fn kind(&self) -> CreationKind {
+        match self {
+            Creation::Task { .. } => CreationKind::Task,
+            Creation::Map { .. } => CreationKind::Map,
+            Creation::MapAuto { .. } => CreationKind::MapAuto,
+        }
+    }
+
+    /// The whole prompt this creation execs. Built here rather than through
+    /// [`LaunchMode::opening_prompt`] because nothing is being steered: the
+    /// text is the skill's *argument* — the task, or the loose idea — not a
+    /// ` steer: …` suffix on a session that already has a subject.
+    fn invocation(&self) -> String {
+        let seeded = |skill: &str, seed: &Option<String>| match seed {
+            None => skill.to_string(),
+            Some(seed) => format!("{skill} {seed}"),
+        };
+        match self {
+            Creation::Task { task } => format!("{} {task}", Route::One.label()),
+            Creation::Map { seed } => seeded(Route::Wayfinder.label(), seed),
+            Creation::MapAuto { seed } => seeded(Route::WayfinderAuto.label(), seed),
+        }
+    }
 }
 
 /// One row of the launch picker: a **complete candidate**, carrying its own
@@ -672,26 +729,44 @@ fn shell_quote(arg: &str) -> String {
 /// `Route` for it exists.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Launch {
-    /// The node's repo, full slug (`owner/name`) — the identity half, kept
+    /// The repo, full slug (`owner/name`) — the identity half, kept
     /// whole because a fork and its upstream share a short name (#15).
     repo: String,
-    /// What is being worked: the map, or one ticket in it.
-    aim: Aim,
-    /// The map issue — `/wf`'s first argument, and its only one when
-    /// the aim is the map itself.
-    map_issue: u64,
     /// The picked checkout: the process's working directory, and the agent's
     /// working tree on the host. An isolated launch works in its own `dl`
     /// workspace instead — the checkout's remaining job there is having
     /// declared the devcontainer.
     cwd: PathBuf,
-    /// The skill this launch execs, resolved from (type, stage).
-    route: Route,
-    /// What the launch picker settled on. The mode half already picked `route`; what
-    /// is left to spend here is the steering text.
-    mode: LaunchMode,
-    /// Host or container, decided from the checkout at [`plan`] time (#80).
+    /// What the agent is asked to do there: work a node, or start something
+    /// new (#114).
+    job: Job,
+    /// Host or container, decided from the checkout at plan time (#80).
     isolation: Isolation,
+}
+
+/// What a launch asks of its agent — the sum that keeps a creation from being
+/// a node with missing fields (#114). A creation has no aim, no map issue and
+/// no stage, because the things it would name do not exist until the launched
+/// skill files them; giving it sentinel zeroes would put a lie in every
+/// consumer. The workspace rule falls out per arm: a node gets its per-ticket
+/// branch, a creation gets the repo's default workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Job {
+    /// Work a node fetched from the tracker.
+    Node {
+        /// The map, or one ticket in it.
+        aim: Aim,
+        /// The map issue — `/wf`'s first argument, and its only one when the
+        /// aim is the map itself.
+        map_issue: u64,
+        /// The skill this launch execs, resolved from (type, stage).
+        route: Route,
+        /// What the launch picker settled on. The mode half already picked
+        /// `route`; what is left to spend here is the steering text.
+        mode: LaunchMode,
+    },
+    /// Start something new in the repo — the skill files the issues.
+    Create(Creation),
 }
 
 /// Agent sessions are started from a picker rather than from a shell someone is
@@ -704,39 +779,53 @@ impl Launch {
         &self.cwd
     }
 
-    /// The issue number this launch is about: the ticket's, or the map's own
-    /// when the whole map is the subject.
-    fn number(&self) -> u64 {
-        match &self.aim {
-            Aim::Map => self.map_issue,
-            Aim::Ticket { number, .. } => *number,
+    /// How this launch reads on screen: `<short_repo>#<number>` for a node —
+    /// the ticket's number, or the map's when the whole map is what was
+    /// picked — and `<short_repo>+new` for a creation, which has no number
+    /// until the skill files one.
+    pub fn key(&self) -> String {
+        match &self.job {
+            Job::Node { aim, map_issue, .. } => {
+                let number = match aim {
+                    Aim::Map => map_issue,
+                    Aim::Ticket { number, .. } => number,
+                };
+                format!("{}#{}", short_repo(&self.repo), number)
+            }
+            Job::Create(_) => format!("{}+new", short_repo(&self.repo)),
         }
     }
 
-    /// How this node reads on screen: `<short_repo>#<number>`, the same
-    /// identity the picker's rows show — the ticket's number, or the map's
-    /// when the whole map is what was picked.
-    pub fn key(&self) -> String {
-        format!("{}#{}", short_repo(&self.repo), self.number())
-    }
-
-    /// The `dl` workspace an isolated launch runs in:
-    /// `owner/repo@wayfinder/<repo>-<n>` — one branch per node, so parallel
-    /// launches never share a tree or a container, and relaunching a node
-    /// reattaches to the workspace it already has.
+    /// The `dl` workspace an isolated launch runs in.
     ///
-    /// The branch name is not `wf`'s invention: `wayfinder/<repo>-<n>` is the
+    /// A node gets `owner/repo@wayfinder/<repo>-<n>` — one branch per node,
+    /// so parallel launches never share a tree or a container, and
+    /// relaunching a node reattaches to the workspace it already has. The
+    /// branch name is not `wf`'s invention: `wayfinder/<repo>-<n>` is the
     /// branch `/wf-tdd` is instructed to do ticket `n`'s work on. `dl` creates
     /// it (locally, off the default branch) when it does not exist yet, so a
     /// build agent wakes up already on its work branch, and a reviewer's
     /// workspace opens on the branch the PR was pushed from.
+    ///
+    /// A creation has no number, so no per-ticket branch exists to name: it
+    /// gets the bare `owner/repo` — the default workspace — and the launched
+    /// skill files its own issues and makes its own branches (#114).
     fn workspace(&self) -> String {
-        format!(
-            "{}@wayfinder/{}-{}",
-            self.repo,
-            short_repo(&self.repo),
-            self.number()
-        )
+        match &self.job {
+            Job::Node { aim, map_issue, .. } => {
+                let number = match aim {
+                    Aim::Map => map_issue,
+                    Aim::Ticket { number, .. } => number,
+                };
+                format!(
+                    "{}@wayfinder/{}-{}",
+                    self.repo,
+                    short_repo(&self.repo),
+                    number
+                )
+            }
+            Job::Create(_) => self.repo.clone(),
+        }
     }
 
     /// Where this launch's agent runs.
@@ -753,7 +842,12 @@ impl Launch {
             Isolation::Host => self.cwd.display().to_string(),
             Isolation::Devlaunch => self.workspace(),
         };
-        format!("{} in {}{}", self.key(), place, self.isolation.suffix())
+        let what = match &self.job {
+            Job::Node { .. } => self.key(),
+            // A creation has no `#n` to name yet, so the notice names the act.
+            Job::Create(creation) => creation.kind().label().to_string(),
+        };
+        format!("{what} in {place}{}", self.isolation.suffix())
     }
 
     /// The agent itself. `claude` takes a single positional prompt, so the
@@ -763,12 +857,17 @@ impl Launch {
     /// one).
     fn claude_argv(&self) -> Vec<String> {
         let mut argv = vec!["claude".to_string(), SKIP_PERMISSIONS.to_string()];
-        argv.extend(self.mode.opening_prompt(self.skill_invocation()));
+        let prompt = match &self.job {
+            Job::Node { mode, .. } => mode.opening_prompt(self.skill_invocation()),
+            Job::Create(creation) => Some(creation.invocation()),
+        };
+        argv.extend(prompt);
         argv
     }
 
-    /// The slash command and its arguments, for the routes that invoke a
+    /// The slash command and its arguments, for the node routes that invoke a
     /// skill. `None` is [`Route::Plain`]: no skill, so nothing to invoke.
+    /// A creation never reaches here — its prompt is [`Creation::invocation`].
     ///
     /// [`Route::Plain`] is absorbed first because it is the arm that needs no
     /// second thought — it has no arguments to shape, whatever it was aimed at.
@@ -777,20 +876,29 @@ impl Launch {
     /// live — only the wayfinder skills take the map argument, since `/wf-tdd`
     /// and `/wf-review` resolve the repo from the checkout they run in.
     fn skill_invocation(&self) -> Option<String> {
-        let skill = self.route.label();
-        match (self.route, &self.aim) {
+        let Job::Node {
+            aim,
+            map_issue,
+            route,
+            ..
+        } = &self.job
+        else {
+            return None;
+        };
+        let skill = route.label();
+        match (route, aim) {
             (Route::Plain, _) => None,
             // Unreachable from a node: [`route`] never answers `One` — it is
             // the creation candidates' route (#114), and a creation launch
             // builds its prompt from the typed task, not from an aim. If a
             // node ever did carry it, the bare skill grills for its task.
             (Route::One, _) => Some(skill.to_string()),
-            (_, Aim::Map) => Some(format!("{skill} {}", self.map_issue)),
+            (_, Aim::Map) => Some(format!("{skill} {map_issue}")),
             (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => {
                 Some(format!("{skill} {number}"))
             }
             (Route::Wayfinder | Route::WayfinderAuto, Aim::Ticket { number, .. }) => {
-                Some(format!("{skill} {} {number}", self.map_issue))
+                Some(format!("{skill} {map_issue} {number}"))
             }
         }
     }
@@ -944,28 +1052,45 @@ pub enum Targets {
 /// Resolve a launch request against the projects cache. Zero or one candidate
 /// never prompts. The aim and mode arrive already settled — this function
 /// answers *where* the agent can run, and resolves the route the mode picked.
+pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
+    let route = staged.route(mode.mode());
+    resolve(checkouts, &staged.repo, |_| Job::Node {
+        aim: staged.aim.clone(),
+        map_issue: staged.map_issue,
+        route,
+        mode: mode.clone(),
+    })
+}
+
+/// Resolve a creation against the projects cache — the same rules as [`plan`]:
+/// zero or one candidate checkout never prompts. The creation arrives already
+/// complete ([`CreationKind::with_text`] refused the empty task), so this
+/// function only answers *where* the skill runs.
+pub fn plan_create(checkouts: &[Checkout], repo: &str, creation: Creation) -> Targets {
+    resolve(checkouts, repo, |_| Job::Create(creation.clone()))
+}
+
+/// The shared half of [`plan`] and [`plan_create`]: every registered checkout
+/// of the repo becomes a complete [`Launch`] carrying the job, and the count
+/// decides whether anyone is prompted.
 ///
 /// Isolation is decided **here**, per candidate, rather than at the exec: a
 /// checkout that has a devcontainer and one that does not can both be
-/// candidates for the same ticket, the notice has to say which is which before
-/// the human picks, and by the exec there is nothing left to tell them with.
-/// It is the one filesystem read in this module's otherwise pure planning path.
+/// candidates, the notice has to say which is which before the human picks,
+/// and by the exec there is nothing left to tell them with. It is the one
+/// filesystem read in this module's otherwise pure planning path.
 ///
 /// # Panics
 ///
 /// Never: the `expect` in the one-candidate arm is guarded by the `match` on
 /// the length immediately above it.
-pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
-    let route = staged.route(mode.mode());
-    let launches: Vec<Launch> = candidate_checkouts(checkouts, &staged.repo)
+fn resolve(checkouts: &[Checkout], repo: &str, job: impl Fn(&Checkout) -> Job) -> Targets {
+    let launches: Vec<Launch> = candidate_checkouts(checkouts, repo)
         .into_iter()
         .map(|c| Launch {
-            repo: staged.repo.clone(),
-            aim: staged.aim.clone(),
-            map_issue: staged.map_issue,
+            repo: repo.to_string(),
             cwd: c.path.clone(),
-            route,
-            mode: mode.clone(),
+            job: job(c),
             isolation: Isolation::detect(&c.path),
         })
         .collect();
@@ -1061,8 +1186,14 @@ mod tests {
             Targets::One(launch) => {
                 assert_eq!(launch.cwd(), Path::new("/data/proj/wayfinder"));
                 assert_eq!(launch.key(), "wayfinder#16");
-                assert_eq!(launch.map_issue, 1);
-                assert!(matches!(launch.aim, Aim::Ticket { number: 16, .. }));
+                assert!(matches!(
+                    &launch.job,
+                    Job::Node {
+                        map_issue: 1,
+                        aim: Aim::Ticket { number: 16, .. },
+                        ..
+                    }
+                ));
             }
             other => panic!("expected One, got {other:?}"),
         }
@@ -1253,6 +1384,139 @@ mod tests {
         assert_eq!(Candidate::Create(CreationKind::Task).field(), "task");
         assert_eq!(Candidate::Create(CreationKind::Map).field(), "seed");
         assert_eq!(Candidate::Create(CreationKind::MapAuto).field(), "seed");
+    }
+
+    #[test]
+    fn a_task_needs_its_text_and_a_map_seed_is_optional() {
+        // Parse, don't validate (#114): an empty task is refused where the
+        // creation is built, so a `/wf-one` with nothing to do is
+        // unrepresentable — and all-whitespace is empty, as the steer field
+        // already treats it. A map's text is only a seed: the charting session
+        // grills for the idea anyway, so nothing typed is a fine seed.
+        assert_eq!(CreationKind::Task.with_text("   "), None);
+        assert_eq!(
+            CreationKind::Task.with_text(" wire the exporter "),
+            Some(Creation::Task {
+                task: "wire the exporter".to_string()
+            })
+        );
+        assert_eq!(
+            CreationKind::Map.with_text(""),
+            Some(Creation::Map { seed: None })
+        );
+        assert_eq!(
+            CreationKind::Map.with_text(" a caching layer "),
+            Some(Creation::Map {
+                seed: Some("a caching layer".to_string())
+            })
+        );
+        assert_eq!(
+            CreationKind::MapAuto.with_text(""),
+            Some(Creation::MapAuto { seed: None })
+        );
+    }
+
+    /// The one-checkout creation launch, reduced to its argv.
+    fn creation_argv(kind: CreationKind, text: &str) -> Vec<String> {
+        let creation = kind.with_text(text).expect("a buildable creation");
+        match plan_create(&cache(), "blooop/wayfinder", creation) {
+            Targets::One(l) => l.agent_argv(),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_new_task_launch_execs_wf_one_with_the_task_verbatim() {
+        // The typed text *is* the ticket — no `steer:` prefix, no skill to
+        // steer: `/wf-one` receives the task as its argument.
+        assert_eq!(
+            creation_argv(CreationKind::Task, "wire the exporter"),
+            vec![
+                "claude".to_string(),
+                SKIP_PERMISSIONS.to_string(),
+                "/wf-one wire the exporter".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_new_map_launch_execs_the_charting_skill_with_an_optional_seed() {
+        // Bare `/wf` charts from nothing; typed text rides as the loose idea.
+        assert_eq!(
+            creation_argv(CreationKind::Map, "").last().expect("prompt"),
+            "/wf"
+        );
+        assert_eq!(
+            creation_argv(CreationKind::Map, "a caching layer")
+                .last()
+                .expect("prompt"),
+            "/wf a caching layer"
+        );
+        assert_eq!(
+            creation_argv(CreationKind::MapAuto, "")
+                .last()
+                .expect("prompt"),
+            "/wf-auto"
+        );
+        assert_eq!(
+            creation_argv(CreationKind::MapAuto, "a caching layer")
+                .last()
+                .expect("prompt"),
+            "/wf-auto a caching layer"
+        );
+    }
+
+    #[test]
+    fn an_isolated_creation_launch_runs_on_the_default_workspace() {
+        // A creation has no issue number, so no per-ticket branch exists to
+        // name: `dl` gets the bare `owner/repo` spec — the default workspace —
+        // and the launched skill files its own issues and makes its own
+        // branches (#114). The command after `--` is quoted like any other.
+        let launch = isolated_creation(
+            CreationKind::Task
+                .with_text("wire the exporter")
+                .expect("text given"),
+        );
+        assert_eq!(
+            launch.agent_argv(),
+            vec![
+                "dl".to_string(),
+                "blooop/wayfinder".to_string(),
+                "--".to_string(),
+                "'claude' '--dangerously-skip-permissions' '/wf-one wire the exporter'".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_notice_names_what_a_creation_starts_and_where() {
+        // The launch notice is the last thing wf says: for a creation there is
+        // no `#n` to name, so it names the act.
+        let creation = CreationKind::Map.with_text("").expect("seedless map");
+        match plan_create(&cache(), "blooop/wayfinder", creation) {
+            Targets::One(l) => {
+                assert_eq!(l.describe(), "new map in /data/proj/wayfinder");
+            }
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(
+            isolated_creation(CreationKind::Task.with_text("x").expect("text")).describe(),
+            "new task in blooop/wayfinder (devlaunch)"
+        );
+    }
+
+    #[test]
+    fn a_creation_resolves_checkouts_like_any_other_launch() {
+        // Same cache, same rules: none registered refuses, several prompt.
+        let creation = || CreationKind::Map.with_text("").expect("seedless map");
+        assert_eq!(
+            plan_create(&cache(), "blooop/dotfiles", creation()),
+            Targets::Unregistered
+        );
+        match plan_create(&cache(), "kinisi/kinisi_ros", creation()) {
+            Targets::Many(launches) => assert_eq!(launches.len(), 2),
+            other => panic!("{other:?}"),
+        }
     }
 
     #[test]
@@ -1632,15 +1896,28 @@ mod tests {
     fn isolated_ticket(number: u64, route: Route, mode: LaunchMode) -> Launch {
         Launch {
             repo: "blooop/wayfinder".to_string(),
-            aim: Aim::Ticket {
-                number,
-                ticket_type: TicketType::Task,
-                stage: Launchable::Ready,
-            },
-            map_issue: 67,
             cwd: PathBuf::from("/data/proj/wayfinder"),
-            route,
-            mode,
+            job: Job::Node {
+                aim: Aim::Ticket {
+                    number,
+                    ticket_type: TicketType::Task,
+                    stage: Launchable::Ready,
+                },
+                map_issue: 67,
+                route,
+                mode,
+            },
+            isolation: Isolation::Devlaunch,
+        }
+    }
+
+    /// A creation launch forced into a container, for the same reason as
+    /// [`isolated`]: `plan_create` reads the real filesystem.
+    fn isolated_creation(creation: Creation) -> Launch {
+        Launch {
+            repo: "blooop/wayfinder".to_string(),
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            job: Job::Create(creation),
             isolation: Isolation::Devlaunch,
         }
     }
@@ -1713,11 +1990,13 @@ mod tests {
         // own container, keyed by the map issue since there is no ticket.
         let launch = Launch {
             repo: "blooop/wayfinder".to_string(),
-            aim: Aim::Map,
-            map_issue: 67,
             cwd: PathBuf::from("/data/proj/wayfinder"),
-            route: Route::WayfinderAuto,
-            mode: auto(""),
+            job: Job::Node {
+                aim: Aim::Map,
+                map_issue: 67,
+                route: Route::WayfinderAuto,
+                mode: auto(""),
+            },
             isolation: Isolation::Devlaunch,
         };
         assert_eq!(

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -641,26 +641,27 @@ impl Staged {
         }
     }
 
-    /// The picker's rows for this stop, in on-screen order — the one
-    /// constructor of [`Candidate`], which is what makes an inconsistent row
-    /// unbuildable (#114). Every stop launches; only the repo-level stop — the
-    /// cluster header, [`Aim::Map`] — adds the creation rows, because creation
-    /// is a repo-level act and a ticket picker carrying it would merge
-    /// concerns the stop grammar keeps apart.
-    /// The row the picker opens on: the default mode's launch row, whatever
-    /// else this stop offers. Creation is never the default — `enter` on a
-    /// node still means "launch this node" first.
+    /// The row the picker opens on: the first row this stop offers. On a node
+    /// that is the default mode's launch row — creation is never the default,
+    /// because `enter` on a node still means "launch this node" first. On the
+    /// map-less door there is no node to launch, so the first creation row
+    /// leads.
     ///
     /// # Panics
     ///
-    /// Never: [`Staged::candidates`] always leads with the launch rows.
+    /// Never: [`Staged::candidates`] is never empty. Every stop offers rows —
+    /// its launch rows, or, on the map-less door, its creation rows.
     pub fn default_candidate(&self) -> Candidate {
-        *self
-            .candidates()
-            .first()
-            .expect("every stop offers its launch rows")
+        *self.candidates().first().expect("every stop offers rows")
     }
 
+    /// The picker's rows for this stop, in on-screen order — the one
+    /// constructor of [`Candidate`], which is what makes an inconsistent row
+    /// unbuildable (#114). Every *node* launches; only the repo-level node —
+    /// the cluster header, [`Aim::Map`] — adds the creation rows, because
+    /// creation is a repo-level act and a ticket picker carrying it would
+    /// merge concerns the stop grammar keeps apart. The map-less door has no
+    /// node, so it offers the creation rows alone.
     pub fn candidates(&self) -> Vec<Candidate> {
         let launches = |aim: Aim| {
             Mode::all()
@@ -841,6 +842,25 @@ enum Job {
     Create(Creation),
 }
 
+impl Job {
+    /// The issue number this job hangs off: the ticket's, or the map's when the
+    /// whole map is what was picked. `None` for a creation, which has no number
+    /// until the launched skill files one.
+    ///
+    /// Held here rather than inlined at each use because the display key and
+    /// the `dl` branch name must never disagree about which number a launch is
+    /// — they are two renderings of the same fact.
+    fn number(&self) -> Option<u64> {
+        match self {
+            Job::Node { aim, map_issue, .. } => Some(match aim {
+                Aim::Map => *map_issue,
+                Aim::Ticket { number, .. } => *number,
+            }),
+            Job::Create(_) => None,
+        }
+    }
+}
+
 /// Agent sessions are started from a picker rather than from a shell someone is
 /// watching, so they do not stop for permission prompts.
 const SKIP_PERMISSIONS: &str = "--dangerously-skip-permissions";
@@ -856,15 +876,9 @@ impl Launch {
     /// picked — and `<short_repo>+new` for a creation, which has no number
     /// until the skill files one.
     pub fn key(&self) -> String {
-        match &self.job {
-            Job::Node { aim, map_issue, .. } => {
-                let number = match aim {
-                    Aim::Map => map_issue,
-                    Aim::Ticket { number, .. } => number,
-                };
-                format!("{}#{}", short_repo(&self.repo), number)
-            }
-            Job::Create(_) => format!("{}+new", short_repo(&self.repo)),
+        match self.job.number() {
+            Some(number) => format!("{}#{}", short_repo(&self.repo), number),
+            None => format!("{}+new", short_repo(&self.repo)),
         }
     }
 
@@ -883,20 +897,14 @@ impl Launch {
     /// gets the bare `owner/repo` — the default workspace — and the launched
     /// skill files its own issues and makes its own branches (#114).
     fn workspace(&self) -> String {
-        match &self.job {
-            Job::Node { aim, map_issue, .. } => {
-                let number = match aim {
-                    Aim::Map => map_issue,
-                    Aim::Ticket { number, .. } => number,
-                };
-                format!(
-                    "{}@wayfinder/{}-{}",
-                    self.repo,
-                    short_repo(&self.repo),
-                    number
-                )
-            }
-            Job::Create(_) => self.repo.clone(),
+        match self.job.number() {
+            Some(number) => format!(
+                "{}@wayfinder/{}-{}",
+                self.repo,
+                short_repo(&self.repo),
+                number
+            ),
+            None => self.repo.clone(),
         }
     }
 
@@ -1122,22 +1130,28 @@ pub enum Targets {
 }
 
 /// Resolve a launch request against the projects cache. Zero or one candidate
-/// never prompts. The aim and mode arrive already settled — this function
-/// answers *where* the agent can run, and resolves the route the mode picked.
-pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
+/// never prompts. The aim, mode **and route** all arrive already settled — the
+/// route comes from the [`Candidate`] the human actually saw drawn, not from a
+/// second derivation here, so what execs is what the row named (#114). This
+/// function answers only *where* the agent can run.
+pub fn plan(checkouts: &[Checkout], staged: &Staged, route: Route, mode: &LaunchMode) -> Targets {
     let StagedAt::Node { aim, map_issue } = staged.at else {
         // Unreachable from the picker: [`Staged::candidates`] offers no launch
         // row on the map-less door, so nothing there can ask for a node
-        // launch. Refusing rather than inventing a node keeps this total.
+        // launch. Refusing rather than inventing a node — there is no aim and
+        // no map issue to invent one from — keeps this total.
         return Targets::Unregistered;
     };
-    let route = route(&aim, mode.mode());
-    resolve(checkouts, &staged.repo, |_| Job::Node {
-        aim,
-        map_issue,
-        route,
-        mode: mode.clone(),
-    })
+    resolve(
+        checkouts,
+        &staged.repo,
+        &Job::Node {
+            aim,
+            map_issue,
+            route,
+            mode: mode.clone(),
+        },
+    )
 }
 
 /// Resolve a creation against the projects cache — the same rules as [`plan`]:
@@ -1145,7 +1159,7 @@ pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targe
 /// complete ([`CreationKind::with_text`] refused the empty task), so this
 /// function only answers *where* the skill runs.
 pub fn plan_create(checkouts: &[Checkout], repo: &str, creation: &Creation) -> Targets {
-    resolve(checkouts, repo, |_| Job::Create(creation.clone()))
+    resolve(checkouts, repo, &Job::Create(creation.clone()))
 }
 
 /// The shared half of [`plan`] and [`plan_create`]: every registered checkout
@@ -1162,13 +1176,15 @@ pub fn plan_create(checkouts: &[Checkout], repo: &str, creation: &Creation) -> T
 ///
 /// Never: the `expect` in the one-candidate arm is guarded by the `match` on
 /// the length immediately above it.
-fn resolve(checkouts: &[Checkout], repo: &str, job: impl Fn(&Checkout) -> Job) -> Targets {
+fn resolve(checkouts: &[Checkout], repo: &str, job: &Job) -> Targets {
     let launches: Vec<Launch> = candidate_checkouts(checkouts, repo)
         .into_iter()
         .map(|c| Launch {
             repo: repo.to_string(),
             cwd: c.path.clone(),
-            job: job(c),
+            // The job is the same whichever checkout hosts it — what differs
+            // per candidate is only where it runs and in what.
+            job: job.clone(),
             isolation: Isolation::detect(&c.path),
         })
         .collect();
@@ -1224,11 +1240,20 @@ mod tests {
     /// every checkout-resolution test wants (route and mode are orthogonal to
     /// which trees are candidates).
     fn plan_wf(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets {
-        plan(
+        let staged = Staged::ticket(ticket, map_issue, Stage::Ready).expect("ready is launchable");
+        plan_picked(
             checkouts,
-            &Staged::ticket(ticket, map_issue, Stage::Ready).expect("ready is launchable"),
+            &staged,
             &LaunchMode::picked(Mode::Interactive, ""),
         )
+    }
+
+    /// [`plan`] as the picker reaches it: the route comes from the row the
+    /// stop would have drawn for this mode, not from a second derivation the
+    /// test invents — so these stay tests of the real second enter.
+    fn plan_picked(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
+        let route = staged.route(mode.mode()).expect("a node stop launches");
+        plan(checkouts, staged, route, mode)
     }
 
     fn cache() -> Vec<Checkout> {
@@ -1633,7 +1658,7 @@ mod tests {
         let mut node = ticket("blooop/wayfinder", 16);
         node.ticket_type = ticket_type;
         let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
-        match plan(&cache(), &staged, mode) {
+        match plan_picked(&cache(), &staged, mode) {
             Targets::One(l) => l.agent_argv(),
             other => panic!("{other:?}"),
         }
@@ -1651,7 +1676,7 @@ mod tests {
     /// The whole argv of a launch aimed at the whole map.
     fn map_argv(mode: &LaunchMode) -> Vec<String> {
         let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
-        match plan(&cache(), &staged, mode) {
+        match plan_picked(&cache(), &staged, mode) {
             Targets::One(l) => l.agent_argv(),
             other => panic!("{other:?}"),
         }
@@ -1714,7 +1739,7 @@ mod tests {
         // A map's key is its own issue number, not a ticket's.
         let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
         assert_eq!(staged.key(), "#59");
-        match plan(&cache(), &staged, &interactive("")) {
+        match plan_picked(&cache(), &staged, &interactive("")) {
             Targets::One(l) => assert_eq!(l.key(), "wayfinder#59"),
             other => panic!("{other:?}"),
         }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -56,6 +56,10 @@ pub enum Route {
     /// decisions settled against the skill's guiding principles, and the whole
     /// remaining lifecycle driven unattended (#96).
     WayfinderAuto,
+    /// `/wf-one <task>` — one tracked ticket, filed and driven by the skill:
+    /// its own single-ticket map, `/wf-tdd` build, `/wf-review` review (#114).
+    /// The only route reached by a creation candidate rather than a mode.
+    One,
     /// `claude` — no skill at all (#112). The only route that invokes nothing:
     /// the session opens in the node's workspace and the human drives it.
     Plain,
@@ -77,6 +81,7 @@ impl Route {
             Route::Review => "/wf-review",
             Route::Wayfinder => "/wf",
             Route::WayfinderAuto => "/wf-auto",
+            Route::One => "/wf-one",
             Route::Plain => "claude",
         }
     }
@@ -92,7 +97,7 @@ impl Route {
     /// discovered at an agent launch.
     pub fn bundled_skill(self) -> Option<&'static str> {
         match self {
-            Route::Tdd | Route::Review | Route::Wayfinder | Route::WayfinderAuto => {
+            Route::Tdd | Route::Review | Route::Wayfinder | Route::WayfinderAuto | Route::One => {
                 Some(self.label().trim_start_matches('/'))
             }
             Route::Plain => None,
@@ -108,7 +113,8 @@ impl Route {
             Route::Tdd => Route::Review,
             Route::Review => Route::Wayfinder,
             Route::Wayfinder => Route::WayfinderAuto,
-            Route::WayfinderAuto => Route::Plain,
+            Route::WayfinderAuto => Route::One,
+            Route::One => Route::Plain,
             Route::Plain => Route::Tdd,
         }
     }
@@ -637,6 +643,11 @@ impl Launch {
         let skill = self.route.label();
         match (self.route, &self.aim) {
             (Route::Plain, _) => None,
+            // Unreachable from a node: [`route`] never answers `One` — it is
+            // the creation candidates' route (#114), and a creation launch
+            // builds its prompt from the typed task, not from an aim. If a
+            // node ever did carry it, the bare skill grills for its task.
+            (Route::One, _) => Some(skill.to_string()),
             (_, Aim::Map) => Some(format!("{skill} {}", self.map_issue)),
             (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => {
                 Some(format!("{skill} {number}"))
@@ -995,6 +1006,16 @@ mod tests {
                 "{typed:?} steers an interactive launch"
             );
         }
+    }
+
+    #[test]
+    fn the_new_task_route_names_the_wf_one_skill() {
+        // #114: `wf` ships `/wf-one` but routed nothing to it — the one skill
+        // in the bundle with no arm in `route`. The creation candidates give
+        // it its arm, so it must exist as a route and name its bundled skill.
+        assert_eq!(Route::One.label(), "/wf-one");
+        assert_eq!(Route::One.bundled_skill(), Some("wf-one"));
+        assert!(Route::all().contains(&Route::One), "reachable in the cycle");
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -611,6 +611,20 @@ impl Staged {
     /// cluster header, [`Aim::Map`] — adds the creation rows, because creation
     /// is a repo-level act and a ticket picker carrying it would merge
     /// concerns the stop grammar keeps apart.
+    /// The row the picker opens on: the default mode's launch row, whatever
+    /// else this stop offers. Creation is never the default — `enter` on a
+    /// node still means "launch this node" first.
+    ///
+    /// # Panics
+    ///
+    /// Never: [`Staged::candidates`] always leads with the launch rows.
+    pub fn default_candidate(&self) -> Candidate {
+        *self
+            .candidates()
+            .first()
+            .expect("every stop offers its launch rows")
+    }
+
     pub fn candidates(&self) -> Vec<Candidate> {
         let launches = Mode::all().into_iter().map(|mode| Candidate::Launch {
             mode,

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1144,7 +1144,7 @@ pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targe
 /// zero or one candidate checkout never prompts. The creation arrives already
 /// complete ([`CreationKind::with_text`] refused the empty task), so this
 /// function only answers *where* the skill runs.
-pub fn plan_create(checkouts: &[Checkout], repo: &str, creation: Creation) -> Targets {
+pub fn plan_create(checkouts: &[Checkout], repo: &str, creation: &Creation) -> Targets {
     resolve(checkouts, repo, |_| Job::Create(creation.clone()))
 }
 
@@ -1497,7 +1497,7 @@ mod tests {
     /// The one-checkout creation launch, reduced to its argv.
     fn creation_argv(kind: CreationKind, text: &str) -> Vec<String> {
         let creation = kind.with_text(text).expect("a buildable creation");
-        match plan_create(&cache(), "blooop/wayfinder", creation) {
+        match plan_create(&cache(), "blooop/wayfinder", &creation) {
             Targets::One(l) => l.agent_argv(),
             other => panic!("{other:?}"),
         }
@@ -1571,7 +1571,7 @@ mod tests {
         // The launch notice is the last thing wf says: for a creation there is
         // no `#n` to name, so it names the act.
         let creation = CreationKind::Map.with_text("").expect("seedless map");
-        match plan_create(&cache(), "blooop/wayfinder", creation) {
+        match plan_create(&cache(), "blooop/wayfinder", &creation) {
             Targets::One(l) => {
                 assert_eq!(l.describe(), "new map in /data/proj/wayfinder");
             }
@@ -1588,10 +1588,10 @@ mod tests {
         // Same cache, same rules: none registered refuses, several prompt.
         let creation = || CreationKind::Map.with_text("").expect("seedless map");
         assert_eq!(
-            plan_create(&cache(), "blooop/dotfiles", creation()),
+            plan_create(&cache(), "blooop/dotfiles", &creation()),
             Targets::Unregistered
         );
-        match plan_create(&cache(), "kinisi/kinisi_ros", creation()) {
+        match plan_create(&cache(), "kinisi/kinisi_ros", &creation()) {
             Targets::Many(launches) => assert_eq!(launches.len(), 2),
             other => panic!("{other:?}"),
         }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -211,6 +211,124 @@ impl Mode {
     }
 }
 
+/// Something new to start in a repo — the creation half of the picker (#114).
+/// Which kind, not yet what: the typed text that completes it (the task, or a
+/// map seed) arrives at the second enter, as [`Creation`].
+///
+/// Three hand-listed kinds rather than a creation × [`Mode`] product, because
+/// the product is dishonest: charting a map with no skill (`plain`) is
+/// meaningless, and a task's lifecycle is `/wf-one`'s own. These are exactly
+/// the combinations that mean something.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreationKind {
+    /// One tracked ticket via `/wf-one`: filed, built, reviewed.
+    Task,
+    /// Chart a new map via `/wf`, with the human in the loop.
+    Map,
+    /// Chart a new map via `/wf-auto`, alone.
+    MapAuto,
+}
+
+impl CreationKind {
+    /// Every kind, in picker order. Written out rather than derived from an
+    /// `after` cycle: three variants with one call site is below the size
+    /// where the cycle device earns its ceremony.
+    pub fn all() -> Vec<CreationKind> {
+        vec![CreationKind::Task, CreationKind::Map, CreationKind::MapAuto]
+    }
+
+    /// How the row reads in the picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            CreationKind::Task => "new task",
+            CreationKind::Map => "new map",
+            CreationKind::MapAuto => "new map, auto",
+        }
+    }
+
+    /// What picking it means — same register as [`Mode::blurb`].
+    pub fn blurb(self) -> &'static str {
+        match self {
+            CreationKind::Task => "one tracked ticket, built and reviewed",
+            CreationKind::Map => "chart a new map in this repo, with you",
+            CreationKind::MapAuto => "chart a new map in this repo, alone",
+        }
+    }
+
+    /// The skill this creation execs. Its own answer rather than [`route`]'s:
+    /// creation has no aim and no stage, so the (aim, mode) table has nothing
+    /// to say about it.
+    pub fn route(self) -> Route {
+        match self {
+            CreationKind::Task => Route::One,
+            CreationKind::Map => Route::Wayfinder,
+            CreationKind::MapAuto => Route::WayfinderAuto,
+        }
+    }
+
+    /// What the text field means on this row — the name drawn beside it.
+    pub fn field(self) -> &'static str {
+        match self {
+            CreationKind::Task => "task",
+            CreationKind::Map | CreationKind::MapAuto => "seed",
+        }
+    }
+}
+
+/// One row of the launch picker: a **complete candidate**, carrying its own
+/// aim and mode and therefore its own resolved route (#114). The picker's
+/// list stopped being a bare [`Mode`] walk when it started answering two
+/// questions — what am I aiming at, and who resolves it — and complete rows
+/// are what keep every one of them naming the skill it execs.
+///
+/// The launch arm carries its route *resolved* rather than re-deriving it at
+/// each use — the [`Targets::Many`] move: the pick cannot produce a launch
+/// inconsistent with the row that was drawn. [`Staged::candidates`] is the
+/// one constructor, so a launch row whose route disagrees with its mode, or a
+/// creation row on a stop that is not repo-level, is never built.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Candidate {
+    /// Launch the staged node, `mode` deciding who resolves it.
+    Launch { mode: Mode, route: Route },
+    /// Start something new in the staged node's repo.
+    Create(CreationKind),
+}
+
+impl Candidate {
+    /// How the row reads in the picker.
+    pub fn label(self) -> &'static str {
+        match self {
+            Candidate::Launch { mode, .. } => mode.label(),
+            Candidate::Create(kind) => kind.label(),
+        }
+    }
+
+    /// What picking it means.
+    pub fn blurb(self) -> &'static str {
+        match self {
+            Candidate::Launch { mode, .. } => mode.blurb(),
+            Candidate::Create(kind) => kind.blurb(),
+        }
+    }
+
+    /// The skill this row execs — already resolved, whichever arm.
+    pub fn route(self) -> Route {
+        match self {
+            Candidate::Launch { route, .. } => route,
+            Candidate::Create(kind) => kind.route(),
+        }
+    }
+
+    /// What the text field means while this row is picked: launch rows steer
+    /// the agent; creation rows take the task or the seed.
+    pub fn field(self) -> &'static str {
+        match self {
+            Candidate::Launch { .. } => "steer",
+            Candidate::Create(kind) => kind.field(),
+        }
+    }
+}
+
 /// What the launch picker settled on: who decides, and what steers them.
 ///
 /// Two independent axes, so genuinely a product and not a four-armed sum: the
@@ -428,6 +546,25 @@ impl Staged {
     /// echoes as the mode word is typed, and what [`plan`] resolves with.
     pub fn route(&self, mode: Mode) -> Route {
         route(&self.aim, mode)
+    }
+
+    /// The picker's rows for this stop, in on-screen order — the one
+    /// constructor of [`Candidate`], which is what makes an inconsistent row
+    /// unbuildable (#114). Every stop launches; only the repo-level stop — the
+    /// cluster header, [`Aim::Map`] — adds the creation rows, because creation
+    /// is a repo-level act and a ticket picker carrying it would merge
+    /// concerns the stop grammar keeps apart.
+    pub fn candidates(&self) -> Vec<Candidate> {
+        let launches = Mode::all().into_iter().map(|mode| Candidate::Launch {
+            mode,
+            route: self.route(mode),
+        });
+        match self.aim {
+            Aim::Ticket { .. } => launches.collect(),
+            Aim::Map => launches
+                .chain(CreationKind::all().into_iter().map(Candidate::Create))
+                .collect(),
+        }
     }
 
     /// How the staged node reads: `#<n>`, the ticket's number or the map's.
@@ -1006,6 +1143,116 @@ mod tests {
                 "{typed:?} steers an interactive launch"
             );
         }
+    }
+
+    #[test]
+    fn a_ticket_picker_lists_exactly_the_three_launch_modes() {
+        // #114: creation is a repo-level act, and a ticket is not a repo-level
+        // stop — its picker stays the pure mode list, concerns unmerged.
+        let staged =
+            Staged::ticket(&ticket("blooop/wayfinder", 16), 1, Stage::Ready).expect("launchable");
+        assert_eq!(
+            staged.candidates(),
+            vec![
+                Candidate::Launch {
+                    mode: Mode::Interactive,
+                    route: Route::Wayfinder
+                },
+                Candidate::Launch {
+                    mode: Mode::Auto,
+                    route: Route::WayfinderAuto
+                },
+                Candidate::Launch {
+                    mode: Mode::Plain,
+                    route: Route::Plain
+                },
+            ]
+        );
+    }
+    #[test]
+    fn a_header_picker_adds_the_creation_rows_after_the_launch_rows() {
+        // The repo-level stop is where creation lives: the same three launch
+        // rows, then the three ways to start something new in this repo. Each
+        // candidate is complete — it carries its own resolved route, the
+        // `Targets::Many` move — so a row and its launch cannot disagree.
+        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        let candidates = staged.candidates();
+        assert_eq!(
+            candidates,
+            vec![
+                Candidate::Launch {
+                    mode: Mode::Interactive,
+                    route: Route::Wayfinder
+                },
+                Candidate::Launch {
+                    mode: Mode::Auto,
+                    route: Route::WayfinderAuto
+                },
+                Candidate::Launch {
+                    mode: Mode::Plain,
+                    route: Route::Plain
+                },
+                Candidate::Create(CreationKind::Task),
+                Candidate::Create(CreationKind::Map),
+                Candidate::Create(CreationKind::MapAuto),
+            ]
+        );
+        // Every row names the skill it execs — including the creation rows,
+        // whose routes are theirs rather than the staged node's.
+        let routes: Vec<Route> = candidates.iter().map(|c| c.route()).collect();
+        assert_eq!(
+            routes[3..],
+            [Route::One, Route::Wayfinder, Route::WayfinderAuto]
+        );
+    }
+
+    #[test]
+    fn a_build_tickets_launch_rows_resolve_its_own_stage_routes() {
+        // Complete candidates mean the per-row route is the (aim, mode) answer
+        // for *this* node: a build ticket's interactive row reads /wf-tdd, not
+        // a generic default.
+        let mut node = ticket("blooop/wayfinder", 16);
+        node.ticket_type = TicketType::Build;
+        let staged = Staged::ticket(&node, 1, Stage::Ready).expect("launchable");
+        assert_eq!(
+            staged.candidates()[0],
+            Candidate::Launch {
+                mode: Mode::Interactive,
+                route: Route::Tdd
+            }
+        );
+    }
+
+    #[test]
+    fn creation_rows_read_as_what_they_start() {
+        assert_eq!(Candidate::Create(CreationKind::Task).label(), "new task");
+        assert_eq!(Candidate::Create(CreationKind::Map).label(), "new map");
+        assert_eq!(
+            Candidate::Create(CreationKind::MapAuto).label(),
+            "new map, auto"
+        );
+        // Launch rows keep reading as their mode.
+        assert_eq!(
+            Candidate::Launch {
+                mode: Mode::Interactive,
+                route: Route::Wayfinder
+            }
+            .label(),
+            "interactive"
+        );
+        // The text field names what typing into it means, per row: steering an
+        // agent, the task itself, or a seed for the charting session.
+        assert_eq!(
+            Candidate::Launch {
+                mode: Mode::Auto,
+                route: Route::WayfinderAuto
+            }
+            .field(),
+            "steer"
+        );
+        assert_eq!(Candidate::Create(CreationKind::Task).field(), "task");
+        assert_eq!(Candidate::Create(CreationKind::Map).field(), "seed");
+        assert_eq!(Candidate::Create(CreationKind::MapAuto).field(), "seed");
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -479,7 +479,7 @@ impl Launchable {
 /// from a node's PRs and a map has none. So the two are arms of one sum rather
 /// than a ticket struct with optional fields, and every consumer that needs a
 /// ticket number has to say which case it is answering.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Aim {
     /// The cluster header: the map itself, charted or driven as a whole.
     Map,
@@ -556,18 +556,37 @@ pub fn route(aim: &Aim, mode: Mode) -> Route {
 /// [`Launch`]es rather than a choice to re-resolve later.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Staged {
-    /// The node's repo, full slug (`owner/name`) — what the checkout cache
-    /// is matched on (#15).
+    /// The repo, full slug (`owner/name`) — what the checkout cache is
+    /// matched on (#15), and the repo any creation lands in.
     pub repo: String,
-    /// What the launch picker names: the map, or one ticket in it.
-    pub aim: Aim,
+    /// What was stood on: a node fetched from the tracker, or a registered
+    /// repo with no map at all.
+    pub at: StagedAt,
     /// Its title as it read when the picker opened — the picker is showing the
     /// human what they picked, not re-reporting a row that may have moved.
     pub title: String,
-    /// The map issue of the cluster the row was picked in (#50) — which map a
-    /// ticket listed twice was launched from, and the launch target itself
-    /// when the cursor was on the cluster header.
-    pub map_issue: u64,
+}
+
+/// What the picker was opened on (#114). A map-less repo is not a node with a
+/// missing issue number — it has no aim, no map and nothing to launch, because
+/// nothing has been filed in it yet — so the two are arms of one sum rather
+/// than a node struct with optional fields. Which rows the picker offers falls
+/// out of this: a node launches (and a map also creates), a bare repo only
+/// creates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedAt {
+    /// A node the tracker knows about.
+    Node {
+        /// What the launch picker names: the map, or one ticket in it.
+        aim: Aim,
+        /// The map issue of the cluster the row was picked in (#50) — which
+        /// map a ticket listed twice was launched from, and the launch target
+        /// itself when the cursor was on the cluster header.
+        map_issue: u64,
+    },
+    /// A registered checkout whose repo has no open map: the empty-state door
+    /// this repo's *first* map is charted from.
+    Project,
 }
 
 impl Staged {
@@ -577,13 +596,15 @@ impl Staged {
     pub fn ticket(ticket: &Ticket, map_issue: u64, stage: Stage) -> Option<Staged> {
         Some(Staged {
             repo: ticket.repo.clone(),
-            aim: Aim::Ticket {
-                number: ticket.number,
-                ticket_type: ticket.ticket_type,
-                stage: Launchable::parse(stage)?,
+            at: StagedAt::Node {
+                aim: Aim::Ticket {
+                    number: ticket.number,
+                    ticket_type: ticket.ticket_type,
+                    stage: Launchable::parse(stage)?,
+                },
+                map_issue,
             },
             title: ticket.title.clone(),
-            map_issue,
         })
     }
 
@@ -593,16 +614,31 @@ impl Staged {
     pub fn map(id: &MapId, title: &str) -> Staged {
         Staged {
             repo: id.repo.clone(),
-            aim: Aim::Map,
+            at: StagedAt::Node {
+                aim: Aim::Map,
+                map_issue: id.number,
+            },
             title: title.to_string(),
-            map_issue: id.number,
         }
     }
 
-    /// Which skill this launch would run in `mode` — what the launch picker
-    /// echoes as the mode word is typed, and what [`plan`] resolves with.
-    pub fn route(&self, mode: Mode) -> Route {
-        route(&self.aim, mode)
+    /// Stage the empty-state door: a registered repo with no open map (#114).
+    /// There is no node, so the picker offers creation alone.
+    pub fn project(repo: &str) -> Staged {
+        Staged {
+            repo: repo.to_string(),
+            at: StagedAt::Project,
+            title: "no map".to_string(),
+        }
+    }
+
+    /// Which skill launching this node in `mode` would run — `None` for the
+    /// map-less door, which has no node to launch and therefore no route.
+    pub fn route(&self, mode: Mode) -> Option<Route> {
+        match &self.at {
+            StagedAt::Node { aim, .. } => Some(route(aim, mode)),
+            StagedAt::Project => None,
+        }
     }
 
     /// The picker's rows for this stop, in on-screen order — the one
@@ -626,23 +662,45 @@ impl Staged {
     }
 
     pub fn candidates(&self) -> Vec<Candidate> {
-        let launches = Mode::all().into_iter().map(|mode| Candidate::Launch {
-            mode,
-            route: self.route(mode),
-        });
-        match self.aim {
-            Aim::Ticket { .. } => launches.collect(),
-            Aim::Map => launches
-                .chain(CreationKind::all().into_iter().map(Candidate::Create))
-                .collect(),
+        let launches = |aim: Aim| {
+            Mode::all()
+                .into_iter()
+                .map(move |mode| Candidate::Launch {
+                    mode,
+                    route: route(&aim, mode),
+                })
+                .collect::<Vec<_>>()
+        };
+        let creations = || CreationKind::all().into_iter().map(Candidate::Create);
+        match self.at {
+            StagedAt::Node {
+                aim: aim @ Aim::Ticket { .. },
+                ..
+            } => launches(aim),
+            StagedAt::Node {
+                aim: aim @ Aim::Map,
+                ..
+            } => launches(aim).into_iter().chain(creations()).collect(),
+            // Nothing has been filed in this repo yet, so there is nothing to
+            // launch — only the three ways to start something.
+            StagedAt::Project => creations().collect(),
         }
     }
 
-    /// How the staged node reads: `#<n>`, the ticket's number or the map's.
+    /// How the staged stop reads: `#<n>` for a node — the ticket's number or
+    /// the map's — and `+new` for the map-less door, which has no number to
+    /// name until a skill files one.
     pub fn key(&self) -> String {
-        match &self.aim {
-            Aim::Map => format!("#{}", self.map_issue),
-            Aim::Ticket { number, .. } => format!("#{number}"),
+        match &self.at {
+            StagedAt::Node {
+                aim: Aim::Map,
+                map_issue,
+            } => format!("#{map_issue}"),
+            StagedAt::Node {
+                aim: Aim::Ticket { number, .. },
+                ..
+            } => format!("#{number}"),
+            StagedAt::Project => "+new".to_string(),
         }
     }
 }
@@ -1067,10 +1125,16 @@ pub enum Targets {
 /// never prompts. The aim and mode arrive already settled — this function
 /// answers *where* the agent can run, and resolves the route the mode picked.
 pub fn plan(checkouts: &[Checkout], staged: &Staged, mode: &LaunchMode) -> Targets {
-    let route = staged.route(mode.mode());
+    let StagedAt::Node { aim, map_issue } = staged.at else {
+        // Unreachable from the picker: [`Staged::candidates`] offers no launch
+        // row on the map-less door, so nothing there can ask for a node
+        // launch. Refusing rather than inventing a node keeps this total.
+        return Targets::Unregistered;
+    };
+    let route = route(&aim, mode.mode());
     resolve(checkouts, &staged.repo, |_| Job::Node {
-        aim: staged.aim.clone(),
-        map_issue: staged.map_issue,
+        aim,
+        map_issue,
         route,
         mode: mode.clone(),
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,18 +534,18 @@ async fn run(
                     loaders.reconcile(&found, &tx);
                     app.startup.searched(&found);
                     if let Some(slug) = focus.take() {
-                        if found.iter().any(|id| id.repo == slug) {
-                            app.scope = Scope::Project(slug);
-                        } else {
-                            // The seed may have focused this repo a moment ago on
-                            // a map that is gone; the search is the authority, so
-                            // the focus goes back.
-                            if app.scope == Scope::Project(slug.clone()) {
-                                app.scope = Scope::All;
-                            }
-                            app.notice = Some(format!(
-                                "{slug} has no wayfinder:map — showing all projects"
-                            ));
+                        // Focused either way now (#114). A repo with no open
+                        // map used to send the focus back to every project,
+                        // which left the repo you were standing in with
+                        // nothing on screen and no way to chart its first map.
+                        // Focused, it renders the empty-state door instead —
+                        // so the answer to "this repo has no map" is somewhere
+                        // to start one rather than somebody else's tickets.
+                        let mapless = !found.iter().any(|id| id.repo == slug);
+                        app.scope = Scope::Project(slug.clone());
+                        if mapless {
+                            app.notice =
+                                Some(format!("{slug} has no wayfinder:map — enter starts one"));
                         }
                     }
                     // Maps the search dropped must stop being rendered as well as

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1191,7 +1191,7 @@ mod tests {
         // route missing from the cycle would be silently skipped above.
         assert_eq!(
             Route::all().len(),
-            5,
+            6,
             "every route must be in the cycle `Route::all` walks"
         );
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,7 @@ use ratatui::Frame;
 
 use crate::app::{App, Overlay, Scope};
 use crate::filter;
-use crate::launch::{Launch, Mode, Staged};
+use crate::launch::{Candidate, Launch, Staged};
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
 use crate::view::{Branch, Fold, GroupKind, Item, Plan};
 
@@ -508,10 +508,10 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
 /// drawn per option rather than once for the cursor's — the difference between
 /// `/wf`, `/wf-auto` and no skill at all (#112) *is* the choice being made, so
 /// every one of them is on screen.
-fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, mode: Mode, steer: &str) {
+fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, candidate: Candidate, steer: &str) {
     let mut lines = vec![Line::default()];
-    for option in Mode::all() {
-        let picked = option == mode;
+    for option in staged.candidates() {
+        let picked = option == candidate;
         let marker = if picked { '▶' } else { ' ' };
         // The cursor's row is the one that will run, so it is the one that reads
         // as bold; the others stay dim enough to scan past.
@@ -521,29 +521,44 @@ fn draw_launch_picker(frame: &mut Frame<'_>, staged: &Staged, mode: Mode, steer:
             Style::new().add_modifier(Modifier::DIM)
         };
         lines.push(Line::from(vec![
-            Span::styled(format!("  {marker} {:<12}", option.label()), emphasis),
+            Span::styled(format!("  {marker} {:<14}", option.label()), emphasis),
             Span::styled(
-                format!("{:<10}", staged.route(option).label()),
+                format!("{:<10}", option.route().label()),
                 Style::new().fg(Color::Cyan),
             ),
             Span::styled(option.blurb(), Style::new().add_modifier(Modifier::DIM)),
         ]));
     }
     lines.push(Line::default());
-    // The steer field is always shown, empty or not: it is the other half of
+    // The text field is always shown, empty or not: it is the other half of
     // what enter will do, and a field that appears only once you have typed
-    // into it cannot tell you that you may.
+    // into it cannot tell you that you may. Its *name* is the picked row's
+    // (#114) — one field, three meanings, and the row says which one is live:
+    // steering an agent, the task itself, or a seed for a charting session.
     lines.push(Line::from(vec![
-        Span::styled("    steer  ", Style::new().add_modifier(Modifier::DIM)),
+        Span::styled(
+            format!("    {:<6} ", candidate.field()),
+            Style::new().add_modifier(Modifier::DIM),
+        ),
         Span::raw(steer.to_string()),
         Span::styled("█", Style::new().add_modifier(Modifier::DIM)),
     ]));
     lines.push(Line::default());
     lines.push(Line::styled(
-        "  enter launch · ↑/↓ mode · type to steer · esc cancel",
+        "  enter launch · ↑/↓ pick · type to fill · esc cancel",
         Style::new().add_modifier(Modifier::DIM),
     ));
-    let title = format!(" launch {} {} ", staged.key(), staged.title);
+    // The repo leads the title because it is the one fact *every* row shares
+    // (#114): the launch rows work this node, and the creation rows start
+    // something new in the repo it belongs to. Naming only the node would be
+    // true of half the list — and the repo is exactly what creation would
+    // otherwise have to ask for.
+    let title = format!(
+        " launch {} · {} {} ",
+        staged.repo,
+        staged.key(),
+        staged.title
+    );
     let width = lines
         .iter()
         .map(|l| l.width() as u16 + 4)
@@ -570,9 +585,9 @@ fn draw_overlay(frame: &mut Frame<'_>, app: &App) {
         Overlay::None => {}
         Overlay::PickLaunch {
             staged,
-            mode,
+            candidate,
             steer,
-        } => draw_launch_picker(frame, staged, *mode, steer),
+        } => draw_launch_picker(frame, staged, *candidate, steer),
         Overlay::PickCheckout { launches, cursor } => {
             draw_checkout_picker(frame, launches, *cursor);
         }
@@ -1481,6 +1496,53 @@ mod tests {
     }
 
     #[test]
+    fn a_header_picker_draws_the_creation_rows_with_their_own_skills() {
+        // #114: on the repo-level stop the list carries both questions, so
+        // every row still has to name the skill it execs — including the rows
+        // that launch nothing on this node.
+        let mut app = fixture_app();
+        while !matches!(app.cursor_stop(), Some(crate::view::Stop::Map(_))) {
+            app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        }
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("new task"), "{screen}");
+        assert!(screen.contains("/wf-one"), "{screen}");
+        assert!(screen.contains("one tracked ticket"), "{screen}");
+        assert!(screen.contains("new map"), "{screen}");
+        assert!(screen.contains("new map, auto"), "{screen}");
+        // The field is named `steer` while a launch row is picked…
+        assert!(screen.contains("steer"), "{screen}");
+        // …and renames itself as the pick moves onto the creation rows, which
+        // is the only thing telling you the text means something else there.
+        for _ in 0..3 {
+            app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
+        let screen = render(&app);
+        assert!(screen.contains("▶ new task"), "{screen}");
+        assert!(screen.contains("task  "), "{screen}");
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("▶ new map"), "{screen}");
+        assert!(screen.contains("seed  "), "{screen}");
+    }
+
+    #[test]
+    fn a_ticket_picker_draws_no_creation_rows() {
+        // The other half of the rule: a ticket is not a repo-level stop, so
+        // its picker is the three modes and nothing else.
+        let app = {
+            let mut app = fixture_app();
+            app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+            app
+        };
+        let screen = render(&app);
+        assert!(screen.contains("interactive"), "{screen}");
+        assert!(!screen.contains("new task"), "{screen}");
+        assert!(!screen.contains("new map"), "{screen}");
+    }
+
+    #[test]
     fn enter_opens_the_launch_picker_over_the_screen_with_every_mode_on_it() {
         let mut app = fixture_app();
 
@@ -1488,8 +1550,10 @@ mod tests {
         // titled with the node it launches.
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         let screen = render(&app);
+        // The repo leads the title (#114): it is the one fact every row shares
+        // once a header's rows can start something new in it.
         assert!(
-            screen.contains("launch #6 Re-entry breadcrumbs"),
+            screen.contains("launch blooop/wayfinder · #6 Re-entry breadcrumbs"),
             "{screen}"
         );
         // Every mode is on screen with the skill each one would run, because

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -68,6 +68,24 @@ fn cluster_header(id: &MapId, map: &Map, lit: &[usize], under_cursor: bool) -> L
     Line::from(spans)
 }
 
+/// The slim header of a focused repo with no open map (#114): the same left
+/// edge every cluster has, so it reads as somewhere to stand rather than as an
+/// error — but dim and countless, because there are no stages to count and
+/// nothing here to launch. `enter` on it opens the creation rows.
+fn mapless_header(repo: &str, under_cursor: bool) -> Line<'static> {
+    let dim = Style::new().add_modifier(Modifier::DIM);
+    Line::from(vec![
+        cursor_span(under_cursor),
+        Span::styled("▌ ", dim),
+        // The name half, as every cluster header shows it.
+        Span::styled(
+            repo.split('/').next_back().unwrap_or(repo).to_string(),
+            dim,
+        ),
+        Span::styled(" · no map — enter to start one", dim),
+    ])
+}
+
 /// A rollup's trailing spans: a dim word for what the counts are *of*, then
 /// the glyph+count pairs in display order, each in the colour its glyph means.
 ///
@@ -396,6 +414,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     under_cursor,
                 ));
             }
+            Item::MaplessHeader(repo) => lines.push(mapless_header(repo, under_cursor)),
             Item::Context { row, prefix } => lines.push(context_line(app.ticket(row), prefix)),
             Item::Group { id, held, fold } => {
                 lines.push(group_line(id.kind, *held, fold, under_cursor));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -78,10 +78,7 @@ fn mapless_header(repo: &str, under_cursor: bool) -> Line<'static> {
         cursor_span(under_cursor),
         Span::styled("▌ ", dim),
         // The name half, as every cluster header shows it.
-        Span::styled(
-            repo.split('/').next_back().unwrap_or(repo).to_string(),
-            dim,
-        ),
+        Span::styled(repo.split('/').next_back().unwrap_or(repo).to_string(), dim),
         Span::styled(" · no map — enter to start one", dim),
     ])
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -120,6 +120,10 @@ pub enum Stop {
     Map(MapId),
     Ticket(Row),
     Group(GroupId),
+    /// A focused repo with no open map, by full slug (#114). Nothing to
+    /// launch — this is the door its *first* map is charted from, and the one
+    /// stop that names a repo rather than something in a map.
+    Project(String),
 }
 
 /// A stop plus the depth it sits at — everything navigation needs.
@@ -136,6 +140,9 @@ pub struct StopAt {
 pub enum Item {
     /// A cluster header — the map this and the following lines belong to.
     Header(MapId),
+    /// The slim header of a focused repo with no open map (#114): no stage
+    /// counts, because there are no stages — just somewhere to stand.
+    MaplessHeader(String),
     /// A ticket row.
     Ticket {
         row: Row,
@@ -184,6 +191,10 @@ impl Item {
             // a top-level row already steps back to it as the previous stop.
             Item::Header(id) => Some(StopAt {
                 stop: Stop::Map(id.clone()),
+                depth: 0,
+            }),
+            Item::MaplessHeader(repo) => Some(StopAt {
+                stop: Stop::Project(repo.clone()),
                 depth: 0,
             }),
             // Nothing to land on. A sifted group leads this arm because it is
@@ -548,7 +559,11 @@ fn attach_rollups(items: &mut [Item], clusters: &[(&MapId, &Map)]) {
             }
             // `Item::Context` cannot appear here: rollups are attached only to
             // the unsifted screens, and only a sift produces context rows.
-            Item::Header(_) | Item::Group { .. } | Item::Context { .. } | Item::Blank => {
+            Item::Header(_)
+            | Item::MaplessHeader(_)
+            | Item::Group { .. }
+            | Item::Context { .. }
+            | Item::Blank => {
                 branches.extend(open.take());
             }
         }
@@ -1015,6 +1030,7 @@ mod tests {
                     Stop::Map(id) => format!("map #{}", id.number),
                     Stop::Ticket(row) => format!("#{}", m.tickets[row.index].number),
                     Stop::Group(g) => format!("{:?}", g.kind),
+                    Stop::Project(repo) => format!("project {repo}"),
                 };
                 (label, at.depth)
             })
@@ -1176,7 +1192,7 @@ mod tests {
             .into_iter()
             .filter_map(|at| match at.stop {
                 Stop::Map(id) => Some(id),
-                Stop::Ticket(_) | Stop::Group(_) => None,
+                Stop::Ticket(_) | Stop::Group(_) | Stop::Project(_) => None,
             })
             .collect();
         assert_eq!(
@@ -1674,6 +1690,7 @@ mod tests {
             .iter()
             .map(|item| match item {
                 Item::Header(id) => format!("▌ {}", id.short_repo()),
+                Item::MaplessHeader(repo) => format!("▌ {repo} no map"),
                 Item::Ticket { row, prefix, .. } => format!("{prefix}#{}", number(row)),
                 Item::Context { row, prefix } => format!("{prefix}#{} dim", number(row)),
                 Item::Group {

--- a/src/view.rs
+++ b/src/view.rs
@@ -293,8 +293,8 @@ impl Plan {
 /// `door` is the map-less repo whose empty-state header closes the body, if
 /// this screen is showing one (#114). It is planned *here*, with everything
 /// else, rather than appended by the caller: on-screen order is this module's
-/// single answer, and a row the caller pushes afterwards is a row
-/// [`attach_rollups`] and every other walk below never sees.
+/// single answer, and a row the caller pushes afterwards is a row the rollup
+/// pass — and every other walk below — never sees.
 pub fn plan(
     clusters: &[(&MapId, &Map)],
     screen: Screen<'_>,

--- a/src/view.rs
+++ b/src/view.rs
@@ -289,7 +289,18 @@ impl Plan {
 }
 
 /// Plan the body for the clusters in scope, in their given (render) order.
-pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
+///
+/// `door` is the map-less repo whose empty-state header closes the body, if
+/// this screen is showing one (#114). It is planned *here*, with everything
+/// else, rather than appended by the caller: on-screen order is this module's
+/// single answer, and a row the caller pushes afterwards is a row
+/// [`attach_rollups`] and every other walk below never sees.
+pub fn plan(
+    clusters: &[(&MapId, &Map)],
+    screen: Screen<'_>,
+    expanded: &Expanded,
+    door: Option<&str>,
+) -> Plan {
     let sieve = Sieve::new(clusters, screen);
     // Under a query the cluster order is the query's to decide: the project
     // holding the best hit leads, as it did when the hits were one flat list.
@@ -312,6 +323,9 @@ pub fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded
     // there is nothing left for a rollup to summarise honestly.
     if !sieve.sifting() {
         attach_rollups(&mut plan.items, clusters);
+    }
+    if let Some(repo) = door {
+        plan.items.push(Item::MaplessHeader(repo.to_string()));
     }
     plan
 }
@@ -960,6 +974,13 @@ fn walk_forest(
 mod tests {
     use super::*;
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, Stage, TicketType};
+
+    /// The body without an empty-state door — the case every test below but
+    /// the door's own is about. Shadows [`super::plan`] so those tests read as
+    /// what they are testing rather than trailing a `None` each.
+    fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
+        super::plan(clusters, screen, expanded, None)
+    }
 
     fn ticket(number: u64, open: bool, assigned: bool, blocked_by: Vec<u64>) -> Ticket {
         let open_blockers = blocked_by.clone(); // callers pass open blockers in fixtures


### PR DESCRIPTION
Creation is a **repo-level act**, so it enters the picker only at repo-level stops — the cluster header, and the new empty-state door. Ticket pickers are untouched: still the three modes, concerns unmerged.

## What changed

**`Route::One` exists.** `/wf-one` was the one skill in the bundle with no arm in `route` — shipped, linked, unreachable. It now has a label, a bundled-skill answer and a place in the `Route::all` cycle, which is what the "every route's label is bundled" test sweeps.

**Picker rows became complete candidates.** `Candidate::{Launch { mode, route }, Create(CreationKind)}` — each row carries its own aim *and* mode and therefore its own **resolved** route, the `Targets::Many` move: a pick cannot produce a launch inconsistent with the row that was drawn. `Staged::candidates` is the sole constructor, so a creation row on a ticket stop is never built. The three creation kinds are hand-listed rather than a creation × mode product, because that product is dishonest — charting with no skill (`plain`) means nothing.

**One text field, three meanings, named by the picked row.** `steer` on a launch row; `task` on **new task**, where the text *is* the ticket and `CreationKind::with_text` refuses an empty one (the picker stays up and says so on the count line, as a done or blocked node already refuses); `seed` on the two **new map** rows, optional. `Creation` is only constructible through that parse, so a `/wf-one` with no task is unrepresentable rather than merely unvalidated.

**`Launch` grew a `Job` sum.** A creation has no aim, no map issue and no stage — the things they would name do not exist until the launched skill files them — so `Job::{Node { aim, map_issue, route, mode }, Create(Creation)}` replaces four fields that a creation would have had to fill with sentinels. The workspace rule falls out per arm: a node gets `owner/repo@wayfinder/<repo>-<n>`, a creation gets the repo's bare default workspace.

**The empty-state door.** `Staged.at: StagedAt::{Node { aim, map_issue }, Project}` — a map-less repo is not a node with a missing number. A *focused* registered repo with no open map now renders one slim `▌ repo · no map — enter to start one` header, a real cursor stop, whose picker is the three creation rows alone. `main.rs` no longer bounces focus back to all-projects when the repo you are standing in has no map — that bounce is precisely what left the first-map case with nothing on screen.

## The defect the live pty test caught

The door first rendered **while maps were still loading**, so a focused repo mid-fetch was indistinguishable from a map-less one — and `enter` in that second-or-two window would start a new map instead of launching the node you were aiming at. `live_launch_exec` hit it on the real tracker. Gated on `Startup::is_loaded`, the same ambiguity `heading` already refuses for "no projects", with a unit test walking searching → map-still-coming → loaded.

## Scope

Widened screens still show no map-less repos: a row per project every frame is the permanent furniture #114 ruled out, and reaching those repos is the project surface's job — [#117](https://github.com/blooop/wayfinder/issues/117), which also retires `ctrl-f`/`ctrl-g`/`ctrl-r`. No new keys here. "Add a ticket to this map" earns no row: `enter` on a header with steering text is already `/wf <map> steer: …`.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features` (clean), and the **whole** suite green including the four live targets — 250 unit + 10 bin + 17 live. Two mutations checked rather than trusted: dropping the `Startup` guard reds the door test alone; dropping the header's creation rows reds five tests across all three layers.

Closes #116

## Summary by Sourcery

Introduce repo-level creation flows in the launch picker and add an empty-state entry point for repos without maps.

New Features:
- Add support for creating a new one-ticket /wf-one task and new maps directly from the launch picker at repo-level stops.
- Introduce a focused-repo empty-state header that acts as a door to create the first map when a registered repo has no open map.

Enhancements:
- Extend routing and launch planning to include the /wf-one route and treat launch picker rows as fully-resolved candidates carrying their own routes and field semantics.
- Refactor launch state to distinguish working an existing node from starting a creation job, simplifying workspace selection and prompts.
- Update UI and interaction models so the launch picker displays both launch and creation rows, with a shared text field whose meaning depends on the selected row, and adjust notices accordingly.

Documentation:
- Expand README launching documentation to cover creation rows, the map-less repo header, and the new /wf-one and map creation flows.

Tests:
- Add and update unit tests across launch planning, app behaviour, UI rendering, skills routing, and examples to cover creation candidates, the /wf-one route, and the mapless door behaviour.