### PR TITLE
Resume the conversation a launch left behind (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,12 @@ registers that checkout.
 
 The registry is a per-machine cache at `~/.cache/wf/projects.json`
 (`$XDG_CACHE_HOME` respected) holding `{path, repo, used}` per checkout, plus
-every open map that the last search found. Deleting it is safe — projects
-re-accrete as you open them, and the maps are re-found on the next start.
+every open map that the last search found and a `{repo, number, agent,
+checkout, at}` session per node you have launched an agent on (see
+[Resuming](#resuming-picking-a-conversation-back-up)). Deleting it is safe —
+projects re-accrete as you open them, the maps are re-found on the next start,
+and the only thing actually lost is the offer to rejoin conversations, which
+still exist where their agents left them.
 
 `used` is what orders the project list: a local stamp, written when you open
 `wf` in a checkout and when you launch an agent from one. A *local* stamp, and
@@ -458,6 +462,66 @@ there are no launch rows, and `enter` with an empty `task` field refuses on the
 count line rather than filing something blank. Which is why the creating default
 is safe: `enter enter` on a fresh screen does nothing at all.
 
+### Resuming: picking a conversation back up
+
+A node you have launched an agent on before carries a `⏎` in the list, and its
+picker leads with a **resume** row:
+
+```
+┌ launch Claude · blooop/wayfinder · #117 The one project surface ────────────┐
+│                                                                             │
+│  ▶ resume        claude --continue   20m ago · pick the conversation back up│
+│    interactive   /wf-tdd             you are in the loop; it grills you     │
+│    auto          /wf-auto            the agent decides alone and drives it  │
+│    plain         claude              no skill; a bare session on the branch │
+│                                                                             │
+│    steer  █                                                                 │
+│                                                                             │
+│  enter launch · ↑/↓ pick · type to fill · esc cancel                        │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+So coming back to work you left is `enter enter`, the same two keys as starting
+it. Starting fresh instead is one `↓`. The row leads for the reason the project
+row takes the cursor on the screen behind it: the default should be the likeliest
+act, and the alternative should cost one key.
+
+**It needs no session store, because neither agent has one worth storing.**
+`claude --continue` continues "the most recent conversation in the current
+directory", and `codex resume --last` filters by cwd unless told `--all`. `wf`
+already gives every node a working directory of its own — that is exactly what
+the per-node workspace `owner/repo@wayfinder/<repo>-<n>` *is* — so going back is
+a matter of exec'ing in the same place. No ids are matched, nothing can point at
+a conversation that moved, and a resume is the same exec every other launch is
+with the agent's own flag in place of a skill.
+
+What `wf` records at each launch is therefore three facts and no more, in the
+same `projects.json` the checkouts live in — the three that between them say
+*where the conversation is*: **which tree**, **host or container**, and **which
+CLI**. The tree is the half a fresh reading cannot recover once you have two
+checkouts of one repo, which is why a resume never asks *which checkout* where a
+fresh launch would: the conversation exists in exactly one of them and the
+record says which. Host-or-container is recorded rather than re-detected because
+an isolated launch's history lives inside `dl`'s clone — re-detecting from a
+checkout that has since lost its `.devcontainer/` would answer "host" and
+quietly resume the checkout's own, different conversation. And the CLI cannot be
+re-derived at all, since a Claude conversation is not rejoinable by Codex — so
+the picker's `←`/`→` is deliberately dead on this row, and the title names the
+recorded agent rather than the picked one.
+
+The workspace name is deliberately *not* recorded: it is a pure function of the
+node (`owner/repo@wayfinder/<repo>-<n>`), so a stored copy could only ever
+disagree with a fresh derivation.
+
+Two honest limits. The record says **`wf` launched an agent here**, not that a
+conversation exists — that is the strongest thing `wf` can know without reading
+the agent's own store, which for an isolated launch is inside a container at a
+path devpod chose. A launch that died before its agent wrote anything leaves a
+resume row that lands on the agent's own "no conversation found". And this is
+**same-machine** only, by construction: it is a local cache of local
+directories. Coming back on another machine is what the breadcrumbs on the
+ticket are for.
+
 **A node launches and a project creates, and neither does the other's job.** A
 cluster header is a *map*, so its picker is the three modes and wraps, exactly
 like a ticket's — the only difference between the two is what they aim at. The
@@ -548,7 +612,8 @@ an empty one.
 | `→` | reveal: enter the project on the project list, else open a `▸ done`/`▸ blocked` group, else step forward one stop — which *is* descending, since a subtree's first row follows its parent |
 | `←` | close: from a project's own row, back out to the project list; else shut an open group, back out to the parent, or step one stop back — which, from a cluster's first row, is that cluster's header |
 | `enter` | on the project list: enter that project. On a project's screen: open the launch picker — the creation rows on the project's own row, the launch modes on a ticket or a cluster header — and a second `enter` runs the agent here and exits. On a group line it folds instead, since there is no agent to run |
-| `←`/`→`, `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick Claude/Codex, pick the row, fill its field (a steering prompt, a task, or a map seed), launch — `esc` backs out with the query and cursor intact |
+| `←`/`→`, `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick Claude/Codex, pick the row, fill its field (a steering prompt, a task, or a map seed), launch — `esc` backs out with the query and cursor intact. `←`/`→` does nothing on a `resume` row, whose agent comes from the record |
+| `⏎` in a row | a previous launch left a conversation on this node: its picker leads with `resume`, and `enter enter` rejoins it |
 | `ctrl-r` | refetch every map in place, keeping your query, level and cursor |
 | `esc` | clear the query; on an empty query, quit |
 | `q` | quit — on an empty query only, since mid-query it types |

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
-use crate::projects::{self, Checkout};
+use crate::projects::{self, Checkout, Resume, Session};
 use crate::refresh::Startup;
 use crate::view::{self, Expanded, GroupId, Lens, Plan, Screen, Stop, StopAt};
 
@@ -227,6 +227,9 @@ pub struct App {
     /// Launch input from the projects cache (#15 handoff): which checkouts
     /// exist on this machine.
     pub checkouts: Vec<Checkout>,
+    /// The other half of that handoff (#35): the conversations previous
+    /// launches left here, at most one per node.
+    pub sessions: Vec<Session>,
     /// Maps whose last fetch failed — **state, not a message.**
     ///
     /// A failure has to be drawn on every frame, and the one-shot `notice` is
@@ -273,6 +276,7 @@ impl App {
             level: Level::Projects,
             notice: None,
             checkouts: Vec::new(),
+            sessions: Vec::new(),
             failed: BTreeSet::new(),
             startup: Startup::loaded(),
             overlay: Overlay::None,
@@ -301,6 +305,38 @@ impl App {
     pub fn with_checkouts(mut self, checkouts: Vec<Checkout>) -> Self {
         self.checkouts = checkouts;
         self
+    }
+
+    /// Attach the conversations previous launches left on this machine (#35) —
+    /// what puts a resume row under the picker's cursor, and a `⏎` beside the
+    /// rows that have one.
+    ///
+    /// Read from the same cache as the checkouts and at the same moment, which
+    /// is what keeps this a **frame-zero** fact: the badge is drawn on the
+    /// first paint, before the map search has answered, because it was never
+    /// the tracker's to answer. Nothing here asks `dl` anything.
+    #[must_use]
+    pub fn with_sessions(mut self, sessions: Vec<Session>) -> Self {
+        self.sessions = sessions;
+        self
+    }
+
+    /// The conversation a previous launch of this node left, if any.
+    pub fn resume(&self, repo: &str, number: u64) -> Option<&Resume> {
+        self.sessions
+            .iter()
+            .find(|s| s.repo == repo && s.number == number)
+            .map(|s| &s.resume)
+    }
+
+    /// Attach `staged`'s resume, if its node has one. One helper rather than
+    /// the same lookup at the two staging sites, so a ticket and a map cannot
+    /// end up disagreeing about what counts as resumable.
+    fn resumable(&self, staged: Staged, number: u64) -> Staged {
+        match self.resume(&staged.repo, number) {
+            Some(resume) => staged.with_resume(resume.clone()),
+            None => staged,
+        }
     }
 
     /// The repo whose screen is up, or `None` on the project list.
@@ -764,6 +800,9 @@ impl App {
             }
             Some(Stop::Map(id)) => {
                 let staged = Staged::map(&MapRef::new(&id, &self.clusters[&id].title));
+                // A map is a node (#96), so a charting session is as
+                // resumable as a build one — and rather more worth resuming.
+                let staged = self.resumable(staged, id.number);
                 self.prewarm(&staged);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
@@ -828,6 +867,7 @@ impl App {
                 Outcome::Continue
             }
             Some(staged) => {
+                let staged = self.resumable(staged, ticket.number);
                 self.prewarm(&staged);
                 self.overlay = Overlay::PickLaunch {
                     candidate: staged.default_candidate(),
@@ -971,6 +1011,18 @@ impl App {
                         &LaunchMode::picked(agent, mode, &steer),
                     )
                 }
+                // A resume needs no resolution: the record already names the
+                // one tree its conversation lives in, so there is nothing for
+                // the checkout picker to ask about and no `Targets` to walk.
+                Candidate::Resume { .. } => {
+                    if let Some(launch) = launch::resume_launch(&staged, &steer) {
+                        self.notice = Some(format!("→ {}", launch.describe()));
+                        return Outcome::Launch(Box::new(launch));
+                    }
+                    // Unreachable: the row is built from the record, so a
+                    // resume row without one cannot be drawn to be picked.
+                    self.notice = Some("nothing to resume here".to_string());
+                }
                 Candidate::Create(kind) => match kind.with_text(&steer) {
                     Some(creation) => return self.resolve_creation(&staged.repo, &creation, agent),
                     // The one per-row refusal (#114): `/wf-one` with no task is
@@ -986,7 +1038,13 @@ impl App {
             // the arrows because it is what the rest of the screen uses to move
             // through a list, and it steps the way `down` does rather than
             // toggling.
-            KeyCode::Left | KeyCode::Right => agent = next_agent(agent),
+            // Dead on the resume row, and only there: that row's agent comes
+            // from the record — a Claude conversation is not rejoinable by
+            // Codex — so moving the axis could only put a title over the row
+            // that disagreed with what `enter` runs.
+            KeyCode::Left | KeyCode::Right if !matches!(candidate, Candidate::Resume { .. }) => {
+                agent = next_agent(agent);
+            }
             KeyCode::Up => candidate = previous_candidate(&staged, candidate),
             KeyCode::Down | KeyCode::Tab => candidate = next_candidate(&staged, candidate),
             KeyCode::Backspace => {
@@ -1159,7 +1217,7 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::launch::{CreationKind, Mode, Route};
+    use crate::launch::{CreationKind, Isolation, Mode, Route};
     use crate::model::{classify, Checks, PrLink, PrStatus, Review, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
@@ -2448,6 +2506,165 @@ mod tests {
             launch::eliding_ctx(launch.agent_argv().last().unwrap()),
             "/wf-auto 1 6 ctx: …"
         );
+    }
+
+    /// The launchable app, plus a conversation left on `number` by a previous
+    /// launch in the wayfinder checkout.
+    fn app_resuming(number: u64, agent: Agent) -> App {
+        launchable_app().with_sessions(vec![Session::new(
+            PROJECT.to_string(),
+            number,
+            agent,
+            std::path::PathBuf::from("/data/proj/wayfinder"),
+            Isolation::Host,
+        )])
+    }
+
+    #[test]
+    fn a_ticket_you_were_working_stages_with_the_way_back_under_the_cursor() {
+        // The point of the whole feature, read off one keystroke: come back to
+        // a ticket you had an agent on and the picker opens *on* the resume
+        // row, so `enter enter` rejoins instead of starting a second session
+        // beside the first.
+        let mut app = app_resuming(6, Agent::Claude);
+        go_to(&mut app, "#6");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::PickLaunch {
+                staged, candidate, ..
+            } => {
+                assert_eq!(staged.key(), "#6");
+                assert_eq!(
+                    *candidate,
+                    Candidate::Resume {
+                        agent: Agent::Claude
+                    }
+                );
+            }
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_ticket_with_no_session_of_its_own_stages_exactly_as_it_always_did() {
+        // The record is per node, so the neighbour of a resumable ticket is
+        // not resumable — the row would otherwise rejoin the wrong work, which
+        // is the one mistake this feature could make that costs real time.
+        let mut app = app_resuming(9, Agent::Claude);
+        go_to(&mut app, "#6");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::PickLaunch { candidate, .. } => assert_eq!(
+                *candidate,
+                Candidate::Launch {
+                    mode: Mode::Interactive,
+                    route: Route::Wayfinder,
+                }
+            ),
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resuming_execs_into_the_tree_the_conversation_is_in_without_asking() {
+        // Two enters and nothing else. The dotfiles repo has two registered
+        // checkouts, so a *fresh* launch of one of its tickets would stop to
+        // ask which tree; a resume never does, because the conversation exists
+        // in exactly one of them and the record says which.
+        let mut app = launchable_app().with_sessions(vec![Session::new(
+            "blooop/dotfiles".to_string(),
+            103,
+            Agent::Claude,
+            std::path::PathBuf::from("/data/k2/dotfiles"),
+            Isolation::Host,
+        )]);
+        app.enter("blooop/dotfiles");
+        go_to(&mut app, "#103");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(launch.cwd(), std::path::Path::new("/data/k2/dotfiles"));
+        assert!(
+            launch.agent_argv().contains(&"--continue".to_string()),
+            "the exec must be the agent's own way back: {:?}",
+            launch.agent_argv()
+        );
+        assert!(
+            launch.describe().starts_with("resume dotfiles#103"),
+            "the notice says it is going back, not starting: {}",
+            launch.describe()
+        );
+    }
+
+    #[test]
+    fn the_agent_keys_are_dead_on_the_resume_row_because_the_record_decides() {
+        // A Claude conversation cannot be rejoined by Codex. The picker's
+        // horizontal axis is a real choice on every other row, so on this one
+        // it has to visibly do nothing rather than change a title over a row
+        // that will run the other CLI regardless.
+        let mut app = app_resuming(6, Agent::Claude);
+        go_to(&mut app, "#6");
+        app.handle_key(key(KeyCode::Enter));
+        app.handle_key(key(KeyCode::Right));
+        match &app.overlay {
+            Overlay::PickLaunch {
+                agent, candidate, ..
+            } => {
+                assert_eq!(*agent, Agent::Claude, "the arrow must not have moved it");
+                assert_eq!(candidate.agent(*agent), Agent::Claude);
+            }
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+        // And on any other row it is alive again, so nothing was disabled but
+        // the one row that cannot honour it.
+        app.handle_key(key(KeyCode::Down));
+        app.handle_key(key(KeyCode::Right));
+        match &app.overlay {
+            Overlay::PickLaunch { agent, .. } => assert_eq!(*agent, Agent::Codex),
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_map_you_have_charted_before_can_be_rejoined_too() {
+        // The record is keyed by node, and a map is a node (#96) — charting
+        // sessions are exactly the long conversations worth coming back to.
+        let mut app = app_resuming(1, Agent::Codex);
+        go_to(&mut app, "map #1");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::PickLaunch { candidate, .. } => assert_eq!(
+                *candidate,
+                Candidate::Resume {
+                    agent: Agent::Codex
+                }
+            ),
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_project_row_offers_no_resume_however_many_sessions_the_repo_has() {
+        // Creation names work that does not exist yet. The repo having live
+        // conversations on three tickets says nothing about a fourth that has
+        // not been filed.
+        let mut app = app_resuming(6, Agent::Claude);
+        go_to(&mut app, &format!("project {PROJECT}"));
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        match &app.overlay {
+            Overlay::PickLaunch {
+                staged, candidate, ..
+            } => {
+                assert_eq!(*candidate, Candidate::Create(CreationKind::Task));
+                assert!(staged
+                    .candidates()
+                    .iter()
+                    .all(|c| !matches!(c, Candidate::Resume { .. })));
+            }
+            other => panic!("expected the launch picker, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -49,7 +49,7 @@ use crate::projects::{Checkout, Resume, Session};
 /// command-line permission switch. Keeping that translation here means the
 /// picker cannot display one agent while the exec path silently starts the
 /// other.
-/// It is also the one half of a [`Resume`](crate::projects::Resume) that
+/// It is also the one half of a [`Resume`] that
 /// cannot be re-derived, so it goes to disk with one — spelt in lower case,
 /// which is what a human editing that cache would write.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -36,10 +36,10 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::model::{MapId, PrLink, Stage, Ticket, TicketType};
-use crate::projects::Checkout;
+use crate::projects::{Checkout, Resume, Session};
 
 /// Which interactive coding agent `wf` becomes after a launch.
 ///
@@ -49,7 +49,11 @@ use crate::projects::Checkout;
 /// command-line permission switch. Keeping that translation here means the
 /// picker cannot display one agent while the exec path silently starts the
 /// other.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// It is also the one half of a [`Resume`](crate::projects::Resume) that
+/// cannot be re-derived, so it goes to disk with one — spelt in lower case,
+/// which is what a human editing that cache would write.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Agent {
     /// Claude Code, which is the longstanding `wf` default.
     #[default]
@@ -80,6 +84,27 @@ impl Agent {
         match self {
             Agent::Claude => '/',
             Agent::Codex => '$',
+        }
+    }
+
+    /// How this CLI is told to rejoin the conversation in its working
+    /// directory, as argv between the program and its permission switch.
+    ///
+    /// Both are **cwd-scoped**, which is the fact the whole resume rests on:
+    /// `claude --continue` continues "the most recent conversation in the
+    /// current directory", and `codex resume` filters by cwd unless `--all`
+    /// says otherwise. `wf` already gives every node a working directory of
+    /// its own — the per-node workspace — so rejoining is a matter of exec'ing
+    /// in the same place, and no session id ever has to be stored, matched or
+    /// go stale.
+    ///
+    /// Codex spells it as a subcommand, which is why this returns a slice
+    /// rather than a flag: the bypass switch and the prompt both have to come
+    /// after it.
+    fn resume_argv(self) -> &'static [&'static str] {
+        match self {
+            Agent::Claude => &["--continue"],
+            Agent::Codex => &["resume", "--last"],
         }
     }
 
@@ -412,6 +437,15 @@ pub enum Candidate {
     Launch { mode: Mode, route: Route },
     /// Start something new in the staged node's repo.
     Create(CreationKind),
+    /// Rejoin the conversation a previous launch of this node left on this
+    /// machine (#35) — no skill, no context block, no fresh session.
+    ///
+    /// Carries the agent from the record rather than taking the picker's,
+    /// because a Claude conversation is not rejoinable by Codex: the row is
+    /// only offered for the CLI that actually ran, and that is the CLI it
+    /// runs. Which is also why the picker's `←/→` does nothing while it is
+    /// picked — see [`Candidate::agent`].
+    Resume { agent: Agent },
 }
 
 impl Candidate {
@@ -420,6 +454,7 @@ impl Candidate {
         match self {
             Candidate::Launch { mode, .. } => mode.label(),
             Candidate::Create(kind) => kind.label(),
+            Candidate::Resume { .. } => "resume",
         }
     }
 
@@ -428,22 +463,51 @@ impl Candidate {
         match self {
             Candidate::Launch { mode, .. } => mode.blurb(),
             Candidate::Create(kind) => kind.blurb(),
+            // Says what it does, not how long ago: the age is a fact about
+            // *this* record and is drawn from it, beside the row.
+            Candidate::Resume { .. } => "pick the conversation back up where you left it",
         }
     }
 
-    /// The skill this row execs — already resolved, whichever arm.
-    pub fn route(self) -> Route {
+    /// Which CLI this row would run: the picked agent for everything that
+    /// starts something, and the recorded one for a resume.
+    ///
+    /// The one place that difference is decided, so the row the picker *draws*
+    /// and the process the exec *becomes* cannot disagree — which is exactly
+    /// the failure this would otherwise have: a title reading Codex over a row
+    /// that runs Claude.
+    pub fn agent(self, picked: Agent) -> Agent {
         match self {
-            Candidate::Launch { route, .. } => route,
-            Candidate::Create(kind) => kind.route(),
+            Candidate::Launch { .. } | Candidate::Create(_) => picked,
+            Candidate::Resume { agent } => agent,
+        }
+    }
+
+    /// How the row's invocation reads in the picker's skill column: the skill
+    /// a launch or creation routes to, or the way back into a conversation.
+    ///
+    /// Replaces a `route()` that could only answer for the two arms that run a
+    /// skill. A resume runs none — that is the whole difference between it and
+    /// [`Mode::Plain`], which starts a fresh bare session in the same place —
+    /// so the column shows the argv it actually execs.
+    pub fn invocation(self, picked: Agent) -> String {
+        let agent = self.agent(picked);
+        match self {
+            Candidate::Launch { route, .. } => route.invocation(agent),
+            Candidate::Create(kind) => kind.route().invocation(agent),
+            Candidate::Resume { .. } => {
+                format!("{} {}", agent.program(), agent.resume_argv().join(" "))
+            }
         }
     }
 
     /// What the text field means while this row is picked: launch rows steer
-    /// the agent; creation rows take the task or the seed.
+    /// the agent; creation rows take the task or the seed; a resume takes the
+    /// first thing the rejoined session hears, which both CLIs accept beside
+    /// their resume flag.
     pub fn field(self) -> &'static str {
         match self {
-            Candidate::Launch { .. } => "steer",
+            Candidate::Launch { .. } | Candidate::Resume { .. } => "steer",
             Candidate::Create(kind) => kind.field(),
         }
     }
@@ -732,6 +796,15 @@ pub enum StagedAt {
         /// ticket listed twice was launched from, and the launch target itself
         /// when the cursor was on the cluster header.
         map: MapRef,
+        /// The conversation a previous launch of this node left on this
+        /// machine, if there is one (#35).
+        ///
+        /// **Here rather than on [`Staged`]**, which is what makes a resume
+        /// row on a project stop unrepresentable: a project names no node, so
+        /// there is nothing whose conversation this could be. The picker's
+        /// resume row is built from this field alone, so a node nobody has
+        /// launched cannot be offered one.
+        resume: Option<Resume>,
     },
     /// A whole project: the repo-level stop every project screen opens on,
     /// and the only stop creation hangs off.
@@ -754,6 +827,7 @@ impl Staged {
                     prs: ticket.prs.clone(),
                 },
                 map: map.clone(),
+                resume: None,
             },
         })
     }
@@ -767,7 +841,34 @@ impl Staged {
             at: StagedAt::Node {
                 aim: Aim::Map,
                 map: map.clone(),
+                resume: None,
             },
+        }
+    }
+
+    /// Attach the conversation a previous launch of this node left (#35) — the
+    /// one thing that puts a resume row in the picker.
+    ///
+    /// A builder rather than a constructor argument because the two node
+    /// constructors above are total without it: a node that has never run is
+    /// the ordinary case, and `None` is not a decision anyone needs to make at
+    /// every call site. On a project stop this is a **no-op** — there is no
+    /// node to have left a conversation, and the field only exists in the node
+    /// arm, so nothing can be attached rather than something being quietly
+    /// dropped.
+    #[must_use]
+    pub fn with_resume(mut self, resume: Resume) -> Staged {
+        if let StagedAt::Node { resume: slot, .. } = &mut self.at {
+            *slot = Some(resume);
+        }
+        self
+    }
+
+    /// The conversation this stop can be resumed into, if any.
+    pub fn resume(&self) -> Option<&Resume> {
+        match &self.at {
+            StagedAt::Node { resume, .. } => resume.as_ref(),
+            StagedAt::Project => None,
         }
     }
 
@@ -812,12 +913,14 @@ impl Staged {
         }
     }
 
-    /// The row the picker opens on: the first row this stop offers. On a node
-    /// that is the default mode's launch row — creation is never the default,
-    /// because `enter` on a node still means "launch this node" first. On the
-    /// project row there is no node to launch, so the first creation row
-    /// leads — and since that row is where an untouched cursor sits, it is
-    /// what `enter` type `enter` runs.
+    /// The row the picker opens on: the first row this stop offers.
+    ///
+    /// On a node that is its **resume** row when a previous launch left a
+    /// conversation there (#35), and the default mode's launch row otherwise —
+    /// creation is never the default, because `enter` on a node still means
+    /// "work this node" first. On the project row there is no node to launch,
+    /// so the first creation row leads — and since that row is where an
+    /// untouched cursor sits, it is what `enter` type `enter` runs.
     ///
     /// # Panics
     ///
@@ -839,14 +942,23 @@ impl Staged {
     /// none of them the repo. So the header's picker is the three modes again,
     /// exactly like a ticket's, and the only difference between them is what
     /// they aim at.
+    ///
+    /// A node you have launched before **leads** with its resume (#35), which
+    /// is the one place this list is not simply the modes. `enter enter` on a
+    /// ticket you were working an hour ago should put you back in that
+    /// conversation rather than open a second one beside it — the same
+    /// argument that put the project row under the untouched cursor, applied
+    /// to the picker: the default is the likeliest act, and starting over is
+    /// one arrow away.
     pub fn candidates(&self) -> Vec<Candidate> {
         match &self.at {
-            StagedAt::Node { aim, .. } => Mode::all()
-                .into_iter()
-                .map(|mode| Candidate::Launch {
+            StagedAt::Node { aim, resume, .. } => resume
+                .iter()
+                .map(|r| Candidate::Resume { agent: r.agent })
+                .chain(Mode::all().into_iter().map(|mode| Candidate::Launch {
                     mode,
                     route: route(aim, mode),
-                })
+                }))
                 .collect(),
             // A project names nothing that exists yet, so there is nothing to
             // launch — only the three ways to start something.
@@ -862,7 +974,9 @@ impl Staged {
     /// name until a skill files one.
     pub fn key(&self) -> String {
         match &self.at {
-            StagedAt::Node { aim: Aim::Map, map } => format!("#{}", map.id.number),
+            StagedAt::Node {
+                aim: Aim::Map, map, ..
+            } => format!("#{}", map.id.number),
             StagedAt::Node {
                 aim: Aim::Ticket { number, .. },
                 ..
@@ -893,7 +1007,7 @@ impl Staged {
     ///   as backing out.
     pub fn node_workspace(&self) -> Option<String> {
         match &self.at {
-            StagedAt::Node { aim, map } => Some(node_workspace_name(
+            StagedAt::Node { aim, map, .. } => Some(node_workspace_name(
                 &self.repo,
                 match aim {
                     Aim::Map => map.id.number,
@@ -912,7 +1026,8 @@ impl Staged {
 /// Two states, not three: there is no "wanted isolation but could not get it".
 /// [`Isolation::detect`] is total — it answers with what will actually happen,
 /// so a launch cannot carry an intention the exec then fails to honour.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Isolation {
     /// No compatible isolation path: the selected agent runs in the checkout
     /// directly.
@@ -1051,6 +1166,20 @@ enum Job {
     },
     /// Start something new in the repo — the skill files the issues.
     Create { creation: Creation, agent: Agent },
+    /// Rejoin the conversation a previous launch of this node left (#35).
+    ///
+    /// Carries the node's number so [`Launch::workspace`] resolves to the same
+    /// per-node workspace the original launch ran in — which is the whole
+    /// mechanism, since that workspace is the cwd both CLIs key their
+    /// conversation history by. No aim, no map and no route: a resume names
+    /// nothing to the agent, because the session it is rejoining already knows
+    /// all of it.
+    Resume {
+        number: u64,
+        agent: Agent,
+        /// The first thing the rejoined session hears, or nothing at all.
+        prompt: Option<String>,
+    },
 }
 
 impl Job {
@@ -1068,15 +1197,16 @@ impl Job {
                 Aim::Ticket { number, .. } => *number,
             }),
             Job::Create { .. } => None,
+            Job::Resume { number, .. } => Some(*number),
         }
     }
 
-    /// The CLI that executes this job, held on both arms because creation has
-    /// no launch mode of its own.
+    /// The CLI that executes this job, held on every arm because neither
+    /// creation nor resume has a launch mode of its own.
     fn agent(&self) -> Agent {
         match self {
             Job::Node { mode, .. } => mode.agent(),
-            Job::Create { agent, .. } => *agent,
+            Job::Create { agent, .. } | Job::Resume { agent, .. } => *agent,
         }
     }
 }
@@ -1141,6 +1271,11 @@ impl Launch {
             Job::Node { .. } => self.key(),
             // A creation has no `#n` to name yet, so the notice names the act.
             Job::Create { creation, .. } => creation.kind().label().to_string(),
+            // A resume has a number, so it names the node *and* says that it
+            // is going back rather than starting: the two are one keystroke
+            // apart in the picker and the notice is the last chance to see
+            // which one was taken.
+            Job::Resume { .. } => format!("resume {}", self.key()),
         };
         format!("{what} in {place}{}", self.isolation.suffix())
     }
@@ -1150,9 +1285,19 @@ impl Launch {
     /// no steering receives no prompt at all.
     fn agent_argv_inner(&self) -> Vec<String> {
         let agent = self.agent();
+        // A resume is the one shape whose argv is not
+        // `<agent> <bypass> [prompt]`: Codex spells it as a subcommand, and a
+        // subcommand has to come before the switches it takes.
         let prompt = match &self.job {
             Job::Node { mode, .. } => mode.opening_prompt(self.skill_invocation()),
             Job::Create { creation, .. } => Some(creation.invocation(agent)),
+            Job::Resume { prompt, .. } => {
+                let mut argv = vec![agent.program().to_string()];
+                argv.extend(agent.resume_argv().iter().map(|a| (*a).to_string()));
+                argv.push(agent.skip_permissions().to_string());
+                argv.extend(prompt.clone());
+                return argv;
+            }
         };
         let mut argv = vec![
             agent.program().to_string(),
@@ -1160,6 +1305,23 @@ impl Launch {
         ];
         argv.extend(prompt);
         argv
+    }
+
+    /// The record this launch leaves for a later resume (#35) — `None` for a
+    /// creation, which has no node to key one on until its skill files one.
+    ///
+    /// Taken from the resolved launch rather than from the picker's intent, so
+    /// what is remembered is the tree the agent actually ran in — including
+    /// which of several checkouts the human picked, which is precisely the bit
+    /// that decides whose conversation comes back.
+    pub fn session(&self) -> Option<Session> {
+        Some(Session::new(
+            self.repo.clone(),
+            self.job.number()?,
+            self.agent(),
+            self.cwd.clone(),
+            self.isolation,
+        ))
     }
 
     /// The selected agent's skill invocation, its arguments, and the context
@@ -1540,7 +1702,7 @@ pub enum Targets {
 /// second derivation here, so what execs is what the row named (#114). This
 /// function answers only *where* the agent can run.
 pub fn plan(checkouts: &[Checkout], staged: &Staged, route: Route, mode: &LaunchMode) -> Targets {
-    let StagedAt::Node { aim, map } = &staged.at else {
+    let StagedAt::Node { aim, map, .. } = &staged.at else {
         // Unreachable from the picker: [`Staged::candidates`] offers no launch
         // row on a project stop, so nothing there can ask for a node
         // launch. Refusing rather than inventing a node — there is no aim and
@@ -1577,6 +1739,48 @@ pub fn plan_create(
             agent,
         },
     )
+}
+
+/// Resolve a resume of the staged node (#35) — `None` when the stop has no
+/// conversation to go back to, which is every stop the picker never drew a
+/// resume row on.
+///
+/// **Deliberately not a [`Targets`]**, and the only launch path that is not.
+/// Everything else asks the cache *where* the agent could run and prompts when
+/// several trees answer; a resume is not a choice about where, because the
+/// conversation exists in exactly one place and the record says which. So this
+/// never consults [`candidate_checkouts`], never prompts, and cannot resolve
+/// into a tree the original launch did not use — including when the human has
+/// since registered a second checkout of the same repo, which is the case a
+/// checkout picker would silently get wrong half the time.
+///
+/// Isolation is re-detected rather than stored: it is a fact about the tree,
+/// the tree is the same one, and a fresh reading cannot disagree with itself
+/// the way a stored copy could once a devcontainer was added or `dl` removed.
+pub fn resume_launch(staged: &Staged, steer: &str) -> Option<Launch> {
+    let resume = staged.resume()?;
+    let number = match &staged.at {
+        StagedAt::Node {
+            aim: Aim::Map, map, ..
+        } => map.id.number,
+        StagedAt::Node {
+            aim: Aim::Ticket { number, .. },
+            ..
+        } => *number,
+        // Unreachable: `Staged::resume` already answered `None` here.
+        StagedAt::Project => return None,
+    };
+    let steer = steer.trim();
+    Some(Launch {
+        repo: staged.repo.clone(),
+        cwd: resume.checkout.clone(),
+        job: Job::Resume {
+            number,
+            agent: resume.agent,
+            prompt: (!steer.is_empty()).then(|| steer.to_string()),
+        },
+        isolation: resume.isolation,
+    })
 }
 
 /// The shared half of [`plan`] and [`plan_create`]: every registered checkout
@@ -1690,6 +1894,264 @@ mod tests {
             checkout("/data/proj/wayfinder", "blooop/wayfinder"),
             checkout("/data/proj/dotfiles", "upstream/dotfiles"),
         ]
+    }
+
+    /// A conversation a previous launch left in the wayfinder checkout.
+    fn resume(agent: Agent) -> Resume {
+        Resume {
+            agent,
+            checkout: PathBuf::from("/data/proj/wayfinder"),
+            isolation: Isolation::Host,
+            at: 1_000,
+        }
+    }
+
+    /// The staged ticket the resume tests work: node #117 of map #47, with
+    /// whatever conversation the cache had for it.
+    fn staged_with(resume: Option<Resume>) -> Staged {
+        let staged = Staged::ticket(
+            &ticket("blooop/wayfinder", 117),
+            &map_ref(47),
+            Stage::Building,
+        )
+        .expect("building is launchable");
+        match resume {
+            Some(resume) => staged.with_resume(resume),
+            None => staged,
+        }
+    }
+
+    #[test]
+    fn a_node_you_have_launched_before_leads_its_picker_with_the_way_back() {
+        // The whole point of the row: come back to a ticket you were working
+        // and `enter enter` rejoins the conversation rather than starting a
+        // second one beside it. So resume is not merely present, it *leads* —
+        // an untouched picker cursor sits on it.
+        let staged = staged_with(Some(resume(Agent::Claude)));
+        assert_eq!(
+            staged.candidates().first(),
+            Some(&Candidate::Resume {
+                agent: Agent::Claude
+            })
+        );
+        assert_eq!(
+            staged.default_candidate(),
+            Candidate::Resume {
+                agent: Agent::Claude
+            }
+        );
+        // And the three ways to start fresh are all still there, in order,
+        // one arrow away.
+        let modes: Vec<Candidate> = staged.candidates().into_iter().skip(1).collect();
+        assert_eq!(modes, staged_with(None).candidates());
+    }
+
+    #[test]
+    fn a_node_nobody_has_launched_offers_no_way_back() {
+        // The row is unrepresentable without the record it is built from, so
+        // this is the compiler's claim as much as the test's: nothing here
+        // can invent a resume for a node that has never run.
+        let staged = staged_with(None);
+        assert!(staged
+            .candidates()
+            .iter()
+            .all(|c| !matches!(c, Candidate::Resume { .. })));
+        assert_eq!(
+            staged.default_candidate(),
+            Candidate::Launch {
+                mode: Mode::Interactive,
+                // The fixture is a task, so interactive routes to /wf — the
+                // point is only that the default is a *launch* row again.
+                route: Route::Wayfinder,
+            },
+            "with nothing to rejoin, the default is what it always was"
+        );
+    }
+
+    #[test]
+    fn a_project_row_has_no_node_and_therefore_no_way_back() {
+        // Creation rows name work that does not exist yet, so there is no
+        // conversation for them to rejoin. Attaching one is not an error, it
+        // is a no-op: the field lives in the node arm, so the state cannot be
+        // built in the first place.
+        let staged = Staged::project("blooop/wayfinder").with_resume(resume(Agent::Claude));
+        assert_eq!(
+            staged.candidates(),
+            Staged::project("blooop/wayfinder").candidates()
+        );
+        assert!(staged
+            .candidates()
+            .iter()
+            .all(|c| !matches!(c, Candidate::Resume { .. })));
+    }
+
+    #[test]
+    fn resuming_execs_each_agents_own_way_back_and_nothing_else() {
+        // The flags are the contract with the two CLIs, so they are pinned
+        // literally. Both are cwd-scoped — `claude --continue` continues "the
+        // most recent conversation in the current directory", and `codex
+        // resume` filters by cwd unless `--all` — which is what makes a
+        // per-node workspace sufficient and a session id unnecessary.
+        // One rule for both: the program, how it is told to go back, then the
+        // switches. Codex forces it — `resume` is a subcommand and has to
+        // precede the flags it takes — and Claude follows the same shape
+        // rather than keeping the bypass in the second slot every *other*
+        // launch puts it in, so there is one ordering here instead of two.
+        let claude = resumed(Agent::Claude, "");
+        assert_eq!(
+            claude.agent_argv(),
+            vec!["claude", "--continue", "--dangerously-skip-permissions"]
+        );
+        let codex = resumed(Agent::Codex, "");
+        assert_eq!(
+            codex.agent_argv(),
+            vec![
+                "codex",
+                "resume",
+                "--last",
+                "--dangerously-bypass-approvals-and-sandbox"
+            ]
+        );
+    }
+
+    #[test]
+    fn a_resume_carries_the_typed_text_as_the_prompt_it_wakes_up_on() {
+        // Both CLIs take a prompt beside the resume flag, so the picker's text
+        // field keeps meaning something on this row: rejoin *and* say this.
+        // It is the whole prompt, not a ` steer: …` suffix — there is no skill
+        // invocation in front of it for a suffix to be addressed to.
+        assert_eq!(
+            resumed(Agent::Claude, "run the tests").agent_argv().last(),
+            Some(&"run the tests".to_string())
+        );
+        assert_eq!(
+            resumed(Agent::Codex, "run the tests").agent_argv().last(),
+            Some(&"run the tests".to_string())
+        );
+    }
+
+    #[test]
+    fn a_resume_hands_no_context_block_because_the_conversation_already_has_one() {
+        // #124's block exists to save a fresh session its rediscovery. A
+        // resumed session did that discovery already, and re-handing it would
+        // be telling an agent mid-conversation what it worked out an hour ago.
+        let prompt = resumed(Agent::Claude, "carry on").agent_argv().join(" ");
+        assert!(!prompt.contains("ctx:"), "{prompt}");
+        assert!(
+            !prompt.contains("/wf"),
+            "a resume invokes no skill: {prompt}"
+        );
+    }
+
+    #[test]
+    fn a_resume_goes_back_into_the_node_workspace_it_was_launched_in() {
+        // The conversation is keyed by cwd, so the way back is the same
+        // workspace — never the repo's default one, which is a different tree
+        // with a different conversation in it.
+        let launch = Launch {
+            repo: "blooop/wayfinder".to_string(),
+            cwd: PathBuf::from("/data/proj/wayfinder"),
+            job: Job::Resume {
+                number: 117,
+                agent: Agent::Claude,
+                prompt: None,
+            },
+            isolation: Isolation::Devlaunch,
+        };
+        let argv = launch.agent_argv();
+        assert_eq!(argv[0], "dl");
+        assert_eq!(argv[1], "blooop/wayfinder@wayfinder/wayfinder-117");
+        assert_eq!(argv[2], "--");
+        assert_eq!(
+            argv[3], "'claude' '--continue' '--dangerously-skip-permissions'",
+            "the agent command still crosses dl's shell quoted"
+        );
+    }
+
+    #[test]
+    fn a_resume_goes_back_the_way_it_went_out_not_the_way_the_tree_looks_now() {
+        // Isolation is **recorded**, never re-detected. An isolated launch's
+        // conversation lives in the container, at a cwd inside `dl`'s own
+        // clone — so if the host checkout later loses its `.devcontainer/`, a
+        // fresh detection would answer Host and quietly resume *the
+        // checkout's* conversation instead, which is a different one and
+        // possibly the human's own. `/nonexistent` has no devcontainer and
+        // could never detect as isolated, which is exactly the point.
+        let recorded = Resume {
+            agent: Agent::Claude,
+            checkout: PathBuf::from("/nonexistent/proj/wayfinder"),
+            isolation: Isolation::Devlaunch,
+            at: 1_000,
+        };
+        let launch = resume_launch(&staged_with(Some(recorded)), "").expect("resolves");
+        assert_eq!(
+            launch.agent_argv().first().map(String::as_str),
+            Some("dl"),
+            "a resume must go back into the container it ran in"
+        );
+        // And the other way: a launch that ran on the host stays on the host,
+        // even once someone adds a devcontainer to that tree. Its conversation
+        // is in the checkout, and a container would be a fresh one.
+        let recorded = Resume {
+            agent: Agent::Claude,
+            checkout: PathBuf::from("/nonexistent/proj/wayfinder"),
+            isolation: Isolation::Host,
+            at: 1_000,
+        };
+        let launch = resume_launch(&staged_with(Some(recorded)), "").expect("resolves");
+        assert_eq!(
+            launch.agent_argv().first().map(String::as_str),
+            Some("claude")
+        );
+    }
+
+    #[test]
+    fn a_node_launch_leaves_the_session_a_later_resume_is_offered_on() {
+        // The record is written from the launch itself rather than from the
+        // picker's intent, so what is remembered is what actually ran.
+        let launch = match plan_wf(&cache(), &ticket("blooop/wayfinder", 117), 47) {
+            Targets::One(launch) => launch,
+            other => panic!("one checkout, got {other:?}"),
+        };
+        let session = launch.session().expect("a node launch is resumable");
+        assert_eq!(session.repo, "blooop/wayfinder");
+        assert_eq!(session.number, 117);
+        assert_eq!(session.resume.agent, Agent::Claude);
+        assert_eq!(
+            session.resume.checkout,
+            PathBuf::from("/data/proj/wayfinder")
+        );
+    }
+
+    #[test]
+    fn a_creation_leaves_no_session_because_it_names_no_node_yet() {
+        // `/wf-one` files its ticket after the exec, so at record time there
+        // is no number to key a resume on. A sentinel zero would put a lie in
+        // the cache and offer node #0 a way back.
+        let creation = Creation::Task {
+            task: "add a flag".to_string(),
+        };
+        let launch = match plan_create(&cache(), "blooop/wayfinder", &creation, Agent::Claude) {
+            Targets::One(launch) => launch,
+            other => panic!("one checkout, got {other:?}"),
+        };
+        assert_eq!(launch.session(), None);
+    }
+
+    #[test]
+    fn resuming_a_node_re_records_it_so_the_way_back_stays_the_latest_one() {
+        // A resume is itself a launch, and the conversation it leaves behind
+        // is the one to come back to next time.
+        assert_eq!(
+            resumed(Agent::Codex, "").session().map(|s| s.number),
+            Some(117)
+        );
+    }
+
+    /// A resolved resume of node #117, as the second enter builds it.
+    fn resumed(agent: Agent, steer: &str) -> Launch {
+        let staged = staged_with(Some(resume(agent)));
+        resume_launch(&staged, steer).expect("a staged resume resolves")
     }
 
     #[test]
@@ -1902,8 +2364,11 @@ mod tests {
         );
         // Every row names the skill it execs — the creation rows' routes are
         // their own rather than any node's.
-        let routes: Vec<Route> = project.iter().map(|c| c.route()).collect();
-        assert_eq!(routes, [Route::One, Route::Wayfinder, Route::WayfinderAuto]);
+        let shown: Vec<String> = project
+            .iter()
+            .map(|c| c.invocation(Agent::Claude))
+            .collect();
+        assert_eq!(shown, ["/wf-one", "/wf", "/wf-auto"]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,9 @@ async fn main() -> Result<()> {
     // [`wf::refresh::spawn_discovery`]); this only decides what `wf` fetches
     // while waiting for it.
     let seed = cache.map_seed();
-    let mut app = App::empty().with_checkouts(cache.checkouts.clone());
+    let mut app = App::empty()
+        .with_checkouts(cache.checkouts.clone())
+        .with_sessions(cache.sessions.clone());
     app.open_maps = seed.clone();
     app.startup = Startup::seeded(&seed);
 
@@ -451,7 +453,25 @@ async fn main() -> Result<()> {
             // refusing a launch over, and the only cost of losing this is one
             // project sitting lower in a list than it might have.
             let mut cache = ProjectsCache::load_or_default(&cache_path);
-            if cache.touch(launch.cwd()) {
+            let mut changed = cache.touch(launch.cwd());
+            // And record the conversation this launch is about to start, so a
+            // later run can offer the way back into it (#35).
+            //
+            // Written **here**, immediately before the terminal is restored
+            // and the image replaced, because this is the last moment `wf`
+            // exists — and written from the resolved launch rather than from
+            // the picker, so what is remembered is the tree the agent actually
+            // gets. A creation records nothing: it has no node to key on until
+            // its skill files one.
+            //
+            // Best-effort like the stamp above it, and for a smaller cost: a
+            // record that fails to write means the resume row is missing next
+            // time, not that anything is wrong with the launch.
+            if let Some(session) = launch.session() {
+                cache.record_session(session);
+                changed = true;
+            }
+            if changed {
                 let _ = cache.save(&cache_path);
             }
             // The prompts the selected agent is about to run. `wf skills

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -16,6 +16,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
+use crate::launch::{Agent, Isolation};
 use crate::model::MapSet;
 
 /// One touched checkout: where it lives, and which repo its `origin` points at.
@@ -60,6 +61,96 @@ impl Checkout {
             path,
             repo,
             used: Some(now_secs()),
+        }
+    }
+}
+
+/// A conversation a previous launch left behind on this machine, and the way
+/// back into it (#35).
+///
+/// Deliberately small, because resuming needs almost nothing. Neither agent
+/// resumes by session id: `claude --continue` continues "the most recent
+/// conversation in the current directory", and `codex resume --last` filters
+/// by cwd unless told otherwise. `wf` already gives every node a cwd of its
+/// own — that is what the per-node workspace *is* — so the way back to a
+/// conversation is simply to exec in the same place. Which leaves three facts
+/// worth keeping and no fourth — the three that between them say *where the
+/// conversation is*: which tree, whether it ran in that tree or in the node's
+/// container, and which CLI ran there.
+///
+/// The agent is here because it cannot be re-derived at all: a Claude
+/// conversation is not rejoinable by Codex, and a resume that guessed would
+/// open an empty session in the right directory and call it a rejoin. The
+/// workspace name is *not* here for the opposite reason — it is a pure
+/// function of the node, so a copy could only ever disagree with a fresh
+/// derivation.
+///
+/// What this does **not** claim is that a conversation exists. It says `wf`
+/// launched an agent here, which is the strongest thing `wf` can know without
+/// reading the agent's own store — a container's store, for an isolated
+/// launch, at a path devpod chose. A launch that died before its agent wrote
+/// anything leaves a resume row that lands on the agent's own "no conversation
+/// found", and that is the honest failure: the row promises what `wf` did, not
+/// what the agent managed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Resume {
+    /// Which CLI ran, and therefore which one can rejoin it.
+    pub agent: Agent,
+    /// The tree the launch exec'd in — the checkout on the host, and the
+    /// tree whose devcontainer an isolated launch's container was built from.
+    pub checkout: PathBuf,
+    /// Whether the agent ran on the host or inside the node's container.
+    ///
+    /// Recorded rather than re-detected, unlike everything else here, because
+    /// it is a fact about **where the conversation is** and not about the
+    /// tree's current shape. An isolated launch's history lives at a cwd
+    /// inside `dl`'s own clone; re-detecting from a checkout that has since
+    /// lost its `.devcontainer/` would answer Host and silently resume the
+    /// checkout's own, different conversation. A `dl` that has gone missing
+    /// makes the exec fail loudly instead, which is the better of the two.
+    pub isolation: Isolation,
+    /// When it was launched, seconds since the Unix epoch — what the picker
+    /// row reads back as "20m ago".
+    pub at: u64,
+}
+
+/// A [`Resume`], keyed to the node whose conversation it is.
+///
+/// Flattened on the wire, so a session reads as one object rather than a node
+/// with a nested record — and so the file stays legible to the human who
+/// deletes it, this being a cache and not truth.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Session {
+    /// The node's repo, full slug — matched whole, since a fork and its
+    /// upstream share a short name (#15).
+    pub repo: String,
+    /// The ticket or map number the launch was aimed at.
+    pub number: u64,
+    #[serde(flatten)]
+    pub resume: Resume,
+}
+
+impl Session {
+    /// A session recorded now. The only constructor, for the same reason
+    /// [`Checkout::new`] is: a record that forgot to stamp itself would read
+    /// as a resume from the epoch.
+    #[must_use]
+    pub fn new(
+        repo: String,
+        number: u64,
+        agent: Agent,
+        checkout: PathBuf,
+        isolation: Isolation,
+    ) -> Self {
+        Self {
+            repo,
+            number,
+            resume: Resume {
+                agent,
+                checkout,
+                isolation,
+                at: now_secs(),
+            },
         }
     }
 }
@@ -125,6 +216,16 @@ pub struct ProjectsCache {
     /// and only the head start is lost — once.
     #[serde(default)]
     pub open_maps: MapSet,
+    /// The conversations previous launches left on this machine (#35), at most
+    /// one per node.
+    ///
+    /// Here rather than in a file of its own because it is the same *kind* of
+    /// thing the rest of this cache is: a per-machine fact `wf` accumulates by
+    /// being used, cheap to lose, rebuilt by the next launch. It also lands
+    /// where the write already happens — the handover already loads this cache
+    /// to stamp the checkout it is about to exec in.
+    #[serde(default)]
+    pub sessions: Vec<Session>,
 }
 
 impl ProjectsCache {
@@ -192,6 +293,36 @@ impl ProjectsCache {
         }
     }
 
+    /// Record that an agent was launched on a node, here — the fact a later
+    /// resume is offered on.
+    ///
+    /// **Upserts by node**, so a node has at most one resume. Both agents
+    /// resume by cwd, so one node in one tree has exactly one conversation to
+    /// come back to; keeping the older record would offer a second door to the
+    /// same place, and — once the launch moved to another checkout — a door
+    /// into the wrong one. The newest launch is the one the human means.
+    pub fn record_session(&mut self, session: Session) {
+        self.sessions
+            .retain(|s| !(s.repo == session.repo && s.number == session.number));
+        self.sessions.push(session);
+    }
+
+    /// The conversation a previous launch of this node left, if there is one
+    /// to rejoin.
+    pub fn resume(&self, repo: &str, number: u64) -> Option<&Resume> {
+        self.sessions
+            .iter()
+            .find(|s| s.repo == repo && s.number == number)
+            .map(|s| &s.resume)
+    }
+
+    /// Drop resumes into trees that are gone. Called by
+    /// [`prune_missing`](Self::prune_missing), because a resume's whole content
+    /// is a place to exec in.
+    fn forget_unreachable_sessions(&mut self) {
+        self.sessions.retain(|s| s.resume.checkout.is_dir());
+    }
+
     /// The head start (#28): every open map the last search found, for repos
     /// still in the cache. Read before the first frame, so the loaders start
     /// fetching at `t≈0` instead of after the ~2.5 s search.
@@ -230,9 +361,10 @@ impl ProjectsCache {
     /// before the first frame. `is_dir()` is also the deliberately lenient
     /// test — a checkout on an unmounted volume comes back when it mounts.
     pub fn prune_missing(&mut self) -> bool {
-        let before = self.checkouts.len();
+        let before = (self.checkouts.len(), self.sessions.len());
         self.checkouts.retain(|c| c.path.is_dir());
-        let removed = self.checkouts.len() != before;
+        self.forget_unreachable_sessions();
+        let removed = (self.checkouts.len(), self.sessions.len()) != before;
         if removed {
             self.forget_unknown_maps();
         }
@@ -552,6 +684,131 @@ mod tests {
             paths,
             vec![p("/data/k1/kinisi_ros"), p("/data/k2/kinisi_ros")]
         );
+    }
+
+    #[test]
+    fn a_launch_leaves_a_resume_the_node_can_be_rejoined_by() {
+        // The one fact resuming needs, and one `wf` creates rather than
+        // discovers: an agent ran on this node, in this tree, on this machine.
+        let mut cache = ProjectsCache::default();
+        cache.record_session(Session::new(
+            "blooop/wayfinder".to_string(),
+            117,
+            Agent::Claude,
+            p("/data/proj/wayfinder"),
+            Isolation::Host,
+        ));
+        let resume = cache
+            .resume("blooop/wayfinder", 117)
+            .expect("the node it was recorded for finds it");
+        assert_eq!(resume.agent, Agent::Claude);
+        assert_eq!(resume.checkout, p("/data/proj/wayfinder"));
+        // Every other node is untouched: a resume belongs to one node, and
+        // offering a neighbour's conversation would rejoin the wrong work.
+        assert_eq!(cache.resume("blooop/wayfinder", 118), None);
+        assert_eq!(cache.resume("blooop/devlaunch", 117), None);
+    }
+
+    #[test]
+    fn relaunching_a_node_replaces_its_resume_rather_than_stacking_them() {
+        // Both agents resume by *cwd* (`claude -c`, `codex resume --last`), so
+        // one node in one tree has exactly one conversation to come back to.
+        // Keeping the older record would offer a second door to the same
+        // place — and, when the tree changed, the wrong place.
+        let mut cache = ProjectsCache::default();
+        let node = || ("blooop/wayfinder".to_string(), 117);
+        cache.record_session(Session::new(
+            node().0,
+            node().1,
+            Agent::Claude,
+            p("/data/k1/wayfinder"),
+            Isolation::Host,
+        ));
+        cache.record_session(Session::new(
+            node().0,
+            node().1,
+            Agent::Codex,
+            p("/data/k2/wayfinder"),
+            Isolation::Host,
+        ));
+        assert_eq!(cache.sessions.len(), 1);
+        let resume = cache.resume("blooop/wayfinder", 117).expect("the newer");
+        assert_eq!(resume.agent, Agent::Codex);
+        assert_eq!(resume.checkout, p("/data/k2/wayfinder"));
+    }
+
+    #[test]
+    fn a_resume_whose_checkout_is_gone_is_pruned_with_it() {
+        // The resume names a tree to exec in. Once that tree is deleted the
+        // conversation is unreachable, so the row must stop being offered —
+        // the same rule the checkout it points at already obeys.
+        let root = std::env::temp_dir().join(format!("wf-test-resume-{}", std::process::id()));
+        let live = root.join("live");
+        let gone = root.join("gone");
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::create_dir_all(&gone).unwrap();
+
+        let mut cache = ProjectsCache::default();
+        cache.register(live.clone(), "blooop/wayfinder".to_string());
+        cache.register(gone.clone(), "blooop/wayfinder".to_string());
+        cache.record_session(Session::new(
+            "blooop/wayfinder".to_string(),
+            117,
+            Agent::Claude,
+            live.clone(),
+            Isolation::Devlaunch,
+        ));
+        cache.record_session(Session::new(
+            "blooop/wayfinder".to_string(),
+            121,
+            Agent::Claude,
+            gone.clone(),
+            Isolation::Host,
+        ));
+
+        std::fs::remove_dir_all(&gone).unwrap();
+        assert!(cache.prune_missing());
+        assert!(cache.resume("blooop/wayfinder", 117).is_some());
+        assert_eq!(
+            cache.resume("blooop/wayfinder", 121),
+            None,
+            "a resume into a deleted tree must stop being offered"
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn a_cache_file_written_before_resume_existed_still_loads() {
+        // The fourth shape change, and the same rule as the other three: the
+        // checkouts survive, and the only thing missing is a resume nobody
+        // could have recorded yet.
+        let cache: ProjectsCache = serde_json::from_str(
+            r#"{"checkouts":[{"path":"/data/proj/wayfinder","repo":"blooop/wayfinder"}]}"#,
+        )
+        .expect("a cache file without sessions parses");
+        assert!(cache.sessions.is_empty());
+        assert_eq!(cache.resume("blooop/wayfinder", 117), None);
+    }
+
+    #[test]
+    fn a_resume_round_trips_through_disk_with_the_agent_that_ran() {
+        // Which agent ran is the half that cannot be re-derived: a Claude
+        // conversation cannot be rejoined by Codex, so if this field does not
+        // survive the write, resume comes back offering the wrong CLI.
+        let dir = std::env::temp_dir().join(format!("wf-test-sessions-{}", std::process::id()));
+        let file = dir.join("projects.json");
+        let mut cache = ProjectsCache::default();
+        cache.register(p("/data/proj/wayfinder"), "blooop/wayfinder".to_string());
+        cache.record_session(Session::new(
+            "blooop/wayfinder".to_string(),
+            117,
+            Agent::Codex,
+            p("/data/proj/wayfinder"),
+            Isolation::Host,
+        ));
+        cache.save(&file).expect("save");
+        assert_eq!(ProjectsCache::load_or_default(&file), cache);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -50,7 +50,13 @@ fn glyph_style(glyph: RowGlyph) -> Style {
 /// half of what a ticket is matched against and the rows below do not draw it:
 /// typing a project name would otherwise sift the whole screen down to one
 /// cluster while underlining nothing anywhere.
-fn cluster_header(id: &MapId, map: &Map, lit: &[usize], under_cursor: bool) -> Line<'static> {
+fn cluster_header(
+    id: &MapId,
+    map: &Map,
+    lit: &[usize],
+    under_cursor: bool,
+    resumable: bool,
+) -> Line<'static> {
     let cyan = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
     // The cursor rides *before* the `▌`, not after it: the bar is the cluster's
     // left edge and every row below hangs off it, so a marker inside it would
@@ -58,6 +64,14 @@ fn cluster_header(id: &MapId, map: &Map, lit: &[usize], under_cursor: bool) -> L
     let mut spans = vec![cursor_span(under_cursor), Span::styled("▌ ", cyan)];
     spans.extend(lit_spans(id.short_repo(), lit, cyan));
     spans.push(Span::styled(format!(" · {}", map.title), cyan));
+    // A map is a node, so a charting session is as resumable as a build one —
+    // and the header is the only place the list can say so (#35).
+    if resumable {
+        spans.push(Span::styled(
+            RESUME_BADGE,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::DIM),
+        ));
+    }
     for (glyph, count) in map.tally() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
@@ -266,6 +280,11 @@ fn pr_badge(ticket_repo: &str, pr: &PrLink) -> Vec<Span<'static>> {
 /// `lit` is where a live query landed in the `#n title` half — the only part of
 /// the row that was matched against, and so the only part that can honestly
 /// claim to be why the row is on screen.
+///
+/// `resumable` adds the `⏎` badge (#35): a conversation from a previous launch
+/// is waiting on this node. A bare flag rather than the record itself, because
+/// the row says only *that* there is a way back — how old it is belongs to the
+/// picker, where the choice is actually made.
 fn ticket_line(
     ticket: &Ticket,
     prefix: &str,
@@ -273,6 +292,7 @@ fn ticket_line(
     branch: &Branch,
     lit: &[usize],
     under_cursor: bool,
+    resumable: bool,
 ) -> Line<'static> {
     // Nested rows carry the cursor column as extra indent, so a branch begins
     // directly under the glyph of the row it hangs from instead of to its left.
@@ -296,6 +316,12 @@ fn ticket_line(
         spans.push(Span::styled(
             format!(" [{name}]"),
             Style::new().add_modifier(Modifier::DIM),
+        ));
+    }
+    if resumable {
+        spans.push(Span::styled(
+            RESUME_BADGE,
+            Style::new().fg(Color::Cyan).add_modifier(Modifier::DIM),
         ));
     }
     for pr in &ticket.prs {
@@ -325,7 +351,10 @@ fn ticket_line(
 /// by omission: a row the query landed on is a match, and a match is drawn as
 /// [`Item::Ticket`], never as one of these.
 fn context_line(ticket: &Ticket, prefix: &str) -> Line<'static> {
-    ticket_line(ticket, prefix, &[], &Branch::Plain, &[], false)
+    // No resume badge either, for the same reason it carries no cursor: a
+    // context row is not somewhere `enter` can be pressed, so a badge about
+    // what `enter` would do there would be an offer the row cannot honour.
+    ticket_line(ticket, prefix, &[], &Branch::Plain, &[], false, false)
         .patch_style(Style::new().add_modifier(Modifier::DIM))
 }
 
@@ -417,7 +446,13 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
             Item::Header(id) => {
                 let map = &app.clusters[id];
                 let lit = query.as_mut().map(|q| q.in_repo(map)).unwrap_or_default();
-                lines.push(cluster_header(id, map, &lit, under_cursor));
+                lines.push(cluster_header(
+                    id,
+                    map,
+                    &lit,
+                    under_cursor,
+                    app.resume(&id.repo, id.number).is_some(),
+                ));
             }
             Item::Ticket {
                 row,
@@ -439,6 +474,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     branch,
                     &lit,
                     under_cursor,
+                    app.resume(&ticket.repo, ticket.number).is_some(),
                 ));
             }
             Item::Project(project) => lines.push(project_line(project, under_cursor)),
@@ -549,6 +585,38 @@ pub fn idle_note(plan: &Plan) -> String {
     }
 }
 
+/// The badge a row carries when a previous launch left a conversation on it
+/// (#35) — the same glyph as the key that rejoins it.
+const RESUME_BADGE: &str = "  ⏎";
+
+/// How long ago `then` was, from `now`, in the one unit that reads: `20m ago`,
+/// `3h ago`, `5d ago`.
+///
+/// A pure function of the two instants rather than a method reading the clock,
+/// so the rendering is pinned by tests instead of raced against a wall clock —
+/// the same reason the launch context carries no snapshot instant.
+///
+/// A clock that moved backwards between the launch and now reads as **the
+/// present**. Both alternatives are worse: a negative age cannot be spelt, and
+/// an unsigned subtraction would wrap to an age of a hundred billion years.
+fn ago(then: u64, now: u64) -> String {
+    let secs = now.saturating_sub(then);
+    match secs {
+        0..=59 => "just now".to_string(),
+        60..=3_599 => format!("{}m ago", secs / 60),
+        3_600..=86_399 => format!("{}h ago", secs / 3_600),
+        _ => format!("{}d ago", secs / 86_400),
+    }
+}
+
+/// Now, in seconds since the Unix epoch — read once per frame that draws an
+/// age, and never anywhere a test asserts on.
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
 /// A centered box `width`×`height` (clamped) inside `area`.
 fn centered(area: Rect, width: u16, height: u16) -> Rect {
     let [area] = Layout::horizontal([Constraint::Length(width.min(area.width))])
@@ -592,13 +660,22 @@ fn draw_launch_picker(
         } else {
             Style::new().add_modifier(Modifier::DIM)
         };
+        // A resume names when the conversation was left, which its label
+        // cannot: three weeks old and twenty minutes old are the same row
+        // otherwise, and they are not the same decision.
+        let blurb = match (option, staged.resume()) {
+            (Candidate::Resume { .. }, Some(resume)) => {
+                format!("{} · {}", ago(resume.at, now_secs()), option.blurb())
+            }
+            _ => option.blurb().to_string(),
+        };
         lines.push(Line::from(vec![
             Span::styled(format!("  {marker} {:<14}", option.label()), emphasis),
             Span::styled(
-                format!("{:<10}", option.route().invocation(agent)),
+                format!("{:<18}", option.invocation(agent)),
                 Style::new().fg(Color::Cyan),
             ),
-            Span::styled(option.blurb(), Style::new().add_modifier(Modifier::DIM)),
+            Span::styled(blurb, Style::new().add_modifier(Modifier::DIM)),
         ]));
     }
     lines.push(Line::default());
@@ -625,9 +702,12 @@ fn draw_launch_picker(
     // something new in the repo it belongs to. Naming only the node would be
     // true of half the list — and the repo is exactly what creation would
     // otherwise have to ask for.
+    // The picked row decides which agent the title names: on a resume it is
+    // the recorded one, since that is what `enter` will become. Anything else
+    // would put a Codex title over a row that runs Claude.
     let title = format!(
         " launch {} · {} · {} {} ",
-        agent.label(),
+        candidate.agent(agent).label(),
         staged.repo,
         staged.key(),
         staged.title()
@@ -892,6 +972,98 @@ mod tests {
             out.push('\n');
         }
         out
+    }
+
+    /// The fixture app, with a conversation left on `number`.
+    fn app_resuming(number: u64) -> App {
+        fixture_app().with_sessions(vec![crate::projects::Session::new(
+            "blooop/wayfinder".to_string(),
+            number,
+            Agent::Claude,
+            std::path::PathBuf::from("/data/proj/wayfinder"),
+            crate::launch::Isolation::Host,
+        )])
+    }
+
+    #[test]
+    fn a_row_you_left_a_conversation_on_says_so_before_anything_is_fetched() {
+        // The badge is drawn from the local cache, so it is on the *first*
+        // frame — the same frame-zero rule the project list follows. Nothing
+        // asks `dl`, and nothing waits for the map search.
+        let screen = render(&app_resuming(7));
+        let row = screen
+            .lines()
+            .find(|l| l.contains("#7 Supervising"))
+            .expect("the row is on screen");
+        assert!(row.contains('⏎'), "{row}");
+        // And only that row: the badge is a fact about one node.
+        let other = screen
+            .lines()
+            .find(|l| l.contains("#6 Re-entry"))
+            .expect("the neighbour is on screen");
+        assert!(!other.contains('⏎'), "{other}");
+    }
+
+    #[test]
+    fn a_map_you_have_charted_before_carries_the_badge_too() {
+        // A map is a node (#96) and its picker offers the resume row, so the
+        // list has to say so — otherwise the only way to discover a charting
+        // session is waiting is to press enter on every header.
+        let screen = render(&app_resuming(1));
+        let header = screen
+            .lines()
+            .find(|l| l.contains("Map: wf"))
+            .expect("the cluster header is on screen");
+        assert!(header.contains('⏎'), "{header}");
+    }
+
+    #[test]
+    fn the_resume_row_says_how_long_ago_you_left_it() {
+        // Whether a conversation is twenty minutes or three weeks old changes
+        // whether you want it back, and it is the one thing the row's label
+        // cannot say. The rendering is a pure function of the two instants, so
+        // it is pinned here rather than against a wall clock.
+        assert_eq!(ago(1_000, 1_000), "just now");
+        assert_eq!(ago(1_000, 1_030), "just now");
+        assert_eq!(ago(1_000, 1_000 + 20 * 60), "20m ago");
+        assert_eq!(ago(1_000, 1_000 + 3 * 3_600), "3h ago");
+        assert_eq!(ago(1_000, 1_000 + 5 * 86_400), "5d ago");
+        // A clock that went backwards between the launch and now reads as the
+        // present rather than as a negative age or a huge one.
+        assert_eq!(ago(2_000, 1_000), "just now");
+    }
+
+    #[test]
+    fn the_picker_draws_the_way_back_as_the_argv_it_will_actually_run() {
+        // The skill column names what execs. Every other row names a skill;
+        // this one has none, so it names the agent's own resume flags — which
+        // is exactly the difference between resuming and `plain`, and the two
+        // sit one row apart.
+        let mut app = app_resuming(6);
+        down(&mut app, 2);
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("resume"), "{screen}");
+        assert!(screen.contains("claude --continue"), "{screen}");
+    }
+
+    #[test]
+    fn the_picker_title_names_the_agent_that_will_actually_rejoin() {
+        // The title is the agent axis's readout, and on the resume row the
+        // axis is the record's rather than the picker's. A Codex title over a
+        // row that runs Claude is the one lie this screen could tell.
+        let mut app = fixture_app().with_sessions(vec![crate::projects::Session::new(
+            "blooop/wayfinder".to_string(),
+            6,
+            Agent::Codex,
+            std::path::PathBuf::from("/data/proj/wayfinder"),
+            crate::launch::Isolation::Host,
+        )]);
+        down(&mut app, 2);
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("launch Codex"), "{screen}");
+        assert!(screen.contains("codex resume --last"), "{screen}");
     }
 
     #[test]

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -8,7 +8,7 @@
 //! actually be wrong is what happens between the keypress and the agent's first
 //! frame, and that only happens once, in `main`.
 //!
-//! It pins down four claims, in the order they can fail:
+//! It pins down six claims, in the order they can fail:
 //!
 //! 0. **The container carries the agent, in a workspace of the ticket's
 //!    own.** This repo has a `.devcontainer/devcontainer.json`, so its
@@ -39,6 +39,16 @@
 //!    the shim reports its own termios, and an agent handed a still-raw tty
 //!    fails here instead of in daily use (the #30 failure mode, now guarded
 //!    from the other side).
+//!
+//! 4. **The launch leaves a way back into itself** (#35). The record has to
+//!    reach disk *before* the exec, because after it there is no `wf` left to
+//!    write anything — so a run that reached the agent and recorded nothing
+//!    would silently lose the conversation it had just started.
+//! 5. **And coming back rejoins it.** A second `wf`, against the cache the
+//!    first one left, opens its picker on a `resume` row and the same
+//!    `enter enter` returns to that conversation instead of starting another.
+//!    This is the one seam no unit test can reach: `resume_launch` is checked
+//!    exhaustively in the library, but only against a record a test handed it.
 //!
 //! Needs network, an authenticated `gh`, and a `blooop/wayfinder` checkout with
 //! at least one ticket on its map — i.e. this repo.
@@ -73,8 +83,11 @@ const COOKED: [&str; 4] = ["echo", "icanon", "isig", "opost"];
 struct Scratch(PathBuf);
 
 impl Scratch {
-    fn new() -> Scratch {
-        let root = std::env::temp_dir().join(format!("wf-it-exec-{}", std::process::id()));
+    /// `name` keeps two tests in this binary from sharing a root: they run as
+    /// threads of one process, so the pid alone is not unique between them and
+    /// the `remove_dir_all` below would delete the other's shims mid-run.
+    fn new(name: &str) -> Scratch {
+        let root = std::env::temp_dir().join(format!("wf-it-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("bin")).expect("scratch bin");
         std::fs::create_dir_all(root.join("cache")).expect("scratch cache");
@@ -256,7 +269,7 @@ fn flags(stty: &str) -> Vec<&str> {
 #[allow(clippy::too_many_lines)]
 #[test]
 fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
-    let scratch = Scratch::new();
+    let scratch = Scratch::new("exec");
     scratch.write_shims();
     let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
 
@@ -311,14 +324,35 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     drop(slave);
     let seen = spawn_reader(master);
 
-    // `▶` marks the cursor on a *ticket row*, so it cannot be drawn until a map
-    // has actually landed — group headers and the empty-list screen have none.
+    // A *cluster header* cannot be drawn until a map has landed. Waiting on
+    // `▶` alone would not do it any more: since #135 the cursor starts on the
+    // project row, which is drawn from the local cache on the very first frame
+    // and so says nothing about the fetch. The needle is one contiguous write
+    // — ratatui emits diffs, so `" #"` before a ticket number is split by the
+    // cursor-positioning escape between them and never appears in the stream.
     // Generous, because a cold cache pays for the map search before the fetch.
-    wait_for(&seen, "▶", Duration::from_secs(60), "the map to load");
+    wait_for(
+        &seen,
+        "▌ wayfinder · ",
+        Duration::from_secs(60),
+        "the map to load",
+    );
+
+    // Down onto a *ticket*. `wf` opens standing on the project row (#135) —
+    // where `enter` means "start something new in this repo" — and this test
+    // is about launching an agent on a node the tracker already knows. `→`
+    // steps forward one stop at a time, so two of them go project → cluster
+    // header → its first ticket.
+    for _ in 0..2 {
+        keys.write_all(b"\x1b[C").expect("send right");
+    }
+    keys.flush().expect("flush the descent");
 
     // First enter stages the launch: the picker opens over the list, titled
     // with the node and cursored on the interactive row. The second enter
-    // takes that row — today's default.
+    // takes that row — today's default. (Nothing has been launched on this
+    // node from this cache before, so there is no resume row above it: the
+    // cache is the test's own, and this run is the first.)
     keys.write_all(b"\r").expect("send enter");
     keys.flush().expect("flush enter");
     wait_for(
@@ -443,6 +477,36 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
          {workspace:?} vs {prompt:?}"
     );
 
+    // Claim 5: the launch left a way back into itself (#35). The record has to
+    // be on disk *before* the exec — after it there is no `wf` left to write
+    // anything — so a run that reached the agent and recorded nothing would
+    // lose the conversation it just started. It names the same node as the
+    // workspace and the prompt, in the tree the agent was exec'd into.
+    let cache_file = scratch.cache().join("wf").join("projects.json");
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&cache_file).expect("the projects cache"))
+            .expect("the cache is JSON");
+    let sessions = written["sessions"]
+        .as_array()
+        .unwrap_or_else(|| panic!("the launch recorded no session: {written}"));
+    let session = sessions
+        .iter()
+        .find(|s| s["repo"] == "blooop/wayfinder")
+        .unwrap_or_else(|| panic!("no session for the launched repo: {written}"));
+    assert_eq!(
+        session["number"].as_u64().map(|n| n.to_string()).as_deref(),
+        Some(workspace_ticket),
+        "the recorded node must be the one that launched: {session}"
+    );
+    assert_eq!(session["agent"], "claude");
+    assert_eq!(
+        Path::new(session["checkout"].as_str().expect("a checkout path"))
+            .canonicalize()
+            .ok(),
+        repo.canonicalize().ok(),
+        "the resume must point at the tree the agent actually ran in"
+    );
+
     // Claim 3a: the tty itself came back. `wf` runs raw the whole time it is
     // up, so an agent that finds a raw tty here is one that would have found a
     // dead keyboard in daily use.
@@ -494,5 +558,136 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
         std::fs::read_to_string(&copied_prompt).ok(),
         std::fs::read_to_string(repo.join("skills/wf-tdd/SKILL.md")).ok(),
         "the launch must refresh the prompt it is about to exec"
+    );
+}
+
+/// Spawn `wf` under a fresh pty in `scratch`, returning the child, a handle to
+/// write keys into it, and the accumulating output.
+///
+/// Extracted for the round trip below, which needs two runs sharing one cache —
+/// the first to leave a conversation behind, the second to find it. The test
+/// above keeps its own inline copy: it asserts on the pid of the process it
+/// spawned, and threading that through a helper would put the thing being
+/// proved behind an abstraction.
+fn spawn_wf(
+    scratch: &Scratch,
+    cwd: &Path,
+) -> (std::process::Child, std::fs::File, Arc<Mutex<Vec<u8>>>) {
+    let (master, slave) = openpty_sized(40, 120);
+    let path = format!(
+        "{}:{}",
+        scratch.bin().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let child = unsafe {
+        Command::new(env!("CARGO_BIN_EXE_wf"))
+            .current_dir(cwd)
+            .env("PATH", &path)
+            .env("XDG_CACHE_HOME", scratch.cache())
+            .env("CLAUDE_CONFIG_DIR", scratch.claude())
+            .env("TERM", "xterm-256color")
+            .stdin(Stdio::from(slave.try_clone().expect("dup slave")))
+            .stdout(Stdio::from(slave.try_clone().expect("dup slave")))
+            .stderr(Stdio::from(slave.try_clone().expect("dup slave")))
+            .pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            })
+            .spawn()
+            .expect("spawn wf under a pty")
+    };
+    let keys = std::fs::File::from(master.try_clone().expect("dup master"));
+    drop(slave);
+    (child, keys, spawn_reader(master))
+}
+
+/// Walk from the project row down to the first cluster's first ticket, stage
+/// it, and take the picker's leading row. The same keys both times, so the two
+/// runs land on the same node — which is what makes the second one a *return*
+/// to the first rather than a fresh launch somewhere else.
+fn launch_the_first_ticket(keys: &mut std::fs::File, seen: &Arc<Mutex<Vec<u8>>>, leading: &str) {
+    wait_for(
+        seen,
+        "▌ wayfinder · ",
+        Duration::from_secs(60),
+        "the map to load",
+    );
+    for _ in 0..2 {
+        keys.write_all(b"\x1b[C").expect("send right");
+    }
+    keys.flush().expect("flush the descent");
+    keys.write_all(b"\r").expect("send enter");
+    keys.flush().expect("flush enter");
+    wait_for(seen, leading, Duration::from_secs(10), "the launch picker");
+    keys.write_all(b"\r").expect("send the second enter");
+    keys.flush().expect("flush the second enter");
+}
+
+/// The round trip (#35): launch a node, come back, and rejoin the very
+/// conversation that launch started.
+///
+/// The one seam no unit test can reach. `launch::resume_launch` is checked
+/// exhaustively in the library, but what it is checked *against* is a `Resume`
+/// the test handed it. Here the record is written by one real `wf` on its way
+/// out of the process and read by a second real `wf` on its way up — through an
+/// actual file, an actual serde round trip, and the cache-loading path in
+/// `main` — so a resume that is offered but points nowhere, or is not offered
+/// at all, fails here and nowhere else.
+///
+/// Both runs press the same keys. The second one presses them against a screen
+/// that now has a resume row leading its picker, so the same `enter enter` that
+/// *started* the work is the one that returns to it — which is the claim the
+/// whole feature is for.
+#[test]
+fn coming_back_to_a_node_rejoins_the_conversation_the_first_launch_started() {
+    let scratch = Scratch::new("resume");
+    scratch.write_shims();
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    // Run one: an ordinary launch, which leaves the record behind.
+    let (mut child, mut keys, seen) = spawn_wf(&scratch, repo);
+    launch_the_first_ticket(&mut keys, &seen, "▶ interactive");
+    wait_for(&seen, RAN, Duration::from_secs(30), "the agent to run");
+    assert!(child.wait().expect("wait").success());
+    let first = std::fs::read_to_string(scratch.report()).expect("the first run's report");
+    let launched = field(&first, "argv=").to_string();
+    assert!(
+        launched.contains("/wf"),
+        "the first run must be a fresh skill launch: {launched}"
+    );
+
+    // Run two: the same keys, against a cache that now knows about that node.
+    // The picker leads with `resume`, so the second enter takes it.
+    let (mut child, mut keys, seen) = spawn_wf(&scratch, repo);
+    launch_the_first_ticket(&mut keys, &seen, "▶ resume");
+    wait_for(&seen, RAN, Duration::from_secs(30), "the agent to run");
+    assert!(child.wait().expect("wait").success());
+
+    let second = std::fs::read_to_string(scratch.report()).expect("the second run's report");
+    let resumed = field(&second, "argv=");
+    // The agent's own way back, and *only* that: no skill, and no `ctx:` block
+    // — the conversation being rejoined worked all of that out already.
+    assert_eq!(
+        resumed, "--continue --dangerously-skip-permissions",
+        "the second run must rejoin rather than start again"
+    );
+
+    // And it went back into the same container the first launch ran in, which
+    // is what makes it the same conversation: both agents key their history by
+    // cwd, and that cwd is inside this workspace.
+    let dl = std::fs::read_to_string(scratch.dl_report()).expect("the dl shim's report");
+    let workspace = field(&dl, "argv=")
+        .split(' ')
+        .next()
+        .expect("a workspace")
+        .to_string();
+    assert!(
+        workspace.starts_with("blooop/wayfinder@wayfinder/wayfinder-"),
+        "the resume must re-enter the node's own workspace, got {workspace:?}"
     );
 }


### PR DESCRIPTION
Closes part of #35.

A node you have launched an agent on carries a `⏎` in the list, and its picker leads with a `resume` row:

```
┌ launch Claude · blooop/wayfinder · #117 The one project surface ────────────┐
│                                                                             │
│  ▶ resume        claude --continue   20m ago · pick the conversation back up│
│    interactive   /wf-tdd             you are in the loop; it grills you     │
│    auto          /wf-auto            the agent decides alone and drives it  │
│    plain         claude              no skill; a bare session on the branch │
│                                                                             │
│    steer  █                                                                 │
└─────────────────────────────────────────────────────────────────────────────┘
```

So coming back to work you left is the same `enter enter` that started it; starting fresh is one `↓`.

## Why this is small

Neither agent needs a session store. `claude --continue` continues "the most recent conversation in the current directory", and `codex resume --last` filters by cwd unless told `--all`. `wf` already gives every node a cwd of its own — that is exactly what the per-node workspace `owner/repo@wayfinder/<repo>-<n>` *is*. So resuming is the same exec every other launch is, with the agent's own flag where the skill invocation goes: no ids to match, nothing that can point at a conversation that moved, and no `ctx:` block, since the session being rejoined worked all of that out already.

## What is recorded

Three facts per launch, in the projects cache beside the checkouts — the three that between them say *where the conversation is*:

- **which tree** — unrecoverable by a fresh reading once a repo has two checkouts, which is why a resume never asks "which checkout" where a fresh launch would;
- **host or container** — recorded rather than re-detected, because an isolated launch's history lives inside `dl`'s clone, and re-detecting from a checkout that has since lost its `.devcontainer/` would answer "host" and quietly resume the checkout's own, different conversation;
- **which CLI** — not re-derivable at all, since a Claude conversation is not rejoinable by Codex. So the picker's `←`/`→` is deliberately dead on that row and the title names the recorded agent.

The workspace name is deliberately *not* stored: it is a pure function of the node, so a copy could only ever disagree with a fresh derivation.

The row is unrepresentable without its record — the resume lives in `StagedAt::Node`, so a project stop cannot offer one — and a creation records nothing, having no node to key on until its skill files one.

## Honest limits

- The record says **`wf` launched an agent here**, not that a conversation exists. That is the strongest thing `wf` can know without reading the agent's own store, which for an isolated launch is inside a container at a path devpod chose. A launch that died before its agent wrote anything leaves a row that lands on the agent's own "no conversation found".
- **Same machine only**, by construction — it is a local cache of local directories. Coming back elsewhere is what the ticket breadcrumbs are for.
- Sessions are never garbage-collected except when their checkout disappears, so the cache grows slowly with nodes you have worked. ~100 bytes each; deleting the file is safe.

## Also in here

`tests/live_launch_exec.rs` **was failing on `main`** — #135 regressed it. `wf` now opens standing on the project row, so the test's first `enter` was opening the creation picker instead of staging a ticket, and it timed out waiting for `▶ interactive`. It now descends onto a ticket first, and its wait needle is a cluster header rather than `▶` (which the project row draws at frame zero from cache, before any fetch) or `" #"` (which never appears contiguously — ratatui writes diffs).

It gained two claims: that the record reaches disk *before* the exec, and a full round trip — one real `wf` launches a node, a second real `wf` against the cache it left rejoins that conversation in the same container. That round trip is the one seam a unit test structurally cannot reach.

## Testing

364 tests pass (was 337 on `main`, where one of them was red); clippy and `cargo fmt --check` clean.

Both agents' resume flags were verified against the installed CLIs rather than assumed, which is where the argv ordering comes from: `codex resume` is a subcommand, so it precedes the bypass switch, and Claude follows the same shape rather than keeping two orderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for resuming prior agent conversations per node and surface this in the UI, backed by a per-machine session cache and end‑to‑end tests.

New Features:
- Allow launching a resume job that rejoins the most recent per-node conversation using agents’ cwd-scoped resume flags.
- Display a resume row at the top of the launch picker for nodes with recorded sessions and mark resumable nodes and maps with a ⏎ badge.
- Show relative age info for resume entries in the picker to indicate how long ago the conversation was left.

Enhancements:
- Extend launch planning and staging to carry per-node resume metadata and derive agent/invocation consistently from recorded sessions.
- Persist session records in the projects cache alongside checkouts, pruning entries whose checkouts disappear and reusing them across runs.
- Wire cached sessions into the app state so staging tickets/maps can attach resume information consistently.

Documentation:
- Document the projects cache’s new per-node session entries and add a dedicated section explaining resuming conversations, its behaviour, and limitations.

Tests:
- Add unit tests around resume candidate ordering, session recording, replacement, pruning, and serialization.
- Add UI tests asserting badges, picker behaviour, and agent labelling for resumable nodes and maps.
- Extend the live integration test to verify sessions are written before exec and that a second wf instance can rejoin the same conversation.