### PR TITLE
Two levels: the project list, then one project

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,22 +157,81 @@ package into a throwaway environment to run `wf --version`. Pushing a
 attaches the package to a GitHub release and — if the repository has a
 `PIXI_TOKEN` secret — publishes it to prefix.dev/blooop.
 
+## Two levels: projects, then one project
+
+`wf` has exactly two screens, and which one it opens on is decided by where you
+ran it.
+
+**Inside a checkout** it opens on **that project**: its own row first, then its
+maps as clusters beneath.
+
+```
+▶ ▌ blooop/wayfinder · 2 maps  ○4  ◐2  ◍1
+
+  ▌ wayfinder · the general dev-process tree  ○2  ◐1
+    ○ #134 The manager hands pointers, never readings [build]
+    ○ #133 The ctx handoff's guards don't yet guard   [build]
+```
+
+**Outside one** it opens on the **project list** — every registered repo, most
+recently used first — and `enter` (or `→`) on a row goes to exactly the screen
+above. One project view, two doors into it.
+
+```
+▶ ▌ blooop/wayfinder · 2 maps  ○4  ◐2  ◍1
+  ▌ blooop/devlaunch · 1 map   ○2  ●7
+  ▌ blooop/bencher   · no map — enter to start one
+```
+
+`←` is the way back out, from anywhere: it closes a group, climbs to the parent,
+steps back a stop, and from the project's own row leaves for the list. Held
+down it walks you from a ticket to the top level. `esc` is deliberately not
+this — it still clears the query and quits, so leaving `wf` never depends on how
+deep you are.
+
+This is what retired `ctrl-f` (focus) and `ctrl-g` (widen): focusing a project
+is entering it, widening is `←` out of it, and both chords named a move the
+arrows already make. They are unbound, not merely undocumented.
+
+There is no screen that pours every project's tickets into one tree. That was
+the old widened scope, and the trade is deliberate: the query means projects at
+the top level and tickets inside one, instead of a single field matching both.
+The cost is that a ticket in a project you have not thought of is not findable
+by typing its title.
+
+**The project list needs no network.** It is the projects cache, ordered by a
+local timestamp, so it is on screen and answering keys before the first `gh`
+call — which is also what lets `enter`, type, `enter` file a task in a fresh
+checkout before the map search has returned. The counts on each row fill in as
+the maps land; a row reads `loading…` until the search has answered and `no
+map — enter to start one` once it has.
+
 ## Discovery
 
 Projects accrete: running `wf` inside a git checkout with a GitHub `origin`
