### PR TITLE
Hand the launched agent its ticket context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 # build output. Only the worktree directory is ignored: `.claude/` also holds
 # settings and skills, which are worth committing.
 /.claude/worktrees/
+
+# The container-seam test's canary (#124). Its fixture title carries
+# `$(touch pwned)` so that a *broken* `shell_quote` is caught by the file
+# appearing rather than only by an argv mismatch — the substitution firing is
+# the whole evidence. The test now runs its shell in a scratch directory so the
+# canary lands there, but a mutation experiment run from an older tree (or from
+# a shell that inherits the crate root) still drops one here, and this file was
+# once committed to a public repo that way.
+/pwned

--- a/README.md
+++ b/README.md
@@ -435,6 +435,22 @@ through `codex --dangerously-bypass-approvals-and-sandbox`. Both receive one
 prompt argument, so the route, numbers, and steering text cannot be split apart
 by the shell.
 
+**Every launch of a node also hands the agent what `wf` already knew**, as a
+`ctx: <json>` block between the skill's arguments and any steering suffix:
+
+```
+/wf-review 124 ctx: {"v":1,"repo":"blooop/wayfinder","map":{…},"aim":{"ticket":{…,"prs":[…]}}} steer: <text>
+```
+
+That is the parent map, the ticket's type and stage, and its linked PRs — the
+three serial `gh` calls a launched skill used to open with, answered before it
+starts. It is an accelerator and never a precondition: a skill invoked by hand
+never went through the picker, finds no block, and discovers exactly as before.
+The one thing it deliberately cannot say is whether the ticket is still yours to
+take — there is no assignee and no ticket status in the schema, so claiming stays
+a live call and a stale block cannot make an agent act on someone else's work.
+The creation rows carry no block at all: they name nothing that exists yet.
+
 The auto mode collapses the ticket rows on purpose: the launched session is a
 *manager*, and what it manages is the node's whole remaining lifecycle —
 `wf-tdd`, the gate, then a fresh-context `wf-review` — so it is the manager
@@ -494,7 +510,7 @@ A checkout that carries a **`.devcontainer/devcontainer.json`** (or a top-level
 [`dl`](https://github.com/blooop/devlaunch):
 
 ```
-dl owner/repo@wayfinder/repo-80 -- 'claude' '--dangerously-skip-permissions' '/wf 67 80'
+dl owner/repo@wayfinder/repo-80 -- 'claude' '--dangerously-skip-permissions' '/wf 67 80 ctx: {"v":1,…}'
 ```
 
 Codex deliberately stays on the host even for such a checkout. `dl` mounts

--- a/skills/wf-auto/SKILL.md
+++ b/skills/wf-auto/SKILL.md
@@ -65,6 +65,8 @@ Blocking is the tracker's native dependency edge, so the frontier renders in the
 
 **Not yet specified** is in-scope fog you can't yet phrase sharply; **Out of scope** is work past the destination. Ticket it when the question is already sharp, even if blocked and unactionable; leave it as fog when it isn't.
 
+A launch from `wf` reads `<sigil>wf-auto <map> [<ticket>] ctx: <json> [steer: <text>]`. The block is the snapshot `wf` already held — the map's title, and for a ticket its type, stage and linked PRs — so a run can open on the node it was handed without rediscovering it. It is an **accelerator, never a precondition**, it never survives into a subagent's own invocation unexamined, and every gate below is still checked from live tracker state. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
+
 Tracker mechanics — pinning the repo, creating and parenting issues, blocking edges, the frontier query, the local-markdown fallback — live in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md) in the sibling `wf` skill. Pin the repo from the working repo's own remote, pass it explicitly on every call, and push branches by name: a fork's map belongs to the fork, never its parent. State the repo and its visibility in your first line of output — an autonomous run on a public repo publishes the whole fog sketch, and the invocation is the only consent there is for that.
 
 ## A run is a manager

--- a/skills/wf-one/SKILL.md
+++ b/skills/wf-one/SKILL.md
@@ -15,6 +15,8 @@ Two issues, not one: wf's cluster header is a map and headers are not cursor sto
 
 ## Set it up
 
+A `wf-one` launch is a **creation**: it names work that does not exist on the tracker yet, so its line is `<sigil>wf-one <task>` and never carries a `ctx: <json>` block. Nor may you synthesize one when handing the ticket to `wf-tdd` or `wf-review` below — the block is `wf`'s record of what it fetched, and a hand-written one would be a claim about tracker state nobody read. Those subagents discover from the ticket, exactly as a hand-typed invocation does. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
+
 Tracker mechanics — pinning the repo, creating and parenting issues, labels, claiming — are in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md) in the sibling `wf` skill. Pin the repo from the working repo's own remote and pass it explicitly on every `gh` call; push branches by name.
 
 1. **The map** (`wayfinder:map`), titled as the work. Body is short, because a one-ticket map has no route to index:

--- a/skills/wf-review/SKILL.md
+++ b/skills/wf-review/SKILL.md
@@ -15,7 +15,9 @@ Adapted from aihero.dev's `/code-review` (see `research/aihero-spine.md` in bloo
 
 ## Invocation
 
-`wf-review <pr>` — a PR number or URL (or a ticket number whose linked open PR is unambiguous). Resolve the repo explicitly and pass `--repo` on every `gh` call.
+`wf-review <pr> [ctx: <json>] [steer: <text>]` — a PR number or URL (or a ticket number whose linked open PR is unambiguous). Resolve the repo explicitly and pass `--repo` on every `gh` call.
+
+A launch from `wf` adds a `ctx: <json>` block after the number, and it carries the ticket's **linked PRs** — which is precisely the lookup this skill otherwise opens with when it is handed a bare ticket number. It is an **accelerator, never a precondition**: with no block, or one you cannot read, resolve the PR the way a hand-typed invocation does. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
 
 ## Inputs — deterministic, never asked
 

--- a/skills/wf-tdd/SKILL.md
+++ b/skills/wf-tdd/SKILL.md
@@ -15,7 +15,9 @@ Adapted from aihero.dev's `/tdd` + `/implement` (see `research/aihero-spine.md` 
 
 ## Invocation
 
-`wf-tdd <ticket>` — an issue number or URL. Resolve the repo explicitly from the working checkout's remote and pass `--repo` on every `gh` call.
+`wf-tdd <ticket> [ctx: <json>] [steer: <text>]` — an issue number or URL. Resolve the repo explicitly from the working checkout's remote and pass `--repo` on every `gh` call.
+
+A launch from `wf` adds a `ctx: <json>` block after the ticket number: the parent map, the ticket's type and stage, and its linked PRs, all already fetched — so the map lookup this stage opens with is a read you can skip. It is an **accelerator, never a precondition**; a hand-typed invocation carries none and discovers exactly as it always has, and the claim below is a live call either way. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
 
 ## The contract is the ticket
 

--- a/skills/wf/GITHUB_TRACKER.md
+++ b/skills/wf/GITHUB_TRACKER.md
@@ -41,6 +41,47 @@ If `origin` is the **parent** — you cloned upstream and added your fork as a s
 gh api "repos/$REPO/issues/NUMBER" --jq .id
 ```
 
+## The launch context (`ctx:`)
+
+A launch line may carry `ctx: <json>` — a snapshot of what `wf` knew at exec time. It is an accelerator, never a precondition: use it to skip discovery reads (which map, which PR, what type and stage); never let it substitute for a live read before any write — claiming, commenting, closing, gating. If it is absent, does not parse, has a `v` you don't recognise, or names a repo or ticket other than the one your arguments and pinned `$REPO` name, ignore it entirely and discover via the commands below, as a hand-invoked session always does.
+
+It sits between the skill's own arguments and any `steer:` suffix, on one line:
+
+```
+<sigil><skill> <args> ctx: {"v":1,…} steer: <text>
+```
+
+Everything after `steer:` is still the human's text, so a steer that happens to contain the letters `ctx:` is steering text and nothing else.
+
+**What it carries** (schema `v: 1`; a ticket aim shown — a whole-map launch reads `"aim": "map"` and names no ticket):
+
+```json
+{
+  "v": 1,
+  "repo": "owner/name",
+  "map": { "repo": "owner/name", "number": 121, "title": "the map's title" },
+  "aim": {
+    "ticket": {
+      "number": 124,
+      "title": "the ticket's title",
+      "ticket_type": "build",
+      "stage": "in_review",
+      "prs": [{ "repo": "owner/name", "number": 130, "status": { "open": { "checks": "passing", "review": "required" } } }]
+    }
+  }
+}
+```
+
+The map carries its own repo because a ticket can sit on a map in another repo. `ticket_type` is one of `build` · `research` · `task` · `grilling` · `prototype` · `untyped`; `stage` one of `ready` · `building` · `in_review` · `needs_attention` — never `done`, because a finished node is not launchable. A PR's `status` is `draft`, `merged`, `closed`, or `open` with its `checks` (`absent` · `pending` · `passing` · `failing`) and `review` (`not_required` · `required` · `approved` · `changes_requested`).
+
+**What it deliberately does not carry**, and why the omissions are the contract rather than an oversight:
+
+- **No assignee and no ticket status.** The one fact whose staleness is dangerous — is this ticket still mine to take — is not in the schema at all, so everything present *is* safe to orient from. Claim-first is unchanged: `gh issue edit <n> --repo "$REPO" --add-assignee @me` is still the first thing a session does, and a ticket taken or closed between the pick and the launch fails there, before any work.
+- **No blockers.** The picker refuses a blocked node before staging, so a launched ticket has none open.
+- **No bodies and no comments** — of the ticket, of the map, of anything. `wf` never fetches them, so the reads that need them are unchanged.
+
+**Precedence: your arguments beat the block, and the tracker beats both.** The ticket number in your invocation is the assignment; a block naming a different number or repo is discarded whole, never merged field by field.
+
 ## Labels (once per repo, idempotent)
 
 ```bash

