### PR TITLE
Warm a staged node's container while the human is still typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,40 @@ already has. The branch is the same `wayfinder/<repo>-<n>` that `/wf-tdd` does
 ticket `n`'s work on, so a build agent wakes up already on its work branch and a
 review launch opens on the branch the PR was pushed from.
 
+**Optional: warm the container at the first enter.** With `WF_PREWARM=1` set,
+staging an isolated node fires a background `dl <workspace> up`, so the image
+pull, the clone and the tool install run while you are still picking a mode and
+typing steer text. By the second enter the container is ready or nearly so —
+`dl` serializes the launch against the warm-up (a per-workspace lock), so the
+agent attaches to the container the prewarm built instead of racing it. On a
+cold node that is most of the wait gone.
+
+It is **off by default**, and the reason is worth reading before you turn it
+on. It makes the first enter — until now a keystroke that only opened an
+overlay — do real work: it fetches the repo, creates a work branch in `dl`'s
+cache, clones it, and builds and starts a container. That is a good trade
+while you are working a map and a bad one while you are browsing it.
+
+Two things to be clear about, because the cleanup is not automatic:
+
+- **An abandoned stage leaves its workspace behind.** Back out of the launch
+  picker, pick a host checkout at the which-checkout prompt, or pick a
+  *creation* row on a map (a creation runs in the repo's bare workspace, not
+  the node's), and the branch, the clone and the container stay. `wf reap`
+  will *not* collect them while the ticket is open — it only removes
+  workspaces whose tickets are **closed** — so until then they are yours to
+  remove with `dl <workspace> rm`.
+
+  Only a **node** is ever warmed. The map-less door offers creation rows
+  alone, so staging it warms nothing: there is no node for a launch to attach
+  to, and a keystroke should not pre-build a repo's default workspace on the
+  chance you file something.
+- **It does reach the network, but it never publishes.** Fetching the repo and
+  pulling the image are the point of doing it early. What it does not do is
+  write anything to GitHub: `dl` creates the work branch locally and never
+  pushes it, so an abandoned stage leaves no branch, no PR and no comment
+  behind.
+
 The tree you picked in the checkout picker is **not** the agent's working tree:
 its jobs are declaring the devcontainer and hosting non-isolated launches. No
 agent mutates your checkout, checks out its branches, or fights a second agent
@@ -505,6 +539,11 @@ it always has:
 
 1. the checkout declares one of those two configs, and
 2. `dl` is on PATH.
+
+**`WF_PREWARM=1` needs `dl` 0.0.24 or newer.** `dl <workspace> up` — start
+without attaching — and the per-workspace launch lock are what the warm-up is
+made of; on an older `dl` the background spawn fails silently and the launch
+simply pays the cold start at the second enter, as it always did.
 
 **Use `dl` 0.0.20 or newer.** Launching several tickets at once means several
 `dl` processes preparing the same repo's cache at the same moment; 0.0.20 is

--- a/src/app.rs
+++ b/src/app.rs
@@ -224,6 +224,12 @@ pub struct App {
     /// toggle — it is a choice about a *map*, not about a frame.
     expanded: Expanded,
     cursor: Cursor,
+    /// Workspaces already prewarmed this session ([`launch::prewarm`]): the
+    /// first enter fires `dl <ws> up` in the background so the container is
+    /// building while the human types steer text, and this is what keeps
+    /// re-staging the same node from firing a second one. Session-scoped on
+    /// purpose — after `wf` execs away, the workspace's own state answers.
+    prewarmed: BTreeSet<String>,
 }
 
 impl App {
@@ -242,6 +248,7 @@ impl App {
             lens: Lens::Leverage,
             expanded: Expanded::new(),
             cursor: Cursor::Untouched,
+            prewarmed: BTreeSet::new(),
         }
     }
 
@@ -669,6 +676,7 @@ impl App {
             Some(Stop::Map(id)) => {
                 let title = self.clusters[&id].title.clone();
                 let staged = Staged::map(&id, &title);
+                self.prewarm(&staged);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
                     staged,
@@ -714,6 +722,7 @@ impl App {
                 Outcome::Continue
             }
             Some(staged) => {
+                self.prewarm(&staged);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
                     staged,
@@ -722,6 +731,45 @@ impl App {
                 Outcome::Continue
             }
         }
+    }
+
+    /// Start warming the staged node's container while the launch picker is
+    /// up: the human's mode-and-steer pause is exactly the window a cold
+    /// `devpod up` needs a head start on.
+    ///
+    /// Nothing happens unless [`launch::prewarm_enabled`] says so — staging
+    /// must stay a keystroke that creates nothing for anyone who has not asked
+    /// for this. Beyond that: host launches plan nothing, a node already
+    /// warmed this session is not warmed twice, and the spawn is
+    /// fire-and-forget — the launch itself neither depends on it nor waits for
+    /// it, beyond `dl`'s own per-workspace serialization.
+    fn prewarm(&mut self, staged: &Staged) {
+        if !self.claim_prewarm(staged, launch::prewarm_enabled()) {
+            return;
+        }
+        if let Some(argv) = launch::prewarm(&self.checkouts, staged) {
+            launch::spawn_detached(&argv);
+        }
+    }
+
+    /// Whether this staging is the one that gets to warm `staged`, recording
+    /// it if so. Split from the spawn deliberately: the gate and the
+    /// once-per-node rule are the parts with logic in them, and this way they
+    /// are testable without a container, a `dl` on `PATH`, or reaching into
+    /// the process environment.
+    ///
+    /// Nothing is recorded while the prewarm is off — `&&` short-circuits —
+    /// so a session that exports `WF_PREWARM` and re-stages a node still
+    /// warms it. A stop with no workspace to warm (the map-less door) is not
+    /// recorded either, because there is nothing to record it under. A node
+    /// whose launch turns out to be host-only *is* recorded: it plans nothing
+    /// now and would plan nothing later, and remembering that saves
+    /// re-walking the checkouts on every re-stage.
+    fn claim_prewarm(&mut self, staged: &Staged, enabled: bool) -> bool {
+        enabled
+            && staged
+                .node_workspace()
+                .is_some_and(|workspace| self.prewarmed.insert(workspace))
     }
 
     /// The second enter: resolve the staged launch against the projects cache
@@ -1851,6 +1899,76 @@ mod tests {
             .as_deref()
             .unwrap()
             .contains("wayfinder#6 in /data/proj/wayfinder"));
+    }
+
+    /// A staged launch of the fixture's #6, for the prewarm-claim tests.
+    fn staged_six(app: &App) -> Staged {
+        Staged::ticket(
+            app.clusters
+                .values()
+                .flat_map(|m| &m.tickets)
+                .find(|t| t.number == 6)
+                .expect("#6 is in the fixture"),
+            1,
+            crate::model::Stage::Ready,
+        )
+        .expect("ready is launchable")
+    }
+
+    #[test]
+    fn nothing_is_claimed_or_recorded_while_the_prewarm_is_off() {
+        // Off is the default, and it has to mean *nothing happens*: staging
+        // is a keystroke, and the human has not committed to a container, a
+        // clone or a branch yet. Recording under a disabled flag would also
+        // mean a session that turns it on mid-flight never warms the nodes it
+        // had already looked at.
+        let mut app = fixture_app();
+        let staged = staged_six(&app);
+        assert!(!app.claim_prewarm(&staged, false));
+        assert!(app.prewarmed.is_empty());
+        // ...and enabling afterwards still gets its turn.
+        assert!(app.claim_prewarm(&staged, true));
+    }
+
+    #[test]
+    fn a_node_is_claimed_once_however_often_it_is_staged() {
+        // Backing out of the launch picker and coming back is ordinary use;
+        // each visit must not add another `dl up` to the pile.
+        let mut app = fixture_app();
+        let staged = staged_six(&app);
+        assert!(app.claim_prewarm(&staged, true), "the first staging warms");
+        for _ in 0..3 {
+            assert!(
+                !app.claim_prewarm(&staged, true),
+                "a re-stage must not warm again"
+            );
+        }
+        assert_eq!(app.prewarmed.len(), 1);
+    }
+
+    #[test]
+    fn distinct_nodes_each_get_their_own_claim() {
+        // The dedup is per node, not a one-shot latch: staging two tickets in
+        // one session must warm both, since they are two workspaces.
+        let mut app = fixture_app();
+        let six = staged_six(&app);
+        let map = Staged::map(&MapId::new("blooop/wayfinder", 1), "a map");
+        assert_ne!(six.node_workspace(), map.node_workspace());
+        assert!(app.claim_prewarm(&six, true));
+        assert!(app.claim_prewarm(&map, true));
+        assert_eq!(app.prewarmed.len(), 2);
+    }
+
+    #[test]
+    fn staging_a_host_launch_spawns_nothing() {
+        // Even claimed, a launch with no container to start plans no command:
+        // the fixture's checkout paths do not exist, so no candidate can
+        // declare a devcontainer, which is exactly the host case.
+        let app = fixture_app().with_checkouts(vec![Checkout {
+            path: std::path::PathBuf::from("/data/proj/wayfinder"),
+            repo: "blooop/wayfinder".to_string(),
+        }]);
+        assert_eq!(launch::prewarm(&app.checkouts, &staged_six(&app)), None);
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -704,6 +704,39 @@ impl Staged {
             StagedAt::Project => "+new".to_string(),
         }
     }
+
+    /// The `dl` workspace **launching this node** would run in, known at stage
+    /// time — what the prewarm warms, and `None` when there is no single
+    /// answer to warm.
+    ///
+    /// Known this early because a node's workspace depends only on the node:
+    /// not on which checkout the second enter picks, and not on the mode. The
+    /// two `None` cases are the ones where staging does not determine a
+    /// workspace:
+    ///
+    /// - **The map-less door** ([`StagedAt::Project`]) offers creation rows
+    ///   alone. There is no node, so there is nothing a launch would attach
+    ///   to.
+    /// - A **creation** picked on a map's picker resolves to the repo's bare
+    ///   default workspace rather than the node's (see the resolved launch's
+    ///   own `workspace`), so a map stop has two possible answers and staging
+    ///   cannot tell which the human will take. It is still warmed on the
+    ///   node's, because that is what the default row launches and what
+    ///   `enter enter` therefore does; arrowing down to a creation row
+    ///   instead leaves the warmed container unused, which is the same cost
+    ///   as backing out.
+    pub fn node_workspace(&self) -> Option<String> {
+        match &self.at {
+            StagedAt::Node { aim, map_issue } => Some(node_workspace_name(
+                &self.repo,
+                match aim {
+                    Aim::Map => *map_issue,
+                    Aim::Ticket { number, .. } => *number,
+                },
+            )),
+            StagedAt::Project => None,
+        }
+    }
 }
 
 /// Where the agent runs: on the host, as `wf` always has, or inside the
