### PR TITLE
Reap what the lattice calls Done, warn at its other end

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,16 +604,43 @@ an agent exiting. `dl <ws> stop`, `dl <ws> rm` and `dl --ls` are yours to run.
 ### `wf reap` — clearing away finished tickets
 
 A workspace per ticket means workspaces accumulate as fast as tickets are
-worked. `wf reap` removes the ones whose tickets are **closed**:
+worked. `wf reap` removes the ones whose **work is over**:
 
 ```
 $ wf reap
   keep  devlaunch-wayfinder-devlaunch-131-a  (devlaunch#131 is still open)
   keep  wayfinder-wayfinder-wayfinder-42-b   (still running — stop it first)
+  warn  devlaunch-wayfinder-devlaunch-118-d  (devlaunch#118's PR #120 closed unmerged — superseded? reap by hand if so)
+  warn  wayfinder-wayfinder-wayfinder-96-e   (wayfinder#96 unclaimed and no PR — an abandoned stage? reap by hand if so)
   reap  devlaunch-wayfinder-devlaunch-127-c  (devlaunch#127 is closed)
+  reap  devlaunch-wayfinder-devlaunch-80-f   (devlaunch#80 open but its PR #97 merged)
 
-delete 1 workspace(s)? [y/N]
+delete 2 workspace(s)? [y/N]
 ```
+
+"Over" is not a judgement `wf` invents for the occasion — it is exactly what
+the stage lattice already calls Done, read off the same fields
+as the `⇄` badge on the screen: a **closed** ticket, or an **open** one whose
+PR merged with nothing still in flight. The second case is the one that earns
+this its keep, since a ticket often outlives the branch that finished it. And
+because the guards run first, an un-`-f`'d reap only ever deletes a checkout
+whose every byte exists on the remote: being wrong costs a re-clone, never
+work.
+
+`warn` rows are the other end of that lattice, and they are **never deleted** —
+no flag makes them so. `wf` prints them because it suspects dead weight on
+evidence too weak to act on:
+
+- every linked PR **closed unmerged** — a human's "not this way", which is not
+  the same as "this branch is disposable";
+- **nobody claimed it and nothing came of it** — no PR, no assignee. An open,
+  unassigned ticket is unclaimed by `wf`'s own convention, and that one bit is
+  what keeps this from firing on every ticket someone is mid-way through.
+
+A stale claim therefore keeps a workspace: an agent that died leaves its ticket
+assigned, and reap does not overrule a person's stated intent. `wf` says only
+what it observed — it does not know whether anyone ever entered a container,
+and does not claim to.
 
 This is the same division of labour the launch draws: **`dl` owns the
 containers, `wf` owns the tickets.** `dl` deliberately does not decide what is
@@ -625,8 +652,12 @@ decides. Needs `dl` **0.0.21 or newer** for the JSON listing.
 
 Kept, always: workspaces `dl` did not create (they are not `wf`'s, whatever
 their branch looks like), branches that are not `wayfinder/<repo>-<n>` for that
-repo, tickets still open, and anything **running** — a ticket closing is no
+repo, tickets with an open or draft PR (in review is where review fixes happen),
+tickets someone has claimed, and anything **running** — a ticket closing is no
 evidence that the session in the container ended.
+
+One `gh api graphql` call per repo answers all of this, however many workspaces
+that repo has.
 
 Kept by default but waivable: a workspace whose clone holds uncommitted or
 unpushed work. `-f` reaps those too, and the plan says what it is discarding:
@@ -640,6 +671,7 @@ unpushed work. `-f` reaps those too, and the plan says what it is discarding:
 *every* workspace it builds, so without it those are unreapable forever. It
 waives the unsaved-work guard only — a running container is still kept, because
 that is a session in progress rather than bytes on disk. `-y` skips the prompt.
+Neither flag can turn a `warn` row into a deletion.
 
 Your host `~/.claude` is bind-mounted in, which is how the Claude agent arrives
 already logged in — and is the reason `wf skills install` keeps the prompts

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -66,16 +66,19 @@ query($owner: String!, $name: String!, $number: Int!) {
   }
 }";
 
+/// The envelope every `gh api graphql` answer arrives in. Generic over the
+/// selection because reap batches its own query through the same shape (#129),
+/// and "errors instead of data" must mean the same thing to both readers.
 #[derive(Deserialize)]