--- a/skills/wf/GITHUB_TRACKER.md
+++ b/skills/wf/GITHUB_TRACKER.md
@@ -72,7 +72,18 @@ Everything after `steer:` is still the human's text, so a steer that happens to 
 }
 ```
 
-The map carries its own repo because a ticket can sit on a map in another repo. `ticket_type` is one of `build` · `research` · `task` · `grilling` · `prototype` · `untyped`; `stage` one of `ready` · `building` · `in_review` · `needs_attention` — never `done`, because a finished node is not launchable. A PR's `status` is `draft`, `merged`, `closed`, or `open` with its `checks` (`absent` · `pending` · `passing` · `failing`) and `review` (`not_required` · `required` · `approved` · `changes_requested`).
+The map carries its own repo because a ticket can sit on a map in another repo.
+
+Every enumerated field, with its whole vocabulary — one line each, and each line is the complete list:
+
+- `aim` — `map` · `ticket`
+- `ticket_type` — `build` · `research` · `task` · `grilling` · `prototype` · `untyped`
+- `stage` — `ready` · `building` · `in_review` · `needs_attention`
+- `status` — `draft` · `open` · `merged` · `closed`
+- `checks` — `absent` · `pending` · `passing` · `failing`
+- `review` — `not_required` · `required` · `approved` · `changes_requested`
+
+A `stage` is never `done`: a finished node is not launchable, so a block cannot claim one. `checks` and `review` exist only inside an `open` status — they are questions about something still in flight.
 
 **What it deliberately does not carry**, and why the omissions are the contract rather than an oversight:
 

--- a/skills/wf/SKILL.md
+++ b/skills/wf/SKILL.md
@@ -134,6 +134,7 @@ Claude and `$` for Codex):
 
 - `<sigil>wf <map> [<ticket>]` — everything below as written
 - `<sigil>wf <map> <ticket> steer: <steering>` — with a steering prompt
+- `<sigil>wf <map> [<ticket>] ctx: <json> [steer: <steering>]` — the same, with the snapshot `wf` already held: the map's title, and for a ticket its type, stage and linked PRs. An **accelerator, never a precondition** — orient from it, verify live before any write, and ignore it entirely if it is absent or disagrees with your arguments. See **The launch context** in [GITHUB_TRACKER.md](GITHUB_TRACKER.md).
 
 ### Chart the map
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, Route, Staged, Targets};
+use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::Checkout;
 use crate::refresh::Startup;
@@ -36,7 +36,12 @@ pub enum Outcome {
     Refresh,
     /// Run this ticket's agent. The last thing `wf` ever does: the loop
     /// returns, the terminal is restored, and the process becomes the agent.
-    Launch(Launch),
+    ///
+    /// Boxed because it is by far the largest thing an outcome can carry — a
+    /// launch holds the whole snapshot it hands its agent (#124) — and every
+    /// other outcome is a keystroke's worth of nothing. One allocation on the
+    /// last keypress of the session buys a small `Outcome` for all the rest.
+    Launch(Box<Launch>),
 }
 
 /// A modal layer over the main screen: the staged second step of a launch
@@ -680,8 +685,7 @@ impl App {
                 Outcome::Continue
             }
             Some(Stop::Map(id)) => {
-                let title = self.clusters[&id].title.clone();
-                let staged = Staged::map(&id, &title);
+                let staged = Staged::map(&MapRef::new(&id, &self.clusters[&id].title));
                 self.prewarm(&staged);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
@@ -724,7 +728,11 @@ impl App {
             ));
             return Outcome::Continue;
         }
-        match Staged::ticket(ticket, row.map.number, stage(&ticket.prs, &ticket.status)) {
+        // The map the row was picked in, carried whole: a ticket can sit on a
+        // map in another repo, and a bare number would name the wrong issue
+        // there (#124).
+        let map = MapRef::new(&row.map, &self.clusters[&row.map].title);
+        match Staged::ticket(ticket, &map, stage(&ticket.prs, &ticket.status)) {
             None => {
                 self.notice = Some(format!("#{} is done — nothing to launch", ticket.number));
                 Outcome::Continue
@@ -824,7 +832,7 @@ impl App {
             }
             Targets::One(launch) => {
                 self.notice = Some(format!("→ {}", launch.describe()));
-                Outcome::Launch(launch)
+                Outcome::Launch(Box::new(launch))
             }
             Targets::Many(launches) => {
                 self.notice = Some(format!("{repo}{key}: which checkout?"));
@@ -935,7 +943,7 @@ impl App {
                     .nth(cursor)
                     .expect("picker cursor stays in range");
                 self.notice = Some(format!("→ {}", launch.describe()));
-                Outcome::Launch(launch)
+                Outcome::Launch(Box::new(launch))
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.overlay = Overlay::PickCheckout {
@@ -1895,7 +1903,11 @@ mod tests {
                     "a task is a decision node"
                 );
                 assert_eq!(staged.key(), "#6");
-                assert_eq!(staged.title, "Re-entry breadcrumbs", "the picker names it");
+                assert_eq!(
+                    staged.title(),
+                    "Re-entry breadcrumbs",
+                    "the picker names it"
+                );
                 assert_eq!(
                     *candidate,
                     Candidate::Launch {
@@ -1916,7 +1928,10 @@ mod tests {
         assert_eq!(launch.key(), "wayfinder#6");
         assert_eq!(launch.cwd(), std::path::Path::new("/data/proj/wayfinder"));
         // The map issue is the cluster's — not a per-repo lookup.
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf 1 6");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf 1 6 ctx: …"
+        );
         assert_eq!(app.overlay, Overlay::None, "one candidate must not prompt");
         assert!(app
             .notice
@@ -1933,7 +1948,7 @@ mod tests {
                 .flat_map(|m| &m.tickets)
                 .find(|t| t.number == 6)
                 .expect("#6 is in the fixture"),
-            1,
+            &MapRef::new(&MapId::new("blooop/wayfinder", 1), "Map: wf"),
             crate::model::Stage::Ready,
         )
         .expect("ready is launchable")
@@ -1976,7 +1991,7 @@ mod tests {
         // one session must warm both, since they are two workspaces.
         let mut app = fixture_app();
         let six = staged_six(&app);
-        let map = Staged::map(&MapId::new("blooop/wayfinder", 1), "a map");
+        let map = Staged::map(&MapRef::new(&MapId::new("blooop/wayfinder", 1), "a map"));
         assert_ne!(six.node_workspace(), map.node_workspace());
         assert!(app.claim_prewarm(&six, true));
         assert!(app.claim_prewarm(&map, true));
@@ -2029,7 +2044,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf 47 6");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf 47 6 ctx: …"
+        );
     }
 
     #[test]
@@ -2167,8 +2185,8 @@ mod tests {
         };
         assert_eq!(launch.agent(), Agent::Codex);
         assert_eq!(
-            launch.agent_argv().last().expect("one prompt"),
-            "$wf 1 6 steer: keep me"
+            launch::eliding_ctx(launch.agent_argv().last().expect("one prompt")),
+            "$wf 1 6 ctx: … steer: keep me"
         );
     }
 
@@ -2218,8 +2236,8 @@ mod tests {
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(
-            launch.agent_argv().last().unwrap(),
-            "/wf-auto 1 6 steer: something"
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-auto 1 6 ctx: … steer: something"
         );
     }
 
@@ -2238,7 +2256,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto 4 103");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-auto 4 103 ctx: …"
+        );
     }
 
     #[test]
@@ -2283,8 +2304,8 @@ mod tests {
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(
-            launch.agent_argv().last().unwrap(),
-            "/wf-auto 1 6",
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-auto 1 6 ctx: …",
             "the staged ticket, not whatever landed at its old index"
         );
 
@@ -2309,7 +2330,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto 1 6");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-auto 1 6 ctx: …"
+        );
     }
 
     #[test]
@@ -2324,7 +2348,7 @@ mod tests {
         match &app.overlay {
             Overlay::PickLaunch { staged, .. } => {
                 assert_eq!(staged.key(), "#1");
-                assert_eq!(staged.title, "Map: wf", "the picker names the map");
+                assert_eq!(staged.title(), "Map: wf", "the picker names the map");
                 assert_eq!(staged.route(Mode::Interactive), Some(Route::Wayfinder));
                 assert_eq!(staged.route(Mode::Auto), Some(Route::WayfinderAuto));
             }
@@ -2335,7 +2359,10 @@ mod tests {
             other => panic!("expected a launch, got {other:?}"),
         };
         assert_eq!(launch.key(), "wayfinder#1");
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf 1");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf 1 ctx: …"
+        );
 
         let mut app = launchable_app();
         go_to(&mut app, "map #1");
@@ -2345,7 +2372,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-auto 1");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-auto 1 ctx: …"
+        );
     }
 
     /// An app focused on a registered repo that has no open map — what `wf`
@@ -2634,7 +2664,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-tdd 65");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-tdd 65 ctx: …"
+        );
 
         let mut in_review = build_app(vec![PrLink {
             repo: "blooop/wayfinder".to_string(),
@@ -2655,7 +2688,10 @@ mod tests {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
         };
-        assert_eq!(launch.agent_argv().last().unwrap(), "/wf-review 65");
+        assert_eq!(
+            launch::eliding_ctx(launch.agent_argv().last().unwrap()),
+            "/wf-review 65 ctx: …"
+        );
 
         // A merged PR with nothing open means done — stage, not ticket state,
         // is what refuses the launch.

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1187,7 +1187,12 @@ impl Launch {
         route.bundled_skill()?;
         let skill = route.invocation(self.agent());
         let invocation = match (route, aim) {
-            (Route::One, _) => skill,
+            // `/wf-one` is a creation's route, and its own doc says a `wf-one`
+            // line never carries a block — it names work that does not exist
+            // on the tracker yet. A node routed here is unreachable from the
+            // picker but representable ([`plan`] takes any [`Route`]), so the
+            // answer is given here rather than left to depend on that.
+            (Route::One, _) => return Some(skill),
             (_, Aim::Map) => format!("{skill} {}", map.id.number),
             (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => format!("{skill} {number}"),
             (Route::Wayfinder | Route::WayfinderAuto, Aim::Ticket { number, .. }) => {
@@ -1607,6 +1612,9 @@ fn resolve(checkouts: &[Checkout], repo: &str, job: &Job) -> Targets {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, Status, TicketType};
 
@@ -2308,33 +2316,254 @@ mod tests {
         );
     }
 
+    /// Every field name a serialized block contains, at any depth — including
+    /// the tag keys the enums write (`ticket`, `open`).
+    fn keys_of(value: &serde_json::Value) -> BTreeSet<String> {
+        let mut keys = BTreeSet::new();
+        let mut stack = vec![value];
+        while let Some(node) = stack.pop() {
+            match node {
+                serde_json::Value::Object(fields) => {
+                    for (key, child) in fields {
+                        keys.insert(key.clone());
+                        stack.push(child);
+                    }
+                }
+                serde_json::Value::Array(items) => stack.extend(items),
+                _ => {}
+            }
+        }
+        keys
+    }
+
     #[test]
     fn the_handed_context_cannot_speak_about_the_claim() {
         // The one fact whose staleness is dangerous — is this ticket still
         // mine to take — is absent from the *type*, not merely from this
         // fixture, so "trust it for orientation, re-read before mutating" is a
-        // shape rather than a rule to remember. The fixture node is unassigned
-        // and unblocked, so its own status vocabulary would show up here if it
-        // were ever serialized.
-        let ctx = ctx_of(&ticket_prompt(
-            TicketType::Build,
-            Stage::Ready,
-            &interactive(""),
-        ))
-        .expect("a ticket launch carries context")
-        .to_string();
+        // shape rather than a rule to remember.
+        //
+        // Asserted over the block's *field names*, and as the whole set rather
+        // than a list of forbidden words. Both halves matter. A substring scan
+        // of the block's text cannot tell a key from a value, so it read
+        // `"stage":"needs_attention"` — a legal, spec-mandated value — as the
+        // word "needs" and would have failed on a node that is simply awaiting
+        // attention. And a blacklist only catches the names someone thought of:
+        // an exact key set fails on *any* new field, which is the only way this
+        // stays true as the schema grows.
+        let with_pr = |stage| {
+            let mut node = ticket("blooop/wayfinder", 16);
+            node.ticket_type = TicketType::Build;
+            node.prs = vec![PrLink {
+                repo: "blooop/wayfinder".to_string(),
+                number: 90,
+                status: PrStatus::Open {
+                    checks: Checks::Failing,
+                    review: Review::ChangesRequested,
+                },
+            }];
+            let staged = Staged::ticket(&node, &map_ref(1), stage).expect("a launchable stage");
+            let prompt = match plan_picked(&cache(), &staged, &interactive("")) {
+                Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+                other => panic!("{other:?}"),
+            };
+            let ctx = ctx_of(&prompt)
+                .expect("a ticket launch carries context")
+                .to_string();
+            keys_of(&serde_json::from_str(&ctx).expect("the block is JSON"))
+        };
+        let named = |names: &[&str]| {
+            names
+                .iter()
+                .map(|n| (*n).to_string())
+                .collect::<BTreeSet<String>>()
+        };
+        // The richest block the schema can produce: a ticket aim with a linked
+        // PR open enough to carry both live signals.
+        let expected = named(&[
+            "v",
+            "repo",
+            "map",
+            "number",
+            "title",
+            "aim",
+            "ticket",
+            "ticket_type",
+            "stage",
+            "prs",
+            "status",
+            "open",
+            "checks",
+            "review",
+        ]);
+        assert_eq!(with_pr(Stage::InReview), expected);
+        // The node the old substring guard would have failed on: awaiting
+        // attention is a stage, not a claim.
+        assert_eq!(with_pr(Stage::NeedsAttention), expected);
         for forbidden in [
             "assignee",
             "assignees",
             "claim",
             "frontier",
-            "blocked",
+            "blocked_by",
             "needs",
         ] {
             assert!(
-                !ctx.contains(forbidden),
-                "{forbidden:?} must be unrepresentable in the handed context, got {ctx}"
+                !expected.contains(forbidden),
+                "{forbidden:?} must be unrepresentable in the handed context"
             );
+        }
+    }
+
+    /// The golden wire words, one exhaustive `match` per enumerated field.
+    ///
+    /// These four are the whole vocabulary the tracker doc publishes, written
+    /// as literals traceable to it rather than derived from the types — a
+    /// derivation would only prove serde agrees with itself. Being `match`es
+    /// with no wildcard is the other half: adding a type, a stage, a check
+    /// rollup or a review decision stops this module compiling until the new
+    /// word has been decided and pinned here.
+    fn type_word(ticket_type: TicketType) -> &'static str {
+        match ticket_type {
+            TicketType::Build => "build",
+            TicketType::Research => "research",
+            TicketType::Task => "task",
+            TicketType::Grilling => "grilling",
+            TicketType::Prototype => "prototype",
+            TicketType::Untyped => "untyped",
+        }
+    }
+
+    /// See [`type_word`].
+    fn stage_word(stage: Launchable) -> &'static str {
+        match stage {
+            Launchable::Ready => "ready",
+            Launchable::Building => "building",
+            Launchable::InReview => "in_review",
+            Launchable::NeedsAttention => "needs_attention",
+        }
+    }
+
+    /// See [`type_word`].
+    fn checks_word(checks: Checks) -> &'static str {
+        match checks {
+            Checks::Absent => "absent",
+            Checks::Pending => "pending",
+            Checks::Passing => "passing",
+            Checks::Failing => "failing",
+        }
+    }
+
+    /// See [`type_word`].
+    fn review_word(review: Review) -> &'static str {
+        match review {
+            Review::NotRequired => "not_required",
+            Review::Required => "required",
+            Review::Approved => "approved",
+            Review::ChangesRequested => "changes_requested",
+        }
+    }
+
+    /// See [`type_word`]. An open PR is the one state that carries more, so
+    /// its word is the tag and the two live signals under it.
+    fn status_words(status: &PrStatus) -> String {
+        match status {
+            PrStatus::Draft => r#""status":"draft""#.to_string(),
+            PrStatus::Merged => r#""status":"merged""#.to_string(),
+            PrStatus::Closed => r#""status":"closed""#.to_string(),
+            PrStatus::Open { checks, review } => format!(
+                r#""status":{{"open":{{"checks":"{}","review":"{}"}}}}"#,
+                checks_word(*checks),
+                review_word(*review)
+            ),
+        }
+    }
+
+    /// Every value the block's enumerated fields can hold, launched for real
+    /// and spelled out (#122 §4).
+    ///
+    /// One test over the whole matrix rather than a property run: the
+    /// vocabularies are small and closed, so every cell fits, and a golden
+    /// literal per cell says what a generator never can — *which* word the wire
+    /// uses. Before this, only `ready`, `build` and a single open PR were ever
+    /// emitted by any test, so every other word the tracker doc publishes
+    /// rested on the doc's say-so.
+    #[test]
+    fn every_stage_type_and_pr_state_spells_itself_on_the_wire() {
+        let types = [
+            TicketType::Build,
+            TicketType::Research,
+            TicketType::Task,
+            TicketType::Grilling,
+            TicketType::Prototype,
+            TicketType::Untyped,
+        ];
+        let stages = [
+            (Stage::Ready, Launchable::Ready),
+            (Stage::Building, Launchable::Building),
+            (Stage::InReview, Launchable::InReview),
+            (Stage::NeedsAttention, Launchable::NeedsAttention),
+        ];
+        for ticket_type in types {
+            for (stage, launchable) in stages {
+                let ctx = ctx_of(&ticket_prompt(ticket_type, stage, &interactive("")))
+                    .expect("a ticket launch carries context")
+                    .to_string();
+                let expected = format!(
+                    r#""ticket_type":"{}","stage":"{}""#,
+                    type_word(ticket_type),
+                    stage_word(launchable)
+                );
+                assert!(ctx.contains(&expected), "expected {expected} in {ctx}");
+            }
+        }
+        let mut pr_states = vec![PrStatus::Draft, PrStatus::Merged, PrStatus::Closed];
+        for checks in [
+            Checks::Absent,
+            Checks::Pending,
+            Checks::Passing,
+            Checks::Failing,
+        ] {
+            for review in [
+                Review::NotRequired,
+                Review::Required,
+                Review::Approved,
+                Review::ChangesRequested,
+            ] {
+                pr_states.push(PrStatus::Open { checks, review });
+            }
+        }
+        for status in pr_states {
+            let expected = status_words(&status);
+            let ctx = ctx_of(&pr_prompt(status))
+                .expect("a ticket launch carries context")
+                .to_string();
+            assert!(ctx.contains(&expected), "expected {expected} in {ctx}");
+        }
+        // The other arm of the matrix's aim axis: a map launch names none of
+        // the ticket vocabulary at all, rather than nulling it out.
+        let map = ctx_of(&map_prompt(&interactive("")))
+            .expect("a map launch carries context")
+            .to_string();
+        assert!(map.ends_with(r#""aim":"map"}"#), "{map}");
+        for absent in ["ticket_type", "stage", "prs"] {
+            assert!(!map.contains(absent), "a map aim names no {absent}: {map}");
+        }
+    }
+
+    /// A review-stage launch whose one linked PR stands where the caller says.
+    fn pr_prompt(status: PrStatus) -> String {
+        let mut node = ticket("blooop/wayfinder", 16);
+        node.ticket_type = TicketType::Build;
+        node.prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status,
+        }];
+        let staged = Staged::ticket(&node, &map_ref(1), Stage::InReview).expect("in review");
+        match plan_picked(&cache(), &staged, &interactive("")) {
+            Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+            other => panic!("{other:?}"),
         }
     }
 
@@ -2358,6 +2587,29 @@ mod tests {
         ] {
             assert_eq!(ctx_of(&creation_argv(kind, text).join(" ")), None);
         }
+        // `/wf-one` is the creation route, and the picker never routes a node
+        // there — but `plan` takes any route, so the block's absence is decided
+        // by the route rather than by that being hard to reach. `wf-one`'s own
+        // doc forbids the block, and the code has to agree with it even on the
+        // combination nothing constructs.
+        let one = Launch {
+            repo: "blooop/wayfinder".to_string(),
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            job: Job::Node {
+                aim: Aim::Ticket {
+                    number: 16,
+                    title: "the ticket".to_string(),
+                    ticket_type: TicketType::Build,
+                    stage: Launchable::Ready,
+                    prs: vec![],
+                },
+                map: map_ref(1),
+                route: Route::One,
+                mode: interactive(""),
+            },
+            isolation: Isolation::Host,
+        };
+        assert_eq!(one.agent_argv().last().map(String::as_str), Some("/wf-one"));
     }
 
     #[test]
@@ -2880,6 +3132,10 @@ mod tests {
         (built(Isolation::Devlaunch), built(Isolation::Host))
     }
 
+    /// Names the scratch directory each recovery runs in, so two calls in one
+    /// test process cannot read each other's leavings.
+    static NEXT_SCRATCH: AtomicUsize = AtomicUsize::new(0);
+
     /// The argument vector a container would actually run, recovered by giving
     /// the single shell command `dl` passes to `devpod ssh --command` to a
     /// **real POSIX shell**.
@@ -2890,10 +3146,26 @@ mod tests {
     /// splitting and quote removal a command line gets, without running the
     /// agent, and NUL separation keeps a recovered argument's own spaces from
     /// being mistaken for a boundary.
+    ///
+    /// The shell runs in a scratch directory of its own, and the directory is
+    /// asserted empty afterwards. The fixture title carries `$(touch pwned)`
+    /// precisely so that a broken [`shell_quote`] is caught by *evidence the
+    /// substitution ran* rather than by an argv mismatch alone — but a canary
+    /// dropped in whatever directory `cargo test` happened to start in is
+    /// litter, and once got committed to this public repo. Relative to the
+    /// shell's own cwd it lands here instead, where the emptiness check reads
+    /// it: the canary got stronger (nothing asserted on it before) and stopped
+    /// writing outside its own scratch.
     fn container_argv(launch: &Launch) -> Vec<String> {
         let argv = launch.agent_argv();
         assert_eq!(argv[0], DEVLAUNCH, "the isolated form is a `dl` launch");
         assert_eq!(argv[2], "--", "the agent command follows a bare `--`");
+        let scratch = std::env::temp_dir().join(format!(
+            "wf-seam-{}-{}",
+            std::process::id(),
+            NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&scratch).expect("a scratch directory for the shell");
         let script = format!(
             "set -- {}\nfor arg; do printf '%s\\0' \"$arg\"; done",
             argv[3]
@@ -2901,12 +3173,23 @@ mod tests {
         let out = Command::new("sh")
             .arg("-c")
             .arg(&script)
+            .current_dir(&scratch)
             .output()
             .expect("a POSIX shell");
         assert!(
             out.status.success(),
             "the container's shell refused the command {:?}",
             argv[3]
+        );
+        let spilled: Vec<_> = std::fs::read_dir(&scratch)
+            .expect("the scratch directory outlives the shell")
+            .map(|entry| entry.expect("a readable entry").file_name())
+            .collect();
+        std::fs::remove_dir_all(&scratch).expect("the scratch directory is ours to remove");
+        assert!(
+            spilled.is_empty(),
+            "the shell executed something the quoting should have made inert, \
+             leaving {spilled:?} behind"
         );
         let recovered = String::from_utf8(out.stdout).expect("the arguments are utf-8");
         let mut words: Vec<String> = recovered.split('\0').map(str::to_string).collect();

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -2855,6 +2855,127 @@ mod tests {
         assert_eq!(shell_quote(""), "''");
     }
 
+    /// The same node launched both ways — into a container and on the host —
+    /// so the container seam can be asserted against what the host's agent is
+    /// handed, rather than against a second spelling of it.
+    fn both_ways(title: &str, route: Route, mode: LaunchMode) -> (Launch, Launch) {
+        let job = Job::Node {
+            aim: Aim::Ticket {
+                number: 80,
+                title: title.to_string(),
+                ticket_type: TicketType::Task,
+                stage: Launchable::Ready,
+                prs: vec![],
+            },
+            map: map_ref(67),
+            route,
+            mode,
+        };
+        let built = |isolation| Launch {
+            repo: "blooop/wayfinder".to_string(),
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            job: job.clone(),
+            isolation,
+        };
+        (built(Isolation::Devlaunch), built(Isolation::Host))
+    }
+
+    /// The argument vector a container would actually run, recovered by giving
+    /// the single shell command `dl` passes to `devpod ssh --command` to a
+    /// **real POSIX shell**.
+    ///
+    /// A hand-written inverse of [`shell_quote`] would only prove this module
+    /// agrees with itself; `sh` is the thing on the other side of the seam, so
+    /// it is what does the unquoting here. `set --` performs exactly the word
+    /// splitting and quote removal a command line gets, without running the
+    /// agent, and NUL separation keeps a recovered argument's own spaces from
+    /// being mistaken for a boundary.
+    fn container_argv(launch: &Launch) -> Vec<String> {
+        let argv = launch.agent_argv();
+        assert_eq!(argv[0], DEVLAUNCH, "the isolated form is a `dl` launch");
+        assert_eq!(argv[2], "--", "the agent command follows a bare `--`");
+        let script = format!(
+            "set -- {}\nfor arg; do printf '%s\\0' \"$arg\"; done",
+            argv[3]
+        );
+        let out = Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .output()
+            .expect("a POSIX shell");
+        assert!(
+            out.status.success(),
+            "the container's shell refused the command {:?}",
+            argv[3]
+        );
+        let recovered = String::from_utf8(out.stdout).expect("the arguments are utf-8");
+        let mut words: Vec<String> = recovered.split('\0').map(str::to_string).collect();
+        assert_eq!(
+            words.pop().as_deref(),
+            Some(""),
+            "every argument is NUL-terminated"
+        );
+        words
+    }
+
+    #[test]
+    fn the_containers_own_shell_hands_the_agent_what_the_host_would() {
+        // The seam the ticket insists on: an isolated launch's prompt is not
+        // an argv entry by the time it arrives — `dl` joins everything after
+        // `--` and hands one string to `devpod ssh --command`, which a shell
+        // inside the container parses. So the claim is that the shell rebuilds
+        // the context block byte for byte, with a title carrying every
+        // character that would end the argument early if the quoting were
+        // wrong: a single quote, a command substitution and a double quote.
+        let (contained, host) = both_ways(
+            r#"don't $(touch pwned) "x""#,
+            Route::Tdd,
+            interactive("merge when green"),
+        );
+        assert_eq!(container_argv(&contained), host.agent_argv());
+        assert_eq!(
+            host.agent_argv(),
+            vec![
+                "claude".to_string(),
+                Agent::Claude.skip_permissions().to_string(),
+                concat!(
+                    r#"/wf-tdd 80 ctx: {"v":1,"repo":"blooop/wayfinder","#,
+                    r#""map":{"repo":"blooop/wayfinder","number":67,"title":"the dev-process tree"},"#,
+                    r#""aim":{"ticket":{"number":80,"title":"don't $(touch pwned) \"x\"","#,
+                    r#""ticket_type":"task","stage":"ready","prs":[]}}} steer: merge when green"#
+                )
+                .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_map_launch_survives_the_container_seam_too() {
+        // The other aim, and the plain session that carries no block at all:
+        // both have to come back out of the shell as they went in.
+        let (contained, host) = both_ways("the ticket", Route::Plain, plain("look around"));
+        assert_eq!(container_argv(&contained), host.agent_argv());
+        let map = Launch {
+            repo: "blooop/wayfinder".to_string(),
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            job: Job::Node {
+                aim: Aim::Map,
+                map: map_ref(67),
+                route: Route::WayfinderAuto,
+                mode: auto(""),
+            },
+            isolation: Isolation::Devlaunch,
+        };
+        assert_eq!(
+            container_argv(&map).last().expect("a prompt"),
+            concat!(
+                r#"/wf-auto 67 ctx: {"v":1,"repo":"blooop/wayfinder","#,
+                r#""map":{"repo":"blooop/wayfinder","number":67,"title":"the dev-process tree"},"#,
+                r#""aim":"map"}"#
+            )
+        );
+    }
+
     #[test]
     fn the_notice_names_the_container_when_there_is_one_and_stays_quiet_otherwise() {
         // An isolated launch works in its workspace, not in the checkout —

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -36,7 +36,9 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use crate::model::{MapId, Stage, Ticket, TicketType};
+use serde::Serialize;
+
+use crate::model::{MapId, PrLink, Stage, Ticket, TicketType};
 use crate::projects::Checkout;
 
 /// Which interactive coding agent `wf` becomes after a launch.
@@ -520,7 +522,12 @@ impl LaunchMode {
 /// no `Option` for the three later steps to carry, wonder about and re-refuse.
 /// Blocked never reaches here at all: blocked is [`crate::model::Status`], not
 /// a stage, and the picker refuses it before anything is staged.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// This is also the stage the launch *hands the agent* in its context block,
+/// and deliberately the same type rather than a copy of it: a handed context
+/// claiming a done node is a compile error rather than a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Launchable {
     Ready,
     Building,
@@ -550,17 +557,91 @@ impl Launchable {
 /// from a node's PRs and a map has none. So the two are arms of one sum rather
 /// than a ticket struct with optional fields, and every consumer that needs a
 /// ticket number has to say which case it is answering.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// It is also what a launch hands its agent as the `aim` of the context block
+/// (#124), serialized **directly**. A parallel `CtxAim` mirroring these arms
+/// would be the same sum written twice and free to drift; one type serialized
+/// once cannot disagree with itself, and the wire spelling is pinned by the
+/// golden literals in this module's tests rather than by a second declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Aim {
     /// The cluster header: the map itself, charted or driven as a whole.
     Map,
-    /// One ticket in the map, carrying the pair its route turns on.
+    /// One ticket in the map, carrying the pair its route turns on — and the
+    /// facts an agent would otherwise rediscover from the tracker before it
+    /// could start: what the ticket is called, and which PRs are linked to it.
+    ///
+    /// What is *not* here is the claim. There is no assignee and no ticket
+    /// status, so the one fact whose staleness is dangerous — is this still
+    /// mine to take — cannot be read out of a handed context at all, and
+    /// "orient from it, verify live" is a shape rather than a rule to
+    /// remember. Blockers are absent for a different reason: the picker
+    /// refuses a blocked node before anything is staged, so a launched ticket
+    /// never has open ones.
     Ticket {
         number: u64,
+        title: String,
         ticket_type: TicketType,
         stage: Launchable,
+        prs: Vec<PrLink>,
     },
 }
+
+/// The map a launch was picked in: its identity *and* its title (#124).
+///
+/// Carries the whole [`MapId`] rather than a bare issue number because a
+/// ticket can sit on a map in another repo — the tracker models it and the
+/// fetch parses it — so a number alone would point a cross-repo launch at
+/// whatever issue happens to hold that number in the ticket's own repo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MapRef {
+    /// Flattened, so the map reads as one object (`repo`, `number`, `title`)
+    /// rather than an identity nested inside a wrapper.
+    #[serde(flatten)]
+    pub id: MapId,
+    /// The map issue's title as the picker showed it.
+    pub title: String,
+}
+
+impl MapRef {
+    /// The map under `id`, titled as the cluster header reads.
+    pub fn new(id: &MapId, title: &str) -> MapRef {
+        MapRef {
+            id: id.clone(),
+            title: title.to_string(),
+        }
+    }
+}
+
+/// What a launch hands its agent in the prompt's `ctx:` block (#124): a
+/// snapshot of what `wf` already knew at exec time, so the session's first
+/// tracker call can be the **claim** rather than a rediscovery of the map, the
+/// ticket and its PRs.
+///
+/// A borrowed, serialize-only view over the launch's own facts — never a
+/// parallel copy of them. Nothing here is a new fact: `wf` fetched every field
+/// to draw the row the human picked.
+///
+/// Deliberately **not** carrying a snapshot instant. No consumer in the
+/// contract reads one — the staleness guard is the mandatory live claim, not a
+/// timestamp comparison — and reading a wall clock would make prompt building
+/// non-deterministic for no gain.
+#[derive(Debug, Serialize)]
+struct LaunchContext<'a> {
+    /// Schema version, and the reading agent's first gate: a `v` it does not
+    /// recognise means discard the block whole and discover as it always did.
+    v: u32,
+    /// The ticket's own repo, full slug — the anchor a reader compares
+    /// against its pinned `$REPO` before trusting anything else here.
+    repo: &'a str,
+    map: &'a MapRef,
+    aim: &'a Aim,
+}
+
+/// The schema this binary writes. Bumped only when a reader that understands
+/// the old shape would misread the new one.
+const CONTEXT_VERSION: u32 = 1;
 
 /// Resolve which skill a launch runs, from what it is aimed at and who is
 /// deciding. Total on every axis (#96): adding a stage, a type or a mode
@@ -633,9 +714,6 @@ pub struct Staged {
     /// What was stood on: a node fetched from the tracker, or a registered
     /// repo with no map at all.
     pub at: StagedAt,
-    /// Its title as it read when the picker opened — the picker is showing the
-    /// human what they picked, not re-reporting a row that may have moved.
-    pub title: String,
 }
 
 /// What the picker was opened on (#114). A map-less repo is not a node with a
@@ -644,16 +722,16 @@ pub struct Staged {
 /// than a node struct with optional fields. Which rows the picker offers falls
 /// out of this: a node launches (and a map also creates), a bare repo only
 /// creates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StagedAt {
     /// A node the tracker knows about.
     Node {
         /// What the launch picker names: the map, or one ticket in it.
         aim: Aim,
-        /// The map issue of the cluster the row was picked in (#50) — which
-        /// map a ticket listed twice was launched from, and the launch target
-        /// itself when the cursor was on the cluster header.
-        map_issue: u64,
+        /// The map of the cluster the row was picked in (#50) — which map a
+        /// ticket listed twice was launched from, and the launch target itself
+        /// when the cursor was on the cluster header.
+        map: MapRef,
     },
     /// A registered checkout whose repo has no open map: the empty-state door
     /// this repo's *first* map is charted from.
@@ -661,35 +739,35 @@ pub enum StagedAt {
 }
 
 impl Staged {
-    /// Stage a launch of `ticket`, picked in the cluster of `map_issue`.
-    /// `None` for a finished ticket, which has no launchable stage — the one
-    /// refusal, made here so that everything downstream is total.
-    pub fn ticket(ticket: &Ticket, map_issue: u64, stage: Stage) -> Option<Staged> {
+    /// Stage a launch of `ticket`, picked in the cluster of `map`. `None` for a
+    /// finished ticket, which has no launchable stage — the one refusal, made
+    /// here so that everything downstream is total.
+    pub fn ticket(ticket: &Ticket, map: &MapRef, stage: Stage) -> Option<Staged> {
         Some(Staged {
             repo: ticket.repo.clone(),
             at: StagedAt::Node {
                 aim: Aim::Ticket {
                     number: ticket.number,
+                    title: ticket.title.clone(),
                     ticket_type: ticket.ticket_type,
                     stage: Launchable::parse(stage)?,
+                    prs: ticket.prs.clone(),
                 },
-                map_issue,
+                map: map.clone(),
             },
-            title: ticket.title.clone(),
         })
     }
 
     /// Stage a launch of a whole map — the cursor was on its cluster header.
     /// Total, unlike the ticket case: a map has no stage to be finished at,
     /// and a finished map is not on screen to put the cursor on.
-    pub fn map(id: &MapId, title: &str) -> Staged {
+    pub fn map(map: &MapRef) -> Staged {
         Staged {
-            repo: id.repo.clone(),
+            repo: map.id.repo.clone(),
             at: StagedAt::Node {
                 aim: Aim::Map,
-                map_issue: id.number,
+                map: map.clone(),
             },
-            title: title.to_string(),
         }
     }
 
@@ -699,7 +777,25 @@ impl Staged {
         Staged {
             repo: repo.to_string(),
             at: StagedAt::Project,
-            title: "no map".to_string(),
+        }
+    }
+
+    /// How the staged stop reads to the human: the ticket's title, the map's,
+    /// or the map-less door's own words.
+    ///
+    /// Derived rather than stored (#124). The title the picker draws and the
+    /// title the launch hands the agent are one fact, and a second copy beside
+    /// the aim would be a field free to disagree with it.
+    pub fn title(&self) -> &str {
+        match &self.at {
+            StagedAt::Node {
+                aim: Aim::Ticket { title, .. },
+                ..
+            } => title,
+            StagedAt::Node {
+                aim: Aim::Map, map, ..
+            } => &map.title,
+            StagedAt::Project => "no map",
         }
     }
 
@@ -734,17 +830,17 @@ impl Staged {
     /// merge concerns the stop grammar keeps apart. The map-less door has no
     /// node, so it offers the creation rows alone.
     pub fn candidates(&self) -> Vec<Candidate> {
-        let launches = |aim: Aim| {
+        let launches = |aim: &Aim| {
             Mode::all()
                 .into_iter()
-                .map(move |mode| Candidate::Launch {
+                .map(|mode| Candidate::Launch {
                     mode,
-                    route: route(&aim, mode),
+                    route: route(aim, mode),
                 })
                 .collect::<Vec<_>>()
         };
         let creations = || CreationKind::all().into_iter().map(Candidate::Create);
-        match self.at {
+        match &self.at {
             StagedAt::Node {
                 aim: aim @ Aim::Ticket { .. },
                 ..
@@ -764,10 +860,7 @@ impl Staged {
     /// name until a skill files one.
     pub fn key(&self) -> String {
         match &self.at {
-            StagedAt::Node {
-                aim: Aim::Map,
-                map_issue,
-            } => format!("#{map_issue}"),
+            StagedAt::Node { aim: Aim::Map, map } => format!("#{}", map.id.number),
             StagedAt::Node {
                 aim: Aim::Ticket { number, .. },
                 ..
@@ -798,10 +891,10 @@ impl Staged {
     ///   as backing out.
     pub fn node_workspace(&self) -> Option<String> {
         match &self.at {
-            StagedAt::Node { aim, map_issue } => Some(node_workspace_name(
+            StagedAt::Node { aim, map } => Some(node_workspace_name(
                 &self.repo,
                 match aim {
-                    Aim::Map => *map_issue,
+                    Aim::Map => map.id.number,
                     Aim::Ticket { number, .. } => *number,
                 },
             )),
@@ -944,9 +1037,10 @@ enum Job {
     Node {
         /// The map, or one ticket in it.
         aim: Aim,
-        /// The map issue — `/wf`'s first argument, and its only one when the
-        /// aim is the map itself.
-        map_issue: u64,
+        /// The map the node was picked in — `/wf`'s first argument, its only
+        /// one when the aim is the map itself, and half of what the launch
+        /// hands the agent (#124).
+        map: MapRef,
         /// The skill this launch execs, resolved from (type, stage).
         route: Route,
         /// What the launch picker settled on. The mode half already picked
@@ -967,8 +1061,8 @@ impl Job {
     /// — they are two renderings of the same fact.
     fn number(&self) -> Option<u64> {
         match self {
-            Job::Node { aim, map_issue, .. } => Some(match aim {
-                Aim::Map => *map_issue,
+            Job::Node { aim, map, .. } => Some(match aim {
+                Aim::Map => map.id.number,
                 Aim::Ticket { number, .. } => *number,
             }),
             Job::Create { .. } => None,
@@ -1066,31 +1160,49 @@ impl Launch {
         argv
     }
 
-    /// The selected agent's skill invocation and arguments for a node. Plain
-    /// mode has no skill, while creation prompts are built by [`Creation`].
+    /// The selected agent's skill invocation, its arguments, and the context
+    /// block that follows them (#124). Plain mode has no skill, while creation
+    /// prompts are built by [`Creation`].
+    ///
+    /// The block goes **after** the skill's own arguments and before any
+    /// ` steer: …` suffix [`LaunchMode::opening_prompt`] adds, which is the
+    /// whole grammar: `steer:`'s existing "everything after this is the
+    /// human's text" rule is undisturbed, and a steer containing the letters
+    /// `ctx:` cannot be mistaken for a block.
+    ///
+    /// A creation is handed none because it names nothing that exists yet, and
+    /// a plain session because there is no skill for it to be addressed to.
+    ///
+    /// The `expect` on the serializer is unreachable: [`LaunchContext`] is a
+    /// fixed set of strings, integers and unit enums, so every failure
+    /// `serde_json` defines for a serializer — a non-string map key, a
+    /// non-finite float, a `Serialize` impl that errors — is impossible here.
     fn skill_invocation(&self) -> Option<String> {
         let Job::Node {
-            aim,
-            map_issue,
-            route,
-            ..
+            aim, map, route, ..
         } = &self.job
         else {
             return None;
         };
         route.bundled_skill()?;
         let skill = route.invocation(self.agent());
-        match (route, aim) {
-            (Route::One, _) => Some(skill),
-            (_, Aim::Map) => Some(format!("{skill} {map_issue}")),
-            (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => {
-                Some(format!("{skill} {number}"))
-            }
+        let invocation = match (route, aim) {
+            (Route::One, _) => skill,
+            (_, Aim::Map) => format!("{skill} {}", map.id.number),
+            (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => format!("{skill} {number}"),
             (Route::Wayfinder | Route::WayfinderAuto, Aim::Ticket { number, .. }) => {
-                Some(format!("{skill} {map_issue} {number}"))
+                format!("{skill} {} {number}", map.id.number)
             }
-            (Route::Plain, _) => None,
-        }
+            (Route::Plain, _) => return None,
+        };
+        let ctx = serde_json::to_string(&LaunchContext {
+            v: CONTEXT_VERSION,
+            repo: &self.repo,
+            map,
+            aim,
+        })
+        .expect("the launch context is plain data and always serializes");
+        Some(format!("{invocation} ctx: {ctx}"))
     }
 
     /// What `wf` becomes: the agent, or `dl` carrying the agent into the
@@ -1210,6 +1322,40 @@ fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
         .map(|dir| dir.join(program))
         .find(|candidate| candidate.is_file())
         .ok_or_else(|| anyhow::anyhow!("`{program}` is not on PATH — is it installed?"))
+}
+
+/// A launch prompt with the JSON of every `ctx:` block replaced by `…` (#124).
+///
+/// Test-only, and a reading aid rather than a parser: the block's own bytes
+/// are pinned byte-for-byte by the golden literals in this module's tests, so
+/// every *other* test — the ones about which skill a node routes to, where the
+/// steering suffix lands, and that the prompt is one argv entry — stays about
+/// what it is about instead of restating a snapshot. Brace counting is enough
+/// because the block is `serde_json`'s own output and no fixture title carries
+/// a brace.
+#[cfg(test)]
+pub(crate) fn eliding_ctx(prompt: &str) -> String {
+    let mut out = String::new();
+    let mut rest = prompt;
+    while let Some((head, json)) = rest.split_once(" ctx: {") {
+        out.push_str(head);
+        out.push_str(" ctx: …");
+        let mut depth = 1usize;
+        rest = "";
+        for (i, c) in json.char_indices() {
+            match c {
+                '{' => depth += 1,
+                '}' => depth -= 1,
+                _ => {}
+            }
+            if depth == 0 {
+                rest = &json[i + 1..];
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 /// The name half of a repo slug (`blooop/wayfinder` → `wayfinder`). Display
@@ -1387,7 +1533,7 @@ pub enum Targets {
 /// second derivation here, so what execs is what the row named (#114). This
 /// function answers only *where* the agent can run.
 pub fn plan(checkouts: &[Checkout], staged: &Staged, route: Route, mode: &LaunchMode) -> Targets {
-    let StagedAt::Node { aim, map_issue } = staged.at else {
+    let StagedAt::Node { aim, map } = &staged.at else {
         // Unreachable from the picker: [`Staged::candidates`] offers no launch
         // row on the map-less door, so nothing there can ask for a node
         // launch. Refusing rather than inventing a node — there is no aim and
@@ -1398,8 +1544,8 @@ pub fn plan(checkouts: &[Checkout], staged: &Staged, route: Route, mode: &Launch
         checkouts,
         &staged.repo,
         &Job::Node {
-            aim,
-            map_issue,
+            aim: aim.clone(),
+            map: map.clone(),
             route,
             mode: mode.clone(),
         },
@@ -1462,7 +1608,7 @@ fn resolve(checkouts: &[Checkout], repo: &str, job: &Job) -> Targets {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, Status, TicketType};
+    use crate::model::{classify, Checks, PrLink, PrStatus, Review, Status, TicketType};
 
     fn ticket(repo: &str, number: u64) -> Ticket {
         Ticket {
@@ -1474,6 +1620,15 @@ mod tests {
             blocked_by: vec![],
             prs: vec![],
         }
+    }
+
+    /// The map every ticket fixture is picked in — its own repo, number and
+    /// title, all three of which the launch hands the agent.
+    fn map_ref(number: u64) -> MapRef {
+        MapRef::new(
+            &MapId::new("blooop/wayfinder", number),
+            "the dev-process tree",
+        )
     }
 
     fn checkout(path: &str, repo: &str) -> Checkout {
@@ -1504,7 +1659,8 @@ mod tests {
     /// every checkout-resolution test wants (route and mode are orthogonal to
     /// which trees are candidates).
     fn plan_wf(checkouts: &[Checkout], ticket: &Ticket, map_issue: u64) -> Targets {
-        let staged = Staged::ticket(ticket, map_issue, Stage::Ready).expect("ready is launchable");
+        let staged =
+            Staged::ticket(ticket, &map_ref(map_issue), Stage::Ready).expect("ready is launchable");
         plan_picked(
             checkouts,
             &staged,
@@ -1556,10 +1712,9 @@ mod tests {
                 assert!(matches!(
                     &launch.job,
                     Job::Node {
-                        map_issue: 1,
                         aim: Aim::Ticket { number: 16, .. },
                         ..
-                    }
+                    } if launch.job.number() == Some(16)
                 ));
             }
             other => panic!("expected One, got {other:?}"),
@@ -1599,18 +1754,18 @@ mod tests {
             other => panic!("{other:?}"),
         };
         assert_eq!(
-            launch.agent_argv(),
+            elided_argv(&launch),
             vec![
                 "claude".to_string(),
                 Agent::Claude.skip_permissions().to_string(),
-                "/wf 1 16".to_string()
+                "/wf 1 16 ctx: …".to_string()
             ]
         );
     }
 
     #[test]
     fn the_agent_runs_codex_with_a_skill_mention_and_one_prompt_argument() {
-        let staged = Staged::ticket(&ticket("blooop/wayfinder", 16), 1, Stage::Ready)
+        let staged = Staged::ticket(&ticket("blooop/wayfinder", 16), &map_ref(1), Stage::Ready)
             .expect("ready is launchable");
         let launch = match plan(
             &cache(),
@@ -1622,11 +1777,11 @@ mod tests {
             other => panic!("{other:?}"),
         };
         assert_eq!(
-            launch.agent_argv(),
+            elided_argv(&launch),
             vec![
                 "codex".to_string(),
                 Agent::Codex.skip_permissions().to_string(),
-                "$wf 1 16 steer: try it".to_string(),
+                "$wf 1 16 ctx: … steer: try it".to_string(),
             ]
         );
     }
@@ -1681,8 +1836,8 @@ mod tests {
     fn a_ticket_picker_lists_exactly_the_three_launch_modes() {
         // #114: creation is a repo-level act, and a ticket is not a repo-level
         // stop — its picker stays the pure mode list, concerns unmerged.
-        let staged =
-            Staged::ticket(&ticket("blooop/wayfinder", 16), 1, Stage::Ready).expect("launchable");
+        let staged = Staged::ticket(&ticket("blooop/wayfinder", 16), &map_ref(1), Stage::Ready)
+            .expect("launchable");
         assert_eq!(
             staged.candidates(),
             vec![
@@ -1707,7 +1862,7 @@ mod tests {
         // rows, then the three ways to start something new in this repo. Each
         // candidate is complete — it carries its own resolved route, the
         // `Targets::Many` move — so a row and its launch cannot disagree.
-        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        let staged = Staged::map(&map_ref(59));
         let candidates = staged.candidates();
         assert_eq!(
             candidates,
@@ -1745,7 +1900,7 @@ mod tests {
         // a generic default.
         let mut node = ticket("blooop/wayfinder", 16);
         node.ticket_type = TicketType::Build;
-        let staged = Staged::ticket(&node, 1, Stage::Ready).expect("launchable");
+        let staged = Staged::ticket(&node, &map_ref(1), Stage::Ready).expect("launchable");
         assert_eq!(
             staged.candidates()[0],
             Candidate::Launch {
@@ -1955,7 +2110,7 @@ mod tests {
     fn ticket_argv(ticket_type: TicketType, stage: Stage, mode: &LaunchMode) -> Vec<String> {
         let mut node = ticket("blooop/wayfinder", 16);
         node.ticket_type = ticket_type;
-        let staged = Staged::ticket(&node, 1, stage).expect("a launchable stage");
+        let staged = Staged::ticket(&node, &map_ref(1), stage).expect("a launchable stage");
         match plan_picked(&cache(), &staged, mode) {
             Targets::One(l) => l.agent_argv(),
             other => panic!("{other:?}"),
@@ -1971,9 +2126,19 @@ mod tests {
             .clone()
     }
 
+    /// A prompt with its context block elided — see [`eliding_ctx`].
+    fn elided(prompt: &str) -> String {
+        eliding_ctx(prompt)
+    }
+
+    /// The whole argv of a launch, each entry read the same way.
+    fn elided_argv(launch: &Launch) -> Vec<String> {
+        launch.agent_argv().iter().map(|a| elided(a)).collect()
+    }
+
     /// The whole argv of a launch aimed at the whole map.
     fn map_argv(mode: &LaunchMode) -> Vec<String> {
-        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        let staged = Staged::map(&map_ref(59));
         match plan_picked(&cache(), &staged, mode) {
             Targets::One(l) => l.agent_argv(),
             other => panic!("{other:?}"),
@@ -1990,52 +2155,223 @@ mod tests {
         // The route picks the skill; only the wayfinder skills take the map
         // argument. The mode is *not* in the suffix — it chose the skill.
         assert_eq!(
-            ticket_prompt(TicketType::Build, Stage::Ready, &interactive("")),
-            "/wf-tdd 16"
+            elided(&ticket_prompt(
+                TicketType::Build,
+                Stage::Ready,
+                &interactive("")
+            )),
+            "/wf-tdd 16 ctx: …"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Build, Stage::InReview, &interactive("")),
-            "/wf-review 16"
+            elided(&ticket_prompt(
+                TicketType::Build,
+                Stage::InReview,
+                &interactive("")
+            )),
+            "/wf-review 16 ctx: …"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Grilling, Stage::Ready, &interactive("")),
-            "/wf 1 16"
+            elided(&ticket_prompt(
+                TicketType::Grilling,
+                Stage::Ready,
+                &interactive("")
+            )),
+            "/wf 1 16 ctx: …"
         );
         assert_eq!(
-            ticket_prompt(TicketType::Grilling, Stage::Ready, &auto("")),
-            "/wf-auto 1 16"
+            elided(&ticket_prompt(
+                TicketType::Grilling,
+                Stage::Ready,
+                &auto("")
+            )),
+            "/wf-auto 1 16 ctx: …"
         );
         // Steering rides as a suffix, whatever the route.
         assert_eq!(
-            ticket_prompt(
+            elided(&ticket_prompt(
                 TicketType::Grilling,
                 Stage::Ready,
                 &auto("skip the flaky suite")
-            ),
-            "/wf-auto 1 16 steer: skip the flaky suite"
+            )),
+            "/wf-auto 1 16 ctx: … steer: skip the flaky suite"
         );
+        assert_eq!(
+            elided(&ticket_prompt(
+                TicketType::Build,
+                Stage::Ready,
+                &interactive("try the other approach")
+            )),
+            "/wf-tdd 16 ctx: … steer: try the other approach"
+        );
+    }
+
+    /// The context block a build launch of the fixture node hands its agent —
+    /// the whole `ctx:` argument, spelt out rather than rebuilt from the
+    /// serializer, so a renamed field or a re-spelt variant fails here (#124).
+    const BUILD_CTX: &str = concat!(
+        r#"{"v":1,"repo":"blooop/wayfinder","#,
+        r#""map":{"repo":"blooop/wayfinder","number":1,"title":"the dev-process tree"},"#,
+        r#""aim":{"ticket":{"number":16,"title":"the ticket","#,
+        r#""ticket_type":"build","stage":"ready","prs":[]}}}"#
+    );
+
+    /// The `ctx:` block of a prompt, or `None` when it carries none.
+    fn ctx_of(prompt: &str) -> Option<&str> {
+        let block = prompt.split_once(" ctx: ")?.1;
+        Some(match block.split_once(" steer: ") {
+            Some((ctx, _)) => ctx,
+            None => block,
+        })
+    }
+
+    #[test]
+    fn a_ticket_launch_hands_the_agent_what_wf_already_knows() {
+        // #124: the discovery prelude every ticket launch runs today — which
+        // map, which PR, what type and stage — is answered in the prompt
+        // itself, so the agent's first tracker call can be the claim. Asserted
+        // as the whole literal argument, because *where* the block sits is the
+        // grammar: after the skill's own arguments, before any steering text.
+        assert_eq!(
+            ticket_prompt(TicketType::Build, Stage::Ready, &interactive("")),
+            format!("/wf-tdd 16 ctx: {BUILD_CTX}")
+        );
+        // A decision route keeps its map argument, and the block follows it.
+        assert_eq!(
+            ticket_prompt(TicketType::Grilling, Stage::Ready, &interactive("")),
+            format!(
+                "/wf 1 16 ctx: {}",
+                BUILD_CTX.replace(r#""ticket_type":"build""#, r#""ticket_type":"grilling""#)
+            )
+        );
+    }
+
+    #[test]
+    fn the_context_sits_between_the_skill_arguments_and_the_steering_text() {
+        // The `steer:` rule is untouched (#122): everything after it is the
+        // human's text, so the block goes in front of it and a steer that
+        // itself contains "ctx:" cannot be mistaken for one.
         assert_eq!(
             ticket_prompt(
                 TicketType::Build,
                 Stage::Ready,
                 &interactive("try the other approach")
             ),
-            "/wf-tdd 16 steer: try the other approach"
+            format!("/wf-tdd 16 ctx: {BUILD_CTX} steer: try the other approach")
         );
+    }
+
+    #[test]
+    fn a_map_launch_is_handed_the_map_and_names_no_ticket() {
+        // A map is not a ticket with missing fields: the aim serializes as the
+        // bare word, and the map's own identity is carried once, in `map`.
+        assert_eq!(
+            map_prompt(&interactive("")),
+            concat!(
+                r#"/wf 59 ctx: {"v":1,"repo":"blooop/wayfinder","#,
+                r#""map":{"repo":"blooop/wayfinder","number":59,"title":"the dev-process tree"},"#,
+                r#""aim":"map"}"#
+            )
+        );
+    }
+
+    #[test]
+    fn the_handed_context_carries_the_prs_a_reviewer_would_otherwise_hunt_for() {
+        // The rediscovery this exists to kill: a review launch's argv is a
+        // bare ticket number, so finding the PR to diff is a tracker round
+        // trip of its own. The link arrives with the launch instead —
+        // cross-repo capable, because the tracker's links are.
+        let mut node = ticket("blooop/wayfinder", 16);
+        node.ticket_type = TicketType::Build;
+        node.prs = vec![PrLink {
+            repo: "blooop/wayfinder".to_string(),
+            number: 90,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::Approved,
+            },
+        }];
+        let staged =
+            Staged::ticket(&node, &map_ref(1), Stage::InReview).expect("in review launches");
+        let prompt = match plan_picked(&cache(), &staged, &interactive("")) {
+            Targets::One(l) => l.agent_argv().last().expect("a prompt").clone(),
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(
+            prompt,
+            concat!(
+                r#"/wf-review 16 ctx: {"v":1,"repo":"blooop/wayfinder","#,
+                r#""map":{"repo":"blooop/wayfinder","number":1,"title":"the dev-process tree"},"#,
+                r#""aim":{"ticket":{"number":16,"title":"the ticket","ticket_type":"build","#,
+                r#""stage":"in_review","prs":[{"repo":"blooop/wayfinder","number":90,"#,
+                r#""status":{"open":{"checks":"passing","review":"approved"}}}]}}}"#
+            )
+        );
+    }
+
+    #[test]
+    fn the_handed_context_cannot_speak_about_the_claim() {
+        // The one fact whose staleness is dangerous — is this ticket still
+        // mine to take — is absent from the *type*, not merely from this
+        // fixture, so "trust it for orientation, re-read before mutating" is a
+        // shape rather than a rule to remember. The fixture node is unassigned
+        // and unblocked, so its own status vocabulary would show up here if it
+        // were ever serialized.
+        let ctx = ctx_of(&ticket_prompt(
+            TicketType::Build,
+            Stage::Ready,
+            &interactive(""),
+        ))
+        .expect("a ticket launch carries context")
+        .to_string();
+        for forbidden in [
+            "assignee",
+            "assignees",
+            "claim",
+            "frontier",
+            "blocked",
+            "needs",
+        ] {
+            assert!(
+                !ctx.contains(forbidden),
+                "{forbidden:?} must be unrepresentable in the handed context, got {ctx}"
+            );
+        }
+    }
+
+    #[test]
+    fn nothing_that_has_no_skill_to_address_is_handed_context() {
+        // The block is addressed to a skill. A plain session has none, and a
+        // creation names nothing that exists yet — so neither carries one, and
+        // the fallback path (a hand-invoked skill, which never saw the picker)
+        // stays exactly what it is today.
+        assert_eq!(
+            ctx_of(
+                &ticket_argv(TicketType::Build, Stage::Ready, &plain("rebase onto main")).join(" ")
+            ),
+            None
+        );
+        assert_eq!(ctx_of(&map_argv(&plain("")).join(" ")), None);
+        for (kind, text) in [
+            (CreationKind::Task, "wire the exporter"),
+            (CreationKind::Map, "a caching layer"),
+            (CreationKind::MapAuto, ""),
+        ] {
+            assert_eq!(ctx_of(&creation_argv(kind, text).join(" ")), None);
+        }
     }
 
     #[test]
     fn a_map_launch_is_the_skill_and_the_map_number_alone() {
         // No ticket argument exists to pass, so none is passed — the map aim
         // is the whole subject (#96).
-        assert_eq!(map_prompt(&interactive("")), "/wf 59");
-        assert_eq!(map_prompt(&auto("")), "/wf-auto 59");
+        assert_eq!(elided(&map_prompt(&interactive(""))), "/wf 59 ctx: …");
+        assert_eq!(elided(&map_prompt(&auto(""))), "/wf-auto 59 ctx: …");
         assert_eq!(
-            map_prompt(&auto("merge when green")),
-            "/wf-auto 59 steer: merge when green"
+            elided(&map_prompt(&auto("merge when green"))),
+            "/wf-auto 59 ctx: … steer: merge when green"
         );
         // A map's key is its own issue number, not a ticket's.
-        let staged = Staged::map(&MapId::new("blooop/wayfinder", 59), "the dev-process tree");
+        let staged = Staged::map(&map_ref(59));
         assert_eq!(staged.key(), "#59");
         match plan_picked(&cache(), &staged, &interactive("")) {
             Targets::One(l) => assert_eq!(l.key(), "wayfinder#59"),
@@ -2094,8 +2430,10 @@ mod tests {
     fn aim(ticket_type: TicketType, stage: Launchable) -> Aim {
         Aim::Ticket {
             number: 16,
+            title: "the ticket".to_string(),
             ticket_type,
             stage,
+            prs: vec![],
         }
     }
 
@@ -2215,7 +2553,7 @@ mod tests {
             let mut node = ticket("blooop/wayfinder", 16);
             node.ticket_type = ticket_type;
             assert_eq!(
-                Staged::ticket(&node, 1, Stage::Done),
+                Staged::ticket(&node, &map_ref(1), Stage::Done),
                 None,
                 "{ticket_type:?}"
             );
@@ -2320,10 +2658,12 @@ mod tests {
             job: Job::Node {
                 aim: Aim::Ticket {
                     number,
+                    title: "the ticket".to_string(),
                     ticket_type: TicketType::Task,
                     stage: Launchable::Ready,
+                    prs: vec![],
                 },
-                map_issue: 67,
+                map: map_ref(67),
                 route,
                 mode,
             },
@@ -2354,18 +2694,20 @@ mod tests {
         // prompt has to arrive already quoted or it lands as three arguments;
         // the workspace spec is a plain argv entry and is not quoted.
         assert_eq!(
-            isolated(Route::Wayfinder, interactive("")).agent_argv(),
+            elided_argv(&isolated(Route::Wayfinder, interactive(""))),
             vec![
                 "dl".to_string(),
                 "blooop/wayfinder@wayfinder/wayfinder-80".to_string(),
                 "--".to_string(),
-                "'claude' '--dangerously-skip-permissions' '/wf 67 80'".to_string(),
+                "'claude' '--dangerously-skip-permissions' '/wf 67 80 ctx: …'".to_string(),
             ]
         );
-        // The steering suffix rides inside the same quoted argument.
+        // The steering suffix rides inside the same quoted argument, after the
+        // context block.
         assert_eq!(
-            isolated(Route::WayfinderAuto, auto("merge when green")).agent_argv()[3],
-            "'claude' '--dangerously-skip-permissions' '/wf-auto 67 80 steer: merge when green'"
+            elided_argv(&isolated(Route::WayfinderAuto, auto("merge when green")))[3],
+            "'claude' '--dangerously-skip-permissions' \
+             '/wf-auto 67 80 ctx: … steer: merge when green'"
         );
     }
 
@@ -2397,13 +2739,16 @@ mod tests {
         // builds must be the one the second enter's `dl` finds. One naming
         // function serves both, and this pins that they cannot drift.
         let node = ticket("blooop/wayfinder", 80);
-        let staged = Staged::ticket(&node, 67, Stage::Ready).expect("launchable");
+        let staged = Staged::ticket(&node, &map_ref(67), Stage::Ready).expect("launchable");
         assert_eq!(
             staged.node_workspace().as_deref(),
             Some(isolated_ticket(80, Route::Tdd, interactive("")).agent_argv()[1].as_str())
         );
         // A staged map warms the map's own node, same as launching it.
-        let map = Staged::map(&MapId::new("blooop/wayfinder", 67), "the tree");
+        let map = Staged::map(&MapRef::new(
+            &MapId::new("blooop/wayfinder", 67),
+            "the tree",
+        ));
         assert_eq!(
             map.node_workspace().as_deref(),
             Some("blooop/wayfinder@wayfinder/wayfinder-67")
@@ -2449,7 +2794,7 @@ mod tests {
         // for a launch that will run on the host. An unregistered repo warms
         // nothing either — there is nothing to launch into at all.
         let node = ticket("blooop/wayfinder", 80);
-        let staged = Staged::ticket(&node, 67, Stage::Ready).expect("launchable");
+        let staged = Staged::ticket(&node, &map_ref(67), Stage::Ready).expect("launchable");
         assert_eq!(prewarm(&cache(), &staged), None);
         assert_eq!(prewarm(&[], &staged), None);
     }
@@ -2479,19 +2824,19 @@ mod tests {
             cwd: PathBuf::from("/data/proj/wayfinder"),
             job: Job::Node {
                 aim: Aim::Map,
-                map_issue: 67,
+                map: map_ref(67),
                 route: Route::WayfinderAuto,
                 mode: auto(""),
             },
             isolation: Isolation::Devlaunch,
         };
         assert_eq!(
-            launch.agent_argv(),
+            elided_argv(&launch),
             vec![
                 "dl".to_string(),
                 "blooop/wayfinder@wayfinder/wayfinder-67".to_string(),
                 "--".to_string(),
-                "'claude' '--dangerously-skip-permissions' '/wf-auto 67'".to_string(),
+                "'claude' '--dangerously-skip-permissions' '/wf-auto 67 ctx: …'".to_string(),
             ]
         );
     }
@@ -2502,8 +2847,8 @@ mod tests {
         // closes, escapes, reopens — the argument stays one argument.
         let launch = isolated(Route::Tdd, interactive("don't touch the CI; rm -rf /"));
         assert_eq!(
-            launch.agent_argv()[3],
-            r"'claude' '--dangerously-skip-permissions' '/wf-tdd 80 steer: don'\''t touch the CI; rm -rf /'"
+            elided_argv(&launch)[3],
+            r"'claude' '--dangerously-skip-permissions' '/wf-tdd 80 ctx: … steer: don'\''t touch the CI; rm -rf /'"
         );
         // Every metacharacter a shell would otherwise act on is inside quotes.
         assert_eq!(shell_quote("a b|c;d&e$f`g"), "'a b|c;d&e$f`g'");