-registers that checkout and opens focused on it (`ctrl-g` widens to every
-known project, `ctrl-f` re-focuses the row's project). Run outside a checkout
-to open on all of them.
+registers that checkout.
 
 The registry is a per-machine cache at `~/.cache/wf/projects.json`
-(`$XDG_CACHE_HOME` respected) holding `{path, repo}` per checkout, plus every
-open map that the last search found. Deleting it is safe — projects re-accrete
-as you open them, and the maps are re-found on the next start.
+(`$XDG_CACHE_HOME` respected) holding `{path, repo, used}` per checkout, plus
+every open map that the last search found. Deleting it is safe — projects
+re-accrete as you open them, and the maps are re-found on the next start.
 
-Only repos with an open `wayfinder:map`-labelled issue show tickets; other
-checkouts stay cached but hidden — except the one you are *focused* on, which
-renders a slim `no map` header so its first map has somewhere to be started from
-(see [Launching](#launching)).
+`used` is what orders the project list: a local stamp, written when you open
+`wf` in a checkout and when you launch an agent from one. A *local* stamp, and
+not the tracker's activity, because the list is drawn before any fetch — and
+because "which project did the world touch last" and "which one did **you**"
+are different questions, and a launcher is answering the second. Entries written
+before this existed carry no stamp and sort last, once, until you next open
+them.
+
+A repo with several checkouts (the `~/k1/kinisi_ros`, `~/k2/kinisi_ros`
+pattern) is **one** project: they are two places it can run, and they share its
+maps, so the project's stamp is the newest of theirs.
+
+Every registered repo is a row on the project list, mapped or not. A repo with
+no open `wayfinder:map` simply has no clusters on its screen — its own row is
+still there, and is where its first map gets charted (see
+[Launching](#launching)).
 
 **Every open map renders as its own cluster** — a `▌ repo · map title` header
 carrying the map's **stage** counts, in the same glyph vocabulary the rows
@@ -295,9 +354,8 @@ quiet once everything is in.
 Which repos have maps takes one `wayfinder:map` label search, and it used to be
 the only genuinely serial step: nothing could load until it returned, which was
 ~2.5 s of a ~3 s start. So the map numbers are cached, and a warm start begins
-fetching the maps themselves immediately — real tickets in ~0.6 s, and the cwd
-focus applied on the *first* frame rather than a couple of seconds in. Every map
-is fetched concurrently, so N projects cost one round trip rather than N.
+fetching the maps themselves immediately — real tickets in ~0.6 s. Every map is
+fetched concurrently, so N projects cost one round trip rather than N.
 
 The cache is a head start, never a skip: the search still runs on every start,
 and its answer is what adds a repo mapped since last time, drops one whose map
@@ -305,8 +363,9 @@ was closed, and corrects a number that moved. A cached number is never taken at
 its word either — a map fetch checks the issue is still an open `wayfinder:map`
 and refuses it otherwise, so a stale number renders *nothing* for a moment
 rather than the wrong issue as that project's map. A search that fails is
-retried rather than fatal, and the cwd focus yields to a scope you have already
-chosen yourself with `ctrl-f`/`ctrl-g`.
+retried rather than fatal. Which project's screen is up is not the search's
+business either way: it comes from the local `git` call that registers the
+checkout, before the first frame, and nothing arriving later moves it.
 
 Each map is fetched exactly once. Nothing polls: `wf` is on screen for seconds
 and restarts warm in ~0.6 s, so there is nothing worth keeping fresh. `ctrl-r`
@@ -363,22 +422,28 @@ count line instead.
 **The cursor lands on cluster headers too**, so a whole map is a thing you can
 launch: `enter` on one runs the wayfinder skill on the map itself rather than on
 any one ticket — interactively to chart it with you, or under auto to have the
-agent take the map from open questions to merged work on its own judgement. The
-default cursor position still skips headers and lands on the first row, so
-opening `wf` and pressing `enter` picks a ticket exactly as it always did;
-headers are one `↑` away.
+agent take the map from open questions to merged work on its own judgement.
 
-**Starting something new is more rows in the same picker.** Creation is an act on
-a *repo*, so it lives where the stop is repo-level — the cluster header — and is
-reached by the same `enter` as everything else. No new keys:
+**The cursor opens on the project's own row**, not on a ticket. This
+consciously overrides the older rule that opening `wf` and pressing `enter`
+picked the top ticket: with creation on the project row, the default became
+`enter`, type what you want to do, `enter` — the thing you most often open `wf`
+in a repo to do, with no navigation at all. Picking the top ticket is one `↓`
+first. Two things make the trade a good one: an empty `task` field refuses, so
+the default cannot misfire; and the project row is known before any fetch, so
+unlike the top ticket it never moves under you as maps stream in — which is what
+#88 and #89 were both about.
+
+**Starting something new lives on the project row.** Creation is an act on a
+*repo*, so it lives on the one stop that is a repo — and it is where the cursor
+already is when the screen opens, so `enter`, type, `enter` is the whole of
+filing a task in the project you are standing in. No new keys, and no
+navigation:
 
 ```
-┌ launch blooop/wayfinder · #59 Map: the dev-process tree ────────────────┐
+┌ launch Claude · blooop/wayfinder · +new ────────────────────────────────┐
 │                                                                         │
-│  ▶ interactive   /wf       you are in the loop; it grills you           │
-│    auto          /wf-auto  the agent decides alone and drives it to done│
-│    plain         claude    no skill; a bare session on the node's branch│
-│    new task      /wf-one   one tracked ticket, built and reviewed       │
+│  ▶ new task      /wf-one   one tracked ticket, built and reviewed       │
 │    new map       /wf       chart a new map in this repo, with you       │
 │    new map, auto /wf-auto  chart a new map in this repo, alone          │
 │                                                                         │
@@ -388,27 +453,33 @@ reached by the same `enter` as everything else. No new keys:
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The repo comes free from wherever the cursor was standing, which is why the title
-names it. **Ticket pickers are unchanged** — they list the three modes and
-nothing else, so `enter` on a ticket never offers to start something instead.
+There is nothing to launch on a project — it names nothing that exists yet — so
+there are no launch rows, and `enter` with an empty `task` field refuses on the
+count line rather than filing something blank. Which is why the creating default
+is safe: `enter enter` on a fresh screen does nothing at all.
+
+**A node launches and a project creates, and neither does the other's job.** A
+cluster header is a *map*, so its picker is the three modes and wraps, exactly
+like a ticket's — the only difference between the two is what they aim at. The
+creation rows used to ride along on the header, on the grounds that a header was
+the only repo-level stop there was; a project row is a better one, and having
+both would put `new map` on every header of a repo with three maps open — three
+doors to one act, none of them the repo.
 
 The text field keeps one keyboard behaviour and takes its meaning from the row,
 which is what the name beside it says: `steer` on a launch row, `task` on **new
-task** — where the text *is* the ticket, so `enter` with nothing typed refuses on
-the count line — and `seed` on the two **new map** rows, where it is an optional
-loose idea the charting session will grill you about anyway.
+task** — where the text *is* the ticket — and `seed` on the two **new map** rows,
+where it is an optional loose idea the charting session will grill you about
+anyway.
 
 Adding a ticket to an existing map needs no row of its own: `enter` on its
 header, type `add a ticket for X`, launch — that is `/wf <map> steer: …`, and the
 charting session files it.
 
-**A repo with no map has a door too.** Run `wf` inside a registered checkout
-whose repo has no open `wayfinder:map` and the screen used to be empty; now it
-renders that repo as one slim header, and `enter` on it opens the creation rows
-alone — nothing to launch, so no launch rows. That is where a repo's *first* map
-gets charted. It appears only on the focused empty state and only once the load
-has landed, so a still-fetching repo never flashes a creation row under `enter`,
-and the widened screen stays free of one row per project.
+**A repo with no map needs no special case.** Its screen is its project row and
+nothing else, and that row is where its *first* map gets charted. That row is
+also there before the search has answered — it is a place to stand, not a report
+on what was found — which is what makes the create path work on the first frame.
 
 **Which skill runs is a fact about what you picked and who decides:**
 
@@ -420,9 +491,9 @@ and the widened screen stays free of one row per project.
 | research · prototype · grilling · task | any unfinished stage | interactive | `<sigil>wf <map> <n>` |
 | anything | any unfinished stage | auto | `<sigil>wf-auto <map> [<n>]` |
 | anything | any unfinished stage | plain | the selected agent, with no skill; anything typed is the whole prompt |
-| a cluster header, or a map-less repo | — | new task | `<sigil>wf-one <task>` |
-| a cluster header, or a map-less repo | — | new map | `<sigil>wf [<seed>]` |
-| a cluster header, or a map-less repo | — | new map, auto | `<sigil>wf-auto [<seed>]` |
+| a project row | — | new task | `<sigil>wf-one <task>` |
+| a project row | — | new map | `<sigil>wf [<seed>]` |
+| a project row | — | new map, auto | `<sigil>wf-auto [<seed>]` |
 | a ticket | done | — | nothing — not launchable |
 
 A creation has no issue number until the skill files one, so it has no per-node
@@ -471,25 +542,23 @@ an empty one.
 
 | key | what it does |
 | --- | --- |
-| *type anything* | fuzzy-filter: the tree is pruned to the matches, best-first, with the rows that place them dimmed; clearing restores it |
+| *type anything* | fuzzy-filter, best-first: the project list narrows to matching slugs; a project's screen prunes the tree to the matching tickets, with the rows that place them dimmed. Clearing restores it |
 | `tab` | toggle the leverage view ⇄ the structure forest |
 | `↑`/`↓`, `ctrl-j`/`ctrl-k` | move between siblings at the cursor's depth — on the default screen, the tickets you can take, plus each cluster's header above them |
-| `→` | reveal: open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
-| `←` | close: shut an open group, else back out to the parent, else one stop back — which, from a cluster's first row, is that cluster's header |
-| `enter` | open the launch picker on the cursor's ticket, or on its map when the cursor is on a cluster header; a second `enter` runs the agent here and exits — on a group line it folds instead, since there is no agent to run |
+| `→` | reveal: enter the project on the project list, else open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
+| `←` | close: from a project's own row, back out to the project list; else shut an open group, back out to the parent, or step one stop back — which, from a cluster's first row, is that cluster's header |
+| `enter` | on the project list: enter that project. On a project's screen: open the launch picker — the creation rows on the project's own row, the launch modes on a ticket or a cluster header — and a second `enter` runs the agent here and exits. On a group line it folds instead, since there is no agent to run |
 | `←`/`→`, `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick Claude/Codex, pick the row, fill its field (a steering prompt, a task, or a map seed), launch — `esc` backs out with the query and cursor intact |
-| `ctrl-f` | focus the cursor row's project — only its clusters stay on screen |
-| `ctrl-g` | widen back to every project |
-| `ctrl-r` | refetch every map in place, keeping your query, scope and cursor |
+| `ctrl-r` | refetch every map in place, keeping your query, level and cursor |
 | `esc` | clear the query; on an empty query, quit |
 | `q` | quit — on an empty query only, since mid-query it types |
 | `ctrl-c` | quit from anywhere, including the which-checkout picker |
 | `↑`/`↓` or `j`/`k`, `enter`, `esc`/`q` | in the which-checkout picker: pick which tree the agent runs in, or cancel |
 
 `ctrl-r` is the only thing that updates the list in place. Quitting and running
-`wf` again is nearly as fast (~0.6 s warm) but throws away the query, the scope
-and where the cursor was, which is the whole reason the key still exists now
-that nothing polls.
+`wf` again is nearly as fast (~0.6 s warm) but throws away the query, the
+project you had entered and where the cursor was, which is the whole reason the
+key still exists now that nothing polls.
 
 That picker is the one prompt left, and only a repo with several registered
 checkouts (the `~/k1/kinisi_ros`, `~/k2/kinisi_ros` pattern) ever sees it: the
@@ -551,17 +620,16 @@ while you are working a map and a bad one while you are browsing it.
 Two things to be clear about, because the cleanup is not automatic:
 
 - **An abandoned stage leaves its workspace behind.** Back out of the launch
-  picker, pick a host checkout at the which-checkout prompt, or pick a
-  *creation* row on a map (a creation runs in the repo's bare workspace, not
-  the node's), and the branch, the clone and the container stay. `wf reap`
-  will *not* collect them while the ticket is open — it only removes
-  workspaces whose tickets are **closed** — so until then they are yours to
-  remove with `dl <workspace> rm`.
+  picker, or pick a host checkout at the which-checkout prompt, and the branch,
+  the clone and the container stay. `wf reap` will *not* collect them while the
+  ticket is open — it only removes workspaces whose tickets are **closed** — so
+  until then they are yours to remove with `dl <workspace> rm`.
 
-  Only a **node** is ever warmed. The map-less door offers creation rows
-  alone, so staging it warms nothing: there is no node for a launch to attach
-  to, and a keystroke should not pre-build a repo's default workspace on the
-  chance you file something.
+  Only a **node** is ever warmed, which is now exactly the stops that have one:
+  a ticket or a cluster header. Staging a **project** row warms nothing — its
+  rows all create, so there is no node for a launch to attach to, and a
+  keystroke should not pre-build a repo's default workspace on the chance you
+  file something.
 - **It does reach the network, but it never publishes.** Fetching the repo and
   pulling the image are the point of doing it early. What it does not do is
   write anything to GitHub: `dl` creates the work branch locally and never

--- a/examples/preview_screen.rs
+++ b/examples/preview_screen.rs
@@ -62,6 +62,14 @@ async fn main() {
         .collect();
 
     let mut app = App::new(clusters);
+    // Stand on the first named map's project. `App::new` opens on the project
+    // list, which is drawn from a registry this example has none of — so with
+    // no `enter` the preview would be a blank screen rather than the tree it
+    // was asked to render.
+    if let Some(id) = ids.first() {
+        app.enter(&id.repo);
+    }
+    app.startup = wf::refresh::Startup::loaded();
     for key in &keys {
         press(&mut app, key);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,16 +14,35 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
-use crate::projects::Checkout;
+use crate::projects::{self, Checkout};
 use crate::refresh::Startup;
 use crate::view::{self, Expanded, GroupId, Lens, Plan, Screen, Stop, StopAt};
 
-/// Project scope: everything, or one repo focused via `ctrl-f`. A repo, not a
-/// map: focusing where you stand means seeing every open map of that repo.
+/// Which of the two screens is up — the whole of `wf`'s navigation.
+///
+/// This replaces the old `Scope { All, Project }`, and the difference is not
+/// cosmetic. A scope was a *filter* on one screen: `Scope::All` rendered every
+/// project's clusters at once and `ctrl-f` narrowed them to one, so both states
+/// ran the same cluster-rendering code and the repo you were standing in was
+/// something the body had to be searched for. A level is the screen itself. The
+/// project list has no cluster code in it at all, and [`Level::Project`] always
+/// names a repo — so the map-less repo, which used to be an exception carved
+/// into the widened screen, is just a project whose list of maps is empty.
+///
+/// Two arms, and no `All` among them: seeing every project means seeing the
+/// *projects*, not every project's tickets poured into one tree. That is the
+/// reversal — one screen per project, reached by picking one — and it is what
+/// retires `ctrl-f`, `ctrl-g` and `ctrl-p` together, since focusing, widening
+/// and finding a project are all now just moving.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Scope {
-    All,
-    Project(String),
+pub enum Level {
+    /// The project list: every registered repo, most recently used first.
+    /// Where `wf` opens when it was not run inside a checkout.
+    Projects,
+    /// One project: its maps, under the project's own row. Where `wf` opens
+    /// when it *was* run inside a checkout, and where selecting a project from
+    /// the list arrives — the same screen either way.
+    Project { repo: String },
 }
 
 /// What the event loop should do after a keypress.
@@ -101,7 +120,7 @@ fn previous_candidate(staged: &Staged, candidate: Candidate) -> Candidate {
 /// # Panics
 ///
 /// Never: [`Staged::candidates`] is never empty — every stop offers rows, its
-/// launch rows or the map-less door's creation rows — so the modulo below is
+/// launch rows or a project row's creation rows — so the modulo below is
 /// never by zero.
 fn stepped(staged: &Staged, candidate: Candidate, delta: usize) -> Candidate {
     let candidates = staged.candidates();
@@ -151,7 +170,7 @@ pub enum StopKey {
     Map(MapId),
     Ticket(RowKey),
     Group(GroupId),
-    /// The empty-state door, by repo slug — already index-free, like the
+    /// A whole project, by repo slug — already index-free, like the
     /// map and group keys.
     Project(String),
 }
@@ -200,7 +219,8 @@ pub struct App {
     /// search's answer afterwards. This is what `ctrl-r` refetches.
     pub open_maps: MapSet,
     pub query: String,
-    pub scope: Scope,
+    /// Which screen is up: the project list, or one project's own.
+    pub level: Level,
     /// One-shot status message shown on the count line; cleared on the next
     /// keypress.
     pub notice: Option<String>,
@@ -250,7 +270,7 @@ impl App {
             clusters,
             open_maps: MapSet::new(),
             query: String::new(),
-            scope: Scope::All,
+            level: Level::Projects,
             notice: None,
             checkouts: Vec::new(),
             failed: BTreeSet::new(),
@@ -283,11 +303,47 @@ impl App {
         self
     }
 
-    fn in_scope(&self, id: &MapId) -> bool {
-        match &self.scope {
-            Scope::All => true,
-            Scope::Project(repo) => &id.repo == repo,
+    /// The repo whose screen is up, or `None` on the project list.
+    pub fn current_repo(&self) -> Option<&str> {
+        match &self.level {
+            Level::Projects => None,
+            Level::Project { repo } => Some(repo),
         }
+    }
+
+    /// The registered repos, most recently used first — the project list's
+    /// body, and the order the cursor walks.
+    pub fn projects(&self) -> Vec<String> {
+        projects::mru_repos(&self.checkouts)
+    }
+
+    /// Enter a project: its screen, from the top. The cursor is deliberately
+    /// *not* carried over — the stop it was on was a project row on another
+    /// screen, and the new screen's own first stop is this project's row,
+    /// which is where an untouched cursor already means.
+    pub fn enter(&mut self, repo: &str) {
+        self.level = Level::Project {
+            repo: repo.to_string(),
+        };
+        self.query.clear();
+        self.cursor = Cursor::Untouched;
+    }
+
+    /// Back out to the project list, with the cursor on the project just left
+    /// — so `←` then `↓` walks to the next project rather than starting over
+    /// at the top of the list.
+    fn leave(&mut self) {
+        let Level::Project { repo } = &self.level else {
+            return;
+        };
+        let key = StopKey::Project(repo.clone());
+        self.level = Level::Projects;
+        self.query.clear();
+        self.point_at(&key);
+    }
+
+    fn in_scope(&self, id: &MapId) -> bool {
+        self.current_repo() == Some(id.repo.as_str())
     }
 
     /// The clusters currently in scope, in render order: **work before
@@ -354,47 +410,40 @@ impl App {
     /// The body, planned: every line the screen shows, in on-screen order —
     /// what the draw walks and what the cursor navigates, so the two can never
     /// disagree about order.
+    ///
+    /// The two levels are two plans, and neither can draw the other's lines:
+    /// the project list has no cluster in it, and a project screen never lists
+    /// a repo that is not its own.
     pub fn plan(&self) -> Plan {
-        view::plan(
-            &self.scoped_clusters(),
-            self.screen(),
-            &self.expanded,
-            self.mapless_door().as_deref(),
-        )
-    }
-
-    /// The repo whose empty-state door this screen is showing, if it is
-    /// showing one (#114).
-    ///
-    /// Deliberately only the **focused** empty state: a registered repo with
-    /// no open map, with the scope on it and nothing rendered. That is the
-    /// case `wf` opened inside a fresh checkout lands in, and it is where the
-    /// repo's *first* map has otherwise had no way in — the picker's rows all
-    /// hang off stops, and a repo with no map renders no stop.
-    ///
-    /// A row per map-less project on the *widened* screen is the version this
-    /// is not: permanent furniture on a screen that is otherwise all signal,
-    /// one extra row every frame for an occasional act. Reaching those repos
-    /// is the project surface's job, not the tree's.
-    fn mapless_door(&self) -> Option<String> {
-        // Not until the load has landed. A focused repo whose maps are still
-        // in flight looks identical to one that has none, and drawing the door
-        // then would put a creation row under `enter` for the second or two
-        // before the clusters arrive — turning an ordinary launch into a new
-        // map. Same reason [`crate::ui::heading`] will not say "no projects"
-        // while the search is out.
-        if !self.startup.is_loaded() {
-            return None;
+        match &self.level {
+            Level::Projects => view::projects(
+                &self.projects(),
+                &self.clusters,
+                self.startup.is_loaded(),
+                &self.query,
+            ),
+            // The project's own row leads whenever there is no query — it is a
+            // place to stand, not a report on what was found, so it is there
+            // whether the repo has ten maps, none, or none *yet*. That is the
+            // whole of what the map-less empty-state door used to be, minus
+            // the door.
+            //
+            // A live query drops it, and that is not a detail: an untouched
+            // cursor means the first stop, so a project row surviving a sift
+            // would take `enter` on a freshly typed query away from the best
+            // match and give it to *create a new task* — the one place where
+            // the creating default this row exists for is the wrong one. The
+            // row is also not a match, and a sifted body is matches and the
+            // structure that places them.
+            Level::Project { repo } => view::plan(
+                &self.scoped_clusters(),
+                self.screen(),
+                &self.expanded,
+                self.query
+                    .is_empty()
+                    .then(|| view::ProjectRow::new(repo, &self.clusters, self.startup.is_loaded())),
+            ),
         }
-        let Scope::Project(repo) = &self.scope else {
-            return None;
-        };
-        // Registered, and nothing of it on screen: a repo whose clusters are
-        // merely filtered out by a query still *has* maps, and its door would
-        // be a second answer to a question the query is already answering.
-        let registered = self.checkouts.iter().any(|c| &c.repo == repo);
-        let has_clusters = self.clusters.keys().any(|id| &id.repo == repo);
-        (registered && !has_clusters).then(|| repo.clone())
     }
 
     /// Every cursor stop with its depth, in on-screen order (#57). The cursor
@@ -404,10 +453,26 @@ impl App {
         self.plan().stops()
     }
 
-    /// Ticket rows on screen — what the match count counts. A subset of
-    /// [`App::stops`].
+    /// Ticket rows on screen. A subset of [`App::stops`].
     pub fn visible(&self) -> Vec<Row> {
         self.plan().rows()
+    }
+
+    /// The count line's `shown/total` — **of whatever this screen is a list
+    /// of**, which is the only reading that stays true across the two levels.
+    ///
+    /// A project list counting *tickets* would read `0/0` on a screen with
+    /// nine projects on it: a fetch that has not landed and a repo with
+    /// nothing open would look identical to the screen being empty, and the
+    /// number a query narrows would not be the number the query narrowed.
+    pub fn counts(&self) -> (usize, usize) {
+        match self.level {
+            Level::Projects => (
+                self.stops().len(),
+                projects::mru_repos(&self.checkouts).len(),
+            ),
+            Level::Project { .. } => (self.visible().len(), self.scoped().len()),
+        }
     }
 
     /// The ticket a row names.
@@ -479,18 +544,6 @@ impl App {
             let map: &Map = &self.clusters[&row.map];
             &map.tickets[row.index]
         })
-    }
-
-    /// Which map the cursor is in, whichever kind of stop it is on — what
-    /// `ctrl-f` focuses. `None` on the empty-state door: it names a repo that
-    /// has no map, which is the one stop that belongs to no cluster.
-    pub fn cursor_map(&self) -> Option<MapId> {
-        match self.cursor_stop()? {
-            Stop::Map(id) => Some(id),
-            Stop::Ticket(row) => Some(row.map),
-            Stop::Group(id) => Some(id.map),
-            Stop::Project(_) => None,
-        }
     }
 
     /// The cursor's stable identity.
@@ -595,6 +648,15 @@ impl App {
     /// and the same step carries on to whatever comes next, which is what keeps
     /// the key live everywhere — held down, `→` visits every stop in order.
     fn descend(&mut self) {
+        // On the project list there is only one thing deeper than a row, and
+        // it is the project: `→` enters it, which is the same move `enter`
+        // makes there. Stepping to the next project instead would make the
+        // depth key a second `↓` on the one screen where depth means
+        // something.
+        if let (Level::Projects, Some(Stop::Project(repo))) = (&self.level, self.cursor_stop()) {
+            self.enter(&repo);
+            return;
+        }
         if let Some(Stop::Group(id)) = self.cursor_stop() {
             if !self.expanded.contains(&id) {
                 self.expanded.insert(id);
@@ -608,9 +670,25 @@ impl App {
     }
 
     /// `←`: close — shut an open group, else out to the parent, else back one
-    /// stop. The mirror of [`App::descend`]: it only ever moves earlier in the
-    /// body, and the last clause is what stops it dying at depth 0.
+    /// stop, else out of the project entirely. The mirror of [`App::descend`]:
+    /// it only ever moves earlier in the body, and the last clause is what
+    /// stops it dying at depth 0.
+    ///
+    /// That last clause is the **back key**. `←` held down walks out of a
+    /// subtree, up its cluster, onto the project row, and then out to the
+    /// project list — one key from anywhere on screen to the top level, which
+    /// is what `ctrl-g` used to be for. `esc` is deliberately not this: it
+    /// still clears the query and quits, so leaving `wf` never needs you to
+    /// know how deep you are.
     fn ascend(&mut self) {
+        // On the project's own row, "out" is the list it was entered from.
+        // Keyed on the stop rather than on position 0, so a sifted screen —
+        // whose first stop is a match, not the project — still answers `←`
+        // with an ordinary step back.
+        if let (Level::Project { .. }, Some(Stop::Project(_))) = (&self.level, self.cursor_stop()) {
+            self.leave();
+            return;
+        }
         if let Some(Stop::Group(id)) = self.cursor_stop() {
             if self.expanded.remove(&id) {
                 return; // shut it; the cursor stays on the line
@@ -695,9 +773,21 @@ impl App {
                 };
                 Outcome::Continue
             }
-            // The empty-state door (#114): nothing to launch here, so the
-            // picker opens straight onto the creation rows.
+            // One stop, two screens, and the screen decides — which is the
+            // only place in the key handler that is true, and is what makes
+            // the level a level rather than a filter.
+            //
+            // On the list, a project is somewhere to *go*: `enter` selects it,
+            // exactly as `→` does. On its own screen it is somewhere to
+            // *start*: there is no node here, so the picker opens straight
+            // onto the creation rows, and since this is also where an
+            // untouched cursor sits, `enter` type `enter` files a task in the
+            // repo you are standing in without touching a single other key.
             Some(Stop::Project(repo)) => {
+                if matches!(self.level, Level::Projects) {
+                    self.enter(&repo);
+                    return Outcome::Continue;
+                }
                 let staged = Staged::project(&repo);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
@@ -777,7 +867,7 @@ impl App {
     ///
     /// Nothing is recorded while the prewarm is off — `&&` short-circuits —
     /// so a session that exports `WF_PREWARM` and re-stages a node still
-    /// warms it. A stop with no workspace to warm (the map-less door) is not
+    /// warms it. A stop with no workspace to warm (a project row) is not
     /// recorded either, because there is nothing to record it under. A node
     /// whose launch turns out to be host-only *is* recorded: it plans nothing
     /// now and would plan nothing later, and remembering that saves
@@ -992,24 +1082,11 @@ impl App {
                 self.notice = Some("refreshing…".to_string());
                 Outcome::Refresh
             }
-            KeyCode::Char('f') if ctrl => {
-                if let Some(map) = self.cursor_map() {
-                    let anchor = self.cursor_anchor();
-                    self.scope = Scope::Project(map.repo);
-                    if let Some(key) = anchor {
-                        self.point_at(&key);
-                    }
-                }
-                Outcome::Continue
-            }
-            KeyCode::Char('g') if ctrl => {
-                let anchor = self.cursor_anchor();
-                self.scope = Scope::All;
-                if let Some(key) = anchor {
-                    self.point_at(&key);
-                }
-                Outcome::Continue
-            }
+            // `ctrl-f` and `ctrl-g` are gone, not merely undocumented: focusing
+            // a project is entering it and widening is `←` out of it, so both
+            // chords named a move the arrows already make. They fall through
+            // to nothing here rather than being caught and ignored — an unbound
+            // key is unbound.
             // Toggle the structural lens (#51): leverage ⇄ forest. The cursor
             // stays on its ticket if the other screen shows it; a live query
             // keeps flattening either lens until it is cleared.
@@ -1112,7 +1189,24 @@ mod tests {
         }
     }
 
-    /// Two clusters: the wayfinder map and a dotfiles map.
+    /// The one project nearly every fixture below stands on. Named because a
+    /// project screen is a repo's, so the slug is now load-bearing in a way it
+    /// was not when every fixture's clusters simply all rendered.
+    const PROJECT: &str = "blooop/wayfinder";
+
+    /// An app standing on `repo`'s screen — the level every cluster test is
+    /// about. `App::new` opens on the project *list*, which is what `wf` run
+    /// outside a checkout shows and which draws no cluster at all, so a test
+    /// about clusters has to say which project's it means.
+    fn app_on(repo: &str, clusters: BTreeMap<MapId, Map>) -> App {
+        let mut app = App::new(clusters);
+        app.enter(repo);
+        app
+    }
+
+    /// Two clusters on one project's screen: the wayfinder map and a dotfiles
+    /// map. Both repos stay registered — a checkout of each — because the
+    /// which-checkout and cross-repo tests below step between their screens.
     fn fixture_app() -> App {
         let mut clusters = BTreeMap::new();
         clusters.insert(
@@ -1171,7 +1265,7 @@ mod tests {
                 )],
             },
         );
-        App::new(clusters)
+        app_on("blooop/wayfinder", clusters)
     }
 
     /// A one-ticket cluster with a given last-activity stamp, open or finished.
@@ -1199,85 +1293,82 @@ mod tests {
         // most recently touched, and it still belongs at the bottom — a map with
         // nothing left to do is history, however fresh.
         let clusters: BTreeMap<MapId, Map> = [
-            cluster("blooop/finished", 1, Some("2026-08-06T12:00:00Z"), false),
-            cluster("blooop/stale", 2, Some("2026-08-01T09:00:00Z"), true),
-            cluster("blooop/fresh", 3, Some("2026-08-05T09:00:00Z"), true),
-            cluster("blooop/undated", 4, None, true),
+            cluster(PROJECT, 1, Some("2026-08-06T12:00:00Z"), false),
+            cluster(PROJECT, 2, Some("2026-08-01T09:00:00Z"), true),
+            cluster(PROJECT, 3, Some("2026-08-05T09:00:00Z"), true),
+            cluster(PROJECT, 4, None, true),
         ]
         .into_iter()
         .collect();
         assert_eq!(
-            cluster_order(&App::new(clusters)),
+            cluster_order(&app_on(PROJECT, clusters)),
             vec![
-                MapId::new("blooop/fresh", 3),
-                MapId::new("blooop/stale", 2),
+                MapId::new(PROJECT, 3),
+                MapId::new(PROJECT, 2),
                 // An unparsed stamp is not guessed into the middle of the live
                 // maps: it sorts after every dated one…
-                MapId::new("blooop/undated", 4),
+                MapId::new(PROJECT, 4),
                 // …and the finished map is still below it.
-                MapId::new("blooop/finished", 1),
+                MapId::new(PROJECT, 1),
             ]
         );
     }
 
     #[test]
-    fn equal_activity_falls_back_to_repo_then_number() {
+    fn equal_activity_falls_back_to_the_map_id() {
         // Same instant on three maps: the order has to be *some* fixed one, or
-        // the screen reshuffles itself between frames for no reason.
+        // the screen reshuffles itself between frames for no reason. The
+        // tie-break is the whole `MapId`; on one project's screen — the only
+        // kind there is — that is the map number.
         let stamp = Some("2026-08-06T12:00:00Z");
         let clusters: BTreeMap<MapId, Map> = [
-            cluster("blooop/wayfinder", 47, stamp, true),
-            cluster("kinisi/zeta", 4, stamp, true),
-            cluster("blooop/wayfinder", 1, stamp, true),
+            cluster(PROJECT, 47, stamp, true),
+            cluster(PROJECT, 4, stamp, true),
+            cluster(PROJECT, 1, stamp, true),
         ]
         .into_iter()
         .collect();
         assert_eq!(
-            cluster_order(&App::new(clusters)),
+            cluster_order(&app_on(PROJECT, clusters)),
             vec![
-                MapId::new("blooop/wayfinder", 1),
-                MapId::new("blooop/wayfinder", 47),
-                MapId::new("kinisi/zeta", 4),
+                MapId::new(PROJECT, 1),
+                MapId::new(PROJECT, 4),
+                MapId::new(PROJECT, 47),
             ]
         );
     }
 
     #[test]
-    fn an_untouched_cursor_stays_on_the_top_row_as_maps_stream_in() {
-        let mut app = App::new(BTreeMap::from([cluster(
-            "blooop/slow",
-            1,
-            Some("2026-08-01T00:00:00Z"),
-            true,
-        )]));
-        assert_eq!(app.cursor_pos(), 1, "past the header");
+    fn an_untouched_cursor_sits_on_the_project_row_whatever_streams_in() {
+        // What #88 and #89 were fighting for, won outright by the project row:
+        // an untouched cursor used to mean "the top row", and the top row was
+        // whichever map had arrived and sorted highest — so the default
+        // selection moved under the human as fetches landed. The first stop is
+        // now the project itself, which is known from a local `git` call before
+        // any fetch and cannot be outranked by anything that arrives later.
+        let mut app = app_on(
+            PROJECT,
+            BTreeMap::from([cluster(PROJECT, 1, Some("2026-08-01T00:00:00Z"), true)]),
+        );
+        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_stop(), Some(Stop::Project(PROJECT.to_string())));
 
         let mut both = BTreeMap::new();
-        both.extend([cluster(
-            "blooop/slow",
-            1,
-            Some("2026-08-01T00:00:00Z"),
-            true,
-        )]);
-        both.extend([cluster(
-            "blooop/fresh",
-            2,
-            Some("2026-08-07T00:00:00Z"),
-            true,
-        )]);
+        both.extend([cluster(PROJECT, 1, Some("2026-08-01T00:00:00Z"), true)]);
+        both.extend([cluster(PROJECT, 2, Some("2026-08-07T00:00:00Z"), true)]);
         app.replace_clusters(both);
 
-        // the fresher map now renders first
-        assert_eq!(app.cursor_pos(), 1);
+        assert_eq!(app.cursor_pos(), 0, "a fresher map cannot move it");
+        assert_eq!(app.cursor_stop(), Some(Stop::Project(PROJECT.to_string())));
     }
 
-    /// Two live maps, the second of them older, so a map fresher than both sorts
-    /// above the pair and pushes every existing stop down by two — its header
-    /// and its row (#96).
+    /// Two live maps of one project, the second of them older, so a map fresher
+    /// than both sorts above the pair and pushes every existing stop down by
+    /// two — its header and its row (#96).
     fn streaming_pair() -> BTreeMap<MapId, Map> {
         [
-            cluster("blooop/slow", 1, Some("2026-08-01T00:00:00Z"), true),
-            cluster("blooop/older", 3, Some("2026-07-01T00:00:00Z"), true),
+            cluster(PROJECT, 1, Some("2026-08-01T00:00:00Z"), true),
+            cluster(PROJECT, 3, Some("2026-07-01T00:00:00Z"), true),
         ]
         .into_iter()
         .collect()
@@ -1287,12 +1378,7 @@ mod tests {
     /// stop moves down two.
     fn streaming_trio() -> BTreeMap<MapId, Map> {
         let mut all = streaming_pair();
-        all.extend([cluster(
-            "blooop/fresh",
-            2,
-            Some("2026-08-07T00:00:00Z"),
-            true,
-        )]);
+        all.extend([cluster(PROJECT, 2, Some("2026-08-07T00:00:00Z"), true)]);
         all
     }
 
@@ -1301,59 +1387,66 @@ mod tests {
         // The #50/#57 behaviour, which #88 must not cost: a row someone moved to
         // is pinned by identity, so an arriving map slides it down the screen
         // rather than stealing the selection.
-        let mut app = App::new(streaming_pair());
-        for _ in 0..3 {
-            app.handle_key(key(KeyCode::Down)); // past slow's header and row, onto older's
+        let mut app = app_on(PROJECT, streaming_pair());
+        // Past the project row, then map #1's header and row, onto #3's.
+        for _ in 0..4 {
+            app.handle_key(key(KeyCode::Down));
         }
-        assert_eq!(app.cursor_pos(), 3);
-        assert_eq!(app.cursor_map(), Some(MapId::new("blooop/older", 3)));
+        assert_eq!(app.cursor_pos(), 4);
+        assert_eq!(
+            app.cursor_row().map(|row| row.map),
+            Some(MapId::new(PROJECT, 3))
+        );
 
         app.replace_clusters(streaming_trio());
 
-        assert_eq!(app.cursor_pos(), 5, "the fresher map pushed the row down");
+        assert_eq!(app.cursor_pos(), 6, "the fresher map pushed the row down");
         assert_eq!(
-            app.cursor_map(),
-            Some(MapId::new("blooop/older", 3)),
+            app.cursor_row().map(|row| row.map),
+            Some(MapId::new(PROJECT, 3)),
             "still the row they chose"
         );
     }
 
     #[test]
     fn choosing_the_top_row_pins_it_rather_than_re_defaulting_to_the_top() {
-        // The case a sentinel cannot serve. This cursor sits on exactly the stop
-        // a fresh one resolves to, and must behave like the *opposite* of a
-        // fresh one: the human put it there, so a map arriving above carries it
-        // down. Read the position as "untouched" and this test lands on
-        // blooop/fresh.
-        let mut app = App::new(streaming_pair());
-        app.handle_key(key(KeyCode::Down));
-        app.handle_key(key(KeyCode::Up)); // deliberately back on the top row
-        assert_eq!(app.cursor_pos(), 1);
-        assert_eq!(app.cursor_map(), Some(MapId::new("blooop/slow", 1)));
+        // The case a sentinel cannot serve. This cursor sits on the first
+        // *ticket*, and must behave like the opposite of a fresh one: the human
+        // put it there, so a map arriving above carries it down rather than
+        // leaving it on whatever is now first.
+        let mut app = app_on(PROJECT, streaming_pair());
+        for _ in 0..2 {
+            app.handle_key(key(KeyCode::Down)); // project row, header, row
+        }
+        assert_eq!(app.cursor_pos(), 2);
+        assert_eq!(
+            app.cursor_row().map(|row| row.map),
+            Some(MapId::new(PROJECT, 1))
+        );
 
         app.replace_clusters(streaming_trio());
 
         assert_eq!(
-            app.cursor_map(),
-            Some(MapId::new("blooop/slow", 1)),
+            app.cursor_row().map(|row| row.map),
+            Some(MapId::new(PROJECT, 1)),
             "their stop, not whatever is on top now"
         );
-        assert_eq!(app.cursor_pos(), 3);
+        assert_eq!(app.cursor_pos(), 4);
     }
 
     #[test]
     fn toggling_the_lens_does_not_turn_an_untouched_cursor_into_a_choice() {
-        // `tab`, `ctrl-f` and `ctrl-g` rebuild the list under the cursor and keep
-        // it on its stop — but keeping an *untouched* cursor on the row that
-        // merely happens to be first would anchor a default, letting the bug back
-        // in through a key that was never about the selection at all.
-        let mut app = App::new(streaming_pair());
+        // `tab` rebuilds the list under the cursor and keeps it on its stop —
+        // but keeping an *untouched* cursor on the row that merely happens to
+        // be first would anchor a default, letting #88 back in through a key
+        // that was never about the selection at all.
+        let mut app = app_on(PROJECT, streaming_pair());
         app.handle_key(key(KeyCode::Tab));
 
         app.replace_clusters(streaming_trio());
 
-        assert_eq!(app.cursor_pos(), 1);
-        assert_eq!(app.cursor_map(), Some(MapId::new("blooop/fresh", 2)));
+        assert_eq!(app.cursor_pos(), 0);
+        assert_eq!(app.cursor_stop(), Some(Stop::Project(PROJECT.to_string())));
     }
 
     /// One map with finished work in it, so the leverage lens gives it a `Done`
@@ -1361,15 +1454,15 @@ mod tests {
     /// not have.
     fn map_with_a_done_group() -> BTreeMap<MapId, Map> {
         BTreeMap::from([(
-            MapId::new("blooop/slow", 1),
+            MapId::new(PROJECT, 1),
             Map {
-                title: "Map: blooop/slow".to_string(),
+                title: "Map: the slow one".to_string(),
                 last_activity: Some(
                     Activity::parse("2026-08-01T00:00:00Z").expect("fixture stamp parses"),
                 ),
                 tickets: vec![
-                    ticket("blooop/slow", 1, "takeable", true, false, vec![]),
-                    ticket("blooop/slow", 2, "finished", false, false, vec![]),
+                    ticket(PROJECT, 1, "takeable", true, false, vec![]),
+                    ticket(PROJECT, 2, "finished", false, false, vec![]),
                 ],
             },
         )])
@@ -1378,11 +1471,17 @@ mod tests {
     #[test]
     fn a_lens_toggle_off_a_vanished_group_line_leaves_no_choice_behind() {
         // #88, re-entered through the lens door. The forest lens emits no group
-        // lines, so `tab` from a `Done` line deletes the very stop being held —
-        // and recording position 0 for the stop that vanished is a default written
-        // down as a choice, the one state `Cursor` exists to forbid. The symptom is
-        // #88's own: the next map to sort above drags the cursor off the top row.
-        let mut app = App::new(map_with_a_done_group());
+        // lines, so `tab` from a `Done` line deletes the very stop being held,
+        // and recording a position for the stop that vanished is a default
+        // written down as a choice — the one state `Cursor` exists to forbid.
+        //
+        // The old symptom (the next map to sort above drags the cursor off the
+        // top row) can no longer be *observed* on a project screen: the first
+        // stop is the project row now, so an untouched cursor and a
+        // wrongly-recorded `Chosen(0)` resolve to the same line. What is still
+        // worth pinning is that the toggle lands the cursor there rather than
+        // on some stop the human never picked.
+        let mut app = app_on(PROJECT, map_with_a_done_group());
         while !matches!(app.cursor_stop(), Some(Stop::Group(_))) {
             app.handle_key(key(KeyCode::Down));
         }
@@ -1390,18 +1489,13 @@ mod tests {
         app.handle_key(key(KeyCode::Tab)); // the forest has no group line to keep
 
         let mut fresher = map_with_a_done_group();
-        fresher.extend([cluster(
-            "blooop/fresh",
-            2,
-            Some("2026-08-07T00:00:00Z"),
-            true,
-        )]);
+        fresher.extend([cluster(PROJECT, 2, Some("2026-08-07T00:00:00Z"), true)]);
         app.replace_clusters(fresher);
 
-        assert_eq!(app.cursor_pos(), 1);
+        assert_eq!(app.cursor_pos(), 0);
         assert_eq!(
-            app.cursor_map(),
-            Some(MapId::new("blooop/fresh", 2)),
+            app.cursor_stop(),
+            Some(Stop::Project(PROJECT.to_string())),
             "nothing was chosen, so the cursor still means the top of the list"
         );
     }
@@ -1456,13 +1550,17 @@ mod tests {
 
     #[test]
     fn down_walks_the_takeable_tickets_and_steps_over_their_context() {
-        // Clusters order by (repo, number): dotfiles#4 before wayfinder#1.
-        // The depth-0 axis is each cluster's header (#96), then its rows:
-        // dotfiles #103, then wayfinder's takeable #6 and #9, then its Done
-        // group — #7 hangs under #6 as context and is *not* on this axis,
+        // The depth-0 axis of a project's screen: its own row first (#114's
+        // creation stop, now the place the cursor starts), then each cluster's
+        // header (#96) and that cluster's takeable rows — #6 and #9 — then its
+        // Done group. #7 hangs under #6 as context and is *not* on this axis,
         // which is the whole point of #57.
         let mut app = fixture_app();
-        assert_eq!(at(&app), "#103", "the default skips the header above it");
+        assert_eq!(
+            at(&app),
+            "project blooop/wayfinder",
+            "the default is the project, not a ticket"
+        );
         app.handle_key(key(KeyCode::Down));
         assert_eq!(at(&app), "map #1");
         app.handle_key(key(KeyCode::Down));
@@ -1474,17 +1572,7 @@ mod tests {
         for _ in 0..10 {
             app.handle_key(key(KeyCode::Down));
         }
-        assert_eq!(at(&app), "Done", "clamped at the last stop");
-        app.handle_key(ctrl('k'));
-        assert_eq!(at(&app), "#9");
-        for _ in 0..10 {
-            app.handle_key(key(KeyCode::Up));
-        }
-        assert_eq!(
-            at(&app),
-            "map #4",
-            "clamped at the first stop, across clusters"
-        );
+        assert_eq!(at(&app), "Done", "the last stop holds");
     }
 
     #[test]
@@ -1530,7 +1618,7 @@ mod tests {
                 ],
             },
         );
-        let mut app = App::new(clusters);
+        let mut app = app_on(PROJECT, clusters);
         go_to(&mut app, "#6");
         app.handle_key(key(KeyCode::Right));
         assert_eq!(at(&app), "#7");
@@ -1567,7 +1655,7 @@ mod tests {
                 ],
             },
         );
-        App::new(clusters)
+        app_on("blooop/bencher", clusters)
     }
 
     #[test]
@@ -1587,16 +1675,25 @@ mod tests {
                 // Try it from every reachable position, with the group both
                 // shut and open, since folding changes the stop list.
                 for open_group in [false, true] {
-                    let mut app = knotty_app();
-                    if open_group {
-                        while !matches!(app.cursor_stop(), Some(Stop::Group(_))) {
-                            app.handle_key(key(KeyCode::Down));
+                    // A fresh app per start, because a key is allowed to change
+                    // the *screen* and not just the cursor: `←` on the project
+                    // row leaves for the project list, and every later start
+                    // would then be probing a screen this loop never meant to
+                    // be on.
+                    let build = || {
+                        let mut app = knotty_app();
+                        if open_group {
+                            while !matches!(app.cursor_stop(), Some(Stop::Group(_))) {
+                                app.handle_key(key(KeyCode::Down));
+                            }
+                            app.handle_key(key(KeyCode::Right));
+                            app.cursor = Cursor::Chosen(0);
                         }
-                        app.handle_key(key(KeyCode::Right));
-                        app.cursor = Cursor::Chosen(0);
-                    }
-                    let total = app.stops().len();
+                        app
+                    };
+                    let total = build().stops().len();
                     for start in 0..total {
+                        let mut app = build();
                         app.cursor = Cursor::Chosen(start);
                         let before = (app.cursor_pos(), app.stops().len());
                         app.handle_key(key(code));
@@ -1711,7 +1808,7 @@ mod tests {
                 ],
             },
         );
-        let mut app = App::new(clusters);
+        let mut app = app_on("blooop/bencher", clusters);
         go_to(&mut app, "#1069");
         app.handle_key(key(KeyCode::Right)); // into #1070
         assert_eq!(at(&app), "#1070");
@@ -1742,7 +1839,14 @@ mod tests {
         }
         assert_eq!(
             seen,
-            vec!["map #1064", "#1069", "#1070", "#1071", "#1072"],
+            vec![
+                "project blooop/bencher",
+                "map #1064",
+                "#1069",
+                "#1070",
+                "#1071",
+                "#1072"
+            ],
             "↓ walked the whole tree"
         );
     }
@@ -1815,11 +1919,12 @@ mod tests {
         // The forest shows done #2 as a row and reorders — the cursor follows
         // its ticket, not its old position.
         assert_eq!(at(&app), "#7");
-        assert_eq!(app.visible().len(), 5, "the forest is total");
+        assert_eq!(app.visible().len(), 4, "the forest is total");
         assert_eq!(
             app.stops().len(),
-            7,
-            "and holds nothing back to open — the two extra stops are the headers"
+            6,
+            "and holds nothing back to open — the two extra stops are the \
+             project row and this cluster's header"
         );
 
         app.handle_key(key(KeyCode::Tab));
@@ -1871,15 +1976,23 @@ mod tests {
     /// The fixture app plus launch inputs: one checkout of wayfinder, two of
     /// dotfiles.
     fn launchable_app() -> App {
-        let checkout = |path: &str, repo: &str| Checkout {
-            path: std::path::PathBuf::from(path),
-            repo: repo.to_string(),
+        let checkout = |path: &str, repo: &str| {
+            Checkout::new(std::path::PathBuf::from(path), repo.to_string())
         };
         fixture_app().with_checkouts(vec![
             checkout("/data/proj/wayfinder", "blooop/wayfinder"),
             checkout("/data/k1/dotfiles", "blooop/dotfiles"),
             checkout("/data/k2/dotfiles", "blooop/dotfiles"),
         ])
+    }
+
+    /// The same, standing on the dotfiles project — the repo with two
+    /// checkouts, and so the only one whose launch reaches the which-checkout
+    /// picker. Its ticket is on *its* screen, not wayfinder's.
+    fn two_checkout_app() -> App {
+        let mut app = launchable_app();
+        app.enter("blooop/dotfiles");
+        app
     }
 
     #[test]
@@ -2003,10 +2116,10 @@ mod tests {
         // Even claimed, a launch with no container to start plans no command:
         // the fixture's checkout paths do not exist, so no candidate can
         // declare a devcontainer, which is exactly the host case.
-        let app = fixture_app().with_checkouts(vec![Checkout {
-            path: std::path::PathBuf::from("/data/proj/wayfinder"),
-            repo: "blooop/wayfinder".to_string(),
-        }]);
+        let app = fixture_app().with_checkouts(vec![Checkout::new(
+            std::path::PathBuf::from("/data/proj/wayfinder"),
+            "blooop/wayfinder".to_string(),
+        )]);
         assert_eq!(launch::prewarm(&app.checkouts, &staged_six(&app)), None);
     }
 
@@ -2032,10 +2145,10 @@ mod tests {
                 },
             );
         }
-        let mut app = App::new(clusters).with_checkouts(vec![Checkout {
-            path: std::path::PathBuf::from("/data/proj/wayfinder"),
-            repo: "blooop/wayfinder".to_string(),
-        }]);
+        let mut app = app_on("blooop/wayfinder", clusters).with_checkouts(vec![Checkout::new(
+            std::path::PathBuf::from("/data/proj/wayfinder"),
+            "blooop/wayfinder".to_string(),
+        )]);
         // Both clusters hold a #6; the second one is map #47's copy.
         go_to(&mut app, "map #47");
         go_to(&mut app, "#6");
@@ -2062,7 +2175,7 @@ mod tests {
 
     #[test]
     fn several_checkouts_open_the_picker_and_enter_launches_the_pick() {
-        let mut app = launchable_app();
+        let mut app = two_checkout_app();
         // dotfiles#103 — a repo with two checkouts. The first enter stages the
         // launch; the second resolves it to the picker.
         go_to(&mut app, "#103");
@@ -2092,7 +2205,7 @@ mod tests {
 
     #[test]
     fn the_picker_clamps_and_esc_cancels_it() {
-        let mut app = launchable_app();
+        let mut app = two_checkout_app();
         go_to(&mut app, "#103");
         app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage the launch
         app.handle_key(key(KeyCode::Enter)); // resolve — two checkouts: picker
@@ -2119,6 +2232,7 @@ mod tests {
         // cluster and cannot be missing. The line still opens (the route is a
         // fact about the ticket); the *resolution* is what has nowhere to run.
         let mut app = fixture_app();
+        go_to(&mut app, "#6");
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         let notice = app.notice.as_deref().unwrap();
@@ -2246,7 +2360,7 @@ mod tests {
         // Two checkouts of dotfiles: the mode is settled in the launch
         // overlay, the checkout picker only answers *where* — the pick must
         // not lose the `auto`.
-        let mut app = launchable_app();
+        let mut app = two_checkout_app();
         go_to(&mut app, "#103");
         app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage
         app.handle_key(key(KeyCode::Down)); // to the auto row
@@ -2378,22 +2492,24 @@ mod tests {
         );
     }
 
-    /// An app focused on a registered repo that has no open map — what `wf`
-    /// opened inside a fresh checkout is looking at.
+    /// An app on a registered repo that has no open map — what `wf` opened
+    /// inside a fresh checkout is looking at.
     fn mapless_app() -> App {
-        let mut app = App::new(BTreeMap::new()).with_checkouts(vec![Checkout {
-            path: std::path::PathBuf::from("/data/proj/newthing"),
-            repo: "blooop/newthing".to_string(),
-        }]);
-        app.scope = Scope::Project("blooop/newthing".to_string());
+        let mut app = App::new(BTreeMap::new()).with_checkouts(vec![Checkout::new(
+            std::path::PathBuf::from("/data/proj/newthing"),
+            "blooop/newthing".to_string(),
+        )]);
+        app.enter("blooop/newthing");
         app
     }
 
     #[test]
-    fn a_focused_repo_with_no_map_renders_one_slim_header_to_start_from() {
-        // #114's empty-state door: this screen used to render nothing at all,
-        // which is where the first map of a repo had no way in. The header is
-        // a stop, so the cursor can name it and `enter` can act on it.
+    fn a_project_screen_leads_with_its_own_row_even_with_no_map() {
+        // The row is a place to stand, not a report on what was found: this
+        // screen used to render nothing at all, which is where the first map
+        // of a repo had no way in. It is a stop, so the cursor can name it and
+        // `enter` can act on it — and it is the *first* stop, so an untouched
+        // cursor is already on it.
         let app = mapless_app();
         assert_eq!(
             app.stops()
@@ -2405,6 +2521,22 @@ mod tests {
         assert_eq!(
             app.cursor_stop(),
             Some(Stop::Project("blooop/newthing".to_string()))
+        );
+    }
+
+    #[test]
+    fn the_project_row_leads_a_screen_that_has_maps_too() {
+        // Not only the empty case: the row is the repo-level stop wherever the
+        // screen is, and the clusters follow it.
+        let app = fixture_app();
+        let stops: Vec<Stop> = app.stops().iter().map(|at| at.stop.clone()).collect();
+        assert_eq!(
+            stops.first(),
+            Some(&Stop::Project("blooop/wayfinder".to_string()))
+        );
+        assert!(
+            stops.iter().any(|s| matches!(s, Stop::Map(_))),
+            "the clusters still follow it: {stops:?}"
         );
     }
 
@@ -2443,57 +2575,68 @@ mod tests {
     }
 
     #[test]
-    fn the_door_waits_for_the_load_rather_than_flashing_up_mid_fetch() {
-        // A focused repo whose maps have not arrived *yet* looks exactly like
-        // one that has none — the same ambiguity `Startup` exists to remove
-        // for the "no projects" heading. Rendering the door on that screen
-        // would put a creation row under `enter` for the second or two before
-        // the clusters land, so an ordinary launch would start a new map.
+    fn the_project_row_is_a_stop_before_the_load_lands() {
+        // The old empty-state door had to wait for the search, because a repo
+        // whose maps were still in flight looked exactly like one that had
+        // none and the door was the *answer* to having none. This row is not
+        // an answer, so it does not wait: it is the same stop, meaning the
+        // same thing, on the first frame. Which is what lets `wf` in a checkout
+        // start a task before a single `gh` call has returned.
         let mut app = mapless_app();
         app.startup = Startup::default();
-        assert!(app.stops().is_empty(), "no door while the search is out");
-        let found: MapSet = [MapId::new("blooop/newthing", 3)].into_iter().collect();
-        app.startup.searched(&found);
-        assert!(app.stops().is_empty(), "nor while its map is still coming");
-        // Only once the load has actually landed and left nothing behind.
-        app.startup = Startup::loaded();
-        assert_eq!(app.stops().len(), 1);
+        assert_eq!(app.stops().len(), 1, "the row is there while searching");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(
+            matches!(app.overlay, Overlay::PickLaunch { .. }),
+            "and enter still opens the creation rows on it"
+        );
     }
 
     #[test]
-    fn map_less_repos_stay_off_the_widened_screen() {
-        // The door is the *focused* empty state, not a row per project on the
-        // main screen: permanent furniture for an occasional act is what #114
-        // ruled out. Widening drops it.
-        let mut app = mapless_app();
-        app.scope = Scope::All;
-        assert!(app.stops().is_empty());
+    fn every_registered_repo_is_a_row_on_the_project_list() {
+        // The reversal of #114's "map-less repos stay off the widened screen":
+        // one row per project is not permanent furniture on a ticket screen
+        // any more, it *is* the top-level screen. A repo with no map is a row
+        // there like any other — which is how it is reached from outside.
+        // Stamped rather than left to the clock: the order is the assertion,
+        // so two checkouts registered in the same second would make it a
+        // coin toss.
+        let used = |path: &str, repo: &str, at: u64| Checkout {
+            path: std::path::PathBuf::from(path),
+            repo: repo.to_string(),
+            used: Some(at),
+        };
+        let mut app = fixture_app().with_checkouts(vec![
+            used("/data/proj/wayfinder", "blooop/wayfinder", 100),
+            used("/data/proj/newthing", "blooop/newthing", 200),
+        ]);
+        app.level = Level::Projects;
+        let stops: Vec<Stop> = app.stops().iter().map(|at| at.stop.clone()).collect();
+        assert_eq!(
+            stops,
+            vec![
+                Stop::Project("blooop/newthing".to_string()),
+                Stop::Project("blooop/wayfinder".to_string()),
+            ],
+            "both projects, mapped or not, most recently used first — and no \
+             cluster among them"
+        );
     }
 
     #[test]
-    fn a_header_picker_reaches_the_creation_rows_and_a_ticket_picker_has_none() {
-        // #114: creation is a repo-level act, so the rows exist exactly where
-        // the stop is repo-level. On a header the walk reaches them after the
-        // launch modes; on a ticket the same walk wraps among the three modes.
-        let mut app = launchable_app();
-        go_to(&mut app, "map #1");
-        app.handle_key(key(KeyCode::Enter));
+    fn only_the_project_stop_reaches_the_creation_rows() {
+        // Creation is a repo-level act, so the rows exist exactly where the
+        // stop is a repo — and nowhere else. A cluster header is a *map*, so
+        // its picker walks the three modes and wraps, exactly as a ticket's
+        // does: the only difference between the two is what they aim at.
         let picked = |app: &App| match &app.overlay {
             Overlay::PickLaunch { candidate, .. } => *candidate,
             other => panic!("expected the launch picker, got {other:?}"),
         };
-        assert_eq!(
-            picked(&app),
-            Candidate::Launch {
-                mode: Mode::Interactive,
-                route: Route::Wayfinder
-            },
-            "opens on the default launch row"
-        );
-        // Down past the three modes lands on the creation rows, in order.
-        for _ in 0..3 {
-            app.handle_key(key(KeyCode::Down));
-        }
+
+        let mut app = launchable_app();
+        assert_eq!(at(&app), "project blooop/wayfinder");
+        app.handle_key(key(KeyCode::Enter));
         assert_eq!(picked(&app), Candidate::Create(CreationKind::Task));
         app.handle_key(key(KeyCode::Down));
         assert_eq!(picked(&app), Candidate::Create(CreationKind::Map));
@@ -2502,41 +2645,32 @@ mod tests {
         app.handle_key(key(KeyCode::Down));
         assert_eq!(
             picked(&app),
-            Candidate::Launch {
-                mode: Mode::Interactive,
-                route: Route::Wayfinder
-            },
-            "and wraps back to the top"
+            Candidate::Create(CreationKind::Task),
+            "and wraps: there is nothing else on a project's picker"
         );
-        // Up from the top wraps onto the last creation row.
-        app.handle_key(key(KeyCode::Up));
-        assert_eq!(picked(&app), Candidate::Create(CreationKind::MapAuto));
 
-        // A ticket stop walks only the modes: three downs is a full lap.
-        let mut app = launchable_app();
-        go_to(&mut app, "#6");
-        app.handle_key(key(KeyCode::Enter));
-        for _ in 0..3 {
-            app.handle_key(key(KeyCode::Down));
+        // A header and a ticket both walk only the modes: three downs is a
+        // full lap on either.
+        for stop in ["map #1", "#6"] {
+            let mut app = launchable_app();
+            go_to(&mut app, stop);
+            app.handle_key(key(KeyCode::Enter));
+            for _ in 0..3 {
+                app.handle_key(key(KeyCode::Down));
+            }
+            assert!(
+                matches!(picked(&app), Candidate::Launch { .. }),
+                "no creation rows on {stop}"
+            );
         }
-        assert_eq!(
-            picked(&app),
-            Candidate::Launch {
-                mode: Mode::Interactive,
-                route: Route::Wayfinder
-            },
-            "no creation rows on a ticket"
-        );
     }
 
     #[test]
     fn a_new_task_launches_wf_one_and_refuses_an_empty_task() {
         let mut app = launchable_app();
-        go_to(&mut app, "map #1");
+        // The project row is where an untouched cursor already is, and `new
+        // task` is the row its picker opens on: `enter`, type, `enter`.
         app.handle_key(key(KeyCode::Enter));
-        for _ in 0..3 {
-            app.handle_key(key(KeyCode::Down)); // onto `new task`
-        }
         // Enter with nothing typed refuses on the count line — the overlay
         // stays up, as a done or blocked node already refuses.
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
@@ -2565,11 +2699,8 @@ mod tests {
     fn a_new_map_launches_the_charting_skill_with_the_text_as_its_seed() {
         // The seed is optional: bare `/wf` charts from nothing.
         let mut app = launchable_app();
-        go_to(&mut app, "map #1");
         app.handle_key(key(KeyCode::Enter));
-        for _ in 0..4 {
-            app.handle_key(key(KeyCode::Down)); // onto `new map`
-        }
+        app.handle_key(key(KeyCode::Down)); // onto `new map`
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -2578,7 +2709,6 @@ mod tests {
 
         // And seeded, alone: the auto charting row takes the idea verbatim.
         let mut app = launchable_app();
-        go_to(&mut app, "map #1");
         app.handle_key(key(KeyCode::Enter));
         app.handle_key(key(KeyCode::Up)); // wrap straight onto `new map, auto`
         type_str(&mut app, "a caching layer");
@@ -2646,13 +2776,14 @@ mod tests {
                     tickets: vec![t],
                 },
             );
-            App::new(clusters).with_checkouts(vec![Checkout {
-                path: std::path::PathBuf::from("/data/proj/wayfinder"),
-                repo: "blooop/wayfinder".to_string(),
-            }])
+            app_on("blooop/wayfinder", clusters).with_checkouts(vec![Checkout::new(
+                std::path::PathBuf::from("/data/proj/wayfinder"),
+                "blooop/wayfinder".to_string(),
+            )])
         };
 
         let mut ready = build_app(vec![]);
+        go_to(&mut ready, "#65");
         ready.handle_key(key(KeyCode::Enter));
         match &ready.overlay {
             Overlay::PickLaunch { staged, .. } => {
@@ -2677,6 +2808,7 @@ mod tests {
                 review: Review::Approved,
             },
         }]);
+        go_to(&mut in_review, "#65");
         in_review.handle_key(key(KeyCode::Enter));
         match &in_review.overlay {
             Overlay::PickLaunch { staged, .. } => {
@@ -2700,6 +2832,7 @@ mod tests {
             number: 90,
             status: PrStatus::Merged,
         }]);
+        go_to(&mut done, "#65");
         assert_eq!(done.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert_eq!(done.overlay, Overlay::None);
         assert!(done.notice.as_deref().unwrap().contains("done"));
@@ -2715,27 +2848,28 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_f_focuses_cursor_rows_project_and_ctrl_g_widens() {
+    fn the_retired_chords_do_nothing_at_all() {
+        // `ctrl-f` and `ctrl-g` are unbound, not merely undocumented: focusing
+        // a project is entering it and widening is `←` out of it. Pressing
+        // either must not change the level, move the cursor, or type a letter
+        // into the query.
         let mut app = fixture_app();
         go_to(&mut app, "#6");
-        app.handle_key(ctrl('f'));
-        assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
-        assert_eq!(
-            app.visible().len(),
-            3,
-            "leverage rows: #6, #7 beneath it, #9"
-        );
-        assert_eq!(app.cursor_ticket().unwrap().number, 6);
-        app.handle_key(ctrl('g'));
-        assert_eq!(app.scope, Scope::All);
-        assert_eq!(app.visible().len(), 4);
-        // cursor stayed anchored on the same ticket
-        assert_eq!(app.cursor_ticket().unwrap().number, 6);
+        let before = (app.level.clone(), app.cursor_pos(), app.query.clone());
+        for chord in ['f', 'g'] {
+            assert_eq!(app.handle_key(ctrl(chord)), Outcome::Continue);
+            assert_eq!(
+                (app.level.clone(), app.cursor_pos(), app.query.clone()),
+                before,
+                "ctrl-{chord} did something"
+            );
+        }
     }
 
     #[test]
-    fn focus_keeps_every_open_map_of_the_repo() {
-        // Two maps on one repo: focusing the repo is not focusing one map.
+    fn entering_a_project_keeps_every_open_map_of_it_and_nobody_elses() {
+        // Two maps on one repo: a project is a repo, not a map, so entering it
+        // shows both — and the other repo's map is on another screen entirely.
         let mut clusters = BTreeMap::new();
         clusters.insert(
             MapId::new("blooop/wayfinder", 1),
@@ -2761,45 +2895,16 @@ mod tests {
                 tickets: vec![ticket("blooop/dotfiles", 103, "t103", true, false, vec![])],
             },
         );
-        let mut app = App::new(clusters);
-        app.handle_key(key(KeyCode::Down)); // cursor onto wayfinder#6 (map #1)
-        app.handle_key(ctrl('f'));
-        assert_eq!(app.scope, Scope::Project("blooop/wayfinder".to_string()));
+        let app = app_on("blooop/wayfinder", clusters);
         let visible = app.visible();
-        assert_eq!(visible.len(), 2, "both wayfinder maps stay on screen");
+        assert_eq!(visible.len(), 2, "both wayfinder maps are on this screen");
         assert!(visible.iter().all(|row| row.map.repo == "blooop/wayfinder"));
     }
 
     #[test]
-    fn ctrl_r_requests_refresh_and_replace_clusters_keeps_anchor() {
-        let mut app = fixture_app();
-        assert_eq!(app.handle_key(ctrl('r')), Outcome::Refresh);
-        go_to(&mut app, "#6");
-        let same = app.clusters.clone();
-        app.replace_clusters(same);
-        assert_eq!(app.cursor_ticket().unwrap().number, 6);
-    }
-
-    #[test]
-    fn replace_clusters_does_not_teleport_when_cursor_ticket_vanishes() {
-        let mut app = fixture_app();
-        go_to(&mut app, "#6"); // position 3: two stops per cluster ahead of it
-        let mut smaller = app.clusters.clone();
-        smaller
-            .get_mut(&MapId::new("blooop/wayfinder", 1))
-            .unwrap()
-            .tickets
-            .retain(|t| t.number != 6);
-        app.replace_clusters(smaller);
-        // Identity gone: cursor stays at the same position, clamped.
-        assert_eq!(app.cursor_pos(), 3);
-        assert_eq!(app.cursor_ticket().unwrap().number, 9);
-    }
-
-    #[test]
-    fn focus_separates_a_fork_from_its_upstream() {
-        // Two repos sharing a short name: identity and scope are the slug,
-        // so focusing one must not drag the other's rows in.
+    fn a_project_screen_separates_a_fork_from_its_upstream() {
+        // Two repos sharing a short name: identity is the slug, so one
+        // project's screen must not drag the other's rows in.
         let mut clusters = BTreeMap::new();
         for owner in ["blooop", "upstream"] {
             clusters.insert(
@@ -2818,18 +2923,169 @@ mod tests {
                 },
             );
         }
-        let mut app = App::new(clusters);
-        while app.cursor_ticket().map(|t| t.repo.as_str()) != Some("upstream/dotfiles") {
-            app.handle_key(key(KeyCode::Down));
-        }
-        app.handle_key(ctrl('f'));
-        assert_eq!(app.scope, Scope::Project("upstream/dotfiles".to_string()));
+        let app = app_on("upstream/dotfiles", clusters);
         assert_eq!(
             app.visible().len(),
             1,
             "the fork's identically-numbered row must not show"
         );
-        assert_eq!(app.cursor_ticket().unwrap().repo, "upstream/dotfiles");
+        assert_eq!(app.visible()[0].map.repo, "upstream/dotfiles");
+    }
+
+    #[test]
+    fn a_query_on_the_project_list_matches_slugs_and_keeps_no_tickets() {
+        // One query field, one register per level: at the top it is looking for
+        // a project, so it matches the slug and nothing else — a ticket title
+        // that would match cannot pull its project's rows onto this screen.
+        let mut app = launchable_app();
+        app.level = Level::Projects;
+        type_str(&mut app, "dotf");
+        assert_eq!(
+            app.stops()
+                .iter()
+                .map(|at| at.stop.clone())
+                .collect::<Vec<_>>(),
+            vec![Stop::Project("blooop/dotfiles".to_string())]
+        );
+        assert!(app.visible().is_empty(), "no ticket rows on the list");
+
+        // And a query that matches no project empties the list rather than
+        // falling back to something.
+        app.query.clear();
+        type_str(&mut app, "zzzz");
+        assert!(app.stops().is_empty());
+    }
+
+    #[test]
+    fn the_count_line_counts_whatever_the_screen_is_a_list_of() {
+        // Tickets on a project's screen, projects on the list. Counting
+        // tickets on the list would read `0/0` under nine projects — the same
+        // number an empty screen shows — and a query would narrow a count it
+        // was not narrowing.
+        let mut app = launchable_app();
+        assert_eq!(
+            app.counts(),
+            (3, 4),
+            "the wayfinder map's rows, its done one collapsed"
+        );
+
+        app.level = Level::Projects;
+        assert_eq!(app.counts(), (2, 2), "wayfinder and dotfiles");
+        type_str(&mut app, "dotf");
+        assert_eq!(app.counts(), (1, 2), "narrowed, out of all of them");
+    }
+
+    #[test]
+    fn a_query_puts_the_best_matching_project_first() {
+        // The fzf order the clusters already follow: with a query live it is
+        // the query's turn to decide, so `enter` after typing runs the thing
+        // you were most plainly reaching for rather than whatever you happened
+        // to open last.
+        let stamped = |path: &str, repo: &str, at: u64| Checkout {
+            path: std::path::PathBuf::from(path),
+            repo: repo.to_string(),
+            used: Some(at),
+        };
+        let mut app = fixture_app().with_checkouts(vec![
+            stamped("/a", "blooop/way", 300),
+            stamped("/b", "blooop/wayfinder", 100),
+        ]);
+        app.level = Level::Projects;
+        assert_eq!(at(&app), "project blooop/way", "most recently used first");
+        type_str(&mut app, "wayfinder");
+        assert_eq!(
+            at(&app),
+            "project blooop/wayfinder",
+            "and the query outranks that"
+        );
+    }
+
+    #[test]
+    fn a_query_hands_enter_back_to_the_best_match() {
+        // The creating default must not survive a sift. An untouched cursor
+        // means the first stop, so a project row left on a sifted screen would
+        // take `enter` on a freshly typed query away from the match and give it
+        // to *new task* — the one place where opening on the project is wrong.
+        let mut app = launchable_app();
+        assert_eq!(at(&app), "project blooop/wayfinder");
+        type_str(&mut app, "bread");
+        assert_eq!(at(&app), "#6", "the hit, not the project");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::PickLaunch { staged, .. } => {
+                assert!(
+                    matches!(staged.candidates()[0], Candidate::Launch { .. }),
+                    "a ticket's picker, not the creation rows"
+                );
+            }
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+        // Clearing the query puts the row back, and the cursor with it.
+        app.overlay = Overlay::None;
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(at(&app), "project blooop/wayfinder");
+    }
+
+    #[test]
+    fn enter_and_right_both_enter_a_project_and_left_comes_back_to_it() {
+        // The whole of the two-level navigation, in one walk. `←` is the back
+        // key: from inside a project it climbs to the project row and then out
+        // to the list, landing on the project just left rather than at the top.
+        let mut app = launchable_app();
+        app.level = Level::Projects;
+        go_to(&mut app, "project blooop/wayfinder");
+        app.handle_key(key(KeyCode::Enter));
+        assert_eq!(
+            app.level,
+            Level::Project {
+                repo: "blooop/wayfinder".to_string()
+            }
+        );
+        // Down into the maps, then `←` all the way back out.
+        go_to(&mut app, "#6");
+        while app.current_repo().is_some() {
+            app.handle_key(key(KeyCode::Left));
+        }
+        assert_eq!(app.level, Level::Projects);
+        assert_eq!(
+            app.cursor_stop(),
+            Some(Stop::Project("blooop/wayfinder".to_string())),
+            "back out onto the project just left"
+        );
+        // `→` is the same door as `enter`.
+        app.handle_key(key(KeyCode::Right));
+        assert_eq!(
+            app.level,
+            Level::Project {
+                repo: "blooop/wayfinder".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn ctrl_r_requests_refresh_and_replace_clusters_keeps_anchor() {
+        let mut app = fixture_app();
+        assert_eq!(app.handle_key(ctrl('r')), Outcome::Refresh);
+        go_to(&mut app, "#6");
+        let same = app.clusters.clone();
+        app.replace_clusters(same);
+        assert_eq!(app.cursor_ticket().unwrap().number, 6);
+    }
+
+    #[test]
+    fn replace_clusters_does_not_teleport_when_cursor_ticket_vanishes() {
+        let mut app = fixture_app();
+        go_to(&mut app, "#6"); // position 2: the project row and the header
+        let mut smaller = app.clusters.clone();
+        smaller
+            .get_mut(&MapId::new("blooop/wayfinder", 1))
+            .unwrap()
+            .tickets
+            .retain(|t| t.number != 6);
+        app.replace_clusters(smaller);
+        // Identity gone: cursor stays at the same position, clamped.
+        assert_eq!(app.cursor_pos(), 2);
+        assert_eq!(app.cursor_ticket().unwrap().number, 9);
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -135,13 +135,27 @@ impl Query {
         self.hit(ticket).map(|hit| hit.score)
     }
 
-    /// The match, with the characters it landed on — and `None` when it landed
-    /// badly enough not to count, which `tight` decides.
-    pub fn hit(&mut self, ticket: &Ticket) -> Option<Hit> {
-        let hay = haystack(ticket);
+    /// Match plain text, scored and with the characters it landed on.
+    ///
+    /// What the project list matches on — a row there is a repo slug and
+    /// nothing else, with no ticket to build a haystack from. It goes through
+    /// the same pattern and the same `tight` rule as a ticket row on
+    /// purpose: the two screens are one query field with one contract, and a
+    /// project list that matched loosely would be the second matching
+    /// vocabulary this rule exists to prevent.
+    pub fn text(&mut self, text: &str) -> Option<(u32, Vec<usize>)> {
+        let (score, indices) = self.matched(text)?;
+        Some((score, indices.into_iter().map(|i| i as usize).collect()))
+    }
+
+    /// The pattern against one haystack: the score and the char indices it
+    /// landed on, sorted, unique and tight — or `None`. The one place a match
+    /// is decided, so [`Query::hit`] and [`Query::text`] cannot come to differ
+    /// about what counts as one.
+    fn matched(&mut self, hay: &str) -> Option<(u32, Vec<u32>)> {
         let mut indices = Vec::new();
         let score = self.pattern.indices(
-            Utf32Str::new(&hay, &mut self.buf),
+            Utf32Str::new(hay, &mut self.buf),
             &mut self.matcher,
             &mut indices,
         )?;
@@ -151,9 +165,14 @@ impl Query {
         // unique before either does.
         indices.sort_unstable();
         indices.dedup();
-        if !tight(&hay.chars().collect::<Vec<char>>(), &indices) {
-            return None;
-        }
+        tight(&hay.chars().collect::<Vec<char>>(), &indices).then_some((score, indices))
+    }
+
+    /// The match, with the characters it landed on — and `None` when it landed
+    /// badly enough not to count, which `tight` decides.
+    pub fn hit(&mut self, ticket: &Ticket) -> Option<Hit> {
+        let hay = haystack(ticket);
+        let (score, indices) = self.matched(&hay)?;
 
         let repo_len = ticket.short_repo().chars().count();
         let mut hit = Hit {

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -716,7 +716,7 @@ pub struct Staged {
     pub at: StagedAt,
 }
 
-/// What the picker was opened on (#114). A map-less repo is not a node with a
+/// What the picker was opened on (#114). A project is not a node with a
 /// missing issue number — it has no aim, no map and nothing to launch, because
 /// nothing has been filed in it yet — so the two are arms of one sum rather
 /// than a node struct with optional fields. Which rows the picker offers falls
@@ -733,8 +733,8 @@ pub enum StagedAt {
         /// when the cursor was on the cluster header.
         map: MapRef,
     },
-    /// A registered checkout whose repo has no open map: the empty-state door
-    /// this repo's *first* map is charted from.
+    /// A whole project: the repo-level stop every project screen opens on,
+    /// and the only stop creation hangs off.
     Project,
 }
 
@@ -771,8 +771,8 @@ impl Staged {
         }
     }
 
-    /// Stage the empty-state door: a registered repo with no open map (#114).
-    /// There is no node, so the picker offers creation alone.
+    /// Stage a project — the repo-level stop. There is no node, so the picker
+    /// offers creation alone.
     pub fn project(repo: &str) -> Staged {
         Staged {
             repo: repo.to_string(),
@@ -781,7 +781,7 @@ impl Staged {
     }
 
     /// How the staged stop reads to the human: the ticket's title, the map's,
-    /// or the map-less door's own words.
+    /// or nothing at all for a project, which the repo already names.
     ///
     /// Derived rather than stored (#124). The title the picker draws and the
     /// title the launch hands the agent are one fact, and a second copy beside
@@ -795,12 +795,16 @@ impl Staged {
             StagedAt::Node {
                 aim: Aim::Map, map, ..
             } => &map.title,
-            StagedAt::Project => "no map",
+            // The repo already leads the picker's title, and a project stop
+            // adds nothing to it: what is being named is the repo itself. It
+            // read `no map` while this stop existed only as the map-less door;
+            // it is now every project's row, and most of them have maps.
+            StagedAt::Project => "",
         }
     }
 
     /// Which skill launching this node in `mode` would run — `None` for the
-    /// map-less door, which has no node to launch and therefore no route.
+    /// project stop, which has no node to launch and therefore no route.
     pub fn route(&self, mode: Mode) -> Option<Route> {
         match &self.at {
             StagedAt::Node { aim, .. } => Some(route(aim, mode)),
@@ -811,52 +815,50 @@ impl Staged {
     /// The row the picker opens on: the first row this stop offers. On a node
     /// that is the default mode's launch row — creation is never the default,
     /// because `enter` on a node still means "launch this node" first. On the
-    /// map-less door there is no node to launch, so the first creation row
-    /// leads.
+    /// project row there is no node to launch, so the first creation row
+    /// leads — and since that row is where an untouched cursor sits, it is
+    /// what `enter` type `enter` runs.
     ///
     /// # Panics
     ///
     /// Never: [`Staged::candidates`] is never empty. Every stop offers rows —
-    /// its launch rows, or, on the map-less door, its creation rows.
+    /// its launch rows, or, on a project row, its creation rows.
     pub fn default_candidate(&self) -> Candidate {
         *self.candidates().first().expect("every stop offers rows")
     }
 
     /// The picker's rows for this stop, in on-screen order — the one
     /// constructor of [`Candidate`], which is what makes an inconsistent row
-    /// unbuildable (#114). Every *node* launches; only the repo-level node —
-    /// the cluster header, [`Aim::Map`] — adds the creation rows, because
-    /// creation is a repo-level act and a ticket picker carrying it would
-    /// merge concerns the stop grammar keeps apart. The map-less door has no
-    /// node, so it offers the creation rows alone.
+    /// unbuildable (#114).
+    ///
+    /// A **node launches, a project creates**, and neither does the other's
+    /// job. Creation used to ride along on the cluster header's picker, on the
+    /// grounds that a header was the only repo-level stop there was; a project
+    /// row is a *better* one, and having both would put "new map" on every
+    /// header of a repo that has three maps open — three doors to one act,
+    /// none of them the repo. So the header's picker is the three modes again,
+    /// exactly like a ticket's, and the only difference between them is what
+    /// they aim at.
     pub fn candidates(&self) -> Vec<Candidate> {
-        let launches = |aim: &Aim| {
-            Mode::all()
+        match &self.at {
+            StagedAt::Node { aim, .. } => Mode::all()
                 .into_iter()
                 .map(|mode| Candidate::Launch {
                     mode,
                     route: route(aim, mode),
                 })
-                .collect::<Vec<_>>()
-        };
-        let creations = || CreationKind::all().into_iter().map(Candidate::Create);
-        match &self.at {
-            StagedAt::Node {
-                aim: aim @ Aim::Ticket { .. },
-                ..
-            } => launches(aim),
-            StagedAt::Node {
-                aim: aim @ Aim::Map,
-                ..
-            } => launches(aim).into_iter().chain(creations()).collect(),
-            // Nothing has been filed in this repo yet, so there is nothing to
+                .collect(),
+            // A project names nothing that exists yet, so there is nothing to
             // launch — only the three ways to start something.
-            StagedAt::Project => creations().collect(),
+            StagedAt::Project => CreationKind::all()
+                .into_iter()
+                .map(Candidate::Create)
+                .collect(),
         }
     }
 
     /// How the staged stop reads: `#<n>` for a node — the ticket's number or
-    /// the map's — and `+new` for the map-less door, which has no number to
+    /// the map's — and `+new` for a project, which has no number to
     /// name until a skill files one.
     pub fn key(&self) -> String {
         match &self.at {
@@ -878,7 +880,7 @@ impl Staged {
     /// two `None` cases are the ones where staging does not determine a
     /// workspace:
     ///
-    /// - **The map-less door** ([`StagedAt::Project`]) offers creation rows
+    /// - **A project row** ([`StagedAt::Project`]) offers creation rows
     ///   alone. There is no node, so there is nothing a launch would attach
     ///   to.
     /// - A **creation** picked on a map's picker resolves to the repo's bare
@@ -1427,7 +1429,7 @@ fn enabled_from(value: Option<&str>) -> bool {
 ///
 /// `None` unless there is exactly one thing to warm. Two ways to get nothing:
 /// the stop names no launchable workspace ([`Staged::node_workspace`] — the
-/// map-less door), or no candidate checkout would launch isolated, which is a
+/// project row), or no candidate checkout would launch isolated, which is a
 /// host launch with no container in it.
 ///
 /// Any *one* isolated candidate is enough — the workspace name is the node's,
@@ -1540,7 +1542,7 @@ pub enum Targets {
 pub fn plan(checkouts: &[Checkout], staged: &Staged, route: Route, mode: &LaunchMode) -> Targets {
     let StagedAt::Node { aim, map } = &staged.at else {
         // Unreachable from the picker: [`Staged::candidates`] offers no launch
-        // row on the map-less door, so nothing there can ask for a node
+        // row on a project stop, so nothing there can ask for a node
         // launch. Refusing rather than inventing a node — there is no aim and
         // no map issue to invent one from — keeps this total.
         return Targets::Unregistered;
@@ -1640,10 +1642,7 @@ mod tests {
     }
 
     fn checkout(path: &str, repo: &str) -> Checkout {
-        Checkout {
-            path: PathBuf::from(path),
-            repo: repo.to_string(),
-        }
+        Checkout::new(PathBuf::from(path), repo.to_string())
     }
 
     /// What the picker composes with the default mode row selected, steered by
@@ -1865,15 +1864,16 @@ mod tests {
         );
     }
     #[test]
-    fn a_header_picker_adds_the_creation_rows_after_the_launch_rows() {
-        // The repo-level stop is where creation lives: the same three launch
-        // rows, then the three ways to start something new in this repo. Each
-        // candidate is complete — it carries its own resolved route, the
-        // `Targets::Many` move — so a row and its launch cannot disagree.
-        let staged = Staged::map(&map_ref(59));
-        let candidates = staged.candidates();
+    fn a_node_launches_and_a_project_creates_and_neither_does_the_others_job() {
+        // The two kinds of stop, and the whole of what tells their pickers
+        // apart. A cluster header is a *map* — a node — so it walks the three
+        // modes exactly as a ticket does; creation belongs to the project row,
+        // which has no node and therefore no launch row. Each candidate is
+        // complete, carrying its own resolved route (the `Targets::Many`
+        // move), so a row and its launch cannot disagree.
+        let header = Staged::map(&map_ref(59)).candidates();
         assert_eq!(
-            candidates,
+            header,
             vec![
                 Candidate::Launch {
                     mode: Mode::Interactive,
@@ -1887,18 +1887,23 @@ mod tests {
                     mode: Mode::Plain,
                     route: Route::Plain
                 },
+            ],
+            "a map's picker carries no creation rows"
+        );
+
+        let project = Staged::project("blooop/wayfinder").candidates();
+        assert_eq!(
+            project,
+            vec![
                 Candidate::Create(CreationKind::Task),
                 Candidate::Create(CreationKind::Map),
                 Candidate::Create(CreationKind::MapAuto),
             ]
         );
-        // Every row names the skill it execs — including the creation rows,
-        // whose routes are theirs rather than the staged node's.
-        let routes: Vec<Route> = candidates.iter().map(|c| c.route()).collect();
-        assert_eq!(
-            routes[3..],
-            [Route::One, Route::Wayfinder, Route::WayfinderAuto]
-        );
+        // Every row names the skill it execs — the creation rows' routes are
+        // their own rather than any node's.
+        let routes: Vec<Route> = project.iter().map(|c| c.route()).collect();
+        assert_eq!(routes, [Route::One, Route::Wayfinder, Route::WayfinderAuto]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,9 +8,10 @@
 //! 3. One `wayfinder:map` label search reconciles that set; every map streams
 //!    in as it lands. `ctrl-r` asks again. Nothing polls: `wf` is on screen for
 //!    seconds and restarts warm in ~0.6 s.
-//! 4. Inside a checkout whose repo has a map, the screen opens focused on
-//!    it (`Scope::Project`, repo column dropped); `ctrl-g` widens to all
-//!    projects, `ctrl-f` re-focuses.
+//! 4. Inside a checkout, the screen opens **on that project** and nowhere
+//!    else; run outside one and it opens on the project list, most recently
+//!    used first. Both are drawn from the cache, so neither waits on the
+//!    search — and `←` walks between them.
 //! 5. `enter` picks a ticket, and that is the end of `wf`: the loop returns,
 //!    the terminal is restored, and this process is replaced by the agent
 //!    ([`wf::launch::Launch::exec`]). The one ordering that matters —
@@ -26,7 +27,7 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 
-use wf::app::{App, Outcome, Scope};
+use wf::app::{App, Outcome};
 use wf::launch::{Agent, Launch};
 use wf::model::{Map, MapId};
 use wf::projects::{self, ProjectsCache};
@@ -71,10 +72,11 @@ usage: wf [--version | --help]
        wf skills [install]
        wf reap [-y] [-f]
 
-With no arguments: opens the picker over every mapped project, focused on the
-checkout you are standing in. enter runs an agent on the picked ticket, in that
-checkout, replacing wf — so wf is gone by the time the agent draws. ctrl-f and
-ctrl-g narrow and widen the scope, ctrl-r refetches, esc quits.
+With no arguments: opens on the project you are standing in, or on the list of
+every registered project — most recently used first — when you are not standing
+in one. enter selects a project, or runs an agent on the picked ticket in that
+project's checkout, replacing wf — so wf is gone by the time the agent draws.
+Left backs out, ctrl-r refetches, esc quits.
 
 wf skills          report which prompt each route would actually run
 wf skills install  link this build's skills into ~/.claude/skills and ~/.codex/skills
@@ -398,22 +400,21 @@ async fn main() -> Result<()> {
     spawn_terminal_guard();
 
     let (tx, updates) = mpsc::unbounded_channel();
-    let discovery = wf::refresh::spawn_discovery(repos, cache_path, tx.clone());
+    let discovery = wf::refresh::spawn_discovery(repos, cache_path.clone(), tx.clone());
 
-    // cwd-open focuses the project (lazygit-style). Only the map *search* can
-    // say authoritatively whether this repo has a map, so the focus is handed to
-    // the loop to apply the moment discovery lands — but a seeded repo can be
-    // focused from the first frame, and usually is, so the picker no longer
-    // opens wide and jumps a couple of seconds later. `focus` is kept either
-    // way: the search still gets to overrule a seed that has gone stale.
-    let focus = here.map(|(_, slug)| slug);
-    if let Some(slug) = focus
-        .as_ref()
-        .filter(|slug| seed.iter().any(|id| &id.repo == *slug))
-    {
-        app.scope = Scope::Project(slug.clone());
+    // cwd-open enters the project, on the first frame and unconditionally.
+    //
+    // It used to wait: the focus was only applied to a repo the cached seed
+    // already knew had a map, and otherwise handed to the loop to apply when
+    // discovery landed, because a focused repo with no maps rendered an empty
+    // screen. It cannot now — a project's screen leads with the project's own
+    // row, which is a place to stand whether or not anything has been filed in
+    // the repo, let alone fetched. So the level is decided by one local `git`
+    // call, before any network call, and nothing arriving later moves it.
+    if let Some((_, slug)) = &here {
+        app.enter(slug);
     }
-    let ending = run(&mut terminal, app, discovery, tx, updates, focus).await;
+    let ending = run(&mut terminal, app, discovery, tx, updates).await;
 
     // The one ordering that matters, and the reason the exec is here rather
     // than in the loop: the terminal must be back in the shell's hands before
@@ -433,6 +434,26 @@ async fn main() -> Result<()> {
     match ending? {
         Ending::Quit => Ok(()),
         Ending::Handover(launch) => {
+            // The launch is a use of this project, and the last chance to say
+            // so: after the exec there is no `wf` left to write anything. This
+            // is what keeps the project list ordered for someone who reaches
+            // their projects *through* it — opening `wf` in a checkout stamps
+            // it, and for everyone else launching is the only other act that
+            // means "this is what I am working on".
+            //
+            // Re-read before writing, exactly as the discovery task does: it
+            // writes the search's findings to this same file while the picker
+            // is up, so the copy loaded before the first frame is stale by
+            // now, and saving it would trade this stamp for next run's head
+            // start.
+            //
+            // Best-effort on purpose. A cache that will not write is not worth
+            // refusing a launch over, and the only cost of losing this is one
+            // project sitting lower in a list than it might have.
+            let mut cache = ProjectsCache::load_or_default(&cache_path);
+            if cache.touch(launch.cwd()) {
+                let _ = cache.save(&cache_path);
+            }
             // The prompts the selected agent is about to run. `wf skills
             // install` links its skills directory at a *copy* of the bundle,
             // and a copy is a thing that can fall behind a `pixi global update
@@ -540,7 +561,6 @@ async fn run(
     discovery: JoinHandle<()>,
     tx: UnboundedSender<LoadEvent>,
     mut updates: UnboundedReceiver<LoadEvent>,
-    mut focus: Option<String>,
 ) -> Result<Ending> {
     let mut clusters: BTreeMap<MapId, Map> = BTreeMap::new();
     // The cached seed starts fetching immediately (#28); the search's answer
@@ -561,21 +581,12 @@ async fn run(
                     // flight at once and each lands on screen as it arrives.
                     loaders.reconcile(&found, &tx);
                     app.startup.searched(&found);
-                    if let Some(slug) = focus.take() {
-                        // Focused either way now (#114). A repo with no open
-                        // map used to send the focus back to every project,
-                        // which left the repo you were standing in with
-                        // nothing on screen and no way to chart its first map.
-                        // Focused, it renders the empty-state door instead —
-                        // so the answer to "this repo has no map" is somewhere
-                        // to start one rather than somebody else's tickets.
-                        let mapless = !found.iter().any(|id| id.repo == slug);
-                        app.scope = Scope::Project(slug.clone());
-                        if mapless {
-                            app.notice =
-                                Some(format!("{slug} has no wayfinder:map — enter starts one"));
-                        }
-                    }
+                    // Nothing to apply here any more: the level was decided
+                    // before the first frame and discovery has no say in it.
+                    // A repo the search finds no map for renders its project
+                    // row saying so, which is both the notice this used to
+                    // post and somewhere to act on it.
+                    //
                     // Maps the search dropped must stop being rendered as well as
                     // stop being fetched — their rows are as stale as their load.
                     // A map that is no longer open also stops being a *failure*:
@@ -617,15 +628,7 @@ async fn run(
                 if key.kind != KeyEventKind::Press {
                     continue;
                 }
-                let scope_before = app.scope.clone();
-                let outcome = app.handle_key(key);
-                // A scope the user chose while the load was still out is theirs
-                // to keep: the pending cwd focus is dropped rather than applied
-                // over their `ctrl-g` when discovery lands a moment later.
-                if app.scope != scope_before {
-                    focus = None;
-                }
-                match outcome {
+                match app.handle_key(key) {
                     Outcome::Quit => return Ok(Ending::Quit),
                     // Through the loaders, not alongside them: a refetch that
                     // raced an in-flight load used to be silently overwritten

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -31,6 +31,74 @@ pub struct Checkout {
     pub path: PathBuf,
     /// Full repo slug from `origin` (e.g. "blooop/wayfinder").
     pub repo: String,
+    /// When `wf` was last *used* here, in seconds since the Unix epoch —
+    /// opened in this checkout, or launched an agent from it.
+    ///
+    /// This is what orders the project list, and the reason it is a local
+    /// stamp rather than the tracker's `updatedAt`: the list is drawn before
+    /// any network call, so the only ordering it can honour at frame zero is
+    /// one already on disk. Map activity says which project the *world* touched
+    /// last; this says which one *you* did, which is the question a launcher is
+    /// answering.
+    ///
+    /// `None` on entries written before the list existed, and on nothing else.
+    /// Unknown sorts last rather than being guessed into place — the same
+    /// answer [`crate::app::App::scoped_clusters`] gives an activity stamp it
+    /// could not parse — and corrects itself the first time the project is
+    /// opened.
+    #[serde(default)]
+    pub used: Option<u64>,
+}
+
+impl Checkout {
+    /// A checkout registered now. The only constructor, so a registration can
+    /// never forget to stamp itself and sink to the bottom of the list it just
+    /// joined.
+    #[must_use]
+    pub fn new(path: PathBuf, repo: String) -> Self {
+        Self {
+            path,
+            repo,
+            used: Some(now_secs()),
+        }
+    }
+}
+
+/// Now, in seconds since the Unix epoch — `0` on a clock set before it, which
+/// no ordering can do anything sensible with anyway and which sorts as the
+/// oldest known use rather than as unknown.
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// The registered repos in most-recently-used order — the project list's body.
+///
+/// A *repo*, not a checkout: two checkouts of one repo (the `~/k1/kinisi_ros`,
+/// `~/k2/kinisi_ros` pattern) are two places one project can run, not two
+/// projects, and they share its maps. So a repo's stamp is the newest of its
+/// checkouts' — the last time you used the project, wherever you used it from.
+///
+/// Newest first, unstamped last, then the slug: an order that never shuffles
+/// between frames, because the cursor is walking it.
+#[must_use]
+pub fn mru_repos(checkouts: &[Checkout]) -> Vec<String> {
+    let mut newest: std::collections::BTreeMap<&str, Option<u64>> =
+        std::collections::BTreeMap::new();
+    for checkout in checkouts {
+        let slot = newest.entry(checkout.repo.as_str()).or_default();
+        *slot = (*slot).max(checkout.used);
+    }
+    let mut repos: Vec<(Option<u64>, &str)> = newest.into_iter().map(|(r, u)| (u, r)).collect();
+    // `Reverse` on the stamp puts the newest first, and `None < Some` reversed
+    // puts the unstamped at the end — the same key shape the cluster order uses
+    // for an activity timestamp that did not parse.
+    repos.sort_by_key(|&(used, repo)| (std::cmp::Reverse(used), repo));
+    repos
+        .into_iter()
+        .map(|(_, repo)| repo.to_string())
+        .collect()
 }
 
 /// The per-machine cache of touched checkouts, plus the last map search's
@@ -87,14 +155,41 @@ impl ProjectsCache {
     }
 
     /// Register (or refresh) a touched checkout. Sorted by path so the
-    /// which-checkout picker is stable between runs.
+    /// which-checkout picker is stable between runs — the *project* list takes
+    /// its own order from [`mru_repos`] rather than from this one.
+    ///
+    /// Registering is a use, so it stamps: opening `wf` in a checkout is what
+    /// puts that project at the top of the list next time.
     pub fn register(&mut self, path: PathBuf, repo: String) {
         match self.checkouts.iter_mut().find(|c| c.path == path) {
-            Some(entry) => entry.repo = repo,
-            None => self.checkouts.push(Checkout { path, repo }),
+            Some(entry) => {
+                entry.repo = repo;
+                entry.used = Some(now_secs());
+            }
+            None => self.checkouts.push(Checkout::new(path, repo)),
         }
         self.checkouts.sort_by(|a, b| a.path.cmp(&b.path));
         self.forget_unknown_maps();
+    }
+
+    /// Stamp the checkout an agent is about to be launched in.
+    ///
+    /// The second half of "use", and the half that matters for a project you
+    /// reach through the list rather than through your shell: entering a
+    /// project is navigation and might be a wrong turn, but launching from it
+    /// is the act the ordering is trying to predict. Unknown paths are ignored
+    /// — a launch resolves against this very cache, so there is no such thing.
+    ///
+    /// Returns whether anything changed, so the caller can skip a write on the
+    /// path where the terminal is already being handed over.
+    pub fn touch(&mut self, path: &Path) -> bool {
+        match self.checkouts.iter_mut().find(|c| c.path == path) {
+            Some(entry) => {
+                entry.used = Some(now_secs());
+                true
+            }
+            None => false,
+        }
     }
 
     /// The head start (#28): every open map the last search found, for repos
@@ -214,6 +309,85 @@ mod tests {
 
     fn p(s: &str) -> PathBuf {
         PathBuf::from(s)
+    }
+
+    /// A checkout with a stamp of its own, so an ordering assertion is not a
+    /// race against the clock.
+    fn used(path: &str, repo: &str, at: Option<u64>) -> Checkout {
+        Checkout {
+            path: p(path),
+            repo: repo.to_string(),
+            used: at,
+        }
+    }
+
+    #[test]
+    fn projects_are_listed_most_recently_used_first() {
+        let repos = mru_repos(&[
+            used("/a", "blooop/old", Some(100)),
+            used("/b", "blooop/new", Some(300)),
+            used("/c", "blooop/mid", Some(200)),
+        ]);
+        assert_eq!(repos, ["blooop/new", "blooop/mid", "blooop/old"]);
+    }
+
+    #[test]
+    fn an_unstamped_checkout_sorts_last_rather_than_being_guessed_into_place() {
+        // What an entry written before `used` existed looks like: unknown is
+        // not zero and not now, it is *after* everything known — the same
+        // answer the cluster order gives an activity stamp it could not parse.
+        // It corrects itself the first time the project is opened.
+        let repos = mru_repos(&[
+            used("/a", "blooop/unstamped", None),
+            used("/b", "blooop/ancient", Some(1)),
+        ]);
+        assert_eq!(repos, ["blooop/ancient", "blooop/unstamped"]);
+    }
+
+    #[test]
+    fn two_checkouts_of_one_repo_are_one_project_stamped_by_the_newer() {
+        // The `~/k1`, `~/k2` pattern: two places one project can run, sharing
+        // its maps. Listing it twice would be listing one project twice, and
+        // taking the older stamp would sink a project you used an hour ago.
+        let repos = mru_repos(&[
+            used("/k1/dotfiles", "blooop/dotfiles", Some(100)),
+            used("/k2/dotfiles", "blooop/dotfiles", Some(400)),
+            used("/proj/wayfinder", "blooop/wayfinder", Some(300)),
+        ]);
+        assert_eq!(repos, ["blooop/dotfiles", "blooop/wayfinder"]);
+    }
+
+    #[test]
+    fn registering_stamps_and_touching_restamps() {
+        // The two halves of "use": opening `wf` in a checkout, and launching
+        // an agent from one. A project reached through the list only ever gets
+        // the second, which is why it exists.
+        let mut cache = ProjectsCache::default();
+        cache.register(p("/data/proj/wayfinder"), "blooop/wayfinder".to_string());
+        let stamped = cache.checkouts[0].used.expect("registering stamps");
+
+        // An entry loaded from an older cache file carries no stamp; a launch
+        // from it gives it one.
+        cache.checkouts[0].used = None;
+        assert!(cache.touch(&p("/data/proj/wayfinder")));
+        assert!(cache.checkouts[0].used.expect("touching stamps") >= stamped);
+
+        // A path the cache does not know is not silently added: a launch
+        // resolves against this very cache, so there is no such path.
+        assert!(!cache.touch(&p("/data/proj/elsewhere")));
+        assert_eq!(cache.checkouts.len(), 1);
+    }
+
+    #[test]
+    fn an_older_cache_file_without_stamps_still_loads() {
+        // The upgrade path, which must not cost anyone their registry: the
+        // field is new, so every existing entry lacks it.
+        let cache: ProjectsCache = serde_json::from_str(
+            r#"{"checkouts":[{"path":"/data/proj/wayfinder","repo":"blooop/wayfinder"}]}"#,
+        )
+        .expect("an older cache file parses");
+        assert_eq!(cache.checkouts[0].used, None);
+        assert_eq!(mru_repos(&cache.checkouts), ["blooop/wayfinder"]);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,11 +13,11 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Clear, Paragraph};
 use ratatui::Frame;
 
-use crate::app::{App, Overlay, Scope};
+use crate::app::{App, Overlay};
 use crate::filter;
 use crate::launch::{Agent, Candidate, Launch, Staged};
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
-use crate::view::{Branch, Fold, GroupKind, Item, Plan};
+use crate::view::{Branch, Fold, GroupKind, Item, Plan, ProjectRow};
 
 /// One colour per glyph meaning, shared by the row column and the rollup
 /// pairs: calm colours for the flowing stages, red for the two that demand
@@ -68,19 +68,49 @@ fn cluster_header(id: &MapId, map: &Map, lit: &[usize], under_cursor: bool) -> L
     Line::from(spans)
 }
 
-/// The slim header of a focused repo with no open map (#114): the same left
-/// edge every cluster has, so it reads as somewhere to stand rather than as an
-/// error — but dim and countless, because there are no stages to count and
-/// nothing here to launch. `enter` on it opens the creation rows.
-fn mapless_header(repo: &str, under_cursor: bool) -> Line<'static> {
+/// A project row: the body of the project list, and the line a project's own
+/// screen opens on.
+///
+/// The same left edge every cluster has, one shade quieter — a project is the
+/// container its maps sit in, so it reads as somewhere to stand rather than as
+/// something that has happened. It carries the full `owner/name` rather than
+/// the short name the cluster headers show, because this is the one place two
+/// forks of one repo sit next to each other and the short names would be
+/// identical.
+///
+/// The tail says what is inside, and has three honest answers: the stage
+/// rollup once maps are on hand, `no map — enter to start one` once the search
+/// has answered and found none, and `loading…` in between. That third one is
+/// the whole reason [`ProjectRow::loaded`] exists — a repo whose maps are still
+/// in flight and a repo that has none are the same zero, and calling the first
+/// "no map" is the lie [`crate::refresh::Startup`] exists to prevent.
+fn project_line(row: &ProjectRow, under_cursor: bool) -> Line<'static> {
     let dim = Style::new().add_modifier(Modifier::DIM);
-    Line::from(vec![
-        cursor_span(under_cursor),
-        Span::styled("▌ ", dim),
-        // The name half, as every cluster header shows it.
-        Span::styled(repo.split('/').next_back().unwrap_or(repo).to_string(), dim),
-        Span::styled(" · no map — enter to start one", dim),
-    ])
+    let cyan = Style::new().fg(Color::Cyan);
+    let mut spans = vec![cursor_span(under_cursor), Span::styled("▌ ", cyan)];
+    spans.extend(lit_spans(&row.repo, &row.lit, cyan));
+    match (row.maps, row.loaded) {
+        (0, false) => spans.push(Span::styled(" · loading…", dim)),
+        (0, true) => spans.push(Span::styled(" · no map — enter to start one", dim)),
+        (n, _) => {
+            spans.push(Span::styled(
+                if n == 1 {
+                    " · 1 map".to_string()
+                } else {
+                    format!(" · {n} maps")
+                },
+                dim,
+            ));
+            for &(glyph, count) in &row.rollup {
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(
+                    format!("{}{count}", glyph.char()),
+                    glyph_style(glyph),
+                ));
+            }
+        }
+    }
+    Line::from(spans)
 }
 
 /// A rollup's trailing spans: a dim word for what the counts are *of*, then
@@ -411,7 +441,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     under_cursor,
                 ));
             }
-            Item::MaplessHeader(repo) => lines.push(mapless_header(repo, under_cursor)),
+            Item::Project(project) => lines.push(project_line(project, under_cursor)),
             Item::Context { row, prefix } => lines.push(context_line(app.ticket(row), prefix)),
             Item::Group { id, held, fold } => {
                 lines.push(group_line(id.kind, *held, fold, under_cursor));
@@ -426,30 +456,50 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
 /// agent right here and `wf` is gone (#34); `esc` clears the query first and
 /// quits on an empty one, and `q` only quits when the query is empty (mid-query
 /// it types).
-const KEY_HINTS: &str =
-    "  enter launch · ←→ open · tab structure · ctrl-f focus · ctrl-r refresh · esc quit";
+/// The hint line, which is the level's — because the keys mean different
+/// enough things on the two screens that one line would have to be vague about
+/// both. `enter` opens a project up here and launches an agent down there;
+/// `tab` and the depth keys have nothing to toggle or descend into on a flat
+/// list of projects; and `←` being the way *back* is worth saying exactly where
+/// there is somewhere to go back to.
+fn key_hints(app: &App) -> &'static str {
+    if app.current_repo().is_some() {
+        "  enter launch · ←→ open · ← back · tab structure · ctrl-r refresh · esc quit"
+    } else {
+        "  enter open · ↑↓ move · type to filter · ctrl-r refresh · esc quit"
+    }
+}
 
 /// The project heading in the title bar.
 ///
-/// An empty screen has three meanings — still loading (#27), every fetch
-/// failed, or genuinely no projects — and telling a user with three registered
-/// projects that they have none is the exact ambiguity
-/// [`crate::refresh::Startup`] exists to remove. So both other cases are named
-/// before "no projects" is claimed. With clusters on screen, the heading
-/// counts the ground they cover: the one repo's slug, or how many projects.
+/// On a project's own screen it is that project — the level *is* the screen, so
+/// the title says which one whatever the fetch has managed so far.
+///
+/// On the project list it counts the registered repos, which is a fact off the
+/// cache and needs no network, so the ambiguity the old heading had to
+/// disentangle is gone with the screen that had it: an empty list now means one
+/// thing (nothing registered) instead of three (still loading, every fetch
+/// failed, or genuinely none). A failed *map* fetch no longer empties this
+/// screen at all — the projects are still listed — so it is named here only
+/// while it is the most interesting thing true, and on the count line
+/// ([`failure_note`]) in every case.
 ///
 /// # Panics
 ///
 /// Never: the arm that takes the single failed id has already matched on
 /// `len() == 1`.
 pub fn heading(app: &App) -> String {
-    if app.clusters.is_empty() {
-        if !app.startup.is_loaded() {
-            return "loading…".to_string();
-        }
-        // Naming the map is the whole value when there is one: "GitHub is
-        // unreachable" and "you have no projects" are different problems with
-        // different fixes, and the empty list looks identical either way.
+    if let Some(repo) = app.current_repo() {
+        return repo.to_string();
+    }
+    let projects = app.projects();
+    if projects.is_empty() {
+        return "no projects — run wf inside a checkout to register it".to_string();
+    }
+    // Naming the map is the whole value when there is one: "GitHub is
+    // unreachable" and "that project has nothing open" are different problems
+    // with different fixes, and a bare count reads the same either way.
+    if app.clusters.is_empty() && app.startup.is_loaded() {
         match app.failed.len() {
             0 => {}
             1 => {
@@ -458,12 +508,9 @@ pub fn heading(app: &App) -> String {
             }
             n => return format!("{n} maps failed to fetch — ctrl-r retries"),
         }
-        return "no projects — run wf inside a checkout to register it".to_string();
     }
-    let repos: std::collections::BTreeSet<&str> =
-        app.clusters.keys().map(|id| id.repo.as_str()).collect();
-    match repos.len() {
-        1 => (*repos.iter().next().expect("len checked")).to_string(),
+    match projects.len() {
+        1 => projects.into_iter().next().expect("len checked"),
         n => format!("{n} projects"),
     }
 }
@@ -585,6 +632,7 @@ fn draw_launch_picker(
         staged.key(),
         staged.title()
     );
+    let title = title.trim_end().to_string() + " ";
     let width = lines
         .iter()
         .map(|l| l.width() as u16 + 4)
@@ -681,14 +729,12 @@ fn draw_checkout_picker(frame: &mut Frame<'_>, launches: &[Launch], cursor: usiz
 /// count line against the query whose matches it counts.
 /// The which-checkout picker, when open, floats over all of it.
 pub fn draw(frame: &mut Frame<'_>, app: &App) {
-    let mut block = match &app.scope {
-        Scope::All => Block::bordered().title(format!(" wf · {} ", heading(app))),
-        // The focused title names the project by its full slug — with one
-        // project on screen there is room, and it disambiguates forks.
-        Scope::Project(repo) => Block::bordered().title(format!(" wf · {repo} — focused ")),
-    };
-    if app.scope != Scope::All {
-        block = block.title_top(Line::from(" ctrl-g all projects ").right_aligned());
+    let mut block = Block::bordered().title(format!(" wf · {} ", heading(app)));
+    // The way back, named on the screen it applies to. A project screen is the
+    // only one with anywhere to go back to, and `←` is the only key that goes
+    // there — so this line appears exactly when it is true.
+    if app.current_repo().is_some() {
+        block = block.title_top(Line::from(" ← all projects ").right_aligned());
     }
     let inner = block.inner(frame.area());
     frame.render_widget(block, frame.area());
@@ -735,8 +781,9 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>()
         .join(" ");
+    let (shown, total) = app.counts();
     let mut count_spans = vec![
-        Span::raw(format!("  {}/{}", app.visible().len(), app.scoped().len())),
+        Span::raw(format!("  {shown}/{total}")),
         Span::styled(
             format!("  {status}"),
             Style::new().add_modifier(Modifier::DIM),
@@ -751,7 +798,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     frame.render_widget(Paragraph::new(Line::from(count_spans)), count_area);
 
     frame.render_widget(
-        Paragraph::new(KEY_HINTS).style(Style::new().add_modifier(Modifier::DIM)),
+        Paragraph::new(key_hints(app)).style(Style::new().add_modifier(Modifier::DIM)),
         hint_area,
     );
     draw_overlay(frame, app);
@@ -803,10 +850,26 @@ mod tests {
         }
     }
 
+    /// An app standing on `repo`'s screen. `App::new` opens on the project
+    /// *list*, which draws no cluster at all, so a test about what a cluster
+    /// looks like has to say which project's screen it is on.
+    fn app_on(repo: &str, clusters: BTreeMap<MapId, Map>) -> App {
+        let mut app = App::new(clusters);
+        app.enter(repo);
+        app
+    }
+
     fn fixture_app() -> App {
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
-        App::new(clusters)
+        app_on("blooop/wayfinder", clusters)
+    }
+
+    /// Step the cursor down `n` stops.
+    fn down(app: &mut App, n: usize) {
+        for _ in 0..n {
+            app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        }
     }
 
     fn type_str(app: &mut App, s: &str) {
@@ -878,7 +941,7 @@ mod tests {
         }];
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), map);
-        let screen = render(&App::new(clusters));
+        let screen = render(&app_on("blooop/wayfinder", clusters));
         // ○0 is not drawn: the counts name the stages the map is actually in.
         assert!(
             screen.contains("▌ wayfinder · Map: wf  ◍1  !1  ●1  ⊘2"),
@@ -1001,7 +1064,7 @@ mod tests {
         }];
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), map);
-        let app = App::new(clusters);
+        let app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         // Same-repo badge: `⇄ PR#n <state>` after the [type] suffix.
         assert!(
@@ -1047,7 +1110,7 @@ mod tests {
         }];
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), map);
-        let screen = render(&App::new(clusters));
+        let screen = render(&app_on("blooop/wayfinder", clusters));
         assert!(screen.contains("◍ #6 Re-entry breadcrumbs"), "{screen}");
         assert!(screen.contains("! #9 Main screen design"), "{screen}");
         // Blocked still overrides whatever stage lies beneath.
@@ -1074,7 +1137,7 @@ mod tests {
         }];
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), map);
-        let mut app = App::new(clusters);
+        let mut app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         assert!(screen.contains("● 1 done (hidden) ◐1"), "{screen}");
 
@@ -1108,7 +1171,7 @@ mod tests {
         }];
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), map);
-        let screen = render(&App::new(clusters));
+        let screen = render(&app_on("blooop/wayfinder", clusters));
         assert!(screen.contains("⇄ PR#14 open"), "{screen}");
         assert!(!screen.contains('✓'), "{screen}");
         assert!(!screen.contains('✗'), "{screen}");
@@ -1144,13 +1207,15 @@ mod tests {
     fn idle_maps_drop_to_the_count_line_and_tab_brings_them_back() {
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        // A second map of the *same* project: a screen is one repo's, so an
+        // idle map has to be one of this repo's to be dropped from it.
         clusters.insert(
-            MapId::new("blooop/dotfiles", 4),
+            MapId::new("blooop/wayfinder", 4),
             Map {
-                title: "Map: dotfiles".to_string(),
+                title: "Map: the archive".to_string(),
                 last_activity: None,
                 tickets: vec![ticket(
-                    "blooop/dotfiles",
+                    "blooop/wayfinder",
                     103,
                     "All done here",
                     false,
@@ -1159,17 +1224,20 @@ mod tests {
                 )],
             },
         );
-        let mut app = App::new(clusters);
+        let mut app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         assert!(
-            !screen.contains("▌ dotfiles"),
+            !screen.contains("Map: the archive"),
             "an idle map leaves the body: {screen}"
         );
         assert!(screen.contains("· 1 idle map hidden"), "{screen}");
         // The forest is the escape hatch: everything renders there.
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         let screen = render(&app);
-        assert!(screen.contains("▌ dotfiles · Map: dotfiles"), "{screen}");
+        assert!(
+            screen.contains("▌ wayfinder · Map: the archive"),
+            "{screen}"
+        );
         assert!(!screen.contains("idle map"), "{screen}");
     }
 
@@ -1194,7 +1262,7 @@ mod tests {
                 )],
             },
         );
-        let app = App::new(clusters);
+        let app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         let first = screen
             .find("▌ wayfinder · Map: wf")
@@ -1218,12 +1286,12 @@ mod tests {
         // of the keys that would have put it there are deliberately set here.
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/archive", 1),
+            MapId::new("blooop/wayfinder", 1),
             Map {
-                title: "Map: archive".to_string(),
+                title: "Map: the archive".to_string(),
                 last_activity: Activity::parse("2026-08-06T12:00:00Z"),
                 tickets: vec![ticket(
-                    "blooop/archive",
+                    "blooop/wayfinder",
                     88,
                     "Shipped last week",
                     false,
@@ -1247,7 +1315,7 @@ mod tests {
                 )],
             },
         );
-        let mut app = App::new(clusters);
+        let mut app = app_on("blooop/wayfinder", clusters);
         // The forest, because that is the screen a finished map appears on at
         // all — leverage drops it as idle.
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
@@ -1256,7 +1324,7 @@ mod tests {
             .find("▌ wayfinder · Map: the selection view")
             .expect("the live cluster");
         let finished = screen
-            .find("▌ archive · Map: archive")
+            .find("▌ wayfinder · Map: the archive")
             .expect("the finished cluster");
         assert!(
             live < finished,
@@ -1300,11 +1368,15 @@ mod tests {
         assert!(lines[2].contains("5/5"), "{screen}");
         // The body follows, still opening on its own blank spacer line — which
         // now reads as the gap between the chrome and the first cluster.
+        // The project row leads the body, with the spacer that separates it
+        // from the first cluster — so the cluster header is two lines further
+        // down than it was when the body opened straight onto it.
+        assert!(lines[4].contains("▌ blooop/wayfinder"), "{screen}");
         let header = lines
             .iter()
             .position(|l| l.contains("▌ wayfinder · Map: wf"))
             .expect("cluster header on screen");
-        assert_eq!(header, 4, "{screen}");
+        assert_eq!(header, 6, "{screen}");
         assert!(
             lines[lines.len() - 2].contains("enter launch"),
             "hints stay on the last line: {screen}"
@@ -1428,7 +1500,7 @@ mod tests {
         ));
         let mut clusters = BTreeMap::new();
         clusters.insert(MapId::new("blooop/wayfinder", 1), map);
-        let mut app = App::new(clusters);
+        let mut app = app_on("blooop/wayfinder", clusters);
         type_str(&mut app, "choose");
         let screen = render(&app);
         assert!(screen.contains("▾ ● 1 of 2 done"), "{screen}");
@@ -1482,9 +1554,11 @@ mod tests {
     /// The fixture map plus Build 4 launch inputs: two checkouts of the repo,
     /// so `enter` opens the which-checkout picker.
     fn launchable_app() -> App {
-        let checkout = |path: &str| crate::projects::Checkout {
-            path: std::path::PathBuf::from(path),
-            repo: "blooop/wayfinder".to_string(),
+        let checkout = |path: &str| {
+            crate::projects::Checkout::new(
+                std::path::PathBuf::from(path),
+                "blooop/wayfinder".to_string(),
+            )
         };
         fixture_app().with_checkouts(vec![
             checkout("/data/k1/wayfinder"),
@@ -1493,11 +1567,21 @@ mod tests {
     }
 
     #[test]
-    fn the_hint_line_advertises_the_one_launch_key_and_no_afk() {
+    fn the_hint_line_is_the_levels_and_advertises_no_afk() {
         let screen = render(&fixture_app());
-        assert!(screen.contains("enter launch"));
+        assert!(screen.contains("enter launch"), "{screen}");
+        assert!(screen.contains("← back"), "{screen}");
         assert!(!screen.contains("ctrl-a"), "{screen}");
         assert!(!screen.contains("afk"), "{screen}");
+
+        // On the list there is nothing to launch, nothing to descend into and
+        // nowhere further back — so the line says none of those.
+        let mut app = fixture_app();
+        app.level = crate::app::Level::Projects;
+        let screen = render(&app);
+        assert!(screen.contains("enter open"), "{screen}");
+        assert!(!screen.contains("← back"), "{screen}");
+        assert!(!screen.contains("tab structure"), "{screen}");
     }
 
     #[test]
@@ -1510,6 +1594,7 @@ mod tests {
     #[test]
     fn the_checkout_picker_floats_over_the_list_with_one_row_per_tree() {
         let mut app = launchable_app();
+        down(&mut app, 2); // past the project row and the cluster header, onto #6
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // stage
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // resolve
         let screen = render(&app);
@@ -1523,14 +1608,15 @@ mod tests {
     }
 
     #[test]
-    fn a_header_picker_draws_the_creation_rows_with_their_own_skills() {
-        // #114: on the repo-level stop the list carries both questions, so
-        // every row still has to name the skill it execs — including the rows
-        // that launch nothing on this node.
+    fn a_project_picker_draws_the_creation_rows_with_their_own_skills() {
+        // Creation is an act on a repo, so the rows live on the one stop that
+        // is a repo — and every row still names the skill it execs, including
+        // the ones that launch no node.
         let mut app = fixture_app();
-        while !matches!(app.cursor_stop(), Some(crate::view::Stop::Map(_))) {
-            app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
-        }
+        assert!(
+            matches!(app.cursor_stop(), Some(crate::view::Stop::Project(_))),
+            "the project row is where an untouched cursor already is"
+        );
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         let screen = render(&app);
         assert!(screen.contains("new task"), "{screen}");
@@ -1538,20 +1624,11 @@ mod tests {
         assert!(screen.contains("one tracked ticket"), "{screen}");
         assert!(screen.contains("new map"), "{screen}");
         assert!(screen.contains("new map, auto"), "{screen}");
-        // The field is named `steer` while a launch row is picked…
-        assert!(screen.contains("steer"), "{screen}");
-        // …and renames itself as the pick moves onto the creation rows, which
-        // is the only thing telling you the text means something else there.
-        for _ in 0..3 {
-            app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
-        }
-        let screen = render(&app);
-        assert!(screen.contains("▶ new task"), "{screen}");
-        assert!(screen.contains("task  "), "{screen}");
-        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
-        let screen = render(&app);
-        assert!(screen.contains("▶ new map"), "{screen}");
-        assert!(screen.contains("seed  "), "{screen}");
+        // The field is named for the row it fills: `task` on the first one,
+        // which is the only thing telling you the text is not steering.
+        assert!(screen.contains("task"), "{screen}");
+        // Nothing to launch here, so no launch row names a mode.
+        assert!(!screen.contains("interactive"), "{screen}");
     }
 
     #[test]
@@ -1560,6 +1637,7 @@ mod tests {
         // its picker is the three modes and nothing else.
         let app = {
             let mut app = fixture_app();
+            down(&mut app, 2); // past the project row and the cluster header
             app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
             app
         };
@@ -1575,6 +1653,7 @@ mod tests {
 
         // Enter on #6 (a task at ready): the picker floats over the list,
         // titled with the node it launches.
+        down(&mut app, 2); // past the project row and the cluster header
         app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         let screen = render(&app);
         // The repo leads the title (#114): it is the one fact every row shares
@@ -1647,10 +1726,16 @@ mod tests {
     fn the_first_frame_says_it_is_loading_rather_than_that_there_is_nothing() {
         // The whole point of #27: this screen is drawn before any network call,
         // so its empty list must not read as "no tickets" or "no projects".
-        let screen = render(&App::empty());
+        let mut app = App::empty();
+        app.enter("blooop/wayfinder");
+        let screen = render(&app);
         assert!(screen.contains("searching for maps…"), "{screen}");
-        assert!(screen.contains("wf · loading…"), "{screen}");
-        assert!(!screen.contains("no projects"), "{screen}");
+        // The screen is this project's from the first frame — the level came
+        // from a local `git` call, not from the fetch — and its row says the
+        // maps are still coming rather than that there are none.
+        assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
+        assert!(screen.contains("▌ blooop/wayfinder · loading…"), "{screen}");
+        assert!(!screen.contains("no map"), "{screen}");
     }
 
     #[test]
@@ -1660,7 +1745,16 @@ mod tests {
         // checkout" there sends the user to fix the one thing that is not
         // broken, so the failure has to win the heading — and it names the
         // *map*, because with several on one repo the repo alone is ambiguous.
-        let mut app = App::empty();
+        let mut app = App::empty().with_checkouts(vec![
+            crate::projects::Checkout::new(
+                std::path::PathBuf::from("/data/proj/wayfinder"),
+                "blooop/wayfinder".to_string(),
+            ),
+            crate::projects::Checkout::new(
+                std::path::PathBuf::from("/data/proj/dotfiles"),
+                "blooop/dotfiles".to_string(),
+            ),
+        ]);
         app.startup = Startup::loaded();
         app.failed.insert(MapId::new("blooop/wayfinder", 35));
         let screen = render(&app);
@@ -1777,30 +1871,72 @@ mod tests {
                 )],
             },
         );
-        let mut app = App::new(clusters);
+        let mut app = app_on("blooop/wayfinder", clusters);
         for _ in 0..40 {
             app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         }
         assert_eq!(app.cursor_ticket().unwrap().number, 50);
         let screen = render(&app);
         assert!(screen.contains("▶ ○ #50 Build: clusters"), "{screen}");
-        // And with the cursor back at the top — the first cluster's header,
-        // since #96 — the top is what shows.
+        // And with the cursor back at the top — the project's own row, which
+        // is the first stop of its screen — the top is what shows.
         for _ in 0..40 {
             app.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
         }
         let screen = render(&app);
-        assert!(screen.contains("▶ ▌ wayfinder · Map: wf"), "{screen}");
+        assert!(screen.contains("▶ ▌ blooop/wayfinder"), "{screen}");
         assert!(screen.contains("○ #1 Open 1"), "{screen}");
     }
 
     #[test]
-    fn focus_mode_names_the_scope_in_the_title() {
-        let mut app = fixture_app();
-        app.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
+    fn the_project_list_draws_a_row_per_project_with_what_is_inside_it() {
+        // The top-level screen: full slugs (two forks of one repo have the same
+        // short name and sit next to each other here), most recently used
+        // first, each saying how much is inside it in the same glyph vocabulary
+        // the rows below use.
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        let stamped = |path: &str, repo: &str, at: u64| crate::projects::Checkout {
+            path: std::path::PathBuf::from(path),
+            repo: repo.to_string(),
+            used: Some(at),
+        };
+        let mut app = App::new(clusters).with_checkouts(vec![
+            stamped("/data/proj/wayfinder", "blooop/wayfinder", 200),
+            stamped("/data/proj/newthing", "blooop/newthing", 100),
+        ]);
+        app.startup = Startup::loaded();
         let screen = render(&app);
-        assert!(screen.contains("wf · blooop/wayfinder — focused"));
-        assert!(screen.contains("ctrl-g all projects"));
-        assert!(screen.contains("▶ ○ #6 Re-entry breadcrumbs"));
+        assert!(screen.contains("wf · 2 projects"), "{screen}");
+        assert!(
+            !screen.contains("← all projects"),
+            "nowhere further out to go"
+        );
+
+        let lines: Vec<&str> = screen.lines().collect();
+        let wayfinder = lines
+            .iter()
+            .position(|l| l.contains("▌ blooop/wayfinder · 1 map"))
+            .expect("the mapped project");
+        let newthing = lines
+            .iter()
+            .position(|l| l.contains("▌ blooop/newthing · no map — enter to start one"))
+            .expect("the map-less project — a row here like any other");
+        assert!(wayfinder < newthing, "most recently used first: {screen}");
+        // The counts are the map's, in the glyphs the rows use.
+        assert!(lines[wayfinder].contains("○1"), "{screen}");
+        // And no ticket got onto this screen.
+        assert!(!screen.contains("#6 Re-entry breadcrumbs"), "{screen}");
+    }
+
+    #[test]
+    fn a_project_screen_names_its_project_and_the_way_back() {
+        let screen = render(&fixture_app());
+        assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
+        // The way back is named on the screen it applies to, and it is the key
+        // that does it — the chords that used to focus and widen are gone.
+        assert!(screen.contains("← all projects"), "{screen}");
+        assert!(!screen.contains("ctrl-f"), "{screen}");
+        assert!(!screen.contains("ctrl-g"), "{screen}");
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -120,10 +120,59 @@ pub enum Stop {
     Map(MapId),
     Ticket(Row),
     Group(GroupId),
-    /// A focused repo with no open map, by full slug (#114). Nothing to
-    /// launch — this is the door its *first* map is charted from, and the one
-    /// stop that names a repo rather than something in a map.
+    /// A whole project, by full slug — a row of the project list, and the row
+    /// the project screen opens on.
+    ///
+    /// The one stop that names a repo rather than something in a map, which is
+    /// why creation lives here: starting a map or a task is an act on a repo,
+    /// and this is the only stop that *is* one. What `enter` does to it
+    /// depends on which screen drew it — enter the project, or create in it —
+    /// and that is the whole of the two-level navigation.
     Project(String),
+}
+
+/// One project, as a row draws it: the slug, how much of it has arrived, and
+/// what stages its tickets are in.
+///
+/// `maps` and `rollup` are the *loaded* picture, not the true one — they count
+/// the clusters in hand this frame — which is what `loaded` is for. A repo with
+/// no clusters means "no map yet" only once the search has answered; before
+/// that it means "still looking", and the two are the same zero. The row is
+/// drawn either way, because it is a place to stand rather than a report: what
+/// `enter` does to it does not depend on whether the fetch has landed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectRow {
+    /// Full slug, `owner/name`.
+    pub repo: String,
+    /// How many of this repo's open maps are on hand.
+    pub maps: usize,
+    /// Stage counts across them, in display order — empty when none are.
+    pub rollup: Vec<(RowGlyph, usize)>,
+    /// Whether the map search has answered, so `maps: 0` can be read as "no
+    /// map" rather than "not yet".
+    pub loaded: bool,
+    /// Where a live query landed in the slug, in char indices — what the row
+    /// underlines. Empty on the structured screen, which has no query.
+    pub lit: Vec<usize>,
+}
+
+impl ProjectRow {
+    /// The row for `repo`, tallied from whichever of its maps have arrived.
+    ///
+    /// Takes every cluster rather than the repo's, so the caller cannot hand it
+    /// a filtered set and get a rollup that quietly means something narrower
+    /// than the row says.
+    #[must_use]
+    pub fn new(repo: &str, clusters: &BTreeMap<MapId, Map>, loaded: bool) -> ProjectRow {
+        let mine = || clusters.iter().filter(|(id, _)| id.repo == repo);
+        ProjectRow {
+            repo: repo.to_string(),
+            maps: mine().count(),
+            rollup: RowGlyph::tally(mine().flat_map(|(_, map)| &map.tickets)),
+            loaded,
+            lit: Vec::new(),
+        }
+    }
 }
 
 /// A stop plus the depth it sits at — everything navigation needs.
@@ -140,9 +189,9 @@ pub struct StopAt {
 pub enum Item {
     /// A cluster header — the map this and the following lines belong to.
     Header(MapId),
-    /// The slim header of a focused repo with no open map (#114): no stage
-    /// counts, because there are no stages — just somewhere to stand.
-    MaplessHeader(String),
+    /// A project row: the body of the project list, and the first line of a
+    /// project's own screen.
+    Project(ProjectRow),
     /// A ticket row.
     Ticket {
         row: Row,
@@ -193,8 +242,8 @@ impl Item {
                 stop: Stop::Map(id.clone()),
                 depth: 0,
             }),
-            Item::MaplessHeader(repo) => Some(StopAt {
-                stop: Stop::Project(repo.clone()),
+            Item::Project(project) => Some(StopAt {
+                stop: Stop::Project(project.repo.clone()),
                 depth: 0,
             }),
             // Nothing to land on. A sifted group leads this arm because it is
@@ -288,18 +337,76 @@ impl Plan {
     }
 }
 
+/// Plan the **project list**: one row per registered repo, in the order given
+/// (most recently used first), sifted by a live query.
+///
+/// The whole top level of the screen, and the only plan that needs no clusters
+/// to be meaningful — `repos` comes from the projects cache, which is read
+/// before the first frame, so this body is drawn without a single network call.
+/// The clusters, when they arrive, only fill in each row's counts.
+///
+/// A query here matches the **slug**, through the same pattern and tightness
+/// rule a ticket row goes through, and rows that miss leave the body. There are
+/// no context rows and nothing to elide: the list is flat, so a match either
+/// keeps its row or is not a match.
+///
+/// The *owner* half is matched here and deliberately not in a ticket's haystack
+/// (see [`filter`]'s `haystack`), and the difference is the screen rather than
+/// an oversight: there, an owner shared by two unrelated repos would drag one
+/// repo's tickets into the other's sift; here the rows **are** repos, the owner
+/// is drawn on every one of them, and narrowing to an org is a thing to want.
+/// Matching what is on screen is the rule both screens are keeping.
+pub fn projects(
+    repos: &[String],
+    clusters: &BTreeMap<MapId, Map>,
+    loaded: bool,
+    query: &str,
+) -> Plan {
+    let mut matcher = filter::Query::new(query);
+    // Best-first under a query, most-recently-used order without one — the same
+    // rule the clusters follow, where a live query is the query's to order and
+    // silence leaves the caller's order standing. `sort_by_key` is stable, so
+    // equally-scored projects keep their MRU order rather than shuffling.
+    let mut scored: Vec<(u32, ProjectRow)> = repos
+        .iter()
+        .filter_map(|repo| {
+            let mut row = ProjectRow::new(repo, clusters, loaded);
+            let Some(matcher) = matcher.as_mut() else {
+                return Some((0, row));
+            };
+            let (score, lit) = matcher.text(repo)?;
+            row.lit = lit;
+            Some((score, row))
+        })
+        .collect();
+    scored.sort_by_key(|(score, _)| Reverse(*score));
+    Plan {
+        items: scored
+            .into_iter()
+            .map(|(_, row)| Item::Project(row))
+            .collect(),
+        idle_hidden: 0,
+    }
+}
+
 /// Plan the body for the clusters in scope, in their given (render) order.
 ///
-/// `door` is the map-less repo whose empty-state header closes the body, if
-/// this screen is showing one (#114). It is planned *here*, with everything
-/// else, rather than appended by the caller: on-screen order is this module's
-/// single answer, and a row the caller pushes afterwards is a row the rollup
-/// pass — and every other walk below — never sees.
+/// `project` is the row the screen **opens on** — the repo whose screen this
+/// is. It is planned *here*, with everything else, rather than pushed on by the
+/// caller: on-screen order is this module's single answer, and a row the caller
+/// prepends afterwards is a row the rollup pass — and every other walk below —
+/// never sees, and one the cursor would find at a position the plan did not put
+/// it at.
+///
+/// It leads rather than trails because it is where the cursor starts. A project
+/// screen's first stop is the project itself, so `enter` on a freshly opened
+/// screen starts something in this repo, and reaching a ticket is one `↓` down
+/// into the maps below.
 pub fn plan(
     clusters: &[(&MapId, &Map)],
     screen: Screen<'_>,
     expanded: &Expanded,
-    door: Option<&str>,
+    project: Option<ProjectRow>,
 ) -> Plan {
     let sieve = Sieve::new(clusters, screen);
     // Under a query the cluster order is the query's to decide: the project
@@ -324,8 +431,17 @@ pub fn plan(
     if !sieve.sifting() {
         attach_rollups(&mut plan.items, clusters);
     }
-    if let Some(repo) = door {
-        plan.items.push(Item::MaplessHeader(repo.to_string()));
+    // Prepended after the rollup pass, which walks the cluster lines and would
+    // have to learn to step over this one otherwise. A spacer follows it for
+    // the same reason clusters have one between them: the row is a level above
+    // what comes next, not the first line of it.
+    if let Some(project) = project {
+        let lead = if plan.items.is_empty() {
+            vec![Item::Project(project)]
+        } else {
+            vec![Item::Project(project), Item::Blank]
+        };
+        plan.items.splice(0..0, lead);
     }
     plan
 }
@@ -574,7 +690,7 @@ fn attach_rollups(items: &mut [Item], clusters: &[(&MapId, &Map)]) {
             // `Item::Context` cannot appear here: rollups are attached only to
             // the unsifted screens, and only a sift produces context rows.
             Item::Header(_)
-            | Item::MaplessHeader(_)
+            | Item::Project(_)
             | Item::Group { .. }
             | Item::Context { .. }
             | Item::Blank => {
@@ -975,8 +1091,8 @@ mod tests {
     use super::*;
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, Stage, TicketType};
 
-    /// The body without an empty-state door — the case every test below but
-    /// the door's own is about. Shadows [`super::plan`] so those tests read as
+    /// The body without a project row — the case every test below but the
+    /// project row's own is about. Shadows [`super::plan`] so those tests read as
     /// what they are testing rather than trailing a `None` each.
     fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
         super::plan(clusters, screen, expanded, None)
@@ -1711,7 +1827,7 @@ mod tests {
             .iter()
             .map(|item| match item {
                 Item::Header(id) => format!("▌ {}", id.short_repo()),
-                Item::MaplessHeader(repo) => format!("▌ {repo} no map"),
+                Item::Project(p) => format!("▌ {} · {} map(s)", p.repo, p.maps),
                 Item::Ticket { row, prefix, .. } => format!("{prefix}#{}", number(row)),
                 Item::Context { row, prefix } => format!("{prefix}#{} dim", number(row)),
                 Item::Group {

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -117,10 +117,10 @@ fn context_section() -> String {
 /// from the launch itself, or the docs are only checked against a second copy
 /// of themselves.
 fn launched_prompt(ticket: &Ticket, map: &MapRef, stage: Stage) -> String {
-    let checkout = wf::projects::Checkout {
-        path: std::path::PathBuf::from("/data/proj/checkout"),
-        repo: ticket.repo.clone(),
-    };
+    let checkout = wf::projects::Checkout::new(
+        std::path::PathBuf::from("/data/proj/checkout"),
+        ticket.repo.clone(),
+    );
     let staged = wf::launch::Staged::ticket(ticket, map, stage).expect("a launchable stage");
     let mode = wf::launch::LaunchMode::picked(
         wf::launch::Agent::Claude,


### PR DESCRIPTION
Replaces the scope filter with two screens. Supersedes [#117](https://github.com/blooop/wayfinder/issues/117) — the `ctrl-p` project modal is not built, because the project surface becomes the level you start on.

## What changes

Which screen opens is decided by where you ran `wf`. **Inside a checkout**, that project — its own row first, then its maps as clusters. **Outside one**, the project list, most recently used first; `enter` or `→` on a row arrives at exactly the same project screen. One project view, two doors into it.

```
▶ ▌ blooop/wayfinder · 2 maps  ○4  ◐2  ◍1
  ▌ blooop/devlaunch · 1 map   ○2  ●7
  ▌ blooop/bencher   · no map — enter to start one
```

`←` is the way back, from anywhere: it closes a group, climbs to the parent, steps back a stop, and from the project's own row leaves for the list. `esc` still clears the query and quits, so leaving `wf` never depends on how deep you are.

**The cursor opens on the project row, not on a ticket.** That makes the default `enter`, type what you want to do, `enter` — the thing you most often open `wf` in a repo to do, with no navigation at all. It consciously overrides "opening `wf` and pressing `enter` picks a ticket"; picking the top ticket is one `↓` first. Two things make the trade good: an empty `task` field already refused, so the creating default cannot misfire; and the project row is known before any fetch, so unlike the top ticket it never moves under you as maps stream in — which is what [#88](https://github.com/blooop/wayfinder/issues/88) and [#89](https://github.com/blooop/wayfinder/issues/89) were both about.

## What falls out

- **`ctrl-f` and `ctrl-g` are unbound**, not merely undocumented. Focusing a project is entering it, widening is `←` out of it.
- **Creation leaves the cluster header for the project row.** A header is a *map*, so its picker is the three modes again, exactly like a ticket's — and a repo with three open maps no longer offers `new map` on all three of them. This narrows [#116](https://github.com/blooop/wayfinder/issues/116)'s header picker back to launches.
- **The map-less empty-state door is gone as a special case.** A repo with no map is a project whose screen has no clusters; its row is on the list like any other, so it is reachable from outside rather than only when focused. It also no longer waits for the search — the row is a place to stand, not a report on what was found.
- **The project list needs no network.** It is the projects cache ordered by a new local `used` stamp, written on registration and on launch, so the create path completes before a single `gh` call returns. Entries from an older cache carry no stamp, sort last, and correct themselves the first time you open them.
- `Scope { All, Project }` becomes `Level { Projects, Project { repo } }` — the screen rather than a filter on one, so `Level::Project` always names a repo and the project list has no cluster code in it at all.

## The cost, taken deliberately

There is no screen pouring every project's tickets into one tree. That was the widened scope, and it reverses [#47](https://github.com/blooop/wayfinder/issues/47)'s "every open map, one screen": the query now means projects at the top level and tickets inside one — one register per level instead of a single field matching both. **A ticket in a project you have not thought of is no longer findable by typing its title.** If that bites, letting a top-level query match ticket text and surface the projects that hit restores it without giving up the project-first default.

One coverage note: `a_lens_toggle_off_a_vanished_group_line_leaves_no_choice_behind` can no longer *observe* its old symptom, because the first stop of a project screen is fixed, so an untouched cursor and a wrongly-recorded `Chosen(0)` resolve to the same line. The test now pins where the toggle lands instead, and says so.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets --all-features` (with `-D warnings`), `cargo test --lib --bins --examples` (302 passing), `cargo test --test live_fetch -- common::` and `cargo doc` are all green. Rendered against this repo's own live map through `examples/preview_screen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a two-level navigation model with a project list screen and per-project screen, driven by a new Level enum instead of Scope, and adjust UI, launch behavior, caching, and docs to be project-centric.

New Features:
- Add a top-level project list screen showing registered repos in most-recently-used order with per-project rollups and query-based filtering.
- Add dedicated per-project screens that open from either the current checkout or the project list, starting on the project row with creation actions for tasks and maps.
- Make left and right arrow keys navigate between project list and project screens, establishing a unified back/enter/descend behavior across the UI.

Bug Fixes:
- Ensure the cursor no longer moves unpredictably as maps stream in by anchoring the default position on the project row rather than the first ticket.
- Resolve prior lens-toggle cursor inconsistencies by redefining the first stop as the project row and adjusting tests accordingly.
- Fix ambiguous empty states so map-less projects and loading states are represented consistently via project rows instead of special-case doors.

Enhancements:
- Replace the Scope-based filtering model with a Level-based screen model, simplifying navigation semantics and removing ctrl-f/ctrl-g/ctrl-p.
- Refine query semantics so project-list queries match project slugs and per-project queries match tickets, with counts reflecting what each screen lists.
- Rework launch picker behavior so nodes (tickets/maps) only offer launch modes, while project rows only offer creation actions, clarifying responsibilities.
- Enhance count-line and heading logic to reflect projects vs tickets appropriately and to better communicate loading and failure states.
- Update cursor movement, depth navigation, and back behavior so left-arrow provides a consistent path from any stop back to the project list.

Documentation:
- Expand README with a full description of the new two-level navigation model, project discovery, project list behavior, and updated keybindings and launching semantics.

Tests:
- Add and update extensive tests for project list ordering by MRU, per-project screens, cursor behavior, query behavior, launch picker behavior, and navigation between levels.
- Adjust existing UI, filtering, launch, and app tests to align with the Level-based model, project rows, and revised creation/launch semantics.

Chores:
- Extend the projects cache format with a used timestamp, migration behavior for older cache files, and utilities for MRU project ordering and stamping on registration and launch.