@@ -898,12 +931,7 @@ impl Launch {
     /// skill files its own issues and makes its own branches (#114).
     fn workspace(&self) -> String {
         match self.job.number() {
-            Some(number) => format!(
-                "{}@wayfinder/{}-{}",
-                self.repo,
-                short_repo(&self.repo),
-                number
-            ),
+            Some(number) => node_workspace_name(&self.repo, number),
             None => self.repo.clone(),
         }
     }
@@ -1105,6 +1133,147 @@ fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
 /// only — never an identity key, because a fork and its upstream share it.
 fn short_repo(slug: &str) -> &str {
     slug.split('/').next_back().unwrap_or(slug)
+}
+
+/// The per-node `dl` workspace, `owner/repo@wayfinder/<repo>-<n>` — one
+/// definition, because two spellings of it would be two workspaces: the
+/// prewarm builds a container that [`Launch::workspace`] then has to find by
+/// the same name. A creation has no node and does not come through here; it
+/// gets the repo's bare default workspace.
+fn node_workspace_name(repo: &str, number: u64) -> String {
+    format!("{}@wayfinder/{}-{}", repo, short_repo(repo), number)
+}
+
+/// The environment variable that turns the prewarm on. See
+/// [`prewarm_enabled`] for why it is off by default.
+const PREWARM_VAR: &str = "WF_PREWARM";
+
+/// The spellings that turn the prewarm on. An **allowlist**, which is where
+/// this deliberately parts company with `dl`'s `DEVLAUNCH_NO_TOOLS` and its
+/// "anything that is not `0`/`false`/`no`" rule.
+///
+/// The two variables point opposite ways, and the safe reading of a value
+/// nobody anticipated goes with the direction. `DEVLAUNCH_NO_TOOLS` is an
+/// opt-*out*, so treating an unrecognised value as "set" disables a
+/// convenience — cheap, and cheap in the safe direction. `WF_PREWARM` is an
+/// opt-*in* to something that creates containers and clones, so the same rule
+/// would make `WF_PREWARM=off` start building containers. Unrecognised means
+/// off here, and only these say yes.
+const TRUTHY: [&str; 4] = ["1", "true", "yes", "on"];
+
+/// Whether staging a launch may start its container early. **Off unless
+/// `WF_PREWARM` is set to something that is not `0`/`false`/`no`.**
+///
+/// Opt-in, and deliberately so. The prewarm turns the *first* enter — a
+/// keystroke that until now only opened an overlay — into real local state:
+/// a work branch in `dl`'s cache, a full clone of the repo, and a running
+/// container. That is an excellent trade when you are working a map and a bad
+/// one when you are browsing it, because a launch you back out of leaves all
+/// three behind — and `wf reap` will not collect them while the ticket is
+/// open. Nobody should discover that by upgrading.
+///
+/// It does reach the network (a fetch, an image pull); what it never does is
+/// *publish*. `dl` creates the work branch locally and never pushes it, so an
+/// abandoned stage leaves nothing on GitHub.
+pub fn prewarm_enabled() -> bool {
+    enabled_from(std::env::var(PREWARM_VAR).ok().as_deref())
+}
+
+/// The reading half of [`prewarm_enabled`], split out so the rule can be
+/// tested without mutating the process environment under parallel tests.
+fn enabled_from(value: Option<&str>) -> bool {
+    match value {
+        None => false,
+        Some(value) => TRUTHY.contains(&value.trim().to_ascii_lowercase().as_str()),
+    }
+}
+
+/// The `dl` invocation that makes a staged node's container ready before the
+/// second enter: `dl <workspace> up` — start or create, never attach.
+///
+/// `None` unless there is exactly one thing to warm. Two ways to get nothing:
+/// the stop names no launchable workspace ([`Staged::node_workspace`] — the
+/// map-less door), or no candidate checkout would launch isolated, which is a
+/// host launch with no container in it.
+///
+/// Any *one* isolated candidate is enough — the workspace name is the node's,
+/// whichever checkout gets picked. If the human then picks a host tree, the
+/// container is left standing, which is the same fate as a launch they cancel
+/// outright: [`crate::reap`] only collects workspaces whose tickets are
+/// closed, so an abandoned stage of an open ticket waits for a hand to remove
+/// it.
+///
+/// This plans the bet; [`prewarm_enabled`] decides whether it is placed. When
+/// it is, `devpod up` — image pull, container create, tool install, the
+/// seconds-to-minutes tail of every cold launch — runs while the human is
+/// still choosing a mode and typing steer text. `dl` serializes the launch
+/// that follows against it (a per-workspace lock), so the second enter
+/// attaches to the container the prewarm built instead of racing it.
+pub fn prewarm(checkouts: &[Checkout], staged: &Staged) -> Option<Vec<String>> {
+    let workspace = staged.node_workspace()?;
+    let isolated = candidate_checkouts(checkouts, &staged.repo)
+        .into_iter()
+        .any(|c| Isolation::detect(&c.path) == Isolation::Devlaunch);
+    isolated.then(|| vec![DEVLAUNCH.to_string(), workspace, "up".to_string()])
+}
+
+/// Run `argv` in the background, detached from this process and its terminal.
+///
+/// Three things have to be true, and a plain `Command::spawn` gives none of
+/// them:
+///
+/// - **It cannot touch the terminal.** The TUI owns the screen, so the child's
+///   stdio is the null device. That alone is not enough: a child can open
+///   `/dev/tty` directly, which `git` and `ssh` do when they want a passphrase,
+///   and `dl` shells out to both. Putting it in its own process group makes the
+///   kernel stop that read with `SIGTTIN` instead of letting it race `wf`'s own
+///   `event::read()` for keystrokes.
+/// - **`wf`'s signals are not its signals.** `ctrl-c` and a closed terminal go
+///   to the *foreground process group*. A prewarm in that group dies mid-clone,
+///   and `dl`'s cleanup of a half-written workspace runs in a Python `except`
+///   that a signal does not reach — so the next launch finds a workspace
+///   directory that exists and is not usable. Its own group is what keeps a
+///   quit from corrupting the cache.
+/// - **It must leave nothing behind.** `main` is explicit that nothing may
+///   outlive the `exec` as a zombie the agent then holds, and `exec` does not
+///   reparent children. So this double-forks: the direct child is a shell that
+///   backgrounds the real command and exits immediately, which reparents the
+///   command to init and lets the shell be waited for right here. The wait is
+///   a process spawn and exit — milliseconds — and it is what makes this
+///   leave no entry in anyone's process table.
+///
+/// Failure is silent by design: it costs the head start and nothing else,
+/// because the launch that follows runs the same `dl` path itself and reports
+/// whatever is actually wrong.
+pub fn spawn_detached(argv: &[String]) {
+    let Some((program, _rest)) = argv.split_first() else {
+        return;
+    };
+    // Resolved here for the same reason `exec` does it: an empty `$PATH` entry
+    // would otherwise let a cloned repo's own `./dl` be what gets run.
+    let Ok(resolved) = resolve_on_path(program) else {
+        return;
+    };
+    let mut command = std::iter::once(resolved.display().to_string())
+        .chain(argv[1..].iter().cloned())
+        .map(|arg| shell_quote(&arg))
+        .collect::<Vec<_>>()
+        .join(" ");
+    command.push_str(" >/dev/null 2>&1 &");
+
+    let spawned = Command::new("sh")
+        .arg("-c")
+        .arg(&command)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .process_group(0)
+        .spawn();
+    // The shell exits as soon as it has backgrounded the command, so this
+    // returns immediately — and reaps it, leaving no zombie for the agent.
+    if let Ok(mut shell) = spawned {
+        let _ = shell.wait();
+    }
 }
 
 /// The checkouts that could host a ticket's agent: every registered checkout of
@@ -2069,6 +2238,69 @@ mod tests {
             isolated(Route::Plain, plain("check what the logs say")).agent_argv()[3],
             "'claude' '--dangerously-skip-permissions' 'check what the logs say'"
         );
+    }
+
+    #[test]
+    fn the_prewarm_names_the_same_workspace_the_launch_will_look_for() {
+        // The whole point of warming at stage time: the container the prewarm
+        // builds must be the one the second enter's `dl` finds. One naming
+        // function serves both, and this pins that they cannot drift.
+        let node = ticket("blooop/wayfinder", 80);
+        let staged = Staged::ticket(&node, 67, Stage::Ready).expect("launchable");
+        assert_eq!(
+            staged.node_workspace().as_deref(),
+            Some(isolated_ticket(80, Route::Tdd, interactive("")).agent_argv()[1].as_str())
+        );
+        // A staged map warms the map's own node, same as launching it.
+        let map = Staged::map(&MapId::new("blooop/wayfinder", 67), "the tree");
+        assert_eq!(
+            map.node_workspace().as_deref(),
+            Some("blooop/wayfinder@wayfinder/wayfinder-67")
+        );
+    }
+
+    #[test]
+    fn the_map_less_door_names_no_workspace_to_warm() {
+        // It offers creation rows alone (#114): no node, so nothing a launch
+        // would attach to, so nothing to warm. A creation resolves to the
+        // repo's bare default workspace, which staging must not pre-build on
+        // the strength of a keystroke.
+        let door = Staged::project("blooop/wayfinder");
+        assert_eq!(door.node_workspace(), None);
+        assert_eq!(prewarm(&cache(), &door), None);
+    }
+
+    #[test]
+    fn the_prewarm_is_off_until_it_is_asked_for() {
+        // Staging must create nothing for anyone who has not opted in.
+        assert!(!enabled_from(None));
+        for off in ["", "0", "false", "no", "FALSE", " No "] {
+            assert!(!enabled_from(Some(off)), "{off:?} means off");
+        }
+        for on in ["1", "true", "yes", "on", "YES", " 1 "] {
+            assert!(enabled_from(Some(on)), "{on:?} means on");
+        }
+        // The allowlist earns its keep here: a value nobody anticipated must
+        // not start building containers. Under `dl`'s opposite rule — which
+        // is right for an opt-out — every one of these would enable it.
+        for unrecognised in ["off", "disabled", "none", "nope", "0.0", "never"] {
+            assert!(
+                !enabled_from(Some(unrecognised)),
+                "{unrecognised:?} must not turn the prewarm on"
+            );
+        }
+    }
+
+    #[test]
+    fn a_host_only_repo_plans_no_prewarm() {
+        // The cache's paths do not exist, so no candidate can detect a
+        // devcontainer: there is no container to warm, and no `dl` is spawned
+        // for a launch that will run on the host. An unregistered repo warms
+        // nothing either — there is nothing to launch into at all.
+        let node = ticket("blooop/wayfinder", 80);
+        let staged = Staged::ticket(&node, 67, Stage::Ready).expect("launchable");
+        assert_eq!(prewarm(&cache(), &staged), None);
+        assert_eq!(prewarm(&[], &staged), None);
     }
 
     #[test]