--- a/src/main.rs
+++ b/src/main.rs
@@ -504,7 +504,7 @@ enum Ending {
     /// The user quit.
     Quit,
     /// A ticket was picked. `wf`'s last act is to become its agent.
-    Handover(Launch),
+    Handover(Box<Launch>),
 }
 
 /// The event loop. It starts with **no data at all** (#27): which repos even

--- a/src/model.rs
+++ b/src/model.rs
@@ -213,7 +213,11 @@ pub fn stage(prs: &[PrLink], status: &Status) -> Stage {
 /// ordinary value rather than a missing one. Every site that decides something
 /// from a type matches all six arms with no wildcard, which is what makes a
 /// new `wayfinder:*` type a compile error rather than a silent misreading.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serialized as its own snake-case name in the launch context (#124), so a
+/// launched agent is told how to open without re-reading the issue's labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TicketType {
     /// `wayfinder:build` — the one execution type (#61): a ticket that is a
     /// build contract, worked by `/tdd` and `/review` across its stages rather
@@ -313,7 +317,12 @@ impl TicketType {
 /// (closing keywords and manual links, mentions excluded; the #49 resolution),
 /// shown as a `⇄` badge on the ticket's row. Evidence of progress, never a row
 /// of its own (#47).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serialized straight into the launch context a picked ticket hands its agent
+/// (#124) — which PR to diff is `wf-review`'s whole rediscovery cost — rather
+/// than copied into a wire type beside this one, so there is nothing here for a
+/// second declaration to drift from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PrLink {
     /// Full slug of the repo the PR lives in. Links are cross-repo capable,
     /// so this may differ from the ticket's repo — the badge says so when it
@@ -334,7 +343,8 @@ impl PrLink {
 /// boundary, so "draft" is a state of its own rather than a flag to remember
 /// to check. Only an open, ready PR carries the live signals: checks and
 /// review are questions about something still in flight.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PrStatus {
     Draft,
     Open { checks: Checks, review: Review },
@@ -345,7 +355,8 @@ pub enum PrStatus {
 /// The check rollup on an open PR. `Absent` is its own meaning — no checks
 /// configured — parsed from the *nullable* `statusCheckRollup` (#49), not a
 /// stand-in for "unknown".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Checks {
     Absent,
     Pending,
@@ -356,7 +367,8 @@ pub enum Checks {
 /// The review decision on an open PR. A null `reviewDecision` means no review
 /// is required (#49) — `NotRequired`, a settled state — where `Required` is a
 /// review asked for and not yet given.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Review {
     NotRequired,
     Required,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -583,7 +583,7 @@ fn draw_launch_picker(
         agent.label(),
         staged.repo,
         staged.key(),
-        staged.title
+        staged.title()
     );
     let width = lines
         .iter()

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -397,7 +397,28 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     // line was empty). `/wf-auto` cannot appear — that needs the word
     // `auto` typed — and neither can a bare map launch, since the default
     // cursor skips cluster headers (#96).
-    let (skill, numbers) = prompt.split_once(' ').expect("a skill and arguments");
+    // A launched skill is handed the context `wf` already had (#124), as a
+    // one-line JSON block after the skill's own arguments. Split it off before
+    // the numeric checks below: it is the rest of the prompt, and the steering
+    // line was empty, so nothing follows it.
+    let (invocation, ctx) = prompt
+        .split_once(" ctx: ")
+        .unwrap_or_else(|| panic!("a launched skill carries its context: {prompt:?}"));
+    let ctx: serde_json::Value = serde_json::from_str(ctx)
+        .unwrap_or_else(|e| panic!("the context block is JSON: {e} in {prompt:?}"));
+    assert_eq!(ctx["v"], 1, "the schema this binary writes");
+    assert_eq!(
+        ctx["repo"], "blooop/wayfinder",
+        "the context is anchored to the repo the launch was picked in"
+    );
+    // The claim is unrepresentable in the schema, which is what makes the
+    // block safe to orient from: whatever the live tracker said about this
+    // node, no assignee can have reached the agent.
+    let flat = ctx.to_string();
+    for forbidden in ["assignee", "claim"] {
+        assert!(!flat.contains(forbidden), "{forbidden:?} in {flat}");
+    }
+    let (skill, numbers) = invocation.split_once(' ').expect("a skill and arguments");
     let halves: Vec<&str> = match skill {
         "/wf" => numbers.splitn(2, ' ').collect(),
         "/wf-tdd" | "/wf-review" => vec![numbers],

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -78,3 +78,124 @@ fn frontier_mirrors_the_binary_map_query() {
         "every snippet in the doc targets $REPO explicitly:\n{snippet}"
     );
 }
+
+/// One skill doc's whole text.
+fn skill_doc(name: &str) -> String {
+    let path = format!("{}/skills/{name}/SKILL.md", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{path} ships in this repo: {e}"))
+}
+
+/// The tracker doc's `## The launch context (`ctx:`)` section — the shared
+/// consumer contract all five skills read (#124).
+fn context_section() -> String {
+    let doc = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/skills/wf/GITHUB_TRACKER.md"
+    ))
+    .expect("the tracker doc ships in this repo");
+    doc.split("## The launch context")
+        .nth(1)
+        .expect("the tracker doc documents the launch context block")
+        .split("\n## ")
+        .next()
+        .expect("split always yields a first piece")
+        .to_string()
+}
+
+/// The prompt a real ticket launch execs — what the docs below describe.
+///
+/// Built through the binary's own launch path rather than quoted, because the
+/// point of these checks is that the docs and the code cannot drift: a bumped
+/// schema version or a re-spelt block prefix has to fail here.
+fn launched_prompt() -> String {
+    let checkout = wf::projects::Checkout {
+        path: std::path::PathBuf::from("/data/proj/wayfinder"),
+        repo: "blooop/wayfinder".to_string(),
+    };
+    let ticket = wf::model::Ticket {
+        repo: "blooop/wayfinder".to_string(),
+        number: 16,
+        title: "the ticket".to_string(),
+        status: wf::model::classify(true, false, vec![]),
+        ticket_type: wf::model::TicketType::Build,
+        blocked_by: vec![],
+        prs: vec![],
+    };
+    let map = wf::launch::MapRef::new(&wf::model::MapId::new("blooop/wayfinder", 1), "the map");
+    let staged = wf::launch::Staged::ticket(&ticket, &map, wf::model::Stage::Ready)
+        .expect("ready is launchable");
+    let mode = wf::launch::LaunchMode::picked(
+        wf::launch::Agent::Claude,
+        wf::launch::Mode::Interactive,
+        "",
+    );
+    let route = staged.route(mode.mode()).expect("a node stop launches");
+    match wf::launch::plan(&[checkout], &staged, route, &mode) {
+        wf::launch::Targets::One(launch) => launch
+            .agent_argv()
+            .last()
+            .expect("a ticket launch has a prompt")
+            .clone(),
+        other => panic!("expected one candidate checkout, got {other:?}"),
+    }
+}
+
+/// The block the docs teach agents to read is the block the binary writes:
+/// same prefix, same schema version.
+#[test]
+fn the_documented_context_block_is_the_one_a_launch_writes() {
+    let prompt = launched_prompt();
+    let section = context_section();
+    let block = prompt
+        .split_once(" ctx: ")
+        .unwrap_or_else(|| panic!("a launched skill carries its context: {prompt}"))
+        .1;
+    assert!(
+        section.contains("`ctx: <json>`"),
+        "the section must quote the block's own spelling:\n{section}"
+    );
+    assert!(
+        block.starts_with(r#"{"v":1,"#),
+        "the block is versioned one-line JSON: {block}"
+    );
+    assert!(
+        section.contains("`v`"),
+        "the version gate is the first thing a reader checks:\n{section}"
+    );
+}
+
+/// The contract is *accelerator, never precondition*, and every failure mode
+/// resolves to the same move — discard the block whole and discover as a
+/// hand-invoked session always has.
+#[test]
+fn the_context_section_states_the_fallback_and_the_live_read() {
+    let section = context_section();
+    for phrase in [
+        "accelerator, never a precondition",
+        "live read",
+        "ignore it entirely",
+    ] {
+        assert!(
+            section.contains(phrase),
+            "the contract must say {phrase:?}:\n{section}"
+        );
+    }
+}
+
+/// Every shipped skill names the block in its own invocation grammar — a
+/// consumer that never learns of it would keep paying the discovery cost the
+/// block exists to remove.
+#[test]
+fn every_bundled_skill_documents_the_context_in_its_grammar() {
+    for name in wf::skills::BUNDLED {
+        let doc = skill_doc(name);
+        assert!(
+            doc.contains("ctx: <json>"),
+            "{name} must name the launch context in its invocation grammar"
+        );
+        assert!(
+            doc.contains("GITHUB_TRACKER.md"),
+            "{name} must point at the shared contract rather than restating it"
+        );
+    }
+}

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -9,6 +9,13 @@
 //! Offline by design, unlike the `live_*` binaries: the seam is the doc text
 //! itself, so no network is involved.
 
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+use serde_json::Value;
+use wf::launch::{Aim, Launchable, MapRef};
+use wf::model::{Checks, MapId, PrLink, PrStatus, Review, Stage, Ticket, TicketType};
+
 /// The fenced bash snippet under the tracker doc's `## Frontier query`
 /// heading — the exact text an agent copies to derive the frontier.
 fn frontier_snippet() -> String {
@@ -104,26 +111,17 @@ fn context_section() -> String {
 
 /// The prompt a real ticket launch execs — what the docs below describe.
 ///
-/// Built through the binary's own launch path rather than quoted, because the
-/// point of these checks is that the docs and the code cannot drift: a bumped
-/// schema version or a re-spelt block prefix has to fail here.
-fn launched_prompt() -> String {
+/// Built through the binary's own launch path rather than quoted, because
+/// these checks exist to bind the docs to the code: the block's prefix, its
+/// schema version, its field names and its value vocabularies all have to come
+/// from the launch itself, or the docs are only checked against a second copy
+/// of themselves.
+fn launched_prompt(ticket: &Ticket, map: &MapRef, stage: Stage) -> String {
     let checkout = wf::projects::Checkout {
-        path: std::path::PathBuf::from("/data/proj/wayfinder"),
-        repo: "blooop/wayfinder".to_string(),
+        path: std::path::PathBuf::from("/data/proj/checkout"),
+        repo: ticket.repo.clone(),
     };
-    let ticket = wf::model::Ticket {
-        repo: "blooop/wayfinder".to_string(),
-        number: 16,
-        title: "the ticket".to_string(),
-        status: wf::model::classify(true, false, vec![]),
-        ticket_type: wf::model::TicketType::Build,
-        blocked_by: vec![],
-        prs: vec![],
-    };
-    let map = wf::launch::MapRef::new(&wf::model::MapId::new("blooop/wayfinder", 1), "the map");
-    let staged = wf::launch::Staged::ticket(&ticket, &map, wf::model::Stage::Ready)
-        .expect("ready is launchable");
+    let staged = wf::launch::Staged::ticket(ticket, map, stage).expect("a launchable stage");
     let mode = wf::launch::LaunchMode::picked(
         wf::launch::Agent::Claude,
         wf::launch::Mode::Interactive,
@@ -140,16 +138,83 @@ fn launched_prompt() -> String {
     }
 }
 
+/// The `ctx:` block of that prompt — the JSON text on its own.
+fn launched_block(ticket: &Ticket, map: &MapRef, stage: Stage) -> String {
+    let prompt = launched_prompt(ticket, map, stage);
+    prompt
+        .split_once(" ctx: ")
+        .unwrap_or_else(|| panic!("a launched skill carries its context: {prompt}"))
+        .1
+        .to_string()
+}
+
+/// The node the tracker doc's worked example describes, field for field.
+///
+/// The example is the docs' most load-bearing sentence — it is what a skill
+/// author reads to learn the field names — so the fixture is built to match it
+/// and the launch is asked what it actually writes.
+fn documented_example_node() -> (Ticket, MapRef) {
+    let ticket = Ticket {
+        repo: "owner/name".to_string(),
+        number: 124,
+        title: "the ticket's title".to_string(),
+        status: wf::model::classify(true, false, vec![]),
+        ticket_type: TicketType::Build,
+        blocked_by: vec![],
+        prs: vec![PrLink {
+            repo: "owner/name".to_string(),
+            number: 130,
+            status: PrStatus::Open {
+                checks: Checks::Passing,
+                review: Review::Required,
+            },
+        }],
+    };
+    let map = MapRef::new(&MapId::new("owner/name", 121), "the map's title");
+    (ticket, map)
+}
+
+/// The fenced `json` example under the context section, parsed.
+fn documented_example() -> Value {
+    let section = context_section();
+    let fenced = section
+        .split("```json")
+        .nth(1)
+        .expect("the context section shows the block it documents")
+        .split("```")
+        .next()
+        .expect("split always yields a first piece");
+    serde_json::from_str(fenced).expect("the documented example is valid JSON")
+}
+
+/// The docs' worked example **is** the JSON a launch writes — every field
+/// name, every nesting, every value.
+///
+/// Compared as parsed JSON rather than as text, so the doc stays free to
+/// pretty-print and reorder; what it may not do is rename a field or respell a
+/// value on one side only. Renaming `repo` to `repository` in either the doc
+/// or the type turns this red, which is the whole reason the block is worth
+/// documenting: a skill can rely on the published names.
+#[test]
+fn the_documented_example_is_the_block_a_launch_writes() {
+    let (ticket, map) = documented_example_node();
+    let block = launched_block(&ticket, &map, Stage::InReview);
+    let emitted: Value =
+        serde_json::from_str(&block).unwrap_or_else(|e| panic!("the block is JSON: {block} ({e})"));
+    assert_eq!(
+        emitted,
+        documented_example(),
+        "the documented example and the emitted block have drifted; emitted:\n{block}"
+    );
+}
+
 /// The block the docs teach agents to read is the block the binary writes:
 /// same prefix, same schema version.
 #[test]
 fn the_documented_context_block_is_the_one_a_launch_writes() {
-    let prompt = launched_prompt();
+    let (ticket, map) = documented_example_node();
+    let block = launched_block(&ticket, &map, Stage::Ready);
     let section = context_section();
-    let block = prompt
-        .split_once(" ctx: ")
-        .unwrap_or_else(|| panic!("a launched skill carries its context: {prompt}"))
-        .1;
     assert!(
         section.contains("`ctx: <json>`"),
         "the section must quote the block's own spelling:\n{section}"
@@ -162,6 +227,140 @@ fn the_documented_context_block_is_the_one_a_launch_writes() {
         section.contains("`v`"),
         "the version gate is the first thing a reader checks:\n{section}"
     );
+}
+
+/// One backticked word, as the wire spells a value: a bare string for a unit
+/// variant, and the single tag key for a variant that carries data.
+fn wire_word<T: Serialize>(value: &T) -> String {
+    match serde_json::to_value(value).expect("the context schema is plain data") {
+        Value::String(word) => word,
+        Value::Object(fields) if fields.len() == 1 => {
+            fields.keys().next().expect("one key").clone()
+        }
+        other => panic!("a wire word is a string or a one-key object, got {other}"),
+    }
+}
+
+/// The whole vocabulary of one enumerated field, as serde spells it.
+fn vocabulary<T: Serialize>(values: &[T]) -> BTreeSet<String> {
+    values.iter().map(wire_word).collect()
+}
+
+/// One value of every arm of the aim sum — the wire only ever sees the tag.
+fn every_aim() -> Vec<Aim> {
+    vec![
+        Aim::Map,
+        Aim::Ticket {
+            number: 1,
+            title: String::new(),
+            ticket_type: TicketType::Build,
+            stage: Launchable::Ready,
+            prs: vec![],
+        },
+    ]
+}
+
+/// One value of every arm of the PR-status sum, likewise.
+fn every_pr_status() -> Vec<PrStatus> {
+    vec![
+        PrStatus::Draft,
+        PrStatus::Open {
+            checks: Checks::Absent,
+            review: Review::NotRequired,
+        },
+        PrStatus::Merged,
+        PrStatus::Closed,
+    ]
+}
+
+/// Every value each enumerated field of the block can hold, as serde spells
+/// it — the answer coming from the same serializer the launch itself runs, so
+/// a `rename_all` change moves this side without anyone editing it.
+///
+/// Adding a variant to any of these types is already a compile error in
+/// `src/launch.rs`, where each word is pinned to a golden literal by an
+/// exhaustive `match`; this side is what then forces the docs to learn it.
+fn emitted_vocabularies() -> Vec<(&'static str, BTreeSet<String>)> {
+    vec![
+        ("aim", vocabulary(&every_aim())),
+        (
+            "ticket_type",
+            vocabulary(&[
+                TicketType::Build,
+                TicketType::Research,
+                TicketType::Task,
+                TicketType::Grilling,
+                TicketType::Prototype,
+                TicketType::Untyped,
+            ]),
+        ),
+        (
+            "stage",
+            vocabulary(&[
+                Launchable::Ready,
+                Launchable::Building,
+                Launchable::InReview,
+                Launchable::NeedsAttention,
+            ]),
+        ),
+        ("status", vocabulary(&every_pr_status())),
+        (
+            "checks",
+            vocabulary(&[
+                Checks::Absent,
+                Checks::Pending,
+                Checks::Passing,
+                Checks::Failing,
+            ]),
+        ),
+        (
+            "review",
+            vocabulary(&[
+                Review::NotRequired,
+                Review::Required,
+                Review::Approved,
+                Review::ChangesRequested,
+            ]),
+        ),
+    ]
+}
+
+/// The vocabulary the context section publishes for one field: the backticked
+/// words on the list line that names it, which the doc promises is the
+/// complete list.
+fn documented_vocabulary(field: &str) -> BTreeSet<String> {
+    let section = context_section();
+    let marker = format!("- `{field}` — ");
+    let line = section
+        .lines()
+        .find(|line| line.trim_start().starts_with(&marker))
+        .unwrap_or_else(|| panic!("the context section must publish `{field}`'s vocabulary"))
+        .split_once('—')
+        .expect("the marker contains an em dash")
+        .1;
+    line.split('`')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
+}
+
+/// Every word the docs publish for an enumerated field is a word the types
+/// serialize, and every word they serialize is published.
+///
+/// This is the check that makes the section's promise real. Without it the
+/// docs could say `"type": "BUILD"` and every other test here would still
+/// pass, because they only pin the *shape* of the block — and a skill reading
+/// the docs would then look for a field the binary never writes.
+#[test]
+fn the_documented_vocabularies_are_the_words_the_types_serialize() {
+    for (field, emitted) in emitted_vocabularies() {
+        assert_eq!(
+            documented_vocabulary(field),
+            emitted,
+            "`{field}`'s documented vocabulary and its serialized one disagree"
+        );
+    }
 }
 
 /// The contract is *accelerator, never precondition*, and every failure mode
@@ -182,17 +381,31 @@ fn the_context_section_states_the_fallback_and_the_live_read() {
     }
 }
 
-/// Every shipped skill names the block in its own invocation grammar — a
-/// consumer that never learns of it would keep paying the discovery cost the
-/// block exists to remove.
+/// Every shipped skill says where it stands on the block — a consumer that
+/// never learns of it would keep paying the discovery cost the block exists to
+/// remove.
+///
+/// `wf-one` is the one skill whose answer is *never*: it is reached only by a
+/// creation, which names nothing that exists yet, so its line carries no block
+/// and it may not synthesize one for the subagents it hands work to. Asserting
+/// that separately is the point — the substring alone was satisfied by the
+/// sentence that denies the block, which is weaker than this test's name.
 #[test]
 fn every_bundled_skill_documents_the_context_in_its_grammar() {
     for name in wf::skills::BUNDLED {
         let doc = skill_doc(name);
-        assert!(
-            doc.contains("ctx: <json>"),
-            "{name} must name the launch context in its invocation grammar"
-        );
+        if name == "wf-one" {
+            assert!(
+                doc.contains("never carries a `ctx: <json>` block"),
+                "{name} is a creation's skill: it must say it carries no block"
+            );
+        } else {
+            assert!(
+                doc.contains("[ctx: <json>]") || doc.contains("ctx: <json> ["),
+                "{name} must show the launch context in its invocation grammar, \
+                 not merely mention it in prose"
+            );
+        }
         assert!(
             doc.contains("GITHUB_TRACKER.md"),
             "{name} must point at the shared contract rather than restating it"


### PR DESCRIPTION
Closes #124. Implements the shape #122's resolution settled: the launch context rides the opening prompt as a `ctx:` block between the skill's own arguments and any `steer:` suffix.

A launched skill's first tracker call can now be the **claim** rather than a rediscovery of the map, the ticket and its PRs.

```
/wf-review 124 ctx: {"v":1,"repo":"blooop/wayfinder","map":{…},"aim":{"ticket":{…,"prs":[…]}}} steer: <text>
```

## The numbers

**Before** — re-measured for this revision (mean of 5, this machine, this session; the earlier revision quoted figures inherited from a discarded attempt and framed them as measured, which they were not). The discovery prelude a build launch runs today is 3 serial `gh` calls:

| call | command timed | mean of 5 |
| --- | --- | --- |
| parent map + labels | `gh api repos/blooop/wayfinder/issues/124` | **402 ms** |
| linked PRs | `gh issue view 124 --json closedByPullRequestsReferences` | **423 ms** |
| map title | `gh issue view 121 --json title` | **347 ms** |

**~1.17 s** for a build launch. A review launch handed a bare ticket number pays **612 ms** more to find its PR (`gh pr list --search 124 --json number,headRefName,statusCheckRollup,reviewDecision`), so **~1.78 s**. These are network round trips from one machine on one day — the point is the order of magnitude and the fact that they are serial, not the third digit.

**After**: those calls are gone, not made faster — every fact they fetched is in the prompt, because `wf` had already fetched it to draw the row you picked. The launch itself makes no extra call: the block is serialized from data already in memory. Cost is prompt bytes — **310 bytes** for this repo's test fixture with one linked PR, **381** for this very ticket's node (arithmetic on the same shape with its real titles), against #122's estimated ~1.5 KB worst case and three orders of magnitude under any argv limit.

What is *not* eliminated: ticket bodies, comments and map bodies. `wf` never fetches them (there is no `body` in the GraphQL selection), so the schema does not pretend to carry them.

## Shape

The schema is the launch's **own** types serialized directly, not a mirror pair beside them — the aim sum, the launchable stage and the PR link each carry their own snake-case wire names, and golden literals in the tests pin the format so a rename fails. Departures from #122's literal Rust sketch, all deliberate:

- **No `CtxAim`/`CtxPr`.** They would be the same sums written twice and free to drift; one type serialized once cannot disagree with itself.
- **The map reference carries its repo**, not just its number: a ticket can sit on a map in another repo, and a bare number would point a cross-repo launch at whatever issue holds that number in the ticket's own repo. #122 gave the PR link a repo for exactly this reason.
- **The snapshot instant is dropped.** No consumer in the contract reads it, the staleness guard is the live claim rather than a timestamp comparison, and a wall-clock read would make prompt building non-deterministic.
- **The staged stop's separate title is deleted rather than duplicated** — the title the picker draws and the title the agent is handed are one fact, so it is derived from the aim.
- **§4's "serializer round-trip … property-tested" is an enumeration, not a round trip.** There is no round trip to test: the context types are `Serialize` only, deliberately — `wf` writes the block and never reads one, and adding `Deserialize` would ship a parser with no caller. And the vocabularies are small and closed (6 types × 4 stages; 3 PR states plus 4×4 open ones), so the whole matrix is enumerated exhaustively against golden literals, which pins *which* word the wire uses where a property run only pins that some round trip holds. This departure was missing from this list in the first revision; the matrix itself was missing too, and is now `every_stage_type_and_pr_state_spells_itself_on_the_wire`.

Two things are unrepresentable rather than checked for: **the claim** (no assignee, no ticket status — so a stale block cannot make an agent act on someone else's ticket; the worst it can do is misdescribe a PR for a few orientation tokens) and **a done stage** (`Launchable`, not `Stage`).

## The seams, and what was red

Both were pre-agreed by #122's resolution; no test was written at an unconfirmed seam.

1. **The prompt-building seam** — the argv a launch execs, asserted as whole literal strings so the block's *position* is pinned, not merely its presence. **Genuinely red first**: the assertion failed with the prompt as the bare skill invocation (`/wf-tdd 16`), not a compile error.
2. **The container seam** — the single shell command the `dl` form hands `devpod ssh --command`, parsed back by a **real POSIX shell** rather than a hand-written inverse of `shell_quote`, and compared against what the *same node launched on the host* hands its agent, so it cannot pass by both sides being wrong together. The fixture title carries a single quote, a command substitution and a double quote. **This one was green on its first run** — the quoting already held; what was missing was any proof from the far side of the seam. Checked non-vacuous rather than assumed: with the quoting removed the recovered command comes back as nine arguments with the JSON's quotes eaten and the substitution executed.

**The fallback is asserted negatively**: plain sessions and all three creation launches carry no block, and no test anywhere makes ctx a precondition for a skill to proceed. A hand-invoked skill finds nothing and discovers exactly as before.

## Consumers

One shared section in `skills/wf/GITHUB_TRACKER.md` — the binding wording from #122 verbatim, the schema with its worked example, the per-field vocabularies and the omissions — and one grammar line in each of the five skills, each pointing at that section rather than restating it. `wf-one` says a creation carries no block and may not synthesize one for its subagents. The README's two verbatim launch lines are updated.

`tests/skill_docs.rs` (from #125) is extended deliberately rather than worked around: it builds real launches through the binary's own path and asserts the docs describe the block the code writes — **as JSON, field for field and word for word**, not merely as a shape.

## What changed after the first review

- **`pwned` is gone from the branch, ignored, and the canary is scoped.** The empty file at the repo root was residue of the container-seam test's own `$(touch pwned)` fixture firing during a `shell_quote` mutation. The canary is worth keeping — it is the only evidence that the far side of the seam did *not* execute anything — so the recovering shell now runs in a scratch directory of its own and that directory being empty afterwards is an assertion in its own right, where before nothing looked at the canary at all. `.gitignore` carries `/pwned` for anything run from an older tree.
- **The docs guard now binds the schema, not just its shape.** It pinned the block's prefix and version; the doc's field names and vocabularies could be rewritten to nonsense with the suite green. Two checks replace that: the doc's worked example is built as a real launch of the node it describes and compared as parsed JSON, and every enumerated field's whole vocabulary is compared against what the types serialize. The doc comment that claimed the two "cannot drift" is rewritten to say what is actually enforced.
- **#122 §4's matrix exists** — see the departures list above for what it is and is not.
- **The claim guard no longer collides with a legal value.** It forbade the substring `"needs"`, which `"stage":"needs_attention"` contains; it is now the block's exact set of *field names*, so a value cannot trip it and any new field fails it.
- **`/wf-one` on a node emits no block**, matching `wf-one`'s own doc. Unreachable from the picker, but `plan` takes any route.
- **The before-numbers were re-measured**, with the commands stated.

## Checks

Full chain green locally on this head, with `RUSTFLAGS=-D warnings RUSTDOCFLAGS=-D warnings`: `fmt --all --check`, `clippy --all-targets --all-features --locked`, `test --locked --lib --bins --examples` (**290 / 10 / 0** passed — `main`'s #130 merge brought the lib count up from 269), `test --locked --test skill_docs` (**7** passed), `doc --no-deps --all-features --locked`.

`tests/live_launch_exec.rs` learned the block (it splits the context off before its numeric checks and asserts the version, the repo anchor and the absence of any assignee) but was **not run** — it needs a real pty, a live tracker and an authenticated `gh`, and is excluded from the CI chain by design. It is updated, not verified. Partial mitigation: `ci.yml` builds the live tests (`cargo test --locked --all-targets --no-run`), so the edit is at least type-checked on every push.

One acceptance check from #122 is left for a human: launch a ticket through `wf` and confirm the session's first tracker call is the claim.