-struct GraphQlResponse {
-    data: Option<ResponseData>,
+pub(crate) struct GraphQlResponse<T> {
+    pub(crate) data: Option<T>,
     #[serde(default)]
-    errors: Vec<GraphQlError>,
+    pub(crate) errors: Vec<GraphQlError>,
 }
 
 #[derive(Deserialize)]
-struct GraphQlError {
-    message: String,
+pub(crate) struct GraphQlError {
+    pub(crate) message: String,
 }
 
 #[derive(Deserialize)]
@@ -103,8 +106,8 @@ struct MapIssue {
 }
 
 #[derive(Deserialize)]
-struct Nodes<T> {
-    nodes: Vec<T>,
+pub(crate) struct Nodes<T> {
+    pub(crate) nodes: Vec<T>,
 }
 
 impl<T> Default for Nodes<T> {
@@ -135,7 +138,7 @@ struct Label {
 }
 
 #[derive(Deserialize)]
-struct Assignee {
+pub(crate) struct Assignee {
     #[allow(dead_code)]
     login: String,
 }
@@ -147,8 +150,8 @@ struct Blocker {
 }
 
 #[derive(Deserialize)]
-struct PrNode {
-    number: u64,
+pub(crate) struct PrNode {
+    pub(crate) number: u64,
     state: String,
     #[serde(rename = "isDraft")]
     is_draft: bool,
@@ -177,7 +180,7 @@ struct RepoRef {
 /// wrong one. The inner strings are open GraphQL enums too: an unknown check
 /// rollup or review decision reads as "in flight", the only claim that stays
 /// true whatever the new value means.
-fn parse_pr(pr: &PrNode) -> Option<PrLink> {
+pub(crate) fn parse_pr(pr: &PrNode) -> Option<PrLink> {
     let status = match (pr.state.as_str(), pr.is_draft) {
         ("MERGED", _) => PrStatus::Merged,
         ("CLOSED", _) => PrStatus::Closed,
@@ -205,7 +208,7 @@ fn parse_pr(pr: &PrNode) -> Option<PrLink> {
     })
 }
 
-fn is_open(state: &str) -> bool {
+pub(crate) fn is_open(state: &str) -> bool {
     state == "OPEN"
 }
 
@@ -258,7 +261,7 @@ pub async fn fetch_map(id: &MapId) -> Result<Map> {
 /// network. Every raw tracker string a ticket is derived from (state,
 /// assignees, blocker states, labels) is interpreted exactly here.
 fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
-    let resp: GraphQlResponse =
+    let resp: GraphQlResponse<ResponseData> =
         serde_json::from_slice(body).context("unparseable GraphQL response from gh")?;
     if let Some(err) = resp.errors.first() {
         bail!("GraphQL error: {}", err.message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,10 +78,14 @@ ctrl-g narrow and widen the scope, ctrl-r refetches, esc quits.
 
 wf skills          report which prompt each route would actually run
 wf skills install  link this build's skills into ~/.claude/skills and ~/.codex/skills
-wf reap            remove the workspaces whose tickets are closed (-y to skip
-                   the prompt). Keeps anything running or holding work that is
-                   not pushed anywhere; -f reaps the unpushed ones too, naming
-                   what it discards. Needs dl 0.0.21 or newer.
+wf reap            remove the workspaces whose work is over — a closed ticket,
+                   or an open one whose PR merged with nothing still in flight
+                   (-y to skip the prompt). Warns about the ones it suspects
+                   but will not delete: a ticket whose PRs all closed unmerged,
+                   or one nobody claimed that nothing came of. Keeps anything
+                   running or holding work that is not pushed anywhere; -f
+                   reaps the unpushed ones too, naming what it discards.
+                   Needs dl 0.0.21 or newer.
 
 The skills wf execs ship in this package, so they update with it. `install`
 links both agents' skills directories at copies kept beside them; every launch
@@ -224,11 +228,11 @@ fn run_skills(install: bool) -> Result<()> {
     Ok(())
 }
 
-/// `wf reap`: remove the workspaces whose tickets are closed.
+/// `wf reap`: remove the workspaces whose nodes the tracker calls finished.
 ///
 /// The division of labour is the one the launch already draws — `dl` owns the
 /// containers, `wf` owns the tickets — so this asks `dl` what exists, asks the
-/// tracker which of those nodes are closed, prints the plan, and hands the
+/// tracker what has become of those nodes, prints the plan, and hands the
 /// finished ones back to `dl`. No terminal is taken: this is a stream command
 /// like `wf skills`, not a second TUI.
 ///
@@ -236,6 +240,12 @@ fn run_skills(install: bool) -> Result<()> {
 /// because a workspace someone expected to go and that stayed is the thing they
 /// most need told about, and a reason they disagree with ("still running" when
 /// they thought they had stopped it) is only actionable while no is an answer.
+///
+/// `warn` rows are the same argument pointed the other way: workspaces `wf`
+/// suspects are dead weight on evidence too weak to act on — a superseded
+/// ticket, or a node nothing has come of. They are printed and never counted
+/// into the prompt, because the only safe thing to do with a suspicion is say
+/// it out loud.
 async fn run_reap(yes: bool, insist: bool) -> Result<()> {
     use std::collections::BTreeSet;
     use std::fmt::Write;
@@ -247,18 +257,28 @@ async fn run_reap(yes: bool, insist: bool) -> Result<()> {
         emit("no wayfinder workspaces on this machine — nothing to reap\n");
         return Ok(());
     }
-    let finished = reap::finished_nodes(&nodes).await?;
-    let verdicts = reap::plan(&workspaces, &finished, insist);
+    let known = reap::node_facts(&nodes).await?;
+    let verdicts = reap::plan(&workspaces, &known, insist);
 
-    let (doomed, kept): (Vec<_>, Vec<_>) = verdicts
-        .iter()
-        .partition(|v| matches!(v, reap::Verdict::Reap { .. }));
+    // The deletion set is asked for rather than re-derived here: `reap::doomed`
+    // is the one definition of what goes, so a warning row cannot become a
+    // deletion by way of a partition written twice.
+    let doomed = reap::doomed(&verdicts);
+    // Grouped rather than in listing order, and in this order: what stays,
+    // then what `wf` is uneasy about, then — last, immediately above the
+    // prompt — what the y/N is actually about.
     let mut out = String::new();
-    for verdict in &kept {
-        let _ = writeln!(out, "  keep  {}  ({})", verdict.id(), verdict.reason());
-    }
-    for verdict in &doomed {
-        let _ = writeln!(out, "  reap  {}  ({})", verdict.id(), verdict.reason());
+    for label in ["keep", "warn", "reap"] {
+        for verdict in &verdicts {
+            let row = match verdict {
+                reap::Verdict::Keep { .. } => "keep",
+                reap::Verdict::Warn { .. } => "warn",
+                reap::Verdict::Reap { .. } => "reap",
+            };
+            if row == label {
+                let _ = writeln!(out, "  {label}  {}  ({})", verdict.id(), verdict.reason());
+            }
+        }
     }
     emit(&out);
     if doomed.is_empty() {

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -19,7 +19,7 @@
 //! workspace holds that says "not yet" — unsaved work, a running container — is
 //! `dl`'s fact, read here rather than argued with.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
@@ -256,9 +256,10 @@ pub fn node_of(workspace: &Workspace) -> Option<Node> {
 
 /// Decide every workspace's fate, in listing order.
 ///
-/// `finished` is the set of nodes the tracker says are closed — gathered once,
-/// [`finished_nodes`], because that is one network call for the lot rather than
-/// one per workspace.
+/// `known` is what the tracker said about each node — gathered once,
+/// [`node_facts`], because that is one network call per repo rather than one
+/// per workspace. A node appears once however many workspaces name it: the fact
+/// is the node's, and the guards below are each workspace's own.
 ///
 /// The guards run before the reason to delete, and their order is the safety
 /// argument: work that would be lost outranks a closed ticket, and a live
@@ -277,7 +278,17 @@ pub fn node_of(workspace: &Workspace) -> Option<Node> {
 /// about bytes on disk. The plan names what is being overridden either way, so
 /// the waiver is read before it is granted, and `dl` gets `--force` only for the
 /// workspaces the human just saw described.
-pub fn plan(workspaces: &[Workspace], finished: &BTreeSet<Node>, insist: bool) -> Vec<Verdict> {
+///
+/// The `Warn` rows never delete, which is why they do not borrow the reap
+/// row's "discarding" cadence: nothing is discarded on a row `wf` will not act
+/// on. Under `-f` they still name the unsaved work, because the reap they are
+/// advising would throw it away — the discard belongs to the by-hand reap, and
+/// the sentence says so.
+pub fn plan(
+    workspaces: &[Workspace],
+    known: &BTreeMap<Node, NodeFact>,
+    insist: bool,
+) -> Vec<Verdict> {
     let mut verdicts = Vec::new();
     for workspace in workspaces {
         let Some(node) = node_of(workspace) else {
@@ -286,35 +297,64 @@ pub fn plan(workspaces: &[Workspace], finished: &BTreeSet<Node>, insist: bool) -
             continue;
         };
         let id = workspace.id.clone();
+        let name = format!("{}#{}", short_repo(&node.repo), node.number);
+        // Naming the waived work in the acted-on line, not only in the keep
+        // line it replaced: this is the row the human is about to approve, and
+        // "and discarding …" is the part they might stop at.
+        let discard = match (&workspace.unsaved, insist) {
+            (Some(unsaved), true) => format!(", discarding {unsaved}"),
+            _ => String::new(),
+        };
         if let (Some(unsaved), false) = (&workspace.unsaved, insist) {
             verdicts.push(Verdict::Keep {
                 id,
                 reason: format!("holds {unsaved}"),
             });
-        } else if workspace.state.as_deref() == Some("Running") {
+            continue;
+        }
+        if workspace.state.as_deref() == Some("Running") {
             verdicts.push(Verdict::Keep {
                 id,
                 reason: "still running — stop it first".to_string(),
             });
-        } else if finished.contains(&node) {
-            let node_name = format!("{}#{} is closed", short_repo(&node.repo), node.number);
-            verdicts.push(Verdict::Reap {
-                id,
-                // Naming the waived work in the reap line, not only in the
-                // keep line it replaced: this is the row the human is about to
-                // approve, and "and discarding …" is the part they might stop
-                // at.
-                reason: match (&workspace.unsaved, insist) {
-                    (Some(unsaved), true) => format!("{node_name}, discarding {unsaved}"),
-                    _ => node_name,
-                },
-            });
-        } else {
+            continue;
+        }
+        let Some(fact) = known.get(&node) else {
+            // Unreachable while the fetch stays never-partial, and deliberately
+            // not an `Unstarted`: a question that went unanswered is not an
+            // observation about the node.
             verdicts.push(Verdict::Keep {
                 id,
-                reason: format!("{}#{} is still open", short_repo(&node.repo), node.number),
+                reason: format!("no tracker answer for {name}"),
             });
-        }
+            continue;
+        };
+        verdicts.push(match fact {
+            NodeFact::Closed => Verdict::Reap {
+                id,
+                reason: format!("{name} is closed{discard}"),
+            },
+            NodeFact::DoneByMerge { pr } => Verdict::Reap {
+                id,
+                reason: format!("{name} open but its PR #{pr} merged{discard}"),
+            },
+            NodeFact::Superseded { pr } => Verdict::Warn {
+                id,
+                reason: format!(
+                    "{name}'s PR #{pr} closed unmerged — superseded? reap by hand if so{discard}"
+                ),
+            },
+            NodeFact::Unstarted => Verdict::Warn {
+                id,
+                reason: format!(
+                    "{name} unclaimed and no PR — an abandoned stage? reap by hand if so{discard}"
+                ),
+            },
+            NodeFact::InFlight { .. } | NodeFact::Claimed => Verdict::Keep {
+                id,
+                reason: format!("{name} is still open"),
+            },
+        });
     }
     verdicts
 }
@@ -668,14 +708,27 @@ mod tests {
         assert_eq!(node_of(&unrecorded), None);
     }
 
+    /// The fact map `plan` decides by, keyed the way the batch answers.
+    fn facts<const N: usize>(entries: [(Node, NodeFact); N]) -> BTreeMap<Node, NodeFact> {
+        BTreeMap::from(entries)
+    }
+
     #[test]
     fn a_closed_ticket_is_reaped_and_an_open_one_is_kept() {
+        // The regression pin: the verdict that existed before reap could read
+        // anything but "closed", said in the same words.
         let listing = vec![
             workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80"),
             workspace("open", "blooop/devlaunch", "wayfinder/devlaunch-81"),
         ];
-        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
-        let verdicts = plan(&listing, &finished, false);
+        let known = facts([
+            (node("blooop/devlaunch", 80), NodeFact::Closed),
+            (
+                node("blooop/devlaunch", 81),
+                NodeFact::InFlight { pr: 91 },
+            ),
+        ]);
+        let verdicts = plan(&listing, &known, false);
         assert_eq!(
             verdicts,
             vec![
@@ -692,14 +745,291 @@ mod tests {
     }
 
     #[test]
+    fn an_open_ticket_whose_only_pr_merged_is_reaped_as_done_by_merge() {
+        // What the stage lattice already calls Done: with nothing in flight, a
+        // merge means done whatever the ticket still says. The row names both
+        // halves, because the open ticket is the part a reader might stop at.
+        let ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        let known = facts([(
+            node("blooop/devlaunch", 80),
+            NodeFact::DoneByMerge { pr: 97 },
+        )]);
+        assert_eq!(
+            plan(&[ws], &known, false),
+            vec![Verdict::Reap {
+                id: "done".to_string(),
+                reason: "devlaunch#80 open but its PR #97 merged".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn an_open_or_draft_pr_still_keeps_and_never_warns() {
+        // The half of the old `Open` catch-all that is the least dead thing wf
+        // manages: in-review is where review fixes happen.
+        let ws = workspace("live", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        for pr in [40, 42] {
+            let known = facts([(node("blooop/devlaunch", 80), NodeFact::InFlight { pr })]);
+            assert_eq!(
+                plan(std::slice::from_ref(&ws), &known, false),
+                vec![Verdict::Keep {
+                    id: "live".to_string(),
+                    reason: "devlaunch#80 is still open".to_string()
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn all_prs_closed_unmerged_warns_and_never_lands_in_the_doomed_set() {
+        // A closed unmerged PR is a human's "not this way", not "this branch is
+        // disposable" — wf's model refuses to read it as evidence and reap must
+        // not invent a stronger reading. So: named, never deleted.
+        let ws = workspace("super", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        let known = facts([(
+            node("blooop/devlaunch", 80),
+            NodeFact::Superseded { pr: 97 },
+        )]);
+        let verdicts = plan(&[ws], &known, false);
+        assert_eq!(
+            verdicts,
+            vec![Verdict::Warn {
+                id: "super".to_string(),
+                reason: "devlaunch#80's PR #97 closed unmerged — superseded? reap by hand if so"
+                    .to_string()
+            }]
+        );
+        assert!(doomed(&verdicts).is_empty());
+    }
+
+    #[test]
+    fn an_unclaimed_node_with_no_pr_warns_instead_of_keeping_quietly() {
+        // Nothing has come of this node: nobody took it up and nothing came
+        // out. The row says only what was observed — never "prewarmed",
+        // "never entered" or "never attached", none of which wf knows.
+        let ws = workspace("ghost", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Unstarted)]);
+        let verdicts = plan(&[ws], &known, false);
+        assert_eq!(
+            verdicts,
+            vec![Verdict::Warn {
+                id: "ghost".to_string(),
+                reason: "devlaunch#80 unclaimed and no PR — an abandoned stage? reap by hand if so"
+                    .to_string()
+            }]
+        );
+        for forbidden in ["prewarm", "never entered", "never attached"] {
+            assert!(!verdicts[0].reason().contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn a_claimed_node_with_no_pr_is_kept_silently() {
+        // The same workspace and the same empty rollup, one assignee apart.
+        // That bit is the whole decision, so it gets its own test: an explicit
+        // claim is a person's statement of intent, and a claim left behind by
+        // an agent that died is settled by the re-entry ritual, not by reap.
+        let ws = workspace("claimed", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Claimed)]);
+        assert_eq!(
+            plan(&[ws], &known, false),
+            vec![Verdict::Keep {
+                id: "claimed".to_string(),
+                reason: "devlaunch#80 is still open".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn a_warned_workspace_never_reaches_the_doomed_set_even_with_y_and_f() {
+        // The safety property of the whole Warn arm, and the reason the doomed
+        // set has one definition instead of a partition at the call site: no
+        // combination of flags turns a warning into a deletion. `-y` only skips
+        // the prompt, so `-f` is the whole flag surface plan can even see.
+        for fact in [NodeFact::Superseded { pr: 97 }, NodeFact::Unstarted] {
+            let mut ws = workspace("warned", "blooop/devlaunch", "wayfinder/devlaunch-80");
+            ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+            let known = facts([(node("blooop/devlaunch", 80), fact)]);
+            for insist in [false, true] {
+                let verdicts = plan(std::slice::from_ref(&ws), &known, insist);
+                assert!(
+                    doomed(&verdicts).is_empty(),
+                    "insist={insist} put a warned workspace in the doomed set"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_warning_rows_advise_a_reap_by_hand_rather_than_announcing_a_discard() {
+        // A row that never deletes must not borrow the reap row's cadence:
+        // nothing is being discarded here. Under -f the discard is real but it
+        // belongs to the by-hand reap being advised, which is where the clause
+        // sits — and the wording is the same for both warning facts.
+        for fact in [NodeFact::Superseded { pr: 97 }, NodeFact::Unstarted] {
+            let mut ws = workspace("warned", "blooop/devlaunch", "wayfinder/devlaunch-80");
+            ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+            let known = facts([(node("blooop/devlaunch", 80), fact)]);
+            let quiet = plan(std::slice::from_ref(&ws), &known, false);
+            assert!(!quiet[0].reason().contains("discarding"));
+            let loud = plan(std::slice::from_ref(&ws), &known, true);
+            assert!(loud[0].reason().ends_with(
+                "reap by hand if so, discarding 1 uncommitted change(s) (pixi.lock)"
+            ));
+        }
+    }
+
+    #[test]
+    fn the_lockfile_dirty_prewarm_shows_its_warning_only_under_f() {
+        // A postCreateCommand that dirties a tracked lockfile hides the warning
+        // behind the unsaved guard. That under-fire is the existing -f contract
+        // doing its job, and the deliberate direction: the advisory row is the
+        // one that can afford to be missed.
+        let mut ws = workspace("ghost", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Unstarted)]);
+        assert_eq!(
+            plan(std::slice::from_ref(&ws), &known, false),
+            vec![Verdict::Keep {
+                id: "ghost".to_string(),
+                reason: "holds 1 uncommitted change(s) (pixi.lock)".to_string()
+            }]
+        );
+        assert_eq!(
+            plan(&[ws], &known, true),
+            vec![Verdict::Warn {
+                id: "ghost".to_string(),
+                reason: "devlaunch#80 unclaimed and no PR — an abandoned stage? \
+                         reap by hand if so, discarding 1 uncommitted change(s) (pixi.lock)"
+                    .to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn a_running_prewarm_reads_as_running_first() {
+        // A just-abandoned prewarm's container is Running — its own `dl up`
+        // started it — so the guard wins the row with or without -f, and the
+        // warning surfaces on the next run. That is the correct next action.
+        let mut ws = workspace("ghost", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.state = Some("Running".to_string());
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Unstarted)]);
+        for insist in [false, true] {
+            assert_eq!(
+                plan(std::slice::from_ref(&ws), &known, insist),
+                vec![Verdict::Keep {
+                    id: "ghost".to_string(),
+                    reason: "still running — stop it first".to_string()
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn done_by_merge_yields_to_unsaved_without_f_and_to_running_always() {
+        // The new facts are a second way for the tracker to say "finished
+        // enough", orthogonal to the guards and beneath them.
+        let known = facts([(
+            node("blooop/devlaunch", 80),
+            NodeFact::DoneByMerge { pr: 97 },
+        )]);
+        let mut dirty = workspace("merged", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        dirty.unsaved = Some("2 uncommitted change(s)".to_string());
+        assert_eq!(
+            plan(&[dirty], &known, false),
+            vec![Verdict::Keep {
+                id: "merged".to_string(),
+                reason: "holds 2 uncommitted change(s)".to_string()
+            }]
+        );
+        let mut running = workspace("merged", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        running.state = Some("Running".to_string());
+        for insist in [false, true] {
+            assert_eq!(
+                plan(std::slice::from_ref(&running), &known, insist),
+                vec![Verdict::Keep {
+                    id: "merged".to_string(),
+                    reason: "still running — stop it first".to_string()
+                }]
+            );
+        }
+    }
+
+    #[test]
+    fn insisting_on_done_by_merge_names_the_discard() {
+        let mut ws = workspace("merged", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        let known = facts([(
+            node("blooop/devlaunch", 80),
+            NodeFact::DoneByMerge { pr: 97 },
+        )]);
+        assert_eq!(
+            plan(&[ws], &known, true),
+            vec![Verdict::Reap {
+                id: "merged".to_string(),
+                reason: "devlaunch#80 open but its PR #97 merged, \
+                         discarding 1 uncommitted change(s) (pixi.lock)"
+                    .to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn two_workspaces_of_one_node_share_the_fact_but_keep_their_own_guards() {
+        // The fact is computed once per node and applied identically to every
+        // workspace whose branch names it; the per-workspace guards are what
+        // differentiate them.
+        let mut running = workspace("live", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        running.state = Some("Running".to_string());
+        let stopped = workspace("idle", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        let known = facts([(
+            node("blooop/devlaunch", 80),
+            NodeFact::DoneByMerge { pr: 97 },
+        )]);
+        assert_eq!(
+            plan(&[running, stopped], &known, false),
+            vec![
+                Verdict::Keep {
+                    id: "live".to_string(),
+                    reason: "still running — stop it first".to_string()
+                },
+                Verdict::Reap {
+                    id: "idle".to_string(),
+                    reason: "devlaunch#80 open but its PR #97 merged".to_string()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_node_the_batch_did_not_answer_for_is_never_acted_on() {
+        // The fetch is never-partial, so this should be unreachable — but the
+        // one shape it could degrade into is the sentinel this whole design
+        // exists to refuse: a missing answer read as "nothing has come of it".
+        // It is neither reaped nor warned about; it says the tracker went
+        // unanswered, which is the truth.
+        let ws = workspace("unknown", "blooop/devlaunch", "wayfinder/devlaunch-80");
+        for insist in [false, true] {
+            let verdicts = plan(std::slice::from_ref(&ws), &BTreeMap::new(), insist);
+            assert_eq!(
+                verdicts,
+                vec![Verdict::Keep {
+                    id: "unknown".to_string(),
+                    reason: "no tracker answer for devlaunch#80".to_string()
+                }]
+            );
+        }
+    }
+
+    #[test]
     fn unsaved_work_keeps_a_workspace_whose_ticket_is_closed() {
         // dl's fact, read rather than argued with: dl would refuse this delete,
         // and a caller that walks into a refusal it could have anticipated is
         // one that eventually learns to pass --force.
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.unsaved = Some("2 uncommitted change(s)".to_string());
-        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
-        let verdicts = plan(&[ws], &finished, false);
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
+        let verdicts = plan(&[ws], &known, false);
         assert_eq!(
             verdicts,
             vec![Verdict::Keep {
@@ -714,9 +1044,9 @@ mod tests {
         // The ticket closing does not mean the session in the container ended.
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.state = Some("Running".to_string());
-        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert_eq!(
-            plan(&[ws], &finished, false),
+            plan(&[ws], &known, false),
             vec![Verdict::Keep {
                 id: "done".to_string(),
                 reason: "still running — stop it first".to_string()
@@ -729,10 +1059,8 @@ mod tests {
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.state = Some("Running".to_string());
         ws.unsaved = Some("1 unpushed commit(s)".to_string());
-        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
-        assert!(plan(&[ws], &finished, false)[0]
-            .reason()
-            .contains("unpushed"));
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
+        assert!(plan(&[ws], &known, false)[0].reason().contains("unpushed"));
     }
 
     #[test]
@@ -746,7 +1074,11 @@ mod tests {
             workspace("mine", "blooop/devlaunch", "wayfinder/devlaunch-81"),
             workspace("plain", "blooop/devlaunch", "main"),
         ];
-        let verdicts = plan(&listing, &BTreeSet::new(), false);
+        let known = facts([(
+            node("blooop/devlaunch", 81),
+            NodeFact::InFlight { pr: 91 },
+        )]);
+        let verdicts = plan(&listing, &known, false);
         assert_eq!(verdicts.len(), 1);
         assert_eq!(verdicts[0].id(), "mine");
     }
@@ -777,19 +1109,20 @@ mod tests {
         // that is the row being approved.
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
-        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert_eq!(
-            plan(std::slice::from_ref(&ws), &finished, true),
+            plan(std::slice::from_ref(&ws), &known, true),
             vec![Verdict::Reap {
                 id: "done".to_string(),
                 reason: "devlaunch#80 is closed, discarding 1 uncommitted change(s) (pixi.lock)"
                     .to_string()
             }]
         );
-        // And it is only ever a waiver of *that* guard: an open ticket is still
-        // an open ticket.
+        // And it is only ever a waiver of *that* guard: an open ticket someone
+        // is working is still an open ticket.
+        let open = facts([(node("blooop/devlaunch", 80), NodeFact::Claimed)]);
         assert!(matches!(
-            plan(&[ws], &BTreeSet::new(), true).as_slice(),
+            plan(&[ws], &open, true).as_slice(),
             [Verdict::Keep { .. }]
         ));
     }
@@ -803,9 +1136,9 @@ mod tests {
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.state = Some("Running".to_string());
         ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
-        let finished = BTreeSet::from([node("blooop/devlaunch", 80)]);
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert_eq!(
-            plan(&[ws], &finished, true),
+            plan(&[ws], &known, true),
             vec![Verdict::Keep {
                 id: "done".to_string(),
                 reason: "still running — stop it first".to_string()

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -26,6 +26,7 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tokio::process::Command;
 
+use crate::fetch::{is_open, parse_pr, Assignee, GraphQlResponse, Nodes, PrNode};
 use crate::model::PrStatus;
 
 /// The branch prefix `wf` mints its workspaces under (#106): the full branch is
@@ -394,64 +395,157 @@ fn parse_workspaces(body: &[u8]) -> Result<Vec<Workspace>> {
     serde_json::from_slice(body).context("unparseable workspace listing from `dl --ls --json`")
 }
 
-/// Which of `nodes` the tracker says are closed.
+/// What the tracker says about each of `nodes`.
 ///
-/// One `gh` search per repo rather than one call per ticket: the numbers are
-/// asked about together, so ten workspaces of one repo cost one round trip.
+/// **One `gh api graphql` call per repo**, and none per workspace: every wanted
+/// number of a repo is aliased into the same query, so ten workspaces of one
+/// repo cost one round trip. (The per-ticket REST loop this replaced cost one
+/// each, which is what the old version of this comment claimed it did not.)
+///
+/// The selection is the reap-relevant subset of the map query's own — issue
+/// state, `assignees`, and the linked-PR rollup — and the PR nodes are read
+/// back through [`fetch`](crate::fetch)'s badge parse rather than re-read here,
+/// so "done" means one thing across the screen and the reaper.
 ///
 /// # Errors
 ///
-/// A `gh` that is missing, unauthenticated or refused. Never partial: a repo
-/// whose state could not be read makes the whole call fail, because the
-/// alternative is treating "could not ask" as "not closed" for some workspaces
-/// and deleting the rest — a half-answered question is the one shape this must
-/// not act on.
-pub async fn finished_nodes(nodes: &BTreeSet<Node>) -> Result<BTreeSet<Node>> {
-    let mut finished = BTreeSet::new();
-    let mut repos: BTreeSet<&str> = BTreeSet::new();
-    for node in nodes {
-        repos.insert(node.repo.as_str());
-    }
+/// A `gh` that is missing, unauthenticated or refused, and any node the batch
+/// did not answer for. Never partial: an unanswered repo or issue fails the
+/// whole call, because the alternative is treating "could not ask" as a fact
+/// about the node — and both directions of that are wrong, one deleting a
+/// workspace on no evidence and the other warning about one.
+pub async fn node_facts(nodes: &BTreeSet<Node>) -> Result<BTreeMap<Node, NodeFact>> {
+    let mut facts = BTreeMap::new();
+    let repos: BTreeSet<&str> = nodes.iter().map(|n| n.repo.as_str()).collect();
     for repo in repos {
-        let wanted: Vec<u64> = nodes
+        let numbers: Vec<u64> = nodes
             .iter()
             .filter(|n| n.repo == repo)
             .map(|n| n.number)
             .collect();
-        for number in wanted {
-            if issue_is_closed(repo, number).await? {
-                finished.insert(Node {
-                    repo: repo.to_string(),
-                    number,
-                });
-            }
+        let (owner, name) = repo
+            .split_once('/')
+            .with_context(|| format!("malformed repo slug {repo:?}"))?;
+        let output = Command::new("gh")
+            .args([
+                "api",
+                "graphql",
+                "-F",
+                &format!("owner={owner}"),
+                "-F",
+                &format!("name={name}"),
+                "-f",
+                &format!("query={}", node_facts_query(&numbers)),
+            ])
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .output()
+            .await
+            .context("failed to run `gh` — is the GitHub CLI installed and on PATH?")?;
+        if !output.status.success() {
+            bail!(
+                "could not read {repo}'s tickets: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
         }
+        facts.extend(parse_node_facts(&output.stdout, repo, &numbers)?);
     }
-    Ok(finished)
+    Ok(facts)
 }
 
-/// Whether one issue is closed. `gh api` rather than a search, because search
-/// indexes lag and a stale "still open" only ever costs a workspace that stays.
-async fn issue_is_closed(repo: &str, number: u64) -> Result<bool> {
-    let output = Command::new("gh")
-        .args([
-            "api",
-            &format!("repos/{repo}/issues/{number}"),
-            "--jq",
-            ".state",
-        ])
-        .stdin(Stdio::null())
-        .kill_on_drop(true)
-        .output()
-        .await
-        .context("failed to run `gh` — is the GitHub CLI installed and on PATH?")?;
-    if !output.status.success() {
-        bail!(
-            "could not read {repo}#{number}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+/// The GraphQL alias one node's answer comes back under. GraphQL has no
+/// variable field aliases, so the numbers are written into the query text —
+/// safe by type, since they are `u64` and nothing else can arrive here.
+fn alias(number: u64) -> String {
+    format!("i{number}")
+}
+
+/// One repo's batch: every wanted issue in one query.
+fn node_facts_query(numbers: &[u64]) -> String {
+    let mut query = String::from("query($owner: String!, $name: String!) {\n  repository(owner: $owner, name: $name) {\n");
+    for &number in numbers {
+        query.push_str(&format!(
+            "    {}: issue(number: {number}) {{\n      \
+               state\n      \
+               assignees(first: 5) {{ nodes {{ login }} }}\n      \
+               closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {{\n        \
+                 nodes {{\n          \
+                   number state isDraft reviewDecision\n          \
+                   statusCheckRollup {{ state }}\n          \
+                   repository {{ nameWithOwner }}\n        \
+                 }}\n      \
+               }}\n    \
+             }}\n",
+            alias(number)
+        ));
+    }
+    query.push_str("  }\n}");
+    query
+}
+
+#[derive(Deserialize)]
+struct BatchData {
+    /// Aliased issues, keyed by [`alias`]. A node the query asked about and
+    /// this map has no live entry for is the never-partial case.
+    repository: Option<BTreeMap<String, Option<IssueFacts>>>,
+}
+
+#[derive(Deserialize)]
+struct IssueFacts {
+    state: String,
+    assignees: Nodes<Assignee>,
+    /// Defaulted for the same reason the map query defaults it: a GitHub
+    /// edition without the field reads as "no linked PRs" rather than failing.
+    #[serde(rename = "closedByPullRequestsReferences", default)]
+    closed_by_prs: Nodes<PrNode>,
+}
+
+/// The parse boundary for one repo's batch, kept apart from the process call so
+/// it is testable without `gh`.
+fn parse_node_facts(
+    body: &[u8],
+    repo: &str,
+    numbers: &[u64],
+) -> Result<BTreeMap<Node, NodeFact>> {
+    let resp: GraphQlResponse<BatchData> =
+        serde_json::from_slice(body).context("unparseable GraphQL response from gh")?;
+    if let Some(err) = resp.errors.first() {
+        bail!("GraphQL error: {}", err.message);
+    }
+    let answered = resp
+        .data
+        .and_then(|d| d.repository)
+        .with_context(|| format!("the tracker did not answer for {repo}"))?;
+    let mut facts = BTreeMap::new();
+    for &number in numbers {
+        let issue = answered
+            .get(&alias(number))
+            .and_then(Option::as_ref)
+            .with_context(|| format!("the tracker did not answer for {repo}#{number}"))?;
+        // The badge reading is fetch's, projected rather than repeated: an
+        // unreadable state yields no badge there and an in-flight PR here.
+        let prs: Vec<PrOutcome> = issue
+            .closed_by_prs
+            .nodes
+            .iter()
+            .map(|pr| {
+                let link = parse_pr(pr);
+                PrOutcome::project(pr.number, link.as_ref().map(|l| &l.status))
+            })
+            .collect();
+        facts.insert(
+            Node {
+                repo: repo.to_string(),
+                number,
+            },
+            node_fact(
+                is_open(&issue.state),
+                !issue.assignees.nodes.is_empty(),
+                &prs,
+            ),
         );
     }
-    Ok(String::from_utf8_lossy(&output.stdout).trim() == "closed")
+    Ok(facts)
 }
 
 /// Hand one finished workspace back to `dl`.
@@ -1144,6 +1238,101 @@ mod tests {
                 reason: "still running — stop it first".to_string()
             }]
         );
+    }
+
+    /// One repo's batch, shaped exactly like the live one: five aliased
+    /// issues covering every arm the fact derivation can land on.
+    const BATCH_RESPONSE: &str = r#"{"data": {"repository": {
+        "i80": {"state": "OPEN", "assignees": {"nodes": []},
+                "closedByPullRequestsReferences": {"nodes": [
+                  {"number": 97, "state": "MERGED", "isDraft": false,
+                   "reviewDecision": null, "statusCheckRollup": {"state": "SUCCESS"},
+                   "repository": {"nameWithOwner": "blooop/devlaunch"}}]}},
+        "i81": {"state": "OPEN", "assignees": {"nodes": [{"login": "blooop"}]},
+                "closedByPullRequestsReferences": {"nodes": []}},
+        "i82": {"state": "OPEN", "assignees": {"nodes": []},
+                "closedByPullRequestsReferences": {"nodes": []}},
+        "i83": {"state": "CLOSED", "assignees": {"nodes": []},
+                "closedByPullRequestsReferences": {"nodes": []}},
+        "i84": {"state": "OPEN", "assignees": {"nodes": []},
+                "closedByPullRequestsReferences": {"nodes": [
+                  {"number": 44, "state": "SOMETHING_NEW", "isDraft": false,
+                   "reviewDecision": null, "statusCheckRollup": null,
+                   "repository": {"nameWithOwner": "blooop/devlaunch"}}]}}
+    }}}"#;
+
+    #[test]
+    fn one_batch_answers_every_node_of_a_repo() {
+        let facts = parse_node_facts(
+            BATCH_RESPONSE.as_bytes(),
+            "blooop/devlaunch",
+            &[80, 81, 82, 83, 84],
+        )
+        .expect("the batch parses");
+        assert_eq!(
+            facts,
+            BTreeMap::from([
+                (
+                    node("blooop/devlaunch", 80),
+                    NodeFact::DoneByMerge { pr: 97 }
+                ),
+                (node("blooop/devlaunch", 81), NodeFact::Claimed),
+                (node("blooop/devlaunch", 82), NodeFact::Unstarted),
+                (node("blooop/devlaunch", 83), NodeFact::Closed),
+                // The unknown PR state travels the whole way: it reached the
+                // fact as a PR in flight rather than being dropped on the floor
+                // and leaving #84 looking like a node nothing came of.
+                (node("blooop/devlaunch", 84), NodeFact::InFlight { pr: 44 }),
+            ])
+        );
+    }
+
+    #[test]
+    fn assignees_reach_the_reap_fact_from_the_same_batch() {
+        // The one bit separating "nobody took this up" from "someone is on it
+        // and has not opened a PR yet" — and without it the warning would fire
+        // on every grilling ticket and every pre-PR build session. It rides in
+        // on a call already being made: zero extra round trips.
+        let facts =
+            parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &[81, 82]).expect("parse");
+        assert_eq!(facts[&node("blooop/devlaunch", 81)], NodeFact::Claimed);
+        assert_eq!(facts[&node("blooop/devlaunch", 82)], NodeFact::Unstarted);
+    }
+
+    #[test]
+    fn a_node_the_batch_did_not_answer_for_is_an_error_not_unstarted() {
+        // The one sentinel this design could grow: a missing answer quietly
+        // becoming "nothing has come of it". Half an answer is the one shape
+        // reap must not act on, so the whole call fails instead.
+        let missing = parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &[80, 99])
+            .expect_err("an unanswered node fails the batch");
+        assert!(missing.to_string().contains("99"), "{missing}");
+        for body in [
+            // The alias came back null: the number names no issue there.
+            r#"{"data": {"repository": {"i80": null}}}"#,
+            // The repo itself came back null.
+            r#"{"data": {"repository": null}}"#,
+            // An error instead of data — never read as "nothing is closed".
+            r#"{"errors": [{"message": "Could not resolve to a Repository"}]}"#,
+            "not json",
+        ] {
+            assert!(
+                parse_node_facts(body.as_bytes(), "blooop/devlaunch", &[80]).is_err(),
+                "{body} parsed as an answer"
+            );
+        }
+    }
+
+    #[test]
+    fn the_batch_asks_one_question_per_node_and_asks_it_about_the_claim() {
+        // The wire contract: every wanted node aliased into the same round
+        // trip, and the same field subset the map query already reads — the
+        // claim included, which is what makes the split free.
+        let query = node_facts_query(&[80, 81]);
+        assert!(query.contains("i80: issue(number: 80)"), "{query}");
+        assert!(query.contains("i81: issue(number: 81)"), "{query}");
+        assert!(query.contains("assignees(first: 5)"), "{query}");
+        assert!(query.contains("includeClosedPrs: true"), "{query}");
     }
 
     #[test]

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -26,6 +26,8 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tokio::process::Command;
 
+use crate::model::PrStatus;
+
 /// The branch prefix `wf` mints its workspaces under (#106): the full branch is
 /// `wayfinder/<short-repo>-<n>`, which is also the branch `/wf-tdd` works on.
 const BRANCH_PREFIX: &str = "wayfinder/";
@@ -57,26 +59,162 @@ pub struct Workspace {
     pub unsaved: Option<String>,
 }
 
-/// What `wf` decided about one workspace. Two arms, both carrying a reason,
+/// What `wf` decided about one workspace. Three arms, each carrying a reason,
 /// because the plan is printed before anything is deleted and a reason the
 /// reader disagrees with is only useful while saying no is still possible.
+///
+/// `Warn` is display-only: a row `wf` wants read but will not act on. It is a
+/// separate arm rather than a flag on `Keep` so that every site deciding what
+/// to print — and, more to the point, what to delete — has to say at compile
+/// time which of the three it means.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Verdict {
     Reap { id: String, reason: String },
+    Warn { id: String, reason: String },
     Keep { id: String, reason: String },
 }
 
 impl Verdict {
     pub fn id(&self) -> &str {
         match self {
-            Verdict::Reap { id, .. } | Verdict::Keep { id, .. } => id,
+            Verdict::Reap { id, .. } | Verdict::Warn { id, .. } | Verdict::Keep { id, .. } => id,
         }
     }
 
     pub fn reason(&self) -> &str {
         match self {
-            Verdict::Reap { reason, .. } | Verdict::Keep { reason, .. } => reason,
+            Verdict::Reap { reason, .. }
+            | Verdict::Warn { reason, .. }
+            | Verdict::Keep { reason, .. } => reason,
         }
+    }
+}
+
+/// The workspaces a plan would actually delete.
+///
+/// The one definition of the doomed set, kept here rather than as a `matches!`
+/// at the call site: "a warned workspace is never deleted" is the safety
+/// property of the whole `Warn` arm, and a property nothing owns is a property
+/// nothing can pin. Every caller partitions through this.
+pub fn doomed(verdicts: &[Verdict]) -> Vec<&Verdict> {
+    verdicts
+        .iter()
+        .filter(|v| matches!(v, Verdict::Reap { .. }))
+        .collect()
+}
+
+/// What one linked PR says about whether its node is still alive — reap's
+/// projection of the badge reading, not a second reading of the tracker.
+///
+/// Three arms, because reap asks less of a PR than the screen does: does this
+/// PR keep the node alive, did it finish it, or does it say nothing. Checks,
+/// review and draftness are all the same answer here.
+///
+/// Every arm carries its number, since that number is the whole content of the
+/// row the human is about to approve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrOutcome {
+    /// Open, draft — or unreadable. See [`PrOutcome::project`].
+    InFlight { pr: u64 },
+    Merged { pr: u64 },
+    ClosedUnmerged { pr: u64 },
+}
+
+impl PrOutcome {
+    /// Project one PR's badge reading, which is [`fetch`](crate::fetch)'s job
+    /// and is not redone here — `status` is exactly what the badge parse made
+    /// of it, and `None` is that parse declining a `state` this binary does not
+    /// recognise.
+    ///
+    /// **An unreadable PR is in flight.** It is the only claim that stays true
+    /// whatever a newer GitHub state turns out to mean, and it is the arm that
+    /// keeps the workspace and prints nothing — so a state added after this
+    /// binary shipped costs a workspace that stays, never one that goes. The
+    /// alternative is worse than wrong: dropping it would leave the node
+    /// looking like it has no PR at all, which reads as
+    /// [`NodeFact::Unstarted`] — a warning invented out of a parse failure.
+    pub fn project(number: u64, status: Option<&PrStatus>) -> PrOutcome {
+        match status {
+            Some(PrStatus::Merged) => PrOutcome::Merged { pr: number },
+            Some(PrStatus::Closed) => PrOutcome::ClosedUnmerged { pr: number },
+            Some(PrStatus::Draft | PrStatus::Open { .. }) | None => {
+                PrOutcome::InFlight { pr: number }
+            }
+        }
+    }
+}
+
+/// What the tracker says about one node, in the terms reap decides by.
+///
+/// Six unconfusable values where a boolean "is it closed" used to be, so that
+/// "closed", "done by merge", "superseded", "in flight", "claimed" and
+/// "nothing has come of it" cannot be mistaken for each other, and so that
+/// every match site has to say out loud what it does with each.
+///
+/// Derived at every read from the batch the tracker just answered — never
+/// stored, so it cannot go stale, be orphaned, or outlive the workspace it
+/// describes. `Unstarted` in particular is a *positive observation* (open, no
+/// PRs, nobody assigned) and is never reachable from a lookup that failed: a
+/// node the batch did not answer for is an error, not an `Unstarted` node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeFact {
+    /// The ticket is closed.
+    Closed,
+    /// Open, but a PR merged and nothing is still in flight — what wf's own
+    /// stage lattice already calls Done, whatever the ticket still says.
+    DoneByMerge { pr: u64 },
+    /// Open, every linked PR closed unmerged. A human's "not this way", which
+    /// is not the same as "this branch is disposable".
+    Superseded { pr: u64 },
+    /// Open, with an open or draft PR: the least dead thing `wf` manages.
+    InFlight { pr: u64 },
+    /// Open, no PRs, but someone has taken it up. An explicit claim is a
+    /// person's statement of intent and reap does not overrule it.
+    Claimed,
+    /// Open, no PRs, unclaimed: nothing has come of this node.
+    Unstarted,
+}
+
+/// Read one node the way reap decides by it — the stage lattice's table,
+/// applied to the same fields the map query already returns.
+///
+/// Total over its inputs, and the order is the argument: a live PR dominates a
+/// merged sibling (a multi-PR ticket between merges is still being worked), a
+/// merge outranks the closed PRs beside it, and only a node with no PR
+/// evidence at all falls through to the claim.
+pub fn node_fact(is_open: bool, is_assigned: bool, prs: &[PrOutcome]) -> NodeFact {
+    if !is_open {
+        return NodeFact::Closed;
+    }
+    let earliest = |pick: fn(&PrOutcome) -> Option<u64>| prs.iter().filter_map(pick).min();
+    if let Some(pr) = earliest(|o| match o {
+        PrOutcome::InFlight { pr } => Some(*pr),
+        _ => None,
+    }) {
+        return NodeFact::InFlight { pr };
+    }
+    if let Some(pr) = earliest(|o| match o {
+        PrOutcome::Merged { pr } => Some(*pr),
+        _ => None,
+    }) {
+        return NodeFact::DoneByMerge { pr };
+    }
+    // Everything left is closed-unmerged, so the highest number is the last
+    // word anyone had on this node.
+    if let Some(pr) = prs
+        .iter()
+        .filter_map(|o| match o {
+            PrOutcome::ClosedUnmerged { pr } => Some(*pr),
+            _ => None,
+        })
+        .max()
+    {
+        return NodeFact::Superseded { pr };
+    }
+    if is_assigned {
+        NodeFact::Claimed
+    } else {
+        NodeFact::Unstarted
     }
 }
 
@@ -313,6 +451,7 @@ pub async fn remove(id: &str, insist: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::{Checks, Review};
 
     fn workspace(id: &str, repo: &str, branch: &str) -> Workspace {
         Workspace {
@@ -330,6 +469,142 @@ mod tests {
             repo: repo.to_string(),
             number,
         }
+    }
+
+    fn open_pr() -> PrStatus {
+        PrStatus::Open {
+            checks: Checks::Passing,
+            review: Review::NotRequired,
+        }
+    }
+
+    #[test]
+    fn a_pr_this_binary_cannot_read_still_counts_as_a_pr_in_flight() {
+        // The badge parse yields nothing for a state this binary does not
+        // recognise -- on purpose, since no badge beats a wrong one. Reap must
+        // still see a PR there. "In flight" is the only claim that stays true
+        // whatever the new state turns out to mean, and it is the arm that
+        // keeps the workspace and prints nothing; the alternative is a node
+        // that reads as having no PR at all and slides into `Unstarted`.
+        assert_eq!(PrOutcome::project(44, None), PrOutcome::InFlight { pr: 44 });
+    }
+
+    #[test]
+    fn the_pr_projection_is_total_over_every_reading_the_badge_parse_can_yield() {
+        // Three arms over the four badge statuses: reap's question is only
+        // "does this PR keep the node alive, finish it, or say nothing".
+        assert_eq!(
+            PrOutcome::project(1, Some(&PrStatus::Draft)),
+            PrOutcome::InFlight { pr: 1 }
+        );
+        assert_eq!(
+            PrOutcome::project(2, Some(&open_pr())),
+            PrOutcome::InFlight { pr: 2 }
+        );
+        assert_eq!(
+            PrOutcome::project(3, Some(&PrStatus::Merged)),
+            PrOutcome::Merged { pr: 3 }
+        );
+        assert_eq!(
+            PrOutcome::project(4, Some(&PrStatus::Closed)),
+            PrOutcome::ClosedUnmerged { pr: 4 }
+        );
+    }
+
+    #[test]
+    fn node_fact_is_total_over_the_rollup_and_the_claim() {
+        let cases: Vec<(&str, Vec<PrOutcome>, NodeFact, NodeFact)> = vec![
+            // (rollup name, rollup, open+assigned, open+unassigned)
+            ("no PRs", vec![], NodeFact::Claimed, NodeFact::Unstarted),
+            (
+                "a draft PR",
+                vec![PrOutcome::project(42, Some(&PrStatus::Draft))],
+                NodeFact::InFlight { pr: 42 },
+                NodeFact::InFlight { pr: 42 },
+            ),
+            (
+                "an open PR",
+                vec![PrOutcome::project(40, Some(&open_pr()))],
+                NodeFact::InFlight { pr: 40 },
+                NodeFact::InFlight { pr: 40 },
+            ),
+            (
+                "a merged PR",
+                vec![PrOutcome::project(33, Some(&PrStatus::Merged))],
+                NodeFact::DoneByMerge { pr: 33 },
+                NodeFact::DoneByMerge { pr: 33 },
+            ),
+            (
+                "a closed-unmerged PR",
+                vec![PrOutcome::project(43, Some(&PrStatus::Closed))],
+                NodeFact::Superseded { pr: 43 },
+                NodeFact::Superseded { pr: 43 },
+            ),
+            (
+                "a merged PR beside an open one",
+                vec![
+                    PrOutcome::project(33, Some(&PrStatus::Merged)),
+                    PrOutcome::project(40, Some(&open_pr())),
+                ],
+                NodeFact::InFlight { pr: 40 },
+                NodeFact::InFlight { pr: 40 },
+            ),
+            (
+                // fetch's own unknown-state fixture, carried the whole way in:
+                // it must not read as "no PR" and slide into `Unstarted`.
+                "a PR this binary cannot read",
+                vec![PrOutcome::project(44, None)],
+                NodeFact::InFlight { pr: 44 },
+                NodeFact::InFlight { pr: 44 },
+            ),
+        ];
+        for (name, prs, claimed, unclaimed) in cases {
+            assert_eq!(node_fact(true, true, &prs), claimed, "open, assigned, {name}");
+            assert_eq!(
+                node_fact(true, false, &prs),
+                unclaimed,
+                "open, unassigned, {name}"
+            );
+            for assigned in [true, false] {
+                assert_eq!(
+                    node_fact(false, assigned, &prs),
+                    NodeFact::Closed,
+                    "closed, assigned={assigned}, {name}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_fact_names_the_pr_its_reason_line_will_quote() {
+        // Which PR the arm carries is the whole content of the printed row, so
+        // it is pinned rather than left to the iteration order: the earliest
+        // live PR for work in flight, the earliest merge for the merge that
+        // finished it, and the *last* word on a superseded node.
+        let in_flight = [
+            PrOutcome::project(40, Some(&open_pr())),
+            PrOutcome::project(37, Some(&PrStatus::Draft)),
+        ];
+        assert_eq!(
+            node_fact(true, false, &in_flight),
+            NodeFact::InFlight { pr: 37 }
+        );
+        let merged = [
+            PrOutcome::project(97, Some(&PrStatus::Merged)),
+            PrOutcome::project(91, Some(&PrStatus::Merged)),
+        ];
+        assert_eq!(
+            node_fact(true, false, &merged),
+            NodeFact::DoneByMerge { pr: 91 }
+        );
+        let superseded = [
+            PrOutcome::project(90, Some(&PrStatus::Closed)),
+            PrOutcome::project(97, Some(&PrStatus::Closed)),
+        ];
+        assert_eq!(
+            node_fact(true, false, &superseded),
+            NodeFact::Superseded { pr: 97 }
+        );
     }
 
     #[test]

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -14,10 +14,20 @@
 //! and knows which tickets are closed — decides.
 //!
 //! Which makes this module's job small and its shape strict: match workspaces
-//! to nodes by the branch `wf` itself minted, ask the tracker which of those
-//! nodes are closed, and hand the finished ones back to `dl`. Everything a
+//! to nodes by the branch `wf` itself minted, ask the tracker what has become
+//! of those nodes, and hand the finished ones back to `dl`. Everything a
 //! workspace holds that says "not yet" — unsaved work, a running container — is
 //! `dl`'s fact, read here rather than argued with.
+//!
+//! "Finished" is not `wf`'s own invention either. It is exactly what the stage
+//! lattice already calls Done — a closed ticket, or an open one whose PR merged
+//! with nothing still in flight — read off the same fields, through the same
+//! per-PR interpretation, as the badge on the screen. Reap claims that end of
+//! the lattice and only warns at the other: a ticket every PR of which closed
+//! unmerged, and a ticket nobody claimed that nothing came of, are named and
+//! left alone. A suspicion is worth printing and never worth acting on, which
+//! is why [`Verdict::Warn`] exists and why [`doomed`] is the single place that
+//! decides what actually goes.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Stdio;
@@ -112,10 +122,10 @@ pub fn doomed(verdicts: &[Verdict]) -> Vec<&Verdict> {
 /// review and draftness are all the same answer here.
 ///
 /// Every arm carries its number, since that number is the whole content of the
-/// row the human is about to approve.
+/// row the human is about to approve. `InFlight` covers open, draft — and
+/// unreadable; see [`PrOutcome::project`] for why that third one belongs there.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrOutcome {
-    /// Open, draft — or unreadable. See [`PrOutcome::project`].
     InFlight { pr: u64 },
     Merged { pr: u64 },
     ClosedUnmerged { pr: u64 },
@@ -460,24 +470,33 @@ fn alias(number: u64) -> String {
     format!("i{number}")
 }
 
+/// What one node's answer has to carry: the reap-relevant subset of the map
+/// query's own sub-issue selection, field for field. `assignees` costs nothing
+/// extra here — it is already selected there, and `classify` already reads it
+/// as the claim, which is what makes the claimed/unstarted split free.
+const NODE_FACT_SELECTION: &str = "\
+      state
+      assignees(first: 5) { nodes { login } }
+      closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
+        nodes {
+          number state isDraft reviewDecision
+          statusCheckRollup { state }
+          repository { nameWithOwner }
+        }
+      }";
+
 /// One repo's batch: every wanted issue in one query.
 fn node_facts_query(numbers: &[u64]) -> String {
-    let mut query = String::from("query($owner: String!, $name: String!) {\n  repository(owner: $owner, name: $name) {\n");
+    use std::fmt::Write;
+    let mut query = String::from(
+        "query($owner: String!, $name: String!) {\n  repository(owner: $owner, name: $name) {\n",
+    );
     for &number in numbers {
-        query.push_str(&format!(
-            "    {}: issue(number: {number}) {{\n      \
-               state\n      \
-               assignees(first: 5) {{ nodes {{ login }} }}\n      \
-               closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {{\n        \
-                 nodes {{\n          \
-                   number state isDraft reviewDecision\n          \
-                   statusCheckRollup {{ state }}\n          \
-                   repository {{ nameWithOwner }}\n        \
-                 }}\n      \
-               }}\n    \
-             }}\n",
+        let _ = write!(
+            query,
+            "    {}: issue(number: {number}) {{\n{NODE_FACT_SELECTION}\n    }}\n",
             alias(number)
-        ));
+        );
     }
     query.push_str("  }\n}");
     query
@@ -502,11 +521,7 @@ struct IssueFacts {
 
 /// The parse boundary for one repo's batch, kept apart from the process call so
 /// it is testable without `gh`.
-fn parse_node_facts(
-    body: &[u8],
-    repo: &str,
-    numbers: &[u64],
-) -> Result<BTreeMap<Node, NodeFact>> {
+fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap<Node, NodeFact>> {
     let resp: GraphQlResponse<BatchData> =
         serde_json::from_slice(body).context("unparseable GraphQL response from gh")?;
     if let Some(err) = resp.errors.first() {
@@ -693,7 +708,11 @@ mod tests {
             ),
         ];
         for (name, prs, claimed, unclaimed) in cases {
-            assert_eq!(node_fact(true, true, &prs), claimed, "open, assigned, {name}");
+            assert_eq!(
+                node_fact(true, true, &prs),
+                claimed,
+                "open, assigned, {name}"
+            );
             assert_eq!(
                 node_fact(true, false, &prs),
                 unclaimed,
@@ -817,10 +836,7 @@ mod tests {
         ];
         let known = facts([
             (node("blooop/devlaunch", 80), NodeFact::Closed),
-            (
-                node("blooop/devlaunch", 81),
-                NodeFact::InFlight { pr: 91 },
-            ),
+            (node("blooop/devlaunch", 81), NodeFact::InFlight { pr: 91 }),
         ]);
         let verdicts = plan(&listing, &known, false);
         assert_eq!(
@@ -967,9 +983,9 @@ mod tests {
             let quiet = plan(std::slice::from_ref(&ws), &known, false);
             assert!(!quiet[0].reason().contains("discarding"));
             let loud = plan(std::slice::from_ref(&ws), &known, true);
-            assert!(loud[0].reason().ends_with(
-                "reap by hand if so, discarding 1 uncommitted change(s) (pixi.lock)"
-            ));
+            assert!(loud[0]
+                .reason()
+                .ends_with("reap by hand if so, discarding 1 uncommitted change(s) (pixi.lock)"));
         }
     }
 
@@ -1168,10 +1184,7 @@ mod tests {
             workspace("mine", "blooop/devlaunch", "wayfinder/devlaunch-81"),
             workspace("plain", "blooop/devlaunch", "main"),
         ];
-        let known = facts([(
-            node("blooop/devlaunch", 81),
-            NodeFact::InFlight { pr: 91 },
-        )]);
+        let known = facts([(node("blooop/devlaunch", 81), NodeFact::InFlight { pr: 91 })]);
         let verdicts = plan(&listing, &known, false);
         assert_eq!(verdicts.len(), 1);
         assert_eq!(verdicts[0].id(), "mine");
@@ -1293,8 +1306,8 @@ mod tests {
         // and has not opened a PR yet" — and without it the warning would fire
         // on every grilling ticket and every pre-PR build session. It rides in
         // on a call already being made: zero extra round trips.
-        let facts =
-            parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &[81, 82]).expect("parse");
+        let facts = parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &[81, 82])
+            .expect("parse");
         assert_eq!(facts[&node("blooop/devlaunch", 81)], NodeFact::Claimed);
         assert_eq!(facts[&node("blooop/devlaunch", 82)], NodeFact::Unstarted);
     }


### PR DESCRIPTION
Reap now claims what `wf`'s own stage lattice already calls **Done**, and warns
at the lattice's other end. Implements the resolutions of #127 and #128; the
predicate, the verdicts and the type sketch are theirs, not this PR's.

Closes #129. Also lands #128's slice, folded in per #129's amended scope note —
same enum, same match sites, same migration, so splitting it would have migrated
`plan()`'s callers and the verdict tests twice.

## What changed

| tracker fact | signals | verdict |
| --- | --- | --- |
| `Closed` | issue CLOSED | **Reap** — unchanged, same words |
| `DoneByMerge` | OPEN, ≥1 merged PR, zero open/draft | **Reap** |
| `Superseded` | OPEN, ≥1 PR, all closed-unmerged | **Warn** |
| `InFlight` | OPEN, ≥1 open or draft PR | **Keep** |
| `Claimed` | OPEN, zero PRs, assigned | **Keep** |
| `Unstarted` | OPEN, zero PRs, unassigned | **Warn** |

`plan()` takes a `BTreeMap<Node, NodeFact>` where it took a `BTreeSet<Node>` of
closed nodes, and `Verdict` grows a third arm. Guard order is untouched:
unsaved → Keep (waivable by `-f`), Running → Keep (never waivable), then the
fact. Worse news still wins the row.

## The one place this departs from #128's sketch

#128 sketched `node_fact(is_open, is_assigned, prs: &[PrLink])`. **That
signature cannot satisfy #128's own totality test.** A linked PR whose `state`
this binary does not recognise (`fetch.rs`'s `"SOMETHING_NEW"` fixture) yields
no badge *on purpose* — so it is not representable as a `PrLink`, it would be
dropped before the derivation saw it, and the node would read as having no PR
at all and slide into `Unstarted`. That is exactly the sentinel #128 exists to
forbid: a warning invented out of a parse failure.

The fix is a type, not a re-design. The derivation takes `PrOutcome` — a total
three-arm projection of the *existing* per-PR interpretation (in flight /
merged / closed-unmerged), each arm carrying its number, with an **unreadable
PR landing on in-flight**: the only claim that stays true whatever a newer
GitHub state means, and the arm that keeps the workspace and prints nothing. A
state added after this binary ships costs a workspace that stays, never one
that goes. It is a projection of `fetch::parse_pr`'s reading rather than a
second reading of the tracker's strings, so #127's one-vocabulary constraint
holds — `parse_pr` is now `pub(crate)` and the batch reads PR nodes through it.

Everything else in #128 stands as resolved: predicate, verdicts, and the
Warn-never-deletes posture.

Also settled while building: **the Warn rows do not borrow Reap's "discarding"
cadence** — nothing is discarded on a row that never deletes. Under `-f` they
read `… reap by hand if so, discarding <unsaved>`, where the discard belongs to
the by-hand reap being advised. Same wording for both warn facts.

## Safety

**Zero new deletion paths.** `reap::doomed()` is now the single definition of
what gets removed, in the reap module rather than as a `matches!` at the call
site — which is what makes *"a warned workspace never reaches the doomed set
even under `-y -f`"* a test with an owner instead of a coincidence between two
partitions. `-f` semantics unchanged, Running never waivable, no new flags.

`Unstarted` is a positive observation, never an absence: a node the batch did
not answer for **fails the whole call**, and `plan` refuses to act on a node it
has no fact for even if one ever reached it.

## Round trips, per repo, per `wf reap`

| | before | after |
| --- | --- | --- |
| `dl --ls --json` | 1 | 1 |
| tracker calls | **1 REST call per node** | **1 GraphQL call per repo** |
| per-workspace calls | 0 | 0 |

Both rows *derived* from the code: the old `finished_nodes` looped
`issue_is_closed` once per node; the new one aliases every wanted number into
one query per repo. The doc comment that already claimed "one search per repo"
is finally true.

**Measured**, on this repo, 8 real nodes, 3 runs each, warm `gh` auth:

```
one batched graphql call:      0.44 / 0.41 / 0.44 s
eight per-issue REST calls:    2.52 / 2.58 / 2.52 s
```

~6x on the tracker phase at 8 nodes, and the gap widens with node count since
the new shape is flat in it. This is `gh` invocation time against the live API,
not `wf` itself — `wf reap`'s tracker phase is one such call per repo either
way, so it is the phase's cost. No multi-workspace `dl` state was available
here, so the end-to-end `wf reap` timing is **not** measured.

## Scope held

- **`src/launch.rs` and `src/app.rs` have an empty diff.** #128's resolution
  turns on the prewarm path being untouched: nothing written at prewarm,
  nothing cleared at launch, no syscall added to the path that `exec`s. The
  existing `claim_prewarm` and `prewarm` tests are the pin and are green
  untouched.
- No sweep (#72 stands), no size or age heuristics, no `headRefName`.
- `fetch.rs` changes are the minimum to share one vocabulary: the GraphQL
  envelope is now generic over its selection, and the PR node type, the badge
  parse and `is_open` are `pub(crate)`.

## Tests

Red-first, one slice at a time: the derivation, then the `plan()` migration,
then the batched parse, then the printer. 21 new tests in `src/reap.rs` —
the six arms table-driven for totality over
{closed, open} × {none, draft, open, merged, closed-unmerged, merged+open,
**unreadable**} × {assigned, unassigned}; the two Warn facts and their
under-fires (Running hides it; a dirty lockfile hides it until `-f`); the
doomed-set invariant; and parse-boundary fixtures for the batch including the
never-partial posture and `assignees` reaching the fact.

Local suite: **310 passed, 0 failed** (`cargo test`), with `cargo fmt --check`,
`cargo clippy --all-targets --all-features -D warnings` and `cargo doc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align `wf reap` with the tracker’s stage lattice, treating tickets as finished when closed or done-by-merge, and introduce non-deleting warnings for suspected but uncertain dead work.

New Features:
- Add a `Warn` verdict alongside `Reap` and `Keep` so `wf reap` can surface suspected dead work without deleting it.
- Derive per-node `NodeFact` (closed, done-by-merge, superseded, in-flight, claimed, unstarted) from tracker data to drive reap decisions.
- Introduce `PrOutcome` as a projection of per-PR status so unreadable or new GitHub states are treated as PRs in flight rather than misclassified.
- Batch tracker lookups with a per-repo GraphQL query that fetches issue state, assignees and linked PRs in one call, shared with the map fetch envelope.

Enhancements:
- Refactor deletion selection into a dedicated `doomed` helper so only reap verdicts can lead to actual workspace removal.
- Rework `plan` to consume a map of node facts instead of a set of closed nodes, making keep/reap/warn decisions explicit and testable.
- Group CLI output for `wf reap` by keep/warn/reap and clarify the prompt to only count truly doomed workspaces.
- Expose selected `fetch` types and helpers (`GraphQlResponse`, `Nodes`, `Assignee`, `PrNode`, `parse_pr`, `is_open`) as `pub(crate)` to share one vocabulary between the map view and reap.

Documentation:
- Update `wf reap` help text and README to describe done-by-merge semantics, non-deleting warn rows, and the use of batched GraphQL calls per repo.

Tests:
- Add an extensive test suite for `PrOutcome`, `NodeFact`, `plan`, `doomed`, and GraphQL batch parsing, covering unreadable PR states, guard precedence, warn invariants, and batch error handling.