### PR DESCRIPTION
On a cold node, most of the wait between picking a ticket and a working agent is `devpod up` — an image pull, a clone, a tool install — and none of it starts until the human has finished choosing a mode and typing steer text. The launch picker is dead time that could be paying for exactly that work.

With `WF_PREWARM=1`, the first enter fires a background `dl <workspace> up` (start or create, never attach). `dl` serializes the launch that follows against it on a per-workspace lock, so the second enter attaches to the container the prewarm built rather than racing it.

## Off unless asked for

The first enter has until now been a keystroke that opened an overlay and nothing else. This makes it fetch a repo, create a work branch, clone it and start a container — a good trade while you are working a map, a bad one while you are browsing it. And `wf reap` does **not** collect an abandoned stage while its ticket is open (it only removes workspaces whose tickets are closed), so a stage you back out of is yours to `dl <workspace> rm`. Nobody should meet that by upgrading, hence the flag.

`WF_PREWARM` is read as an **allowlist** (`1`/`true`/`yes`/`on`) rather than `dl`'s "anything that is not `0`/`false`/`no`". The two variables point opposite ways: `dl`'s are opt-*outs*, where an unrecognised value disabling a convenience is cheap and safe; this is an opt-*in*, where the same rule would make `WF_PREWARM=off` start building containers.

It reaches the network (a fetch, an image pull) but never publishes: `dl` creates the work branch locally and never pushes it, so an abandoned stage leaves no branch, no PR and no comment on GitHub.

## One name, one workspace

`Staged::workspace()` and `Launch::workspace()` now share a single `workspace_name`, because two spellings would be two containers — the prewarm builds one the launch then has to find. Which checkout the human picks at the second enter cannot change it, and there is a test pinning the two against each other.

## The spawn is actually detached

A plain `Command::spawn` is not, and all three of these bit:

- **Its own process group**, so `ctrl-c` and a closed terminal do not kill it mid-clone. `dl`'s cleanup of a half-written workspace runs in a Python `except` that a signal never reaches, so a death there leaves a workspace directory that exists and is not usable.
- Also what stops a child reaching for `/dev/tty` — `git` and `ssh` do, for a passphrase — from racing the TUI for keystrokes; in a background group the kernel stops it with `SIGTTIN` instead.
- **A double-fork** through a shell that exits immediately (and is waited for), so nothing outlives the `exec` as a zombie the agent then holds. `main` is explicit that this must not happen.

## Requires dl 0.0.24

`dl <ws> up` and the per-workspace launch lock are blooop/devlaunch#138. On an older `dl` the background spawn fails silently and the launch pays the cold start at the second enter, exactly as it does today — but the flag is not worth setting until that lands.

## Verification

233 tests pass; clippy and `cargo fmt` clean. The gate and the once-per-node rule are covered by tests that were **mutation-checked** — removing the dedup or ignoring the flag each makes one fail. (An earlier version of these tests asserted nothing at all; a review caught it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional prewarming of devcontainer workspaces when staging a node so cold launches start faster without changing default behavior.

New Features:
- Introduce an opt-in WF_PREWARM flag that triggers background dl <workspace> up for isolated staged nodes.
- Track prewarmed workspaces per session to avoid duplicate prewarming for the same node.
- Share a single workspace naming function between staging and launch so both target the same dl workspace.

Enhancements:
- Add a detached background spawn helper to run dl safely without interfering with the TUI or leaving zombie processes.

Documentation:
- Document the WF_PREWARM behavior, its tradeoffs, cleanup expectations, and minimum dl version requirement in the README.

Tests:
- Add tests covering workspace naming consistency, prewarm enablement rules, host-only behavior, per-node deduplication, and claim logic.