### PR TITLE
wf notices what reap would claim, without being asked (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ ask again.
 count line when it arrives:
 
 ```
-  12/30    · 2 reclaimable: devlaunch-…-127-c, devlaunch-…-80-f — wf reap
+  12/30  · 2 reclaimable: devlaunch-github-…oop-wayfinder-127, +1 more — wf reap
 ```
 
 It is the same reading `wf reap` prints, taken by the same code — a `dl --ls
@@ -390,6 +390,15 @@ The picker draws at exactly the speed it did without it. Nothing is deleted, and
 nothing can be: this names workspaces and a command, and you type the command.
 It names them rather than only counting them, because "2 reclaimable" is not
 something you can agree or disagree with.
+
+A `dl` workspace id is around forty characters and this segment shares one line
+with the load state and the match count, so the line is **budgeted** rather than
+written and clipped: the count, the `(+N to check by hand)` aside and the
+`— wf reap` pointer are laid down first, and the names take what is left. As many
+are spelt out whole as fit; the next one is shortened in the middle, keeping the
+project at the front and the ticket number at the back; the rest are counted as
+`+N more`. On a terminal too narrow for a name anybody could read, the names go
+and the command stays.
 
 It **fails silent**. No `dl` on PATH, a listing that failed, a GraphQL error, no
 network, or simply nothing to reclaim: the segment is absent, and there is no

--- a/README.md
+++ b/README.md
@@ -403,15 +403,19 @@ That one is settled by the compiler and needs no test.
 `wf reap` as a whole *command* is another matter: it has to be public for `main`
 to dispatch it, and `reap::run(true, true)` is a forced reap. So the picker file
 may not write the word `reap` at all — nor `Command`, `process::`,
-`tokio::spawn` or `fs::` — and `main.rs` carries the list of every line of code
-in itself that writes `reap`, and may not write `Command` either. A word, not a
-path, so an alias or a `crate::` route has to appear in that list too. Those are
-greps over the source text of two files. They catch a cleanup wired in by
-accident, which is the mistake anyone is actually likely to make; they do not
-stop someone who means to get around them, and several review rounds of this
-feature were spent proving exactly that. A grep over two files cannot see the
-same call written in a third, or a second name for the module exported from the
-library.
+`tokio::spawn` or `fs` — and `main.rs` carries the list of every line of code in
+itself that writes `reap`, and may not write `Command` or `fs` either. Words,
+not paths: `use std::fs as sys;` writes no `fs::` and `use crate::reap as tidy;`
+writes no `reap::`, and both of those were live escapes against the narrower
+spelling. `main.rs`'s list is of lines of *code* — its `USAGE` help text writes
+`wf reap` because that is the command it documents, and it is cut out before the
+list is taken, with the cut checked against `USAGE`'s own line count so it
+cannot run past the literal and swallow code. Those are greps over the source
+text of two files. They catch a cleanup wired in by accident, which is the
+mistake anyone is actually likely to make; they do not stop someone who means to
+get around them, and several review rounds of this feature were spent proving
+exactly that. A grep over two files cannot see the same call written in a third,
+or a second name for the module exported from the library.
 
 Everything else is watched rather than proven. A test drives the real event loop
 against a recording `dl` and `gh`, through every arm the loop has — quit,
@@ -422,17 +426,23 @@ argv the run made, plus a scratch `HOME` laid out the way this machine is
 after. That catches a workspace deleted by running `dl` and one deleted
 in-process, whatever file the call was written in, inside three stated bounds.
 It starts at the loop's composition — the function that spawns the reading and
-runs the loop — so what `wf` does above and below that call is outside it; the
-tokens above are what cover that part of the picker file. It runs for the length
-of that call plus 400 ms after the reading lands, after every key and after it
+runs the loop — so what `wf` does above and below that call is outside it; what
+stands there instead is the token list above, in those two files and no others.
+It runs for the length of that call plus 400 ms after the reading lands, after
+every key and after it
 returns, so a deletion deferred past the window is not seen (a spawned task that
 sleeps a second and a half is green; the same one with the window at three
 seconds is caught). And it sees only what the child's fixtures reach: a deletion
 in the one fold arm a failed map search would take is green, because the `gh`
-shim succeeds. An `std::fs` call aimed outside that scratch `HOME` is caught by
-nothing — a `remove_dir_all` pointed at a directory elsewhere on the disk passes
-the whole suite, and really does destroy it. Nothing in any Rust file catches
-that.
+shim succeeds. An `std::fs` call is caught by nothing when it is aimed outside
+that scratch `HOME` **or written outside the span the run covers** — and that
+span is the loop's composition, so "outside" it is the whole of the picker's own
+entry point and the whole of `main`. A `remove_dir_all` pointed at a directory
+elsewhere on the disk passes the whole suite and really does destroy it; a
+`remove_dir_all` aimed squarely *inside* the watched home, written in either of
+those two functions, passed it too until the `fs` token above went on. What
+catches the second kind is that token, in the two files that carry it, and it is
+a grep. Nothing catches either kind in a third file.
 
 The picker does delete one thing, and it is not a workspace: the launch path
 brings the installed skill copies back in step with the bundle, which removes

--- a/README.md
+++ b/README.md
@@ -391,13 +391,31 @@ this names workspaces and a command, and you type the command. It names them
 rather than only counting them, because "2 reclaimable" is not something you can
 agree or disagree with.
 
-The picker *cannot* delete them, and that is a property of the build rather than
-a promise. The function that removes a workspace is private to the library
-module that owns `wf reap`; the picker lives in the binary, so a line anywhere
-in it — or in any helper, alias or submodule it calls — that tries to reach that
-function does not compile. Shelling out to `dl` instead is caught by a test that
-drives the real event loop with a recording `dl` on `PATH` and reads back every
-argv it ran.
+Nothing on this path deletes anything, and it is worth being exact about what
+holds that up, because it is three different things with three different
+reaches.
+
+The function that removes a workspace is private to the library module that owns
+`wf reap`. The picker is in the binary, so no line of it — no helper, alias or
+submodule — can call that function, and the edit that tries does not compile.
+`wf reap` as a whole *command* is another matter: it has to be public for `main`
+to dispatch it, and `reap::run(true, true)` is a forced reap. So the picker file
+may not name `reap` at all, and `main.rs` must name the module exactly once and
+call into it exactly once — counted by reachability rather than by one spelling,
+so an aliased import cannot slip past. Those two are greps over two files, and a
+grep over a file cannot see the same call made in a third.
+
+Everything else is watched rather than proven. A test drives the real event loop
+against a recording `dl` and `gh`, through every arm the loop has — quit,
+refresh, continue, and the launch that ends the session — and reads back every
+argv the run made, plus a scratch `HOME` laid out the way this machine is
+(`~/.cache/devlaunch/repos/<owner>/<repo>/<id>` for the clone,
+`~/.devpod/contexts/<ctx>/workspaces/<id>` for the record), compared before and
+after. That catches a workspace deleted by running `dl` and one deleted
+in-process, whatever file the call was written in — for the length of the
+session and a stated window after it. It does not catch a deletion deferred past
+that window, or an `std::fs` call aimed somewhere else; nothing in any Rust file
+catches those.
 
 A `dl` workspace id is around forty characters and this segment shares one line
 with the load state and the match count, so the line is **budgeted** rather than

--- a/README.md
+++ b/README.md
@@ -377,6 +377,26 @@ refetches everything when you want it — after closing a ticket in the browser,
 say. A fetch that fails says so on the count line and stays failed until you
 ask again.
 
+**What a `wf reap` would claim is read in the background too**, and lands on the
+count line when it arrives:
+
+```
+  12/30    · 2 reclaimable: devlaunch-…-127-c, devlaunch-…-80-f — wf reap
+```
+
+It is the same reading `wf reap` prints, taken by the same code — a `dl --ls
+--json` and one batched tracker query, neither of them on the way to a frame.
+The picker draws at exactly the speed it did without it. Nothing is deleted, and
+nothing can be: this names workspaces and a command, and you type the command.
+It names them rather than only counting them, because "2 reclaimable" is not
+something you can agree or disagree with.
+
+It **fails silent**. No `dl` on PATH, a listing that failed, a GraphQL error, no
+network, or simply nothing to reclaim: the segment is absent, and there is no
+error and no delay. A cleanup convenience is not worth a degraded launcher.
+Workspaces `wf reap` would *warn* about rather than delete are never counted
+into it — they show up only as a `(+N to check by hand)` aside.
+
 ## Launching
 
 Picking a ticket runs the agent chosen in the launch picker, with that project's
@@ -753,7 +773,9 @@ an agent exiting. `dl <ws> stop`, `dl <ws> rm` and `dl --ls` are yours to run.
 ### `wf reap` — clearing away finished tickets
 
 A workspace per ticket means workspaces accumulate as fast as tickets are
-worked. `wf reap` removes the ones whose **work is over**:
+worked. `wf reap` removes the ones whose **work is over** — and the picker
+[says so on its count line](#startup) without being asked, so running it is a
+decision rather than a thing you have to remember:
 
 ```
 $ wf reap
@@ -806,7 +828,13 @@ tickets someone has claimed, and anything **running** — a ticket closing is no
 evidence that the session in the container ended.
 
 One `gh api graphql` call per repo answers all of this, however many workspaces
-that repo has.
+that repo has — which is also what makes the picker's background reading cheap
+enough to take on every start.
+
+**Deleting stays yours.** `wf` notices; it never reaps unattended. The plan is
+printed so a reason you disagree with can be caught while "no" is still an
+answer, and the count-line hint is the same reading with the same posture: it
+names what would go and stops there.
 
 Kept by default but waivable: a workspace whose clone holds uncommitted or
 unpushed work. `-f` reaps those too, and the plan says what it is discarding:

--- a/README.md
+++ b/README.md
@@ -402,14 +402,16 @@ That one is settled by the compiler and needs no test.
 
 `wf reap` as a whole *command* is another matter: it has to be public for `main`
 to dispatch it, and `reap::run(true, true)` is a forced reap. So the picker file
-may not write the word `reap` at all, and `main.rs` carries the list of every
-line in itself that does — a word, not a path, so an alias or a `crate::` route
-has to appear in it too. Those are greps over the source text of two files.
-They catch a cleanup wired in by accident, which is the mistake anyone is
-actually likely to make; they do not stop someone who means to get around them,
-and several review rounds of this feature were spent proving exactly that. A
-grep over two files cannot see the same call written in a third, or a second
-name for the module exported from the library.
+may not write the word `reap` at all — nor `Command`, `process::`,
+`tokio::spawn` or `fs::` — and `main.rs` carries the list of every line of code
+in itself that writes `reap`, and may not write `Command` either. A word, not a
+path, so an alias or a `crate::` route has to appear in that list too. Those are
+greps over the source text of two files. They catch a cleanup wired in by
+accident, which is the mistake anyone is actually likely to make; they do not
+stop someone who means to get around them, and several review rounds of this
+feature were spent proving exactly that. A grep over two files cannot see the
+same call written in a third, or a second name for the module exported from the
+library.
 
 Everything else is watched rather than proven. A test drives the real event loop
 against a recording `dl` and `gh`, through every arm the loop has — quit,
@@ -418,12 +420,19 @@ argv the run made, plus a scratch `HOME` laid out the way this machine is
 (`~/.cache/devlaunch/repos/<owner>/<repo>/<id>` for the clone,
 `~/.devpod/contexts/<ctx>/workspaces/<id>` for the record), compared before and
 after. That catches a workspace deleted by running `dl` and one deleted
-in-process, whatever file the call was written in — for the length of the
-session, plus 400 ms after the reading lands, after every key, and after the
-session returns. It does not catch a deletion deferred past that window (a
-spawned task that sleeps a second and a half is green; the same one with the
-window at three seconds is caught), or an `std::fs` call aimed somewhere else;
-nothing in any Rust file catches those.
+in-process, whatever file the call was written in, inside three stated bounds.
+It starts at the loop's composition — the function that spawns the reading and
+runs the loop — so what `wf` does above and below that call is outside it; the
+tokens above are what cover that part of the picker file. It runs for the length
+of that call plus 400 ms after the reading lands, after every key and after it
+returns, so a deletion deferred past the window is not seen (a spawned task that
+sleeps a second and a half is green; the same one with the window at three
+seconds is caught). And it sees only what the child's fixtures reach: a deletion
+in the one fold arm a failed map search would take is green, because the `gh`
+shim succeeds. An `std::fs` call aimed outside that scratch `HOME` is caught by
+nothing — a `remove_dir_all` pointed at a directory elsewhere on the disk passes
+the whole suite, and really does destroy it. Nothing in any Rust file catches
+that.
 
 The picker does delete one thing, and it is not a workspace: the launch path
 brings the installed skill copies back in step with the bundle, which removes

--- a/README.md
+++ b/README.md
@@ -398,7 +398,9 @@ written and clipped: the count, the `(+N to check by hand)` aside and the
 are spelt out whole as fit; the next one is shortened in the middle, keeping the
 project at the front and the ticket number at the back; the rest are counted as
 `+N more`. On a terminal too narrow for a name anybody could read, the names go
-and the command stays.
+and the command stays; narrower still, the aside goes and the command *still*
+stays, because it is the only part of the line you can act on. The segment never
+overruns the width it is given at any terminal size.
 
 It **fails silent**. No `dl` on PATH, a listing that failed, a GraphQL error, no
 network, or simply nothing to reclaim: the segment is absent, and there is no

--- a/README.md
+++ b/README.md
@@ -386,10 +386,18 @@ count line when it arrives:
 
 It is the same reading `wf reap` prints, taken by the same code — a `dl --ls
 --json` and one batched tracker query, neither of them on the way to a frame.
-The picker draws at exactly the speed it did without it. Nothing is deleted, and
-nothing can be: this names workspaces and a command, and you type the command.
-It names them rather than only counting them, because "2 reclaimable" is not
-something you can agree or disagree with.
+The picker draws at exactly the speed it did without it. Nothing is deleted:
+this names workspaces and a command, and you type the command. It names them
+rather than only counting them, because "2 reclaimable" is not something you can
+agree or disagree with.
+
+The picker *cannot* delete them, and that is a property of the build rather than
+a promise. The function that removes a workspace is private to the library
+module that owns `wf reap`; the picker lives in the binary, so a line anywhere
+in it — or in any helper, alias or submodule it calls — that tries to reach that
+function does not compile. Shelling out to `dl` instead is caught by a test that
+drives the real event loop with a recording `dl` on `PATH` and reads back every
+argv it ran.
 
 A `dl` workspace id is around forty characters and this segment shares one line
 with the load state and the match count, so the line is **budgeted** rather than

--- a/README.md
+++ b/README.md
@@ -391,19 +391,25 @@ this names workspaces and a command, and you type the command. It names them
 rather than only counting them, because "2 reclaimable" is not something you can
 agree or disagree with.
 
-Nothing on this path deletes anything, and it is worth being exact about what
+**This path does not delete workspaces**, and it is worth being exact about what
 holds that up, because it is three different things with three different
-reaches.
+reaches — and only the first of them is a proof.
 
 The function that removes a workspace is private to the library module that owns
 `wf reap`. The picker is in the binary, so no line of it — no helper, alias or
 submodule — can call that function, and the edit that tries does not compile.
+That one is settled by the compiler and needs no test.
+
 `wf reap` as a whole *command* is another matter: it has to be public for `main`
 to dispatch it, and `reap::run(true, true)` is a forced reap. So the picker file
-may not name `reap` at all, and `main.rs` must name the module exactly once and
-call into it exactly once — counted by reachability rather than by one spelling,
-so an aliased import cannot slip past. Those two are greps over two files, and a
-grep over a file cannot see the same call made in a third.
+may not write the word `reap` at all, and `main.rs` carries the list of every
+line in itself that does — a word, not a path, so an alias or a `crate::` route
+has to appear in it too. Those are greps over the source text of two files.
+They catch a cleanup wired in by accident, which is the mistake anyone is
+actually likely to make; they do not stop someone who means to get around them,
+and several review rounds of this feature were spent proving exactly that. A
+grep over two files cannot see the same call written in a third, or a second
+name for the module exported from the library.
 
 Everything else is watched rather than proven. A test drives the real event loop
 against a recording `dl` and `gh`, through every arm the loop has — quit,
@@ -413,9 +419,16 @@ argv the run made, plus a scratch `HOME` laid out the way this machine is
 `~/.devpod/contexts/<ctx>/workspaces/<id>` for the record), compared before and
 after. That catches a workspace deleted by running `dl` and one deleted
 in-process, whatever file the call was written in — for the length of the
-session and a stated window after it. It does not catch a deletion deferred past
-that window, or an `std::fs` call aimed somewhere else; nothing in any Rust file
-catches those.
+session, plus 400 ms after the reading lands, after every key, and after the
+session returns. It does not catch a deletion deferred past that window (a
+spawned task that sleeps a second and a half is green; the same one with the
+window at three seconds is caught), or an `std::fs` call aimed somewhere else;
+nothing in any Rust file catches those.
+
+The picker does delete one thing, and it is not a workspace: the launch path
+brings the installed skill copies back in step with the bundle, which removes
+and rewrites `~/.claude/wf-skills/<skill>` when a copy has fallen behind. That
+is `wf`'s copy of `wf`'s own prompts.
 
 A `dl` workspace id is around forty characters and this segment shares one line
 with the load state and the match count, so the line is **budgeted** rather than

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::{self, Checkout, Resume, Session};
+use crate::reclaim::Reclaimable;
 use crate::refresh::Startup;
 use crate::view::{self, Expanded, GroupId, Lens, Plan, Screen, Stop, StopAt};
 
@@ -248,6 +249,15 @@ pub struct App {
     /// before any of it, so this is what stops an empty list from reading as
     /// "no tickets" while the fetch is still out.
     pub startup: Startup,
+    /// What a `wf reap` would claim, once the background reading lands (#137)
+    /// — `None` until then, and `None` forever if the reading failed or found
+    /// nothing, which are deliberately the same thing.
+    ///
+    /// **State, not a notice**, for the reason [`App::failed`] is: the reading
+    /// arrives once and nothing asks again, so a message the next keypress
+    /// cleared would be gone before it was read. Nothing in the picker acts on
+    /// it — it is a sentence naming a command a person may choose to type.
+    pub reclaimable: Option<Reclaimable>,
     pub overlay: Overlay,
     /// The structural screen `tab` toggles (#51). Only the lens is stored;
     /// whether the body is currently *flattened* is derived from the query in
@@ -279,6 +289,7 @@ impl App {
             sessions: Vec::new(),
             failed: BTreeSet::new(),
             startup: Startup::loaded(),
+            reclaimable: None,
             overlay: Overlay::None,
             lens: Lens::Leverage,
             expanded: Expanded::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod launch;
 pub mod model;
 pub mod projects;
 pub mod reap;
+pub mod reclaim;
 pub mod refresh;
 pub mod skills;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,23 @@
 //!   invocation in the chosen checkout. Unattended work is not a feature — it
 //!   is another terminal session you start and switch away from.
 
+/// Write a whole report to stdout, tolerating a reader that has gone away.
+///
+/// `println!` panics on a closed pipe: Rust ignores `SIGPIPE`, so the write
+/// returns `EPIPE` and the macro unwraps it. `wf skills | head` is an ordinary
+/// thing to type and a panic is an absurd answer to it — the reader stopped
+/// listening, which is not this program's problem to report. One write of one
+/// string rather than a line at a time, so there is a single place for that to
+/// be true.
+///
+/// Here rather than in the binary because [`reap::run`] emits from inside the
+/// library and `wf skills` emits from outside it, and a second copy of this is
+/// a second place for the `EPIPE` reasoning to be got wrong.
+pub fn emit(text: &str) {
+    use std::io::Write;
+    let _ = std::io::stdout().write_all(text.as_bytes());
+}
+
 pub mod app;
 pub mod fetch;
 pub mod filter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@ pub mod fetch;
 pub mod filter;
 pub mod launch;
 pub mod model;
+/// Test scaffolding shared by more than one module, and by both crates —
+/// `src/probe.rs` is declared here *and* in `src/main.rs`, which is the only
+/// way the binary's tests can reach it. Never compiled into a release.
+#[cfg(test)]
+mod probe;
 pub mod projects;
 pub mod reap;
 pub mod reclaim;

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,6 +403,11 @@ async fn main() -> Result<()> {
 
     let (tx, updates) = mpsc::unbounded_channel();
     let discovery = wf::refresh::spawn_discovery(repos, cache_path.clone(), tx.clone());
+    // And what a `wf reap` would claim (#137), read behind the screen exactly
+    // as the search is: a `dl --ls --json` subprocess and one batched GraphQL
+    // call, neither of them on the way to a frame. It folds into the count line
+    // when it lands, says nothing when it fails, and can delete nothing.
+    let survey = wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone());
 
     // cwd-open enters the project, on the first frame and unconditionally.
     //
@@ -416,7 +421,7 @@ async fn main() -> Result<()> {
     if let Some((_, slug)) = &here {
         app.enter(slug);
     }
-    let ending = run(&mut terminal, app, discovery, tx, updates).await;
+    let ending = run(&mut terminal, app, discovery, survey, tx, updates).await;
 
     // The one ordering that matters, and the reason the exec is here rather
     // than in the loop: the terminal must be back in the shell's hands before
@@ -579,6 +584,7 @@ async fn run(
     terminal: &mut DefaultTerminal,
     mut app: App,
     discovery: JoinHandle<()>,
+    survey: JoinHandle<()>,
     tx: UnboundedSender<LoadEvent>,
     mut updates: UnboundedReceiver<LoadEvent>,
 ) -> Result<Ending> {
@@ -639,6 +645,13 @@ async fn run(
                         }
                     }
                 }
+                // The background reading landed (#137). A plain state write on
+                // a screen that has been up and answering keys the whole time —
+                // it changes one dim segment of the count line and nothing else,
+                // and it arrives at most once because nothing asks again.
+                LoadEvent::Reclaimable(found) => {
+                    app.reclaimable = Some(found);
+                }
             }
         }
 
@@ -668,6 +681,11 @@ async fn run(
                         loaders.shutdown().await;
                         discovery.abort();
                         let _ = discovery.await;
+                        // The reading holds a `dl` and a `gh` of its own, and
+                        // the same reasoning applies: an in-flight child that
+                        // outlives the `exec` is inherited by the agent.
+                        survey.abort();
+                        let _ = survey.await;
                         return Ok(Ending::Handover(launch));
                     }
                     Outcome::Continue => {}
@@ -683,6 +701,36 @@ mod tests {
 
     fn argv(args: &[&str]) -> Vec<String> {
         args.iter().copied().map(String::from).collect()
+    }
+
+    #[test]
+    fn the_reclaim_reading_is_spawned_and_never_awaited_on_the_way_to_a_frame() {
+        // #137's "off the critical path", pinned where it could be lost.
+        // Everything else about the reading is testable against a value; this
+        // is the one claim that lives in this file's control flow, and the way
+        // to break it is a single `.await` — so the guard is that the reading
+        // is *handed to* the spawner and mentioned nowhere else.
+        //
+        // The startup path is the reason it matters: the screen goes up before
+        // any network call, over a ~0.6 s warm start and a ~2.5 s map search
+        // that are both already overlapped with a drawn UI. A subprocess and a
+        // GraphQL round trip awaited here would be neither.
+        // Spelt in pieces so the needle is not itself a match in this file.
+        let call = format!("{}::{}()", "wf::reclaim", "survey_live");
+        let spawned = format!("{}({call},", "spawn_survey");
+        let compact: String = include_str!("main.rs")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(
+            compact.matches(&call).count(),
+            1,
+            "the reading is taken in exactly one place"
+        );
+        assert!(
+            compact.contains(&spawned),
+            "the reading must be handed to the spawner, never awaited"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,19 @@
 //!
 //! The other half is not. `wf::reap::run` has to be public for the arm below to
 //! dispatch it, and it *contains* the deletion — `reap::run(true, true)` is a
-//! forced reap with the unsaved-work guard waived. Nothing stops a line
-//! anywhere in this crate calling it, so what stands in its place is a count:
-//! [`tests::the_binary_reaches_reap_at_exactly_one_place`] pins that this file
-//! names the library's `reap` once and calls into it once, whatever spelling or
-//! alias is used, and `picker.rs` may not name it at all. Those are two greps
-//! over two files. A third file calling `reap::run` is caught by neither; see
-//! [`picker`] for what does and does not cover that, and #137 for the crate
-//! split that would.
+//! forced reap with the unsaved-work guard waived. Nothing in the language
+//! stops a line anywhere in this crate calling it, so what stands in its place
+//! is a grep: [`tests::the_binary_writes_reap_only_where_it_is_listed_here`]
+//! holds the whole list of lines in this file that write the word `reap`, and
+//! `picker.rs` may not write it at all.
+//!
+//! That is a guard over the source text of two files, and it is worth what that
+//! is: it catches a cleanup wired in here by accident, which is the mistake
+//! anyone is actually likely to make. It does not stop someone routing around
+//! it. A third file calling `wf::reap::run` is caught by neither grep, and
+//! neither is a second name for the module re-exported from the library. See
+//! [`picker`] for the guard that watches a run rather than a file, and #137 for
+//! the crate split that would settle it.
 
 use anyhow::Result;
 use tokio::signal::unix::{signal, SignalKind};
@@ -264,10 +269,11 @@ async fn main() -> Result<()> {
         Invocation::SkillsInstall => run_skills(true),
         // The one place in this binary that reaches a deletion, and it reaches
         // it as a whole command: prompt, plan, and the private `remove` this
-        // crate could not spell if it wanted to. Pinned as a *count* by
-        // `the_binary_reaches_reap_at_exactly_one_place` — an arm that merely
-        // exists says nothing about the rest of the file, and a prologue before
-        // this match is how an earlier round deleted a workspace on
+        // crate could not spell if it wanted to. Listed, with every other line
+        // here that writes the word, by
+        // `the_binary_writes_reap_only_where_it_is_listed_here` — an arm that
+        // merely exists says nothing about the rest of the file, and a prologue
+        // before this match is how an earlier round deleted a workspace on
         // `wf --version`.
         Invocation::Reap { yes, insist } => reap::run(yes, insist).await,
         // And the one shape that opens the TUI, which is the whole of what this
@@ -331,8 +337,31 @@ mod tests {
         args.iter().copied().map(String::from).collect()
     }
 
+    /// Every line of `code` that writes `token` as a word of its own — not as
+    /// part of a longer identifier, so `parse_reap` and `Reap` are not
+    /// occurrences of `reap`.
+    ///
+    /// A *word*, and that is the whole technique. Counting `"reap::"` was green
+    /// for `use wf::reap as tidy;`, and counting `"wf::reap"` was green for
+    /// `use crate::reap as tidy;` — each round found another spelling of the
+    /// same path. There is no spelling of the module that does not write its
+    /// name, so the name is what is counted. `picker.rs` has been immune since
+    /// round 5 for exactly this reason; this is that technique, applied here.
+    fn lines_naming<'a>(code: &'a str, token: &str) -> Vec<&'a str> {
+        let ident = |c: char| c.is_alphanumeric() || c == '_';
+        code.lines()
+            .filter(|line| {
+                line.match_indices(token).any(|(at, _)| {
+                    !line[..at].chars().next_back().is_some_and(ident)
+                        && !line[at + token.len()..].chars().next().is_some_and(ident)
+                })
+            })
+            .map(str::trim)
+            .collect()
+    }
+
     #[test]
-    fn the_binary_reaches_reap_at_exactly_one_place() {
+    fn the_binary_writes_reap_only_where_it_is_listed_here() {
         // What is left for a grep to say once the deletion itself is out of
         // reach.
         //
@@ -344,45 +373,38 @@ mod tests {
         // that as a prologue before the match, and `wf --version` reaped a
         // workspace and exited 0.
         //
-        // So the claim is a count of **reachability**, not of one spelling.
-        // The version of this test that counted `"reap::"` alone was green for
-        // `use wf::reap as tidy;` plus `tidy::run(true, true)`, because an
-        // alias produces no `reap::` anywhere. Three assertions close that,
-        // and each is load-bearing:
+        // So this is the whole list of lines in this file that write the word
+        // `reap`, and it is compared as a list rather than as a count. Two of
+        // them are code — the import and the arm — and the rest are the help
+        // text, which is prose in a string and calls nothing. Any new line that
+        // writes the word fails here, whatever it writes around it: an alias
+        // (`use wf::reap as tidy;`, `use crate::reap as tidy;`), a path through
+        // the crate root, a call split over two lines. The module cannot be
+        // reached without its name being written somewhere, and every somewhere
+        // is below.
         //
-        // 1. the module is named once — a second `wf::reap::run(…)` written
-        //    inline, or an alias *added* beside the import, pushes this to two;
-        // 2. that one naming is the plain import — `use wf::reap as tidy;` and
-        //    `use wf::reap::run as nuke;` both leave the count at one and fail
-        //    here instead;
-        // 3. the name it binds is used once — a glob `use wf::*;` names no
-        //    `wf::reap` at all, but still has to write `reap::run` to call it,
-        //    and a second call anywhere in the file lands here.
+        // What this does **not** reach: a third file calling `wf::reap::run`,
+        // and a re-export that gives the module a second name in the library.
+        // It is a grep over one file, and a grep over one file cannot see
+        // either. What it is good for is the accident — a maintainer wiring a
+        // cleanup in without noticing — and that is the claim the module doc
+        // makes for it too.
         //
-        // Between them, every way this file can reach `reap` has to be spelt
-        // in one of two places, and both are checked below. What none of it
-        // reaches is a *third* file calling `reap::run`; that is stated in the
-        // module doc rather than pretended away.
+        // If you changed the usage text, update the prose lines below; the two
+        // code lines are the ones that matter.
         let code = probe::code_only(include_str!("main.rs"));
         assert_eq!(
-            code.matches("wf::reap").count(),
-            1,
-            "this file may name the library's `reap` once, and that once is its import"
-        );
-        assert!(
-            code.contains("use wf::reap;"),
-            "and it must be the plain import: an alias is a second name for the \
-             same module, spelt so that a grep for `reap::` misses it"
-        );
-        assert_eq!(
-            code.matches("reap::").count(),
-            1,
-            "the imported name may be used once, for the `wf reap` argv and \
-             nothing else"
-        );
-        assert!(
-            code.contains("Invocation::Reap { yes, insist } => reap::run(yes, insist).await,"),
-            "and that once is the arm the `reap` argv produced"
+            lines_naming(&code, "reap"),
+            [
+                "use wf::reap;",
+                "wf reap [-y] [-f]",
+                "wf reap            remove the workspaces whose work is over — a closed ticket,",
+                "\"reap\" => Invocation::Reap {",
+                "[first, rest @ ..] if first == \"reap\" => parse_reap(rest),",
+                "\"wf: unknown reap argument {other:?} (expected `-y` or `-f`)\\n{USAGE}\"",
+                "Invocation::Reap { yes, insist } => reap::run(yes, insist).await,",
+            ],
+            "this file writes `reap` somewhere new"
         );
         // The other half of the same claim, at the other arm: opening the TUI
         // is the whole of what `wf` with no arguments does.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,15 +16,22 @@
 //!    the terminal is restored, and this process is replaced by the agent
 //!    ([`wf::launch::Launch::exec`]).
 //!
-//! This file is argv and the commands that answer on a stream — `--version`,
-//! `wf skills`, `wf reap`. The picker itself is [`picker`], a module of its
-//! own, because `wf reap` deletes workspaces for a living and the picker must
-//! be provably unable to: that is one grep over one file only if the two do not
-//! share one (#137).
+//! This file is argv and nothing else: it decides what was asked for and hands
+//! it to whoever answers. `wf skills` is [`run_skills`] here because linking a
+//! directory is a few lines; `wf reap` is [`wf::reap::run`] in the *library*,
+//! because reaping deletes workspaces and the deletion it calls
+//! ([`wf::reap`]'s private `remove`) is not something this crate may name. The
+//! picker is [`picker`], a module of its own.
+//!
+//! That arrangement is #137's separation, and it is a fact about visibility
+//! rather than a claim anyone has to check: the picker cannot call the deletion
+//! because the deletion is private to a module in another crate. No alias,
+//! helper or submodule of this binary changes that — the edit does not compile.
 
-use anyhow::{bail, Context, Result};
+use anyhow::Result;
 use tokio::signal::unix::{signal, SignalKind};
 
+use wf::emit;
 use wf::launch::Agent;
 use wf::reap;
 use wf::skills;
@@ -228,110 +235,6 @@ fn run_skills(install: bool) -> Result<()> {
     Ok(())
 }
 
-/// `wf reap`: remove the workspaces whose nodes the tracker calls finished.
-///
-/// The division of labour is the one the launch already draws — `dl` owns the
-/// containers, `wf` owns the tickets — so this asks `dl` what exists, asks the
-/// tracker what has become of those nodes, prints the plan, and hands the
-/// finished ones back to `dl`. No terminal is taken: this is a stream command
-/// like `wf skills`, not a second TUI.
-///
-/// The plan is printed **before** the prompt and includes what is being kept,
-/// because a workspace someone expected to go and that stayed is the thing they
-/// most need told about, and a reason they disagree with ("still running" when
-/// they thought they had stopped it) is only actionable while no is an answer.
-///
-/// `warn` rows are the same argument pointed the other way: workspaces `wf`
-/// suspects are dead weight on evidence too weak to act on — a superseded
-/// ticket, or a node nothing has come of. They are printed and never counted
-/// into the prompt, because the only safe thing to do with a suspicion is say
-/// it out loud.
-async fn run_reap(yes: bool, insist: bool) -> Result<()> {
-    use std::collections::BTreeSet;
-    use std::fmt::Write;
-    use std::io::Write as _;
-
-    let workspaces = reap::workspaces().await?;
-    let nodes: BTreeSet<reap::Node> = workspaces.iter().filter_map(reap::node_of).collect();
-    if nodes.is_empty() {
-        emit("no wayfinder workspaces on this machine — nothing to reap\n");
-        return Ok(());
-    }
-    let known = reap::node_facts(&nodes).await?;
-    let verdicts = reap::plan(&workspaces, &known, insist);
-
-    // The deletion set is asked for rather than re-derived here: `reap::doomed`
-    // is the one definition of what goes, so a warning row cannot become a
-    // deletion by way of a partition written twice.
-    let doomed = reap::doomed(&verdicts);
-    // Grouped rather than in listing order, and in this order: what stays,
-    // then what `wf` is uneasy about, then — last, immediately above the
-    // prompt — what the y/N is actually about.
-    let mut out = String::new();
-    for label in ["keep", "warn", "reap"] {
-        for verdict in &verdicts {
-            let row = match verdict {
-                reap::Verdict::Keep { .. } => "keep",
-                reap::Verdict::Warn { .. } => "warn",
-                reap::Verdict::Reap { .. } => "reap",
-            };
-            if row == label {
-                let _ = writeln!(out, "  {label}  {}  ({})", verdict.id(), verdict.reason());
-            }
-        }
-    }
-    emit(&out);
-    if doomed.is_empty() {
-        emit("nothing to reap\n");
-        return Ok(());
-    }
-
-    if !yes {
-        emit(&format!("\ndelete {} workspace(s)? [y/N] ", doomed.len()));
-        let _ = std::io::stdout().flush();
-        let mut answer = String::new();
-        std::io::stdin()
-            .read_line(&mut answer)
-            .context("cannot read the answer")?;
-        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
-            emit("aborted\n");
-            return Ok(());
-        }
-    }
-
-    // One at a time, reporting each: `dl <ws> rm` tears down a container, and a
-    // failure part-way through leaves a set the next run has to be able to make
-    // sense of. Failures are collected rather than propagated at the first one,
-    // so a single wedged workspace does not strand the rest.
-    let mut failed = Vec::new();
-    for verdict in &doomed {
-        match reap::remove(verdict.id(), insist).await {
-            Ok(()) => emit(&format!("removed {}\n", verdict.id())),
-            Err(e) => {
-                emit(&format!("could not remove {}: {e}\n", verdict.id()));
-                failed.push(verdict.id().to_string());
-            }
-        }
-    }
-    if !failed.is_empty() {
-        bail!("{} workspace(s) could not be removed", failed.len());
-    }
-    Ok(())
-}
-
-/// Write a whole report to stdout, tolerating a reader that has gone away.
-///
-/// `println!` panics on a closed pipe: Rust ignores `SIGPIPE`, so the write
-/// returns `EPIPE` and the macro unwraps it. `wf skills | head` is an ordinary
-/// thing to type and a panic is an absurd answer to it — the reader stopped
-/// listening, which is not this program's problem to report. One write of one
-/// string rather than a line at a time, so there is a single place for that to
-/// be true.
-fn emit(text: &str) {
-    use std::io::Write;
-    let _ = std::io::stdout().write_all(text.as_bytes());
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     match parse_args(std::env::args().skip(1)) {
@@ -348,7 +251,12 @@ async fn main() -> Result<()> {
         // whatever script installs the tool.
         Invocation::SkillsReport => run_skills(false),
         Invocation::SkillsInstall => run_skills(true),
-        Invocation::Reap { yes, insist } => run_reap(yes, insist).await,
+        // The one thing in this binary that deletes anything, and it is a
+        // *call into the library* — `reap::remove` is private there, so this
+        // whole crate, the picker included, has no way to spell a deletion
+        // except by choosing this arm. Pinned by
+        // `the_binary_reaches_the_deletion_at_exactly_one_place`.
+        Invocation::Reap { yes, insist } => reap::run(yes, insist).await,
         // And the one shape that opens the TUI, which is the whole of what this
         // arm may do. Everything the picker touches lives in a module that
         // cannot name a deletion — see [`picker`] — and this line is what keeps
@@ -413,15 +321,35 @@ mod tests {
     }
 
     #[test]
-    fn the_tui_invocation_is_nothing_but_the_picker() {
-        // The composition site, structurally. `wf reap` lives in this file and
-        // deletes workspaces for a living, so this file can never carry the
-        // denylist [`picker`] does — and the picker path through it is exactly
-        // one expression long, which is a thing a grep *can* pin. Anything else
-        // wired into this arm, before or after or instead, fails here; anything
-        // wired inside the picker fails
-        // `picker::tests::no_deletion_is_reachable_from_the_picker`.
+    fn the_binary_reaches_the_deletion_at_exactly_one_place() {
+        // What is left for a grep to say once the deletion is out of reach.
+        //
+        // `reap::remove` is private to the library's `reap` module, so nothing
+        // in this crate can call it — that half needs no test, it is a compile
+        // error. What this crate *can* still name is `reap::run`, the whole
+        // `wf reap` command, prompt and plan and all. A previous round's
+        // escape was a prologue in `main` before the match; the same edit
+        // spelt with `reap::run(true, true)` would delete unattended too. So
+        // the claim here is a count, not a `contains`: this file reaches into
+        // `reap` exactly once, and that once is the arm `parse_args` produced
+        // for the words `wf reap`.
+        //
+        // Nothing weaker would do. `contains` says an arm exists and says
+        // nothing about the rest of the file, which is precisely how the
+        // prologue got in.
         let code = probe::code_only(include_str!("main.rs"));
+        assert_eq!(
+            code.matches("reap::").count(),
+            1,
+            "this file may reach into `reap` once, for the `wf reap` argv and \
+             nothing else"
+        );
+        assert!(
+            code.contains("Invocation::Reap { yes, insist } => reap::run(yes, insist).await,"),
+            "and that once is the arm the `reap` argv produced"
+        );
+        // The other half of the same claim, at the other arm: opening the TUI
+        // is the whole of what `wf` with no arguments does.
         assert!(
             code.contains("Invocation::Tui => picker::run_picker().await,"),
             "opening the TUI must be the whole of what that arm does"

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,14 @@ use wf::launch::{Agent, Launch};
 use wf::model::{Map, MapId};
 use wf::projects::{self, ProjectsCache};
 use wf::reap;
-use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup};
+use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup, Survey};
 use wf::skills;
+
+/// Test scaffolding shared with the library's own tests — the same
+/// `src/probe.rs`, compiled into this crate too, because that is the only way
+/// the binary's tests can reach it. Never compiled into a release.
+#[cfg(test)]
+mod probe;
 
 /// How long the loop waits on a keypress before redrawing — the cadence at
 /// which streamed load events reach the screen.
@@ -573,6 +579,96 @@ enum Ending {
     Handover(Box<Launch>),
 }
 
+/// Fold one arrival into what the screen draws.
+///
+/// Split out of [`run`]'s loop so the wiring can be *tested*, which is the
+/// whole difficulty with an event loop: everything between the channel and the
+/// screen used to be reachable only by standing up a terminal and driving it.
+/// Each arm below is now a call a test can make and a frame it can read.
+///
+/// **Deliberately not `async`.** Folding an arrival into the app state reads no
+/// file, runs no process and waits for nothing — the work was all done by the
+/// task that sent the event. Saying so in the signature is what makes #137's
+/// separation structural at this end of the path: this is where a reap would be
+/// wired if anyone ever wired one, and a function that cannot await cannot ask
+/// `dl` to remove anything.
+fn fold(
+    event: LoadEvent,
+    app: &mut App,
+    clusters: &mut BTreeMap<MapId, Map>,
+    loaders: &mut Loaders,
+    tx: &UnboundedSender<LoadEvent>,
+) {
+    match event {
+        LoadEvent::Discovered(found) => {
+            // Reconciling the loaders *is* the load for every map the
+            // seed did not already cover: those fetches are all in
+            // flight at once and each lands on screen as it arrives.
+            loaders.reconcile(&found, tx);
+            app.startup.searched(&found);
+            // Nothing to apply here any more: the level was decided
+            // before the first frame and discovery has no say in it.
+            // A repo the search finds no map for renders its project
+            // row saying so, which is both the notice this used to
+            // post and somewhere to act on it.
+            //
+            // Maps the search dropped must stop being rendered as well as
+            // stop being fetched — their rows are as stale as their load.
+            // A map that is no longer open also stops being a *failure*:
+            // there is nothing left to have failed.
+            clusters.retain(|id, _| found.contains(id));
+            app.failed.retain(|id| found.contains(id));
+            app.open_maps = found;
+            app.replace_clusters(clusters.clone());
+        }
+        // Discovery retries, so this is a status report and not an end
+        // state: `wf` stays on screen and recovers when the search does.
+        LoadEvent::SearchFailed => {
+            app.notice = Some("map search failed — retrying".to_string());
+        }
+        LoadEvent::Fetched { id, outcome } => {
+            app.startup.record_arrival(&id);
+            match outcome {
+                MapFetch::Loaded(new_map) => {
+                    app.failed.remove(&id);
+                    clusters.insert(id, new_map);
+                    app.replace_clusters(clusters.clone());
+                }
+                // Nothing polls any more, so a failed load is not a blip
+                // the next cycle papers over — it is the final word on
+                // that map until someone asks again. Recorded as state
+                // rather than announced as a notice, because a notice
+                // is gone on the next keypress and this is not.
+                MapFetch::Failed => {
+                    app.failed.insert(id);
+                }
+            }
+        }
+        // The background reading landed (#137). A plain state write on
+        // a screen that has been up and answering keys the whole time —
+        // it changes one dim segment of the count line and nothing else,
+        // and it arrives at most once because nothing asks again.
+        LoadEvent::Reclaimable(found) => {
+            app.reclaimable = Some(found);
+        }
+    }
+}
+
+/// Stop everything running behind the screen, and wait for it to be gone.
+///
+/// The last thing before a handover, and the reason it is a function of its
+/// own: "aborted *and awaited*" is a claim about two tasks that a test can now
+/// make on both at once. Nothing after this point can be drawn, and the process
+/// is about to be replaced — an in-flight `gh` or `dl` that outlives the `exec`
+/// is inherited by the agent as a child holding the terminal it just took over.
+async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
+    discovery.abort();
+    let _ = discovery.await;
+    // The reading holds a `dl` and a `gh` of its own, and the same reasoning
+    // applies — [`Survey::stop`] is where the waiting is spelt out.
+    survey.stop().await;
+}
+
 /// The event loop. It starts with **no data at all** (#27): which repos even
 /// have maps, and the maps themselves, arrive as [`LoadEvent`]s while the screen
 /// is already up and answering keys.
@@ -584,7 +680,7 @@ async fn run(
     terminal: &mut DefaultTerminal,
     mut app: App,
     discovery: JoinHandle<()>,
-    survey: JoinHandle<()>,
+    survey: Survey,
     tx: UnboundedSender<LoadEvent>,
     mut updates: UnboundedReceiver<LoadEvent>,
 ) -> Result<Ending> {
@@ -600,59 +696,7 @@ async fn run(
         // cluster; App::replace_clusters keeps the cursor pinned to row
         // identity, query and scope untouched.
         while let Ok(event) = updates.try_recv() {
-            match event {
-                LoadEvent::Discovered(found) => {
-                    // Reconciling the loaders *is* the load for every map the
-                    // seed did not already cover: those fetches are all in
-                    // flight at once and each lands on screen as it arrives.
-                    loaders.reconcile(&found, &tx);
-                    app.startup.searched(&found);
-                    // Nothing to apply here any more: the level was decided
-                    // before the first frame and discovery has no say in it.
-                    // A repo the search finds no map for renders its project
-                    // row saying so, which is both the notice this used to
-                    // post and somewhere to act on it.
-                    //
-                    // Maps the search dropped must stop being rendered as well as
-                    // stop being fetched — their rows are as stale as their load.
-                    // A map that is no longer open also stops being a *failure*:
-                    // there is nothing left to have failed.
-                    clusters.retain(|id, _| found.contains(id));
-                    app.failed.retain(|id| found.contains(id));
-                    app.open_maps = found;
-                    app.replace_clusters(clusters.clone());
-                }
-                // Discovery retries, so this is a status report and not an end
-                // state: `wf` stays on screen and recovers when the search does.
-                LoadEvent::SearchFailed => {
-                    app.notice = Some("map search failed — retrying".to_string());
-                }
-                LoadEvent::Fetched { id, outcome } => {
-                    app.startup.record_arrival(&id);
-                    match outcome {
-                        MapFetch::Loaded(new_map) => {
-                            app.failed.remove(&id);
-                            clusters.insert(id, new_map);
-                            app.replace_clusters(clusters.clone());
-                        }
-                        // Nothing polls any more, so a failed load is not a blip
-                        // the next cycle papers over — it is the final word on
-                        // that map until someone asks again. Recorded as state
-                        // rather than announced as a notice, because a notice
-                        // is gone on the next keypress and this is not.
-                        MapFetch::Failed => {
-                            app.failed.insert(id);
-                        }
-                    }
-                }
-                // The background reading landed (#137). A plain state write on
-                // a screen that has been up and answering keys the whole time —
-                // it changes one dim segment of the count line and nothing else,
-                // and it arrives at most once because nothing asks again.
-                LoadEvent::Reclaimable(found) => {
-                    app.reclaimable = Some(found);
-                }
-            }
+            fold(event, &mut app, &mut clusters, &mut loaders, &tx);
         }
 
         terminal.draw(|frame| wf::ui::draw(frame, &app))?;
@@ -679,13 +723,7 @@ async fn run(
                     // as a zombie holding the terminal it just took over.
                     Outcome::Launch(launch) => {
                         loaders.shutdown().await;
-                        discovery.abort();
-                        let _ = discovery.await;
-                        // The reading holds a `dl` and a `gh` of its own, and
-                        // the same reasoning applies: an in-flight child that
-                        // outlives the `exec` is inherited by the agent.
-                        survey.abort();
-                        let _ = survey.await;
+                        stop_background(discovery, survey).await;
                         return Ok(Ending::Handover(launch));
                     }
                     Outcome::Continue => {}
@@ -703,33 +741,127 @@ mod tests {
         args.iter().copied().map(String::from).collect()
     }
 
-    #[test]
-    fn the_reclaim_reading_is_spawned_and_never_awaited_on_the_way_to_a_frame() {
-        // #137's "off the critical path", pinned where it could be lost.
-        // Everything else about the reading is testable against a value; this
-        // is the one claim that lives in this file's control flow, and the way
-        // to break it is a single `.await` — so the guard is that the reading
-        // is *handed to* the spawner and mentioned nowhere else.
-        //
-        // The startup path is the reason it matters: the screen goes up before
-        // any network call, over a ~0.6 s warm start and a ~2.5 s map search
-        // that are both already overlapped with a drawn UI. A subprocess and a
-        // GraphQL round trip awaited here would be neither.
-        // Spelt in pieces so the needle is not itself a match in this file.
-        let call = format!("{}::{}()", "wf::reclaim", "survey_live");
-        let spawned = format!("{}({call},", "spawn_survey");
-        let compact: String = include_str!("main.rs")
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join("");
-        assert_eq!(
-            compact.matches(&call).count(),
-            1,
-            "the reading is taken in exactly one place"
+    /// The reading a `wf reap` of this machine would produce, built the one way
+    /// production builds one — through [`wf::reclaim::reading`], over a plan.
+    /// There is no test-only constructor to reach from here, which is the point:
+    /// what the loop folds is what the survey would have sent.
+    fn a_reading() -> wf::reclaim::Reclaimable {
+        let ws = reap::Workspace {
+            id: "devlaunch-github-com-blooop-wayfinder-129".to_string(),
+            devlaunch: true,
+            repo: Some("blooop/wayfinder".to_string()),
+            branch: Some("wayfinder/wayfinder-129".to_string()),
+            state: Some("Stopped".to_string()),
+            unsaved: None,
+        };
+        let known = [(
+            reap::Node {
+                repo: "blooop/wayfinder".to_string(),
+                number: 129,
+            },
+            reap::NodeFact::Closed,
+        )]
+        .into_iter()
+        .collect();
+        wf::reclaim::reading(&[ws], &known).expect("a closed ticket is reclaimable")
+    }
+
+    /// Fold a landed reading into a fresh app and draw the screen it produces.
+    /// Run in a child process by the two tests below, under a `PATH` whose `dl`
+    /// and `gh` write down everything they are asked to do.
+    #[tokio::test]
+    #[ignore = "run by `probe::record` from the two tests below, under recording shims"]
+    async fn reclaimable_arm_probe() {
+        if !probe::is_child() {
+            return;
+        }
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut app = App::empty();
+        let mut clusters = BTreeMap::new();
+        let mut loaders = Loaders::new();
+        fold(
+            LoadEvent::Reclaimable(a_reading()),
+            &mut app,
+            &mut clusters,
+            &mut loaders,
+            &tx,
         );
-        assert!(
-            compact.contains(&spawned),
-            "the reading must be handed to the spawner, never awaited"
+        let backend = ratatui::backend::TestBackend::new(100, 12);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| wf::ui::draw(frame, &app))
+            .expect("draw");
+        let buf = terminal.backend().buffer();
+        for y in 0..buf.area.height {
+            let mut line = String::new();
+            for x in 0..buf.area.width {
+                line.push_str(buf[(x, y)].symbol());
+            }
+            println!("{}{}", probe::MARK, line.trim_end());
+        }
+    }
+
+    #[test]
+    fn a_landed_reading_reaches_the_screen() {
+        // The wiring #137 is, end to end at this end of it: the event arrives,
+        // the loop folds it, and the count line says what a reap would claim.
+        // An arm that dropped the payload on the floor — `Reclaimable(_) => {}`
+        // — leaves every other test in this tree green, because every other
+        // test hands the reading to the thing it is testing.
+        let run = probe::record("tests::reclaimable_arm_probe", "", "");
+        let screen = run.printed();
+        let line = screen
+            .iter()
+            .find(|line| line.contains("reclaimable"))
+            .unwrap_or_else(|| panic!("the count line must say so:\n{}", screen.join("\n")));
+        assert!(line.contains("1 reclaimable"), "{line}");
+        assert!(line.contains("129"), "it names the workspace: {line}");
+        assert!(line.contains("wf reap"), "and the command: {line}");
+    }
+
+    #[test]
+    fn folding_a_reading_into_the_screen_runs_nothing_at_all() {
+        // #137 ships ahead of #138 on one argument: reading what a reap would
+        // claim and performing one are separated. This arm is exactly where a
+        // reap would be wired — `use wf::reap;` is already in scope in this
+        // file — so the separation is asserted here as a fact about a run.
+        // Anything this path asks of `dl` or `gh`, by any spelling, in any
+        // module it calls into, is recorded; the whole fold must record none.
+        let run = probe::record("tests::reclaimable_arm_probe", "", "");
+        run.ran_nothing();
+    }
+
+    #[tokio::test]
+    async fn a_handover_leaves_no_background_work_running() {
+        // The last thing before `exec`, and the one that cannot be seen from
+        // the outside afterwards: both tasks must be aborted *and waited for*,
+        // because it is dropping their futures that closes the `gh` and `dl`
+        // they hold. An `abort()` without the wait, a handle dropped, a handle
+        // forgotten — all three leave a child alive for the agent to inherit.
+        //
+        // Each task holds an `Arc` that cannot be released until its future is
+        // dropped, so the counts are the witness.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let witness = std::sync::Arc::new(());
+        let for_discovery = std::sync::Arc::clone(&witness);
+        let for_survey = std::sync::Arc::clone(&witness);
+        let discovery = tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            drop(for_discovery);
+        });
+        let survey = wf::refresh::spawn_survey(
+            async move {
+                std::future::pending::<()>().await;
+                drop(for_survey);
+                None
+            },
+            tx,
+        );
+        stop_background(discovery, survey).await;
+        assert_eq!(
+            std::sync::Arc::strong_count(&witness),
+            1,
+            "background work outlived the handover"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,14 @@
 //! forced reap with the unsaved-work guard waived. Nothing in the language
 //! stops a line anywhere in this crate calling it, so what stands in its place
 //! is a grep: [`tests::the_binary_writes_reap_only_where_it_is_listed_here`]
-//! holds the whole list of lines in this file that write the word `reap`, and
-//! `picker.rs` may not write it at all.
+//! holds the whole list of lines of *code* in this file that write the word
+//! `reap`, and `picker.rs` may not write it at all. Lines of code, not lines:
+//! `USAGE` writes `wf reap` twice because that is the command it documents, and
+//! the help text is cut out before the list is taken — the cut being checked
+//! against `USAGE`'s own line count, because an unbounded one was itself an
+//! escape (see `tests::without_usage`). The same test also forbids this file
+//! the two ways to delete that go nowhere near `reap`: `Command`, and the bare
+//! word `fs`, which no spelling of `std::fs` can avoid writing.
 //!
 //! That is a guard over the source text of two files, and it is worth what that
 //! is: it catches a cleanup wired in here by accident, which is the mistake
@@ -374,9 +380,20 @@ mod tests {
     ///
     /// # Panics
     ///
-    /// If `USAGE` is not found, or its literal is not closed by a line ending
-    /// `";` — the same fail-closed posture as [`probe::code_only`]: a shape
-    /// this cannot locate is refused rather than skipped.
+    /// If `USAGE` is not found; if no line at or below it ends `";`; or if the
+    /// first line that does is not `USAGE`'s own closing line, measured against
+    /// the constant's line count. The third is not decoration — without it this
+    /// function cut from `USAGE` to whatever `";` came next, however far below,
+    /// and that was an escape rather than a hypothetical: see the comment on
+    /// the assertion.
+    ///
+    /// All three are the fail-closed posture of [`probe::code_only`]: a shape
+    /// this cannot account for fails the guard rather than being skipped past.
+    /// It is a real constraint on `USAGE` and not only on attackers, and it is
+    /// stated from the three lines below rather than from a run: the literal
+    /// has to open with `const USAGE: &str = "` at column 0, and it has to
+    /// close on a line whose last two characters are `";`. A `concat!`, or a
+    /// trailing comment on the closing line, is a shape this refuses.
     fn without_usage(code: &str) -> String {
         let lines: Vec<&str> = code.lines().collect();
         let opens = lines
@@ -388,6 +405,38 @@ mod tests {
                 .iter()
                 .position(|line| line.trim_end().ends_with("\";"))
                 .expect("the USAGE literal is closed by a line ending `\";`");
+        // The line found above is the first one ending `";` at or below the
+        // `const`. That it closes *`USAGE`'s own* literal is a separate fact,
+        // and it has to be checked rather than assumed: a trailing comment on
+        // the closing line makes `ends_with` miss it, the search runs on to the
+        // next `";`-terminated line anywhere below, and everything between is
+        // cut out of the list. That is not hypothetical and it was this
+        // function's own doing: written without this assertion, a helper placed
+        // directly under `USAGE` — `async fn wash_up() { reap::run(true, true);
+        // let _ = "swept"; }`, called from `main()`'s first line — was cut out
+        // whole by a trailing comment on `USAGE`'s closing line, and the whole
+        // selection was green. With the assertion the same edit is bins 16/1;
+        // without the trailing comment it is bins 16/1 on the list below, which
+        // is what says the comment was the vehicle.
+        //
+        // Comparing the span to the constant's own line count is what ties the
+        // cut to the literal: it is the compiler that says how many lines
+        // `USAGE` has. A rewrap that changes that count changes both sides
+        // together — measured, not assumed: rewording and rewrapping the
+        // `wf reap` paragraph from eight lines to ten stays green — so this
+        // does not put back the pin on the wrapping that it removed.
+        assert_eq!(
+            closes - opens,
+            USAGE.lines().count(),
+            "the lines cut here are not `USAGE`. Counting this file's code with \
+             its comment lines already dropped, the `const` is at line {}, the \
+             first line below it ending `\";` is line {}, and `USAGE` itself is \
+             {} lines — so that line closes some other literal and this cut is \
+             swallowing code that the `reap` list below would otherwise read",
+            opens + 1,
+            closes + 1,
+            USAGE.lines().count()
+        );
         lines
             .iter()
             .enumerate()
@@ -418,18 +467,28 @@ mod tests {
         // because it is prose and pinning its line wrapping here made the guard
         // fail on rewraps and say something untrue when it did.
         //
-        // Any new line that writes the word fails here, whatever it writes
-        // around it: an alias (`use wf::reap as tidy;`, `use crate::reap as
-        // tidy;`), a path through the crate root, a call split over two lines.
-        // The module cannot be reached without its name being written
-        // somewhere, and every somewhere is below.
+        // Any new line of code *this reads* that writes the word fails here,
+        // whatever it writes around it: an alias (`use wf::reap as tidy;`,
+        // `use crate::reap as tidy;`), a path through the crate root, a call
+        // split over two lines — each of those was a reviewer's escape and each
+        // is red now. The module cannot be reached without its name being
+        // written somewhere, so the name is what is counted.
         //
-        // What this does **not** reach: a third file calling `wf::reap::run`,
-        // and a re-export that gives the module a second name in the library.
-        // It is a grep over one file, and a grep over one file cannot see
-        // either. What it is good for is the accident — a maintainer wiring a
-        // cleanup in without noticing — and that is the claim the module doc
-        // makes for it too.
+        // "That this reads" is doing work in that sentence, and it is the part
+        // that has failed twice. What this test sees is `code_only` minus
+        // `without_usage`'s cut, and both of those are text handling that can be
+        // argued out of reading part of the file — `code_only` was defeated by a
+        // decoy and then by indentation, and `without_usage` shipped for one
+        // round with an unbounded cut that hid a `reap::run(true, true)` call
+        // outright. Both now check their own shape and fail closed, which is why
+        // this comment says what it reads rather than "every line".
+        //
+        // What this does **not** reach, in the design rather than by defect: a
+        // third file calling `wf::reap::run`, and a re-export that gives the
+        // module a second name in the library. It is a grep over one file, and a
+        // grep over one file cannot see either. What it is good for is the
+        // accident — a maintainer wiring a cleanup in without noticing — and
+        // that is the claim the module doc makes for it too.
         let code = probe::code_only("main.rs", include_str!("main.rs"));
         assert_eq!(
             lines_naming(&without_usage(&code), "reap"),
@@ -473,6 +532,23 @@ mod tests {
             !code.contains("Command"),
             "this file dispatches; it does not run anything itself, and a \
              subprocess started here runs on every `wf` invocation"
+        );
+
+        // And the deletion that starts no subprocess at all. A reviewer put
+        // `std::fs::remove_dir_all` of the real clone and record paths in
+        // `main()`: `wf --version` printed the version, exited 0, and destroyed
+        // both, with the whole selection green — the same accidental cleanup
+        // the line above is for, written in-process instead of as argv.
+        //
+        // Bare `fs`, not `fs::`, for the reason `lines_naming`'s doc gives for
+        // `reap`: `use std::fs as sys;` writes no `fs::` and reopens the whole
+        // thing. The module cannot be reached without its name being written,
+        // so the name is what is counted. It is free here — `fs` does not
+        // occur in this file's code at all, in an identifier or anywhere else.
+        assert!(
+            !code.contains("fs"),
+            "this file dispatches; deleting a directory in-process is not \
+             something it does, under any spelling of `std::fs`"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,21 @@
 //! ([`wf::reap`]'s private `remove`) is not something this crate may name. The
 //! picker is [`picker`], a module of its own.
 //!
-//! That arrangement is #137's separation, and it is a fact about visibility
-//! rather than a claim anyone has to check: the picker cannot call the deletion
-//! because the deletion is private to a module in another crate. No alias,
-//! helper or submodule of this binary changes that — the edit does not compile.
+//! Half of that arrangement is a fact about visibility, and needs no checking:
+//! the deletion is private to a module in another crate, so no alias, helper or
+//! submodule of this binary can call it, and the edit that tries does not
+//! compile.
+//!
+//! The other half is not. `wf::reap::run` has to be public for the arm below to
+//! dispatch it, and it *contains* the deletion — `reap::run(true, true)` is a
+//! forced reap with the unsaved-work guard waived. Nothing stops a line
+//! anywhere in this crate calling it, so what stands in its place is a count:
+//! [`tests::the_binary_reaches_reap_at_exactly_one_place`] pins that this file
+//! names the library's `reap` once and calls into it once, whatever spelling or
+//! alias is used, and `picker.rs` may not name it at all. Those are two greps
+//! over two files. A third file calling `reap::run` is caught by neither; see
+//! [`picker`] for what does and does not cover that, and #137 for the crate
+//! split that would.
 
 use anyhow::Result;
 use tokio::signal::unix::{signal, SignalKind};
@@ -251,17 +262,17 @@ async fn main() -> Result<()> {
         // whatever script installs the tool.
         Invocation::SkillsReport => run_skills(false),
         Invocation::SkillsInstall => run_skills(true),
-        // The one thing in this binary that deletes anything, and it is a
-        // *call into the library* — `reap::remove` is private there, so this
-        // whole crate, the picker included, has no way to spell a deletion
-        // except by choosing this arm. Pinned by
-        // `the_binary_reaches_the_deletion_at_exactly_one_place`.
+        // The one place in this binary that reaches a deletion, and it reaches
+        // it as a whole command: prompt, plan, and the private `remove` this
+        // crate could not spell if it wanted to. Pinned as a *count* by
+        // `the_binary_reaches_reap_at_exactly_one_place` — an arm that merely
+        // exists says nothing about the rest of the file, and a prologue before
+        // this match is how an earlier round deleted a workspace on
+        // `wf --version`.
         Invocation::Reap { yes, insist } => reap::run(yes, insist).await,
         // And the one shape that opens the TUI, which is the whole of what this
-        // arm may do. Everything the picker touches lives in a module that
-        // cannot name a deletion — see [`picker`] — and this line is what keeps
-        // `main.rs`, where `wf reap` does its deleting, out of that path
-        // entirely. Pinned by `the_tui_invocation_is_nothing_but_the_picker`.
+        // arm may do — the picker is handed the process, not a deletion, and
+        // this line is what keeps the rest of this file out of its path.
         Invocation::Tui => picker::run_picker().await,
     }
 }
@@ -321,27 +332,52 @@ mod tests {
     }
 
     #[test]
-    fn the_binary_reaches_the_deletion_at_exactly_one_place() {
-        // What is left for a grep to say once the deletion is out of reach.
+    fn the_binary_reaches_reap_at_exactly_one_place() {
+        // What is left for a grep to say once the deletion itself is out of
+        // reach.
         //
         // `reap::remove` is private to the library's `reap` module, so nothing
         // in this crate can call it — that half needs no test, it is a compile
         // error. What this crate *can* still name is `reap::run`, the whole
-        // `wf reap` command, prompt and plan and all. A previous round's
-        // escape was a prologue in `main` before the match; the same edit
-        // spelt with `reap::run(true, true)` would delete unattended too. So
-        // the claim here is a count, not a `contains`: this file reaches into
-        // `reap` exactly once, and that once is the arm `parse_args` produced
-        // for the words `wf reap`.
+        // `wf reap` command, prompt and plan and all, and `reap::run(true,
+        // true)` is a forced deletion. A previous round's escape was exactly
+        // that as a prologue before the match, and `wf --version` reaped a
+        // workspace and exited 0.
         //
-        // Nothing weaker would do. `contains` says an arm exists and says
-        // nothing about the rest of the file, which is precisely how the
-        // prologue got in.
+        // So the claim is a count of **reachability**, not of one spelling.
+        // The version of this test that counted `"reap::"` alone was green for
+        // `use wf::reap as tidy;` plus `tidy::run(true, true)`, because an
+        // alias produces no `reap::` anywhere. Three assertions close that,
+        // and each is load-bearing:
+        //
+        // 1. the module is named once — a second `wf::reap::run(…)` written
+        //    inline, or an alias *added* beside the import, pushes this to two;
+        // 2. that one naming is the plain import — `use wf::reap as tidy;` and
+        //    `use wf::reap::run as nuke;` both leave the count at one and fail
+        //    here instead;
+        // 3. the name it binds is used once — a glob `use wf::*;` names no
+        //    `wf::reap` at all, but still has to write `reap::run` to call it,
+        //    and a second call anywhere in the file lands here.
+        //
+        // Between them, every way this file can reach `reap` has to be spelt
+        // in one of two places, and both are checked below. What none of it
+        // reaches is a *third* file calling `reap::run`; that is stated in the
+        // module doc rather than pretended away.
         let code = probe::code_only(include_str!("main.rs"));
+        assert_eq!(
+            code.matches("wf::reap").count(),
+            1,
+            "this file may name the library's `reap` once, and that once is its import"
+        );
+        assert!(
+            code.contains("use wf::reap;"),
+            "and it must be the plain import: an alias is a second name for the \
+             same module, spelt so that a grep for `reap::` misses it"
+        );
         assert_eq!(
             code.matches("reap::").count(),
             1,
-            "this file may reach into `reap` once, for the `wf reap` argv and \
+            "the imported name may be used once, for the `wf reap` argv and \
              nothing else"
         );
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,43 @@ mod tests {
             .collect()
     }
 
+    /// `code` with the `USAGE` literal cut out — from its `const` line to the
+    /// line that closes the string.
+    ///
+    /// `USAGE` is help text. It writes `wf reap` because that is the command it
+    /// documents, and it calls nothing. Leaving it in [`lines_naming`]'s input
+    /// put two of its hand-wrapped lines into the list below, which turned that
+    /// list into a pin on the wrapping: rewording the `wf reap` paragraph — no
+    /// capability changed, the same code, the same seven sites — failed the
+    /// guard, and failed it with a message saying the file wrote `reap`
+    /// somewhere new, which was not true. Cutting the literal out leaves the
+    /// list five lines of code, which is what the guard is about.
+    ///
+    /// # Panics
+    ///
+    /// If `USAGE` is not found, or its literal is not closed by a line ending
+    /// `";` — the same fail-closed posture as [`probe::code_only`]: a shape
+    /// this cannot locate is refused rather than skipped.
+    fn without_usage(code: &str) -> String {
+        let lines: Vec<&str> = code.lines().collect();
+        let opens = lines
+            .iter()
+            .position(|line| line.starts_with("const USAGE: &str = \""))
+            .expect("main.rs defines USAGE at column 0");
+        let closes = opens
+            + lines[opens..]
+                .iter()
+                .position(|line| line.trim_end().ends_with("\";"))
+                .expect("the USAGE literal is closed by a line ending `\";`");
+        lines
+            .iter()
+            .enumerate()
+            .filter(|(at, _)| !(opens..=closes).contains(at))
+            .map(|(_, line)| *line)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     #[test]
     fn the_binary_writes_reap_only_where_it_is_listed_here() {
         // What is left for a grep to say once the deletion itself is out of
@@ -373,15 +410,19 @@ mod tests {
         // that as a prologue before the match, and `wf --version` reaped a
         // workspace and exited 0.
         //
-        // So this is the whole list of lines in this file that write the word
-        // `reap`, and it is compared as a list rather than as a count. Two of
-        // them are code — the import and the arm — and the rest are the help
-        // text, which is prose in a string and calls nothing. Any new line that
-        // writes the word fails here, whatever it writes around it: an alias
-        // (`use wf::reap as tidy;`, `use crate::reap as tidy;`), a path through
-        // the crate root, a call split over two lines. The module cannot be
-        // reached without its name being written somewhere, and every somewhere
-        // is below.
+        // So this is the whole list of lines of *code* in this file that write
+        // the word `reap`, compared as a list rather than as a count. All five
+        // are code: the import, the two parse arms — one of which calls
+        // `parse_reap` — the rejection message, and the dispatch arm that calls
+        // `reap::run`. The help text is cut out first (see `without_usage`),
+        // because it is prose and pinning its line wrapping here made the guard
+        // fail on rewraps and say something untrue when it did.
+        //
+        // Any new line that writes the word fails here, whatever it writes
+        // around it: an alias (`use wf::reap as tidy;`, `use crate::reap as
+        // tidy;`), a path through the crate root, a call split over two lines.
+        // The module cannot be reached without its name being written
+        // somewhere, and every somewhere is below.
         //
         // What this does **not** reach: a third file calling `wf::reap::run`,
         // and a re-export that gives the module a second name in the library.
@@ -389,28 +430,49 @@ mod tests {
         // either. What it is good for is the accident — a maintainer wiring a
         // cleanup in without noticing — and that is the claim the module doc
         // makes for it too.
-        //
-        // If you changed the usage text, update the prose lines below; the two
-        // code lines are the ones that matter.
-        let code = probe::code_only(include_str!("main.rs"));
+        let code = probe::code_only("main.rs", include_str!("main.rs"));
         assert_eq!(
-            lines_naming(&code, "reap"),
+            lines_naming(&without_usage(&code), "reap"),
             [
                 "use wf::reap;",
-                "wf reap [-y] [-f]",
-                "wf reap            remove the workspaces whose work is over — a closed ticket,",
-                "\"reap\" => Invocation::Reap {",
+                "\"reap\" => Invocation::Reap {", // }
                 "[first, rest @ ..] if first == \"reap\" => parse_reap(rest),",
                 "\"wf: unknown reap argument {other:?} (expected `-y` or `-f`)\\n{USAGE}\"",
                 "Invocation::Reap { yes, insist } => reap::run(yes, insist).await,",
             ],
-            "this file writes `reap` somewhere new"
+            "the lines of code in this file that write `reap` are no longer the five \
+             listed here. A line that is not in the list is a way this binary reaches \
+             `wf::reap::run`, which is a forced deletion when it is called with both \
+             flags; a listed line that is gone means the list is stale. Read the diff \
+             and decide which before editing the list"
         );
+        // The dangling opening brace in the second entry is real: the arm it
+        // quotes opens a struct literal and rustfmt wraps the line there. The
+        // trailing comment that closes it is not decoration —
+        // `probe::code_only` counts braces as text to find where this module
+        // ends, so a string that opens one and never closes it fails this
+        // file's own guard. That is the fail-closed cost described in that
+        // function's doc, paid here, in the one place this file pays it.
+
         // The other half of the same claim, at the other arm: opening the TUI
         // is the whole of what `wf` with no arguments does.
         assert!(
             code.contains("Invocation::Tui => picker::run_picker().await,"),
             "opening the TUI must be the whole of what that arm does"
+        );
+
+        // And the deletion that does not go through `reap` at all. `main` is
+        // argv and dispatch; it starts no subprocess of its own. A prologue
+        // reading `Command::new("dl").args([id, "rm", "--force"]).output()` is
+        // the most ordinary shape an accidental cleanup takes, it runs on every
+        // invocation including `wf --version`, and until this line nothing in
+        // this file looked for it. `process::` and `tokio::spawn` are *not*
+        // added beside it: this file genuinely uses both, for the signal
+        // handler and the exit code.
+        assert!(
+            !code.contains("Command"),
+            "this file dispatches; it does not run anything itself, and a \
+             subprocess started here runs on every `wf` invocation"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,36 +14,28 @@
 //!    search — and `←` walks between them.
 //! 5. `enter` picks a ticket, and that is the end of `wf`: the loop returns,
 //!    the terminal is restored, and this process is replaced by the agent
-//!    ([`wf::launch::Launch::exec`]). The one ordering that matters —
-//!    restore *then* exec — is the two statements at the bottom of [`main`],
-//!    because after the exec there is no `wf` left to restore anything.
-
-use std::collections::BTreeMap;
+//!    ([`wf::launch::Launch::exec`]).
+//!
+//! This file is argv and the commands that answer on a stream — `--version`,
+//! `wf skills`, `wf reap`. The picker itself is [`picker`], a module of its
+//! own, because `wf reap` deletes workspaces for a living and the picker must
+//! be provably unable to: that is one grep over one file only if the two do not
+//! share one (#137).
 
 use anyhow::{bail, Context, Result};
-use ratatui::crossterm::event::{self, Event, KeyEventKind};
-use ratatui::DefaultTerminal;
 use tokio::signal::unix::{signal, SignalKind};
-use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tokio::task::JoinHandle;
 
-use wf::app::{App, Outcome};
-use wf::launch::{Agent, Launch};
-use wf::model::{Map, MapId};
-use wf::projects::{self, ProjectsCache};
+use wf::launch::Agent;
 use wf::reap;
-use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup, Survey};
 use wf::skills;
+
+mod picker;
 
 /// Test scaffolding shared with the library's own tests — the same
 /// `src/probe.rs`, compiled into this crate too, because that is the only way
 /// the binary's tests can reach it. Never compiled into a release.
 #[cfg(test)]
 mod probe;
-
-/// How long the loop waits on a keypress before redrawing — the cadence at
-/// which streamed load events reach the screen.
-const TICK: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// Everything `wf`'s argv can mean. Only one shape opens the TUI; the others
 /// answer on a stream and exit, touching neither the terminal nor `gh` — which
@@ -345,177 +337,24 @@ async fn main() -> Result<()> {
     match parse_args(std::env::args().skip(1)) {
         Invocation::Print(text) => {
             println!("{text}");
-            return Ok(());
+            Ok(())
         }
         Invocation::Reject(text) => {
             eprintln!("{text}");
-            std::process::exit(2);
+            std::process::exit(2)
         }
         // Both skills paths answer on a stream and exit, like `--version`:
         // no terminal, no `gh`, so they stay usable in a package test and in
         // whatever script installs the tool.
-        Invocation::SkillsReport => {
-            run_skills(false)?;
-            return Ok(());
-        }
-        Invocation::SkillsInstall => {
-            run_skills(true)?;
-            return Ok(());
-        }
-        Invocation::Reap { yes, insist } => {
-            run_reap(yes, insist).await?;
-            return Ok(());
-        }
-        Invocation::Tui => {}
-    }
-
-    // Accretive registration: running wf here is what makes this checkout
-    // a project. Non-checkouts and non-GitHub remotes are simply None. This
-    // is local git (<10ms) and the projects cache it writes is what the first
-    // frame is drawn from, so it stays ahead of the screen.
-    let cwd = std::env::current_dir().context("cannot resolve the working directory")?;
-    let here = projects::discover_checkout(&cwd).await;
-    let cache_path =
-        projects::default_cache_path().context("cannot resolve the XDG cache directory")?;
-    let mut cache = ProjectsCache::load_or_default(&cache_path);
-    // Accretion needs a matching forget: a checkout that has been deleted must
-    // stop offering itself as somewhere an agent could run.
-    let pruned = cache.prune_missing();
-    if let Some((path, slug)) = &here {
-        cache.register(path.clone(), slug.clone());
-        cache.save(&cache_path)?;
-    } else if pruned {
-        cache.save(&cache_path)?;
-    }
-    let repos = cache.repos();
-    // The head start (#28): the map numbers the last search found. Reading them
-    // is one local file read that has already happened, so the fetches can start
-    // before the first frame instead of after the ~2.5 s search — which is where
-    // time-to-*data* actually went. The search still runs (see
-    // [`wf::refresh::spawn_discovery`]); this only decides what `wf` fetches
-    // while waiting for it.
-    let seed = cache.map_seed();
-    let mut app = App::empty()
-        .with_checkouts(cache.checkouts.clone())
-        .with_sessions(cache.sessions.clone());
-    app.open_maps = seed.clone();
-    app.startup = Startup::seeded(&seed);
-
-    // The screen goes up *before* any network call (#27). Everything that used
-    // to run here — the map search, a serial fetch per repo — now streams into a
-    // UI that is already drawn and already reading keys.
-    let mut terminal = ratatui::init();
-    spawn_terminal_guard();
-
-    let (tx, updates) = mpsc::unbounded_channel();
-    let discovery = wf::refresh::spawn_discovery(repos, cache_path.clone(), tx.clone());
-    // And what a `wf reap` would claim (#137), read behind the screen exactly
-    // as the search is: a `dl --ls --json` subprocess and one batched GraphQL
-    // call, neither of them on the way to a frame. It folds into the count line
-    // when it lands, says nothing when it fails, and can delete nothing.
-    let survey = wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone());
-
-    // cwd-open enters the project, on the first frame and unconditionally.
-    //
-    // It used to wait: the focus was only applied to a repo the cached seed
-    // already knew had a map, and otherwise handed to the loop to apply when
-    // discovery landed, because a focused repo with no maps rendered an empty
-    // screen. It cannot now — a project's screen leads with the project's own
-    // row, which is a place to stand whether or not anything has been filed in
-    // the repo, let alone fetched. So the level is decided by one local `git`
-    // call, before any network call, and nothing arriving later moves it.
-    if let Some((_, slug)) = &here {
-        app.enter(slug);
-    }
-    let ending = run(&mut terminal, app, discovery, survey, tx, updates).await;
-
-    // The one ordering that matters, and the reason the exec is here rather
-    // than in the loop: the terminal must be back in the shell's hands before
-    // the process image is replaced, because afterwards there is no `wf` left
-    // to put it back.
-    //
-    // `show_cursor` is part of that and not a flourish. Nothing in the picker
-    // ever positions a cursor, so every `Terminal::draw` writes `ESC[?25l`, and
-    // the only thing that writes it back is `Terminal`'s `Drop` —
-    // `ratatui::restore()` is just raw-mode-off plus leave-alternate-screen.
-    // On the quit path `Drop` runs at the end of `main`; on the handover path
-    // `exec` replaces the image first and it never runs. So the agent would
-    // inherit an invisible cursor, on a terminal-global mode that outlives the
-    // alternate screen. This is the line the deleted `suspend()` had.
-    let _ = terminal.show_cursor();
-    ratatui::restore();
-    match ending? {
-        Ending::Quit => Ok(()),
-        Ending::Handover(launch) => {
-            // The launch is a use of this project, and the last chance to say
-            // so: after the exec there is no `wf` left to write anything. This
-            // is what keeps the project list ordered for someone who reaches
-            // their projects *through* it — opening `wf` in a checkout stamps
-            // it, and for everyone else launching is the only other act that
-            // means "this is what I am working on".
-            //
-            // Re-read before writing, exactly as the discovery task does: it
-            // writes the search's findings to this same file while the picker
-            // is up, so the copy loaded before the first frame is stale by
-            // now, and saving it would trade this stamp for next run's head
-            // start.
-            //
-            // Best-effort on purpose. A cache that will not write is not worth
-            // refusing a launch over, and the only cost of losing this is one
-            // project sitting lower in a list than it might have.
-            let mut cache = ProjectsCache::load_or_default(&cache_path);
-            let mut changed = cache.touch(launch.cwd());
-            // And record the conversation this launch is about to start, so a
-            // later run can offer the way back into it (#35).
-            //
-            // Written **here**, immediately before the terminal is restored
-            // and the image replaced, because this is the last moment `wf`
-            // exists — and written from the resolved launch rather than from
-            // the picker, so what is remembered is the tree the agent actually
-            // gets. A creation records nothing: it has no node to key on until
-            // its skill files one.
-            //
-            // Best-effort like the stamp above it, and for a smaller cost: a
-            // record that fails to write means the resume row is missing next
-            // time, not that anything is wrong with the launch.
-            if let Some(session) = launch.session() {
-                cache.record_session(session);
-                changed = true;
-            }
-            if changed {
-                let _ = cache.save(&cache_path);
-            }
-            // The prompts the selected agent is about to run. `wf skills
-            // install` links its skills directory at a *copy* of the bundle,
-            // and a copy is a thing that can fall behind a `pixi global update
-            // wf`. This is where it cannot: the process that refreshes it is
-            // the same one that then execs the prompt, so no launch ever gets
-            // ahead by even one release.
-            refresh_skills(launch.agent());
-            // Only ever returns an error: on success this process *is* the agent.
-            Err(launch.exec())
-        }
-    }
-}
-
-/// Bring the installed skill copies back in step with the bundle they were
-/// installed from.
-///
-/// Best-effort, and deliberately silent when there is nothing to do: a machine
-/// with no home directory to resolve, and one that never ran
-/// `wf skills install`, are not worth a word on the way into an agent. A copy
-/// that could not be *written* is different — the agent is about to run a
-/// prompt that is not the one that was installed — so that one is said out
-/// loud.
-fn refresh_skills(agent: Agent) {
-    let Ok(target) = skills::Target::resolve(agent) else {
-        return;
-    };
-    if let Err(err) = skills::refresh(&target) {
-        eprintln!(
-            "wf: could not refresh the {} skills: {err:#}",
-            agent.label()
-        );
+        Invocation::SkillsReport => run_skills(false),
+        Invocation::SkillsInstall => run_skills(true),
+        Invocation::Reap { yes, insist } => run_reap(yes, insist).await,
+        // And the one shape that opens the TUI, which is the whole of what this
+        // arm may do. Everything the picker touches lives in a module that
+        // cannot name a deletion — see [`picker`] — and this line is what keeps
+        // `main.rs`, where `wf reap` does its deleting, out of that path
+        // entirely. Pinned by `the_tui_invocation_is_nothing_but_the_picker`.
+        Invocation::Tui => picker::run_picker().await,
     }
 }
 
@@ -565,174 +404,6 @@ fn spawn_terminal_guard() {
     }
 }
 
-/// Why the event loop ended — the two ways `wf` gives the terminal back.
-///
-/// A sum rather than "quit, plus maybe a launch on the side": these are the
-/// only two exits, they are mutually exclusive, and the second carries exactly
-/// what the caller needs to finish the job. Nothing here performs the launch,
-/// because performing it means the terminal must already be restored — and this
-/// value is what carries that requirement out to where it can be met.
-enum Ending {
-    /// The user quit.
-    Quit,
-    /// A ticket was picked. `wf`'s last act is to become its agent.
-    Handover(Box<Launch>),
-}
-
-/// Fold one arrival into what the screen draws.
-///
-/// Split out of [`run`]'s loop so the wiring can be *tested*, which is the
-/// whole difficulty with an event loop: everything between the channel and the
-/// screen used to be reachable only by standing up a terminal and driving it.
-/// Each arm below is now a call a test can make and a frame it can read.
-///
-/// **Deliberately not `async`.** Folding an arrival into the app state reads no
-/// file, runs no process and waits for nothing — the work was all done by the
-/// task that sent the event. Saying so in the signature is what makes #137's
-/// separation structural at this end of the path: this is where a reap would be
-/// wired if anyone ever wired one, and a function that cannot await cannot ask
-/// `dl` to remove anything.
-fn fold(
-    event: LoadEvent,
-    app: &mut App,
-    clusters: &mut BTreeMap<MapId, Map>,
-    loaders: &mut Loaders,
-    tx: &UnboundedSender<LoadEvent>,
-) {
-    match event {
-        LoadEvent::Discovered(found) => {
-            // Reconciling the loaders *is* the load for every map the
-            // seed did not already cover: those fetches are all in
-            // flight at once and each lands on screen as it arrives.
-            loaders.reconcile(&found, tx);
-            app.startup.searched(&found);
-            // Nothing to apply here any more: the level was decided
-            // before the first frame and discovery has no say in it.
-            // A repo the search finds no map for renders its project
-            // row saying so, which is both the notice this used to
-            // post and somewhere to act on it.
-            //
-            // Maps the search dropped must stop being rendered as well as
-            // stop being fetched — their rows are as stale as their load.
-            // A map that is no longer open also stops being a *failure*:
-            // there is nothing left to have failed.
-            clusters.retain(|id, _| found.contains(id));
-            app.failed.retain(|id| found.contains(id));
-            app.open_maps = found;
-            app.replace_clusters(clusters.clone());
-        }
-        // Discovery retries, so this is a status report and not an end
-        // state: `wf` stays on screen and recovers when the search does.
-        LoadEvent::SearchFailed => {
-            app.notice = Some("map search failed — retrying".to_string());
-        }
-        LoadEvent::Fetched { id, outcome } => {
-            app.startup.record_arrival(&id);
-            match outcome {
-                MapFetch::Loaded(new_map) => {
-                    app.failed.remove(&id);
-                    clusters.insert(id, new_map);
-                    app.replace_clusters(clusters.clone());
-                }
-                // Nothing polls any more, so a failed load is not a blip
-                // the next cycle papers over — it is the final word on
-                // that map until someone asks again. Recorded as state
-                // rather than announced as a notice, because a notice
-                // is gone on the next keypress and this is not.
-                MapFetch::Failed => {
-                    app.failed.insert(id);
-                }
-            }
-        }
-        // The background reading landed (#137). A plain state write on
-        // a screen that has been up and answering keys the whole time —
-        // it changes one dim segment of the count line and nothing else,
-        // and it arrives at most once because nothing asks again.
-        LoadEvent::Reclaimable(found) => {
-            app.reclaimable = Some(found);
-        }
-    }
-}
-
-/// Stop everything running behind the screen, and wait for it to be gone.
-///
-/// The last thing before a handover, and the reason it is a function of its
-/// own: "aborted *and awaited*" is a claim about two tasks that a test can now
-/// make on both at once. Nothing after this point can be drawn, and the process
-/// is about to be replaced — an in-flight `gh` or `dl` that outlives the `exec`
-/// is inherited by the agent as a child holding the terminal it just took over.
-async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
-    discovery.abort();
-    let _ = discovery.await;
-    // The reading holds a `dl` and a `gh` of its own, and the same reasoning
-    // applies — [`Survey::stop`] is where the waiting is spelt out.
-    survey.stop().await;
-}
-
-/// The event loop. It starts with **no data at all** (#27): which repos even
-/// have maps, and the maps themselves, arrive as [`LoadEvent`]s while the screen
-/// is already up and answering keys.
-///
-/// `focus` is the cwd checkout's repo slug, if `wf` was run inside one — held
-/// as an `Option` that is *taken*, so the lazygit-style focus can be applied at
-/// most once, when discovery makes it answerable.
-async fn run(
-    terminal: &mut DefaultTerminal,
-    mut app: App,
-    discovery: JoinHandle<()>,
-    survey: Survey,
-    tx: UnboundedSender<LoadEvent>,
-    mut updates: UnboundedReceiver<LoadEvent>,
-) -> Result<Ending> {
-    let mut clusters: BTreeMap<MapId, Map> = BTreeMap::new();
-    // The cached seed starts fetching immediately (#28); the search's answer
-    // reconciles this set rather than adding to it, so a map that closed or
-    // opened is corrected in the tasks actually doing the fetching, not just
-    // in the state the screen reads.
-    let mut loaders = Loaders::new();
-    loaders.reconcile(&app.open_maps, &tx);
-    loop {
-        // Drain everything that landed before drawing. A fetch swaps one map's
-        // cluster; App::replace_clusters keeps the cursor pinned to row
-        // identity, query and scope untouched.
-        while let Ok(event) = updates.try_recv() {
-            fold(event, &mut app, &mut clusters, &mut loaders, &tx);
-        }
-
-        terminal.draw(|frame| wf::ui::draw(frame, &app))?;
-        if event::poll(TICK)? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind != KeyEventKind::Press {
-                    continue;
-                }
-                match app.handle_key(key) {
-                    Outcome::Quit => return Ok(Ending::Quit),
-                    // Through the loaders, not alongside them: a refetch that
-                    // raced an in-flight load used to be silently overwritten
-                    // by the older snapshot. One channel, send order, newest
-                    // write wins. Results stream in as they land, so the last
-                    // word on how it went is the count line, not this notice.
-                    Outcome::Refresh => {
-                        loaders.restart(&app.open_maps, &tx);
-                        app.startup.reloading();
-                        app.failed.clear();
-                    }
-                    // Nothing after this can be drawn. Stop the background work
-                    // *and wait for it* before handing over: an in-flight `gh`
-                    // outlives the `exec` otherwise, and the agent inherits it
-                    // as a zombie holding the terminal it just took over.
-                    Outcome::Launch(launch) => {
-                        loaders.shutdown().await;
-                        stop_background(discovery, survey).await;
-                        return Ok(Ending::Handover(launch));
-                    }
-                    Outcome::Continue => {}
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -741,127 +412,19 @@ mod tests {
         args.iter().copied().map(String::from).collect()
     }
 
-    /// The reading a `wf reap` of this machine would produce, built the one way
-    /// production builds one — through [`wf::reclaim::reading`], over a plan.
-    /// There is no test-only constructor to reach from here, which is the point:
-    /// what the loop folds is what the survey would have sent.
-    fn a_reading() -> wf::reclaim::Reclaimable {
-        let ws = reap::Workspace {
-            id: "devlaunch-github-com-blooop-wayfinder-129".to_string(),
-            devlaunch: true,
-            repo: Some("blooop/wayfinder".to_string()),
-            branch: Some("wayfinder/wayfinder-129".to_string()),
-            state: Some("Stopped".to_string()),
-            unsaved: None,
-        };
-        let known = [(
-            reap::Node {
-                repo: "blooop/wayfinder".to_string(),
-                number: 129,
-            },
-            reap::NodeFact::Closed,
-        )]
-        .into_iter()
-        .collect();
-        wf::reclaim::reading(&[ws], &known).expect("a closed ticket is reclaimable")
-    }
-
-    /// Fold a landed reading into a fresh app and draw the screen it produces.
-    /// Run in a child process by the two tests below, under a `PATH` whose `dl`
-    /// and `gh` write down everything they are asked to do.
-    #[tokio::test]
-    #[ignore = "run by `probe::record` from the two tests below, under recording shims"]
-    async fn reclaimable_arm_probe() {
-        if !probe::is_child() {
-            return;
-        }
-        let (tx, _rx) = mpsc::unbounded_channel();
-        let mut app = App::empty();
-        let mut clusters = BTreeMap::new();
-        let mut loaders = Loaders::new();
-        fold(
-            LoadEvent::Reclaimable(a_reading()),
-            &mut app,
-            &mut clusters,
-            &mut loaders,
-            &tx,
-        );
-        let backend = ratatui::backend::TestBackend::new(100, 12);
-        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
-        terminal
-            .draw(|frame| wf::ui::draw(frame, &app))
-            .expect("draw");
-        let buf = terminal.backend().buffer();
-        for y in 0..buf.area.height {
-            let mut line = String::new();
-            for x in 0..buf.area.width {
-                line.push_str(buf[(x, y)].symbol());
-            }
-            println!("{}{}", probe::MARK, line.trim_end());
-        }
-    }
-
     #[test]
-    fn a_landed_reading_reaches_the_screen() {
-        // The wiring #137 is, end to end at this end of it: the event arrives,
-        // the loop folds it, and the count line says what a reap would claim.
-        // An arm that dropped the payload on the floor — `Reclaimable(_) => {}`
-        // — leaves every other test in this tree green, because every other
-        // test hands the reading to the thing it is testing.
-        let run = probe::record("tests::reclaimable_arm_probe", "", "");
-        let screen = run.printed();
-        let line = screen
-            .iter()
-            .find(|line| line.contains("reclaimable"))
-            .unwrap_or_else(|| panic!("the count line must say so:\n{}", screen.join("\n")));
-        assert!(line.contains("1 reclaimable"), "{line}");
-        assert!(line.contains("129"), "it names the workspace: {line}");
-        assert!(line.contains("wf reap"), "and the command: {line}");
-    }
-
-    #[test]
-    fn folding_a_reading_into_the_screen_runs_nothing_at_all() {
-        // #137 ships ahead of #138 on one argument: reading what a reap would
-        // claim and performing one are separated. This arm is exactly where a
-        // reap would be wired — `use wf::reap;` is already in scope in this
-        // file — so the separation is asserted here as a fact about a run.
-        // Anything this path asks of `dl` or `gh`, by any spelling, in any
-        // module it calls into, is recorded; the whole fold must record none.
-        let run = probe::record("tests::reclaimable_arm_probe", "", "");
-        run.ran_nothing();
-    }
-
-    #[tokio::test]
-    async fn a_handover_leaves_no_background_work_running() {
-        // The last thing before `exec`, and the one that cannot be seen from
-        // the outside afterwards: both tasks must be aborted *and waited for*,
-        // because it is dropping their futures that closes the `gh` and `dl`
-        // they hold. An `abort()` without the wait, a handle dropped, a handle
-        // forgotten — all three leave a child alive for the agent to inherit.
-        //
-        // Each task holds an `Arc` that cannot be released until its future is
-        // dropped, so the counts are the witness.
-        let (tx, _rx) = mpsc::unbounded_channel();
-        let witness = std::sync::Arc::new(());
-        let for_discovery = std::sync::Arc::clone(&witness);
-        let for_survey = std::sync::Arc::clone(&witness);
-        let discovery = tokio::spawn(async move {
-            std::future::pending::<()>().await;
-            drop(for_discovery);
-        });
-        let survey = wf::refresh::spawn_survey(
-            async move {
-                std::future::pending::<()>().await;
-                drop(for_survey);
-                None
-            },
-            tx,
-        );
-        stop_background(discovery, survey).await;
-        assert_eq!(
-            std::sync::Arc::strong_count(&witness),
-            1,
-            "background work outlived the handover"
+    fn the_tui_invocation_is_nothing_but_the_picker() {
+        // The composition site, structurally. `wf reap` lives in this file and
+        // deletes workspaces for a living, so this file can never carry the
+        // denylist [`picker`] does — and the picker path through it is exactly
+        // one expression long, which is a thing a grep *can* pin. Anything else
+        // wired into this arm, before or after or instead, fails here; anything
+        // wired inside the picker fails
+        // `picker::tests::no_deletion_is_reachable_from_the_picker`.
+        let code = probe::code_only(include_str!("main.rs"));
+        assert!(
+            code.contains("Invocation::Tui => picker::run_picker().await,"),
+            "opening the TUI must be the whole of what that arm does"
         );
     }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -3,34 +3,46 @@
 //! The background reading of what a `wf reap` would claim flows through this
 //! assembly — spawned in [`session`], carried on the one channel, folded in
 //! [`fold`], drawn from [`Picker::tick`] — and #137 asks that nothing on that
-//! path be able to delete a workspace. Three things carry that, and it is worth
-//! being exact about which one carries what, because two review rounds were
-//! spent on a claim that was larger than its evidence.
+//! path delete a workspace. Four rounds of review each found a different hole
+//! in a stronger version of this note than the one below, so it is worth being
+//! exact about what each guard covers and where each one stops.
 //!
-//! 1. **Reap's deletion cannot be named here at all.** `wf::reap`'s `remove` is
-//!    private to its module, in the library; this is the binary. Every route
-//!    three rounds of review found into a deletion — a prologue in `main`, a
-//!    helper in `main.rs`, an aliased import, a submodule of this file — ended
-//!    at that function, and every one of them is now a compile error. Nothing
-//!    has to notice; the build refuses.
-//! 2. **Running a command is watched, over the whole loop.**
+//! 1. **The deletion itself cannot be *named*.** `wf::reap`'s `remove` is
+//!    private to its module, in the library; this is the binary. A prologue in
+//!    `main`, a helper in `main.rs`, an aliased import, a submodule of this
+//!    file — every route that ends at that function is a compile error, and
+//!    nothing has to notice, because the build refuses.
+//!
+//!    That does **not** close `wf::reap::run`, which is public because `main`
+//!    must dispatch `wf reap`, and which contains the deletion:
+//!    `reap::run(true, true)` *is* the forced reap. Visibility cannot separate
+//!    the picker from a function the same binary has to call, so what stands in
+//!    its place is a denylist — `reap` is a forbidden token in this file
+//!    ([`tests::the_picker_names_neither_a_subprocess_nor_reap`]) and `main.rs`
+//!    counts its own two mentions of the module. A denylist over two files
+//!    cannot see the same call made one hop away in a third. That hole is real;
+//!    the only thing that would close it is the picker living in a crate that
+//!    cannot depend on reap at all, which is a change to `wf`'s build and its
+//!    own decision (#137).
+//! 2. **Running a command is watched, across every arm of the loop.**
 //!    [`tests::no_deletion_survives_a_whole_session_of_the_real_assembly`]
 //!    drives [`session`] for real against recording `dl` and `gh` shims, so a
 //!    `dl <ws> rm` reached from anywhere the loop can reach — a helper in
 //!    `app.rs`, a task spawned in a fold arm, a function named nothing anyone
-//!    thought to forbid — is written down as argv. This is the guard that does
-//!    not care what file the route was spelt in.
+//!    thought to forbid — is written down as argv. It does not care what file
+//!    the route was spelt in. It cares about *which arm* and about *when*: all
+//!    four [`Outcome`] arms are driven, the launch one included, and the
+//!    recording runs from the composition site to a stated window past the
+//!    ending (`WATCH`, in the tests below). A cleanup deferred longer than that
+//!    is not seen. The bound is stated rather than silent because it cannot be
+//!    removed — a probe can always be outwaited.
 //! 3. **Destruction that runs no command is watched where it would land.** The
-//!    same run gives the child a scratch `HOME` holding a directory per
-//!    workspace the fixture lists, and compares the tree before and after. An
-//!    `fs::remove_dir_all` aimed at a workspace fails it. An `fs` call aimed
-//!    somewhere else is caught by nothing — as it would be in any file of any
-//!    crate, and this file claims no better.
-//!
-//! What is left of the source-text guard is
-//! [`tests::the_picker_names_no_way_of_running_a_command`], which is three
-//! tokens about starting subprocesses and outliving the loop. It is not the
-//! separation; (1) is.
+//!    same run gives the child a scratch `HOME` laid out the way this machine
+//!    is — `~/.cache/devlaunch/repos/<owner>/<repo>/<id>` for the clone,
+//!    `~/.devpod/contexts/<ctx>/workspaces/<id>` for the record — and compares
+//!    the tree before and after. An `fs::remove_dir_all` aimed at a workspace
+//!    fails it. An `fs` call aimed somewhere else is caught by nothing — as it
+//!    would be in any file of any crate, and this file claims no better.
 //!
 //! The ordering that matters is at the bottom of [`run_picker`]: restore the
 //! terminal, *then* exec, because after the exec there is no `wf` left to
@@ -195,9 +207,10 @@ impl Picker {
 /// It is worth saying what that does *not* buy, because an earlier round of
 /// this file said it did. Not being async rules out `.await` in these arms and
 /// nothing more: a synchronous `std::process::Command`, or a `tokio::spawn`ed
-/// task, reaches `dl` from here perfectly well. What actually stops a deletion
-/// in this arm is the module doc's (1) and (2) — the deletion cannot be named,
-/// and running a command is recorded.
+/// task, reaches `dl` from here perfectly well. What stands against a deletion
+/// in this arm is the module doc's (2) and (3) — a command it runs is recorded,
+/// and a workspace it removes in-process leaves a hole in the scratch home —
+/// with the limits stated there.
 fn fold(
     event: LoadEvent,
     app: &mut App,
@@ -262,16 +275,16 @@ fn fold(
 
 /// Start the background reading of what a `wf reap` would claim (#137).
 ///
-/// The composition site, and a function rather than a line inside
-/// [`run_picker`] so that it is somewhere a probe can *call*. Wrapping the
-/// reading here — awaiting it before it is handed over, folding a deletion into
-/// it — is the edit this covers, and the reason the first frame is measured
-/// against it in [`tests::the_first_frame_is_drawn_before_anything_is_asked`].
+/// A function rather than a line inside [`session`] because *spawning* the
+/// reading — as against awaiting it — is the property
+/// [`tests::the_first_frame_is_drawn_before_anything_is_asked`] pins, and a
+/// name is somewhere to say that. Its only caller is [`session`], which the
+/// probe drives whole, so this is not a seam anything reaches around.
 ///
 /// Read behind the screen exactly as the map search is: a `dl --ls --json`
 /// subprocess and one batched GraphQL call, neither of them on the way to a
-/// frame. It folds into the count line when it lands, says nothing when it
-/// fails, and can delete nothing.
+/// frame. It folds into the count line when it lands and says nothing when it
+/// fails.
 fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
     wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone())
 }
@@ -296,10 +309,12 @@ async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
 /// is already up and answering keys.
 ///
 /// Generic over the backend and over [`Keys`] so that the probe drives *this*
-/// function rather than a hand-written imitation of it. Everything the loop
-/// body can reach — a helper in another module, a task it spawns, a `dl` it
-/// shells out to — is recorded there as argv, and the escapes three review
-/// rounds found were all one line inside this loop.
+/// function rather than a hand-written imitation of it, and it drives every one
+/// of the four arms below: a scripted keyboard that only ever sent `Esc` left
+/// `Refresh` and `Launch` unentered, which is where a fifth escape was found.
+/// Whatever the loop body reaches — a helper in another module, a task it
+/// spawns, a `dl` it shells out to — is recorded there as argv, for as long as
+/// that probe watches.
 async fn run<B: Backend, K: Keys>(
     terminal: &mut Terminal<B>,
     keys: &mut K,
@@ -516,16 +531,25 @@ mod tests {
     use crate::probe;
     use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 
-    /// How long the loop runs on after the reading has reached the screen.
+    /// How long the probe waits after each thing it does — after the reading
+    /// reaches the screen, after each key it types, and after the session ends.
     ///
     /// The reason this is not zero. A current-thread runtime polls a spawned
     /// task only at an await point, so a probe that stopped the moment it had
     /// what it came for would give `tokio::spawn(async move { … })` in a fold
     /// arm a window of exactly nothing — the task is dropped unpolled and the
     /// deletion "did not happen". In the real event loop that window is
-    /// seconds. This is the window this probe gives it, and it is generous on
-    /// purpose: what is being watched is a `/bin/sh` shim.
-    const SETTLE: Duration = Duration::from_millis(400);
+    /// seconds.
+    ///
+    /// **This is the bound on what the recording claims, and it is stated
+    /// rather than hidden**, because it cannot be removed. A cleanup that
+    /// sleeps for longer than the probe watches is not observed, and no choice
+    /// of number changes that — a longer window costs suite time and buys a
+    /// bigger number to sleep past. What is bought instead is that the window
+    /// is *everywhere* rather than only at the end: the probe waits this long
+    /// between every key, so a task spawned in any arm is polled before the
+    /// next thing happens, and again after the session returns.
+    pub const WATCH: Duration = Duration::from_millis(400);
 
     /// How long the probe will wait for the background reading to arrive
     /// before quitting anyway. A reading that never lands leaves the screen
@@ -537,31 +561,54 @@ mod tests {
     /// not the real thing.
     ///
     /// It drives the loop the way a person does: watch the screen, wait for
-    /// what you came for, then quit. The first time it is asked for a key the
+    /// what you came for, then type. The first time it is asked for a key the
     /// first frame has just been painted and nothing else has happened yet, so
     /// that is where the ordering note goes.
+    ///
+    /// The keys it types are a *plan*, because one of them is not enough. `run`
+    /// has four [`Outcome`] arms and for three review rounds this script sent
+    /// only `Esc`, so `Refresh` and `Launch` were never entered and a deletion
+    /// written into either was green — including in `Launch`, which is both the
+    /// product's primary action and the natural home of a "free the disk on the
+    /// way out" cleanup. A plan that runs out falls back to `Esc`, so a loop
+    /// that failed to end where it was supposed to ends anyway and fails on an
+    /// assertion rather than on the suite's timeout.
     struct Script {
-        /// When to quit regardless, so a reading that never lands ends the run.
+        /// What to type, in order, one key per [`WATCH`].
+        plan: std::collections::VecDeque<KeyEvent>,
+        /// When to start typing regardless, so a reading that never lands does
+        /// not hang the run.
         deadline: std::time::Instant,
-        /// When the reading first reached the app. The loop runs on for
-        /// [`SETTLE`] past this — see there.
-        landed: Option<std::time::Instant>,
+        /// When the next key may be sent: [`WATCH`] after the reading landed,
+        /// and [`WATCH`] after each key since. `None` until the reading lands.
+        due: Option<std::time::Instant>,
         /// Whether the first frame has been noted yet.
         noted: bool,
     }
 
     impl Script {
-        fn new() -> Self {
+        fn new(plan: Vec<KeyEvent>) -> Self {
             Self {
+                plan: plan.into(),
                 deadline: std::time::Instant::now() + LANDING,
-                landed: None,
+                due: None,
                 noted: false,
             }
         }
     }
 
+    /// A key with no modifiers, and the `ctrl` variant `Refresh` needs.
+    fn press(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
     impl Keys for Script {
         async fn next_press(&mut self, app: &App, timeout: Duration) -> Result<Option<KeyEvent>> {
+            let now = std::time::Instant::now();
             if !self.noted {
                 self.noted = true;
                 // The first frame is painted and nothing has been awaited
@@ -572,12 +619,13 @@ mod tests {
                 // `the_first_frame_is_drawn_before_anything_is_asked` reads.
                 probe::note("the first frame");
             }
-            if self.landed.is_none() && app.reclaimable.is_some() {
-                self.landed = Some(std::time::Instant::now());
+            if self.due.is_none() && app.reclaimable.is_some() {
+                self.due = Some(now + WATCH);
             }
-            let seen_enough = self.landed.is_some_and(|at| at.elapsed() >= SETTLE);
-            if seen_enough || std::time::Instant::now() >= self.deadline {
-                return Ok(Some(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+            let ready = self.due.is_some_and(|at| now >= at);
+            if ready || now >= self.deadline {
+                self.due = Some(now + WATCH);
+                return Ok(Some(self.plan.pop_front().unwrap_or(press(KeyCode::Esc))));
             }
             // Far shorter than the real `TICK`, because this is the probe's own
             // cadence and a probe that took a quarter of a second per frame
@@ -590,8 +638,8 @@ mod tests {
     }
 
     /// A whole session, driven for real in a child process whose `dl` and `gh`
-    /// are recording shims and whose `HOME` is a scratch machine with the
-    /// fixture's workspaces on it.
+    /// are recording shims and whose `HOME` is a scratch machine laid out the
+    /// way this one is, with the fixture's workspaces on it.
     ///
     /// This is the assembly and not an imitation of it: [`session`] is the
     /// function `run_picker` calls, it starts the real
@@ -604,20 +652,21 @@ mod tests {
     ///
     /// The runtime is built by hand rather than by `#[tokio::test]` so that it
     /// is current-thread: that is what makes the ordering above deterministic
-    /// rather than a race between the first frame and a worker thread.
-    #[test]
-    #[ignore = "run by `probe::record` from the tests below, under recording shims"]
-    fn picker_session_probe() {
-        if !probe::is_child() {
-            return;
-        }
+    /// rather than a race between the first frame and a worker thread. It is
+    /// also kept alive past the session and driven for one more [`WATCH`], so
+    /// that a task spawned by the arm that *ended* the loop is polled rather
+    /// than dropped with the runtime — the launch arm being exactly where a
+    /// cleanup on the way out would go.
+    ///
+    /// The screen is printed on the way out for the assertions that read it.
+    fn drive(app: App, plan: Vec<KeyEvent>) -> Ending {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("a runtime for the probe");
         let backend = ratatui::backend::TestBackend::new(100, 12);
         let mut terminal = Terminal::new(backend).expect("terminal");
-        let mut keys = Script::new();
+        let mut keys = Script::new(plan);
 
         // No repos, so the map search answers immediately without asking `gh`
         // anything — the reading is what this run is about, and a discovery
@@ -627,14 +676,13 @@ mod tests {
         let ending = runtime.block_on(session(
             &mut terminal,
             &mut keys,
-            App::empty(),
+            app,
             Vec::new(),
             probe::child_scratch().join("projects.json"),
         ));
-        assert!(
-            matches!(ending.expect("the session"), Ending::Quit),
-            "the scripted keyboard quits, and nothing else ends this loop"
-        );
+        // Built inside the runtime's context, not passed into it: a `sleep`
+        // constructed outside one has no timer to register with.
+        runtime.block_on(async { tokio::time::sleep(WATCH).await });
 
         let buf = terminal.backend().buffer();
         for y in 0..buf.area.height {
@@ -644,14 +692,94 @@ mod tests {
             }
             println!("{}{}", probe::MARK, line.trim_end());
         }
+        ending.expect("the session")
+    }
+
+    /// The quit path, with the two arms that do not end the loop driven on the
+    /// way: `ctrl-r` is [`Outcome::Refresh`], `down` on a screen with nothing
+    /// on it is [`Outcome::Continue`], `esc` is [`Outcome::Quit`].
+    #[test]
+    #[ignore = "run by `probe::record` from the tests below, under recording shims"]
+    fn picker_session_probe() {
+        if !probe::is_child() {
+            return;
+        }
+        let ending = drive(
+            App::empty(),
+            vec![
+                ctrl(KeyCode::Char('r')),
+                press(KeyCode::Down),
+                press(KeyCode::Esc),
+            ],
+        );
+        assert!(
+            matches!(ending, Ending::Quit),
+            "the scripted keyboard quits, and nothing else ends this loop"
+        );
+    }
+
+    /// The launch path — [`Outcome::Launch`], the fourth arm and the product's
+    /// primary action, which no probe drove for the first four rounds of this
+    /// PR.
+    ///
+    /// A registered checkout with no map on it is the shortest real route to
+    /// one: the project's own row is the first stop, `enter` opens the launch
+    /// picker on its creation candidates, `down` moves to `new map` — which
+    /// needs no text typed into it — and `enter` resolves it against the one
+    /// registered checkout and returns a launch. The loop then shuts the
+    /// background work down and returns [`Ending::Handover`], which is where
+    /// `run_picker` would `exec`; this stops one line short of that.
+    ///
+    /// The checkout path is in the probe's own scratch directory rather than
+    /// under `HOME`, because `HOME` is what is being watched for changes.
+    #[test]
+    #[ignore = "run by `probe::record` from the tests below, under recording shims"]
+    fn picker_launch_probe() {
+        if !probe::is_child() {
+            return;
+        }
+        let repo = "blooop/wayfinder";
+        let mut app = App::empty().with_checkouts(vec![projects::Checkout::new(
+            probe::child_scratch().join("checkout"),
+            repo.to_string(),
+        )]);
+        app.enter(repo);
+        let ending = drive(
+            app,
+            vec![
+                ctrl(KeyCode::Char('r')),
+                press(KeyCode::Enter),
+                press(KeyCode::Down),
+                press(KeyCode::Enter),
+            ],
+        );
+        match ending {
+            Ending::Handover(launch) => assert_eq!(
+                launch.cwd(),
+                probe::child_scratch().join("checkout"),
+                "the launch resolves to the one registered checkout"
+            ),
+            Ending::Quit => {
+                panic!("the launch arm was never entered — the plan ran out and the fallback quit")
+            }
+        }
     }
 
     /// One recorded run of [`picker_session_probe`], for the assertions below
     /// to share. Each of them calls this rather than the probe directly,
-    /// because the child costs a process and a `SETTLE`.
+    /// because the child costs a process and several [`WATCH`]es.
     fn a_session() -> probe::Recording {
         probe::record(
             "picker::tests::picker_session_probe",
+            probe::DL_LISTING,
+            probe::GH_FACTS,
+        )
+    }
+
+    /// The same, for the run that ends in a launch.
+    fn a_launching_session() -> probe::Recording {
+        probe::record(
+            "picker::tests::picker_launch_probe",
             probe::DL_LISTING,
             probe::GH_FACTS,
         )
@@ -668,6 +796,10 @@ mod tests {
         // thought to forbid — is recorded here, because destroying a workspace
         // means running `dl`. And a destruction that runs no command at all is
         // caught by the scratch home, which must come back untouched.
+        //
+        // Bounded, and the bound is [`WATCH`]: this is what the run *did*, not
+        // what the code cannot do. A cleanup that waits longer than the probe
+        // does is not here.
         let run = a_session();
         run.destroyed_nothing();
         assert_eq!(
@@ -682,6 +814,29 @@ mod tests {
             "one batched read of the tracker: {}",
             run.argv[2]
         );
+    }
+
+    #[test]
+    fn no_deletion_survives_the_arm_that_launches_either() {
+        // The same claim over the fourth arm, which is the one that matters
+        // most and the one nothing drove until now. `Outcome::Launch` is where
+        // a "free the disk on the way out" cleanup goes: the screen is about to
+        // be given back, the picker knows exactly which workspaces a reap would
+        // claim, and after the `exec` there is no `wf` left to be blamed. The
+        // run this reads ends in that arm, and it asks the machine the same two
+        // questions and no others.
+        //
+        // The arm also shuts the background work down, so a `dl` or `gh` still
+        // in flight would land in this log after the reading did.
+        let run = a_launching_session();
+        run.destroyed_nothing();
+        assert_eq!(
+            run.argv.len(),
+            3,
+            "launching asks nothing extra of the machine: {:?}",
+            run.argv
+        );
+        assert_eq!(run.argv[1], "dl <--ls> <--json>");
     }
 
     #[test]
@@ -726,30 +881,45 @@ mod tests {
     }
 
     #[test]
-    fn the_picker_names_no_way_of_running_a_command() {
-        // What is left for source text to say, now that the deletion itself is
-        // out of reach by construction — `wf::reap`'s `remove` is private to
-        // its module, in a *different crate* from this one, so no helper, no
-        // alias and no submodule of the binary can call it and the edit that
-        // tries is a compile error rather than a test failure.
+    fn the_picker_names_neither_a_subprocess_nor_reap() {
+        // What is left for source text to say, and it is worth being exact
+        // about each token, because a list that claims to be a separation is
+        // how three of this PR's four rounds were spent.
         //
-        // This is much narrower than the list it replaces, and it is worth
-        // being exact about what it is for. Shelling out to `dl` is caught by
-        // the run above, over the whole loop, whatever file it is spelt in.
-        // What that run cannot catch is a subprocess this file starts *after*
-        // the probe stops watching — so `Command` and `process::` stay
-        // forbidden here, where a screen-painting module has no use for either.
-        // `tokio::spawn` is on the list because a spawned task is how an
-        // `.await` gets into [`Picker::tick`] and [`fold`], neither of which is
-        // async, and a task that outlives the loop outlives the probe with it.
+        // `reap` is the one that matters. `wf::reap`'s `remove` is private, in
+        // a different crate, so no helper, alias or submodule can call it and
+        // the edit that tries is a compile error. But `wf::reap::run` is
+        // public — `main` has to dispatch `wf reap` — and `reap::run(true,
+        // true)` *is* the forced deletion, waiver and all. Nothing about
+        // visibility stops this file calling it, so this line does. Bare rather
+        // than `reap::`, because the module cannot be reached without its own
+        // name being written somewhere: `use wf::reap as tidy;` is caught here
+        // too, which `reap::` alone would miss.
         //
-        // It is *not* a claim that nothing in the picker's path can delete.
-        // `std::fs::remove_dir_all` in a submodule of this module names none of
-        // these and would compile; what stops it is the scratch home the run
-        // above compares, and outside that home nothing stops it — which is
-        // true of any code in any file in any crate.
+        // `Command` and `process::` are for the subprocess the run above
+        // cannot see — one started after the probe stops watching. A
+        // screen-painting module has no use for either. `tokio::spawn` is on
+        // the list because a spawned task is how an `.await` gets into
+        // [`Picker::tick`] and [`fold`], neither of which is async, and a task
+        // that outlives the loop outlives the probe with it.
+        //
+        // It is *not* a claim that nothing on the picker's path can delete, and
+        // a grep over one file could never be one. The same call spelt in
+        // `app.rs` or in a submodule of this module names none of these and
+        // compiles; what stands against it there is the recorded argv and the
+        // scratch home the run above compares — and outside that home, or after
+        // that run, nothing does, which is true of any code in any file.
+        //
+        // Which is also why this list is shorter than the ones
+        // [`wf::reclaim`] and [`wf::refresh`] carry, rather than having drifted
+        // from them. Those are leaf modules that read and format, so `fs::` and
+        // `remove` cost them nothing and close the only spelling they have. This
+        // file is a *composition site*: it is reached by a probe that watches the
+        // filesystem directly, and banning `fs::` here would read as "the picker
+        // cannot touch a file" while a submodule of it still could. The
+        // behavioural guard is the honest one for that, so it is the one used.
         let code = probe::code_only(include_str!("picker.rs"));
-        for forbidden in ["Command", "process::", "tokio::spawn"] {
+        for forbidden in ["reap", "Command", "process::", "tokio::spawn"] {
             assert!(
                 !code.contains(forbidden),
                 "the picker draws a screen and drains a channel: it names {forbidden:?}"

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -19,11 +19,14 @@
 //!    the picker from a function the same binary has to call, so what stands in
 //!    its place is a denylist — `reap` is a forbidden token in this file
 //!    ([`tests::the_picker_names_neither_a_subprocess_nor_reap`]) and `main.rs`
-//!    counts its own two mentions of the module. A denylist over two files
-//!    cannot see the same call made one hop away in a third. That hole is real;
-//!    the only thing that would close it is the picker living in a crate that
-//!    cannot depend on reap at all, which is a change to `wf`'s build and its
-//!    own decision (#137).
+//!    holds the list of every line in itself that writes the word. Those are
+//!    greps over the source text of two files: they catch a cleanup wired in by
+//!    accident, and they do not stop anyone who means to get around them. The
+//!    same call made one hop away in a third file is caught by neither, and so
+//!    is a second name for the module re-exported from the library. Those holes
+//!    are real; the only thing that would close them is the picker living in a
+//!    crate that cannot depend on reap at all, which is a change to `wf`'s
+//!    build and its own decision (#137).
 //! 2. **Running a command is watched, across every arm of the loop.**
 //!    [`tests::no_deletion_survives_a_whole_session_of_the_real_assembly`]
 //!    drives [`session`] for real against recording `dl` and `gh` shims, so a
@@ -43,6 +46,15 @@
 //!    the tree before and after. An `fs::remove_dir_all` aimed at a workspace
 //!    fails it. An `fs` call aimed somewhere else is caught by nothing — as it
 //!    would be in any file of any crate, and this file claims no better.
+//!
+//! None of that says the picker deletes nothing at all. [`run_picker`] calls
+//! [`refresh_skills`] on the way into the agent, and a copy that has fallen
+//! behind the bundle is rewritten by removing it first — `wf::skills`' `clear`
+//! is a `remove_dir_all` under `~/.claude/wf-skills`, reached from this file's
+//! own code on this file's own launch path. It is `wf`'s copy of `wf`'s own
+//! prompts, not a workspace and not anyone's work; the probe above stops one
+//! line short of it; and the claim here is about workspaces, which is why it is
+//! written as one rather than as "nothing here deletes".
 //!
 //! The ordering that matters is at the bottom of [`run_picker`]: restore the
 //! terminal, *then* exec, because after the exec there is no `wf` left to
@@ -804,15 +816,15 @@ mod tests {
         run.destroyed_nothing();
         assert_eq!(
             run.argv.len(),
-            3,
+            2,
             "a session asks for the listing and the tracker, and nothing else: {:?}",
             run.argv
         );
-        assert_eq!(run.argv[1], "dl <--ls> <--json>");
+        assert_eq!(run.argv[0], "dl <--ls> <--json>");
         assert!(
-            run.argv[2].starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"),
+            run.argv[1].starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"),
             "one batched read of the tracker: {}",
-            run.argv[2]
+            run.argv[1]
         );
     }
 
@@ -832,11 +844,11 @@ mod tests {
         run.destroyed_nothing();
         assert_eq!(
             run.argv.len(),
-            3,
+            2,
             "launching asks nothing extra of the machine: {:?}",
             run.argv
         );
-        assert_eq!(run.argv[1], "dl <--ls> <--json>");
+        assert_eq!(run.argv[0], "dl <--ls> <--json>");
     }
 
     #[test]
@@ -849,12 +861,15 @@ mod tests {
         // fact: awaiting the reading anywhere in `session` before the loop
         // starts, which *does* compile, puts `dl <--ls> <--json>` above the
         // note and fails here.
+        //
+        // Read off the timeline rather than the argv, because the note is the
+        // one line in it the code under test did not write.
         let run = a_session();
         assert_eq!(
-            run.argv.first().map(String::as_str),
-            Some("note <the first frame>"),
+            run.timeline.first().map(String::as_str),
+            Some("note| <the first frame>"),
             "the first frame waited for something: {:?}",
-            run.argv
+            run.timeline
         );
     }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -19,7 +19,11 @@
 //!    the picker from a function the same binary has to call, so what stands in
 //!    its place is a denylist — `reap` is a forbidden token in this file
 //!    ([`tests::the_picker_names_neither_a_subprocess_nor_reap`]) and `main.rs`
-//!    holds the list of every line in itself that writes the word. Those are
+//!    holds the list of every line of its own *code* that writes the word. Not
+//!    every line: the `USAGE` help text writes `wf reap` twice, because that is
+//!    the command it documents, and it is cut out before the list is taken —
+//!    with the cut checked against `USAGE`'s own line count, because an
+//!    unbounded cut was itself an escape. Those are
 //!    greps over the source text of two files: they catch a cleanup wired in by
 //!    accident, and they do not stop anyone who means to get around them. The
 //!    same call made one hop away in a third file is caught by neither, and so
@@ -41,9 +45,12 @@
 //!      `run_picker` composes the registration, the terminal, the `session`
 //!      call and the handover, and no test in this repository executes it, so
 //!      everything it does above and below that call is outside the recording.
-//!      What covers that part of this file is the denylist in (1), widened to
-//!      `fs::` for exactly this reason after a reviewer deleted a workspace
-//!      from `run_picker` with the whole selection green;
+//!      What stands there instead is the denylist in (1), which is why it
+//!      carries `fs` — twice over: a reviewer deleted a workspace from
+//!      `run_picker` with `std::fs::remove_dir_all` and the whole selection
+//!      green, and when the token was added as `fs::`, the next reviewer
+//!      reopened it with `use std::fs as sys;`. It is the bare name now, for
+//!      the reason `reap` is;
 //!    - **which arm**: all four [`Outcome`] arms are driven, the launch one
 //!      included, and so is [`fold`] — but only through the events the child's
 //!      fixtures actually produce. Its `Discovered`, `Fetched` and
@@ -60,11 +67,14 @@
 //!    same run gives the child a scratch `HOME` laid out the way this machine
 //!    is — `~/.cache/devlaunch/repos/<owner>/<repo>/<id>` for the clone,
 //!    `~/.devpod/contexts/<ctx>/workspaces/<id>` for the record — and compares
-//!    the tree before and after. An `fs::remove_dir_all` aimed at a workspace
-//!    fails it *if it runs inside `session`* — the same three bounds as (2)
-//!    apply, and the `run_picker` escape above was one of them being real. An
-//!    `fs` call aimed somewhere else is caught by nothing — as it would be in
-//!    any file of any crate, and this file claims no better.
+//!    the tree before and after. A `remove_dir_all` aimed at a workspace fails
+//!    it *if it runs inside `session`* — the same three bounds as (2) apply,
+//!    and the `run_picker` escape above was one of them being real. An `fs`
+//!    call aimed outside that home, **or written outside `session`** — which is
+//!    the whole of [`run_picker`] and the whole of `main.rs` — is caught by
+//!    nothing here; what covers those two files is the denylist in (1), and
+//!    nothing covers a third file. That is as true of any code in any crate,
+//!    and this file claims no better.
 //!
 //! None of that says the picker deletes nothing at all. [`run_picker`] calls
 //! [`refresh_skills`] on the way into the agent, and a copy that has fallen
@@ -937,36 +947,52 @@ mod tests {
         // [`Picker::tick`] and [`fold`], neither of which is async, and a task
         // that outlives the loop outlives the probe with it.
         //
-        // `fs::` is here because the probe drives [`session`], and
-        // [`run_picker`] is the function *above* it — composed of a
-        // registration, a terminal, the `session` call and the handover, and
-        // executed by no test in this repository. A reviewer planted
-        // `std::fs::remove_dir_all` in `run_picker` aimed at the real layout
+        // `fs` is here because the probe drives [`session`], and [`run_picker`]
+        // is the function *above* it — composed of a registration, a terminal,
+        // the `session` call and the handover, and executed by no test in this
+        // repository. A reviewer planted `std::fs::remove_dir_all` in
+        // `run_picker` aimed at the real layout
         // (`~/.cache/devlaunch/repos/<owner>/<repo>/<id>` and
         // `~/.devpod/contexts/default/workspaces/<id>`); it named none of the
         // four tokens above, the whole selection was green, and driven under a
-        // pty it destroyed a workspace while the picker drew normally. So the
-        // token is what covers the part of this file the run does not reach.
-        // Adding it cost nothing: `fs::` appears nowhere in this file's code.
+        // pty it destroyed a workspace while the picker drew normally.
         //
-        // It is *not* a claim that nothing on the picker's path can delete, and
-        // a grep over one file could never be one. The same call spelt in
-        // `app.rs` or in a submodule of this module names none of these and
-        // compiles; what stands against it there is the recorded argv and the
-        // scratch home the run above compares — and outside that home, outside
-        // [`session`], or after that run, nothing does, which is true of any
-        // code in any file.
+        // Bare `fs`, and that is the second attempt. The token went on as
+        // `fs::`, and the next reviewer reopened the same escape with one line:
+        // `use std::fs as sys;` writes no `fs::` anywhere, and
+        // `sys::remove_dir_all(…)` in `run_picker` was green again and really
+        // destroyed the fixture. It is the same lesson `reap` above is written
+        // from — the module cannot be reached without its own name being
+        // written — and it was not applied here the first time. Measured:
+        // `fs::` in the list is green against the alias and the bare name is
+        // bins 16/1; bare `fs` still costs this file nothing, because `fs`
+        // does not occur in its code at all, in an identifier or anywhere else.
         //
-        // The list is still one short of the ones [`wf::reclaim`] and
-        // [`wf::refresh`] carry. Those two also forbid `remove`, and this file
-        // cannot: `app.failed.remove(&id)` is `App`'s own bookkeeping, one
-        // occurrence, and renaming a `HashMap` method to satisfy a grep is the
-        // distortion a previous round was asked to undo. `"rm"` and `--force`
-        // are absent from this file's code and could be added at no cost; they
-        // are the argv of the subprocess `Command` and `process::` already
-        // forbid spelling, and the recorded run reads argv directly.
+        // So what this token covers is the part of this file the run does not
+        // reach. It is *not* a claim that nothing on the picker's path can
+        // delete, and a grep over one file could never be one. The same call
+        // spelt in `app.rs` or in a submodule of this module names none of
+        // these and compiles; what stands against it there is the recorded argv
+        // and the scratch home the run above compares — and outside that home,
+        // outside [`session`], or after that run, nothing does, which is true
+        // of any code in any file.
+        //
+        // The list is five tokens, against six in [`wf::reclaim`] and seven in
+        // [`wf::refresh`], and the difference is worth writing down rather than
+        // rounding off. Both siblings forbid `remove`, `"rm"` and `--force`;
+        // this file forbids none of the three. `remove` it cannot:
+        // `app.failed.remove(&id)` is `App`'s own bookkeeping, one occurrence,
+        // and renaming a `HashMap` method to satisfy a grep is the distortion a
+        // previous round was asked to undo. `"rm"` and `--force` are absent
+        // from this file's code and could be added at no cost; they are the
+        // argv of the subprocess `Command` and `process::` already forbid
+        // spelling, and the recorded run reads argv directly. Going the other
+        // way, `tokio::spawn` is on this list and on neither sibling's, because
+        // a task spawned here outlives the loop and the probe with it; `reap`
+        // is here and in `refresh`'s list but not in `reclaim`'s, which calls
+        // `reap::plan` and `reap::doomed` by name and pins that call instead.
         let code = probe::code_only("picker.rs", include_str!("picker.rs"));
-        for forbidden in ["reap", "Command", "process::", "tokio::spawn", "fs::"] {
+        for forbidden in ["reap", "Command", "process::", "tokio::spawn", "fs"] {
             assert!(
                 !code.contains(forbidden),
                 "the picker draws a screen and drains a channel: it names {forbidden:?}"

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,30 +1,49 @@
 //! The picker: the screen, the loop that feeds it, and the handover (#26/#34).
 //!
-//! A module of the `wf` binary rather than lines of [`main`](crate::main),
-//! because of what #137 needs to be able to say. The background reading of what
-//! a `wf reap` would claim flows through this assembly — spawned here, carried
-//! on the one channel, folded here, drawn from here — and "nothing on that path
-//! can delete a workspace" is a claim about *the whole assembly*, not about one
-//! expression in it. `main.rs` also owns `wf reap`, which deletes for a living,
-//! so a denylist over `main.rs` could never be more than a claim about a region
-//! of it. Over this file it is one grep with nothing carved out:
-//! [`tests::no_deletion_is_reachable_from_the_picker`].
+//! The background reading of what a `wf reap` would claim flows through this
+//! assembly — spawned in [`session`], carried on the one channel, folded in
+//! [`fold`], drawn from [`Picker::tick`] — and #137 asks that nothing on that
+//! path be able to delete a workspace. Three things carry that, and it is worth
+//! being exact about which one carries what, because two review rounds were
+//! spent on a claim that was larger than its evidence.
 //!
-//! The three joints that grep covers, each of which was reachable before this
-//! file existed: [`Picker::tick`]'s drain loop, [`fold`]'s arms, and
-//! [`spawn_reading`] — the composition site where the reading becomes a task.
-//! Two of them are also watched at run time, as argv, by the probe below.
+//! 1. **Reap's deletion cannot be named here at all.** `wf::reap`'s `remove` is
+//!    private to its module, in the library; this is the binary. Every route
+//!    three rounds of review found into a deletion — a prologue in `main`, a
+//!    helper in `main.rs`, an aliased import, a submodule of this file — ended
+//!    at that function, and every one of them is now a compile error. Nothing
+//!    has to notice; the build refuses.
+//! 2. **Running a command is watched, over the whole loop.**
+//!    [`tests::no_deletion_survives_a_whole_session_of_the_real_assembly`]
+//!    drives [`session`] for real against recording `dl` and `gh` shims, so a
+//!    `dl <ws> rm` reached from anywhere the loop can reach — a helper in
+//!    `app.rs`, a task spawned in a fold arm, a function named nothing anyone
+//!    thought to forbid — is written down as argv. This is the guard that does
+//!    not care what file the route was spelt in.
+//! 3. **Destruction that runs no command is watched where it would land.** The
+//!    same run gives the child a scratch `HOME` holding a directory per
+//!    workspace the fixture lists, and compares the tree before and after. An
+//!    `fs::remove_dir_all` aimed at a workspace fails it. An `fs` call aimed
+//!    somewhere else is caught by nothing — as it would be in any file of any
+//!    crate, and this file claims no better.
+//!
+//! What is left of the source-text guard is
+//! [`tests::the_picker_names_no_way_of_running_a_command`], which is three
+//! tokens about starting subprocesses and outliving the loop. It is not the
+//! separation; (1) is.
 //!
 //! The ordering that matters is at the bottom of [`run_picker`]: restore the
 //! terminal, *then* exec, because after the exec there is no `wf` left to
 //! restore anything.
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use ratatui::backend::Backend;
-use ratatui::crossterm::event::{self, Event, KeyEventKind};
-use ratatui::{DefaultTerminal, Terminal};
+use ratatui::crossterm::event::{self, Event, KeyEvent, KeyEventKind};
+use ratatui::Terminal;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 
@@ -37,7 +56,51 @@ use wf::skills;
 
 /// How long the loop waits on a keypress before redrawing — the cadence at
 /// which streamed load events reach the screen.
-const TICK: std::time::Duration = std::time::Duration::from_millis(250);
+const TICK: Duration = Duration::from_millis(250);
+
+/// Where the loop's keypresses come from.
+///
+/// Injected rather than read straight from the terminal, and that is the
+/// difference between [`run`] being observable and not. A loop that calls
+/// `crossterm::event::poll` can only be entered by a process attached to a
+/// tty — so for three review rounds `run`'s body was the one part of this
+/// assembly nothing drove, and every escape that was found in that time was
+/// written into it. The probe below now drives the real loop with a scripted
+/// keyboard; anything the loop reaches for is recorded as argv.
+///
+/// `async` because the loop has no other await point. On the real terminal
+/// this blocks the thread inside `poll`, exactly as the inline call it
+/// replaced did; in the probe it is a `sleep`, which is what lets a
+/// current-thread runtime poll the background reading between frames — and
+/// what gives a task a fold arm *spawned* the window a real loop would.
+trait Keys {
+    /// The next key **press**, or `None` when `timeout` elapsed with nothing
+    /// to report. Releases and repeats are not presses and are not reported.
+    ///
+    /// `app` is what was just painted. The real keyboard has no use for it —
+    /// the person reading the screen is the one holding that — but it is what
+    /// lets the probe drive the loop the way a person does: watch for the
+    /// thing it came to see, then quit.
+    async fn next_press(&mut self, app: &App, timeout: Duration) -> Result<Option<KeyEvent>>;
+}
+
+/// The real keyboard: whatever is typed at the terminal `wf` is attached to.
+struct Typed;
+
+impl Keys for Typed {
+    async fn next_press(&mut self, _app: &App, timeout: Duration) -> Result<Option<KeyEvent>> {
+        if !event::poll(timeout)? {
+            return Ok(None);
+        }
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press => Ok(Some(key)),
+            // A release, a repeat, a resize, a paste: nothing the picker acts
+            // on, and indistinguishable from the timeout as far as the loop is
+            // concerned — it redraws and asks again.
+            _ => Ok(None),
+        }
+    }
+}
 
 /// Why the event loop ended — the two ways `wf` gives the terminal back.
 ///
@@ -95,14 +158,11 @@ impl Picker {
     ///
     /// **Deliberately not `async`**, for the reason [`fold`] is not: draining a
     /// channel and painting a buffer read no file, run no process and wait for
-    /// nothing. This is the loop body that used to sit inside [`run`], where it
-    /// was async by inheritance — and where `reap::remove(id, false).await` was
-    /// three lines of edit away from deleting every workspace the reading had
-    /// just named, unattended. Here that edit does not compile.
+    /// nothing, and the signature is where that is said.
     ///
     /// Generic over the backend so the probe can drive a real tick against a
-    /// `TestBackend`: the thing under test is the assembly, and an assembly
-    /// only a terminal can enter is one nothing observes.
+    /// `TestBackend` — the same genericity [`run`] has, and for the same
+    /// reason: an assembly only a terminal can enter is one nothing observes.
     fn tick<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<()> {
         // A fetch swaps one map's cluster; App::replace_clusters keeps the
         // cursor pinned to row identity, query and scope untouched.
@@ -129,10 +189,15 @@ impl Picker {
 ///
 /// **Deliberately not `async`.** Folding an arrival into the app state reads no
 /// file, runs no process and waits for nothing — the work was all done by the
-/// task that sent the event. Saying so in the signature is what makes #137's
-/// separation structural at this end of the path: this is where a reap would be
-/// wired if anyone ever wired one, and a function that cannot await cannot ask
-/// `dl` to remove anything.
+/// task that sent the event, and a signature that says so is a signature the
+/// next reader can rely on.
+///
+/// It is worth saying what that does *not* buy, because an earlier round of
+/// this file said it did. Not being async rules out `.await` in these arms and
+/// nothing more: a synchronous `std::process::Command`, or a `tokio::spawn`ed
+/// task, reaches `dl` from here perfectly well. What actually stops a deletion
+/// in this arm is the module doc's (1) and (2) — the deletion cannot be named,
+/// and running a command is recorded.
 fn fold(
     event: LoadEvent,
     app: &mut App,
@@ -171,11 +236,7 @@ fn fold(
             app.startup.record_arrival(&id);
             match outcome {
                 MapFetch::Loaded(new_map) => {
-                    // `retain` rather than the set method that shares its name
-                    // with the thing this whole file may not do — see
-                    // [`tests::no_deletion_is_reachable_from_the_picker`]. It
-                    // also matches the two lines above it.
-                    app.failed.retain(|failed| failed != &id);
+                    app.failed.remove(&id);
                     clusters.insert(id, new_map);
                     app.replace_clusters(clusters.clone());
                 }
@@ -233,45 +294,71 @@ async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
 /// The event loop. It starts with **no data at all** (#27): which repos even
 /// have maps, and the maps themselves, arrive as [`LoadEvent`]s while the screen
 /// is already up and answering keys.
-async fn run(
-    terminal: &mut DefaultTerminal,
+///
+/// Generic over the backend and over [`Keys`] so that the probe drives *this*
+/// function rather than a hand-written imitation of it. Everything the loop
+/// body can reach — a helper in another module, a task it spawns, a `dl` it
+/// shells out to — is recorded there as argv, and the escapes three review
+/// rounds found were all one line inside this loop.
+async fn run<B: Backend, K: Keys>(
+    terminal: &mut Terminal<B>,
+    keys: &mut K,
     mut picker: Picker,
     discovery: JoinHandle<()>,
     survey: Survey,
 ) -> Result<Ending> {
     loop {
         picker.tick(terminal)?;
-        if event::poll(TICK)? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind != KeyEventKind::Press {
-                    continue;
-                }
-                match picker.app.handle_key(key) {
-                    Outcome::Quit => return Ok(Ending::Quit),
-                    // Through the loaders, not alongside them: a refetch that
-                    // raced an in-flight load used to be silently overwritten
-                    // by the older snapshot. One channel, send order, newest
-                    // write wins. Results stream in as they land, so the last
-                    // word on how it went is the count line, not this notice.
-                    Outcome::Refresh => {
-                        picker.loaders.restart(&picker.app.open_maps, &picker.tx);
-                        picker.app.startup.reloading();
-                        picker.app.failed.clear();
-                    }
-                    // Nothing after this can be drawn. Stop the background work
-                    // *and wait for it* before handing over: an in-flight `gh`
-                    // outlives the `exec` otherwise, and the agent inherits it
-                    // as a zombie holding the terminal it just took over.
-                    Outcome::Launch(launch) => {
-                        picker.loaders.shutdown().await;
-                        stop_background(discovery, survey).await;
-                        return Ok(Ending::Handover(launch));
-                    }
-                    Outcome::Continue => {}
-                }
+        let Some(key) = keys.next_press(&picker.app, TICK).await? else {
+            continue;
+        };
+        match picker.app.handle_key(key) {
+            Outcome::Quit => return Ok(Ending::Quit),
+            // Through the loaders, not alongside them: a refetch that
+            // raced an in-flight load used to be silently overwritten
+            // by the older snapshot. One channel, send order, newest
+            // write wins. Results stream in as they land, so the last
+            // word on how it went is the count line, not this notice.
+            Outcome::Refresh => {
+                picker.loaders.restart(&picker.app.open_maps, &picker.tx);
+                picker.app.startup.reloading();
+                picker.app.failed.clear();
             }
+            // Nothing after this can be drawn. Stop the background work
+            // *and wait for it* before handing over: an in-flight `gh`
+            // outlives the `exec` otherwise, and the agent inherits it
+            // as a zombie holding the terminal it just took over.
+            Outcome::Launch(launch) => {
+                picker.loaders.shutdown().await;
+                stop_background(discovery, survey).await;
+                return Ok(Ending::Handover(launch));
+            }
+            Outcome::Continue => {}
         }
     }
+}
+
+/// Compose the picker over one channel and run it to an [`Ending`].
+///
+/// Everything between the terminal and the ending: the two pieces of background
+/// work, the state the screen is drawn from, and the loop that joins them. A
+/// function rather than lines of [`run_picker`] because this is the composition
+/// site — where the reading becomes a task — and the probe drives it whole.
+/// Awaiting the reading here rather than spawning it, folding a deletion into
+/// the loop, reaching for `dl` from a helper in any other file: all of it is
+/// inside what the probe records.
+async fn session<B: Backend, K: Keys>(
+    terminal: &mut Terminal<B>,
+    keys: &mut K,
+    app: App,
+    repos: Vec<String>,
+    cache_path: PathBuf,
+) -> Result<Ending> {
+    let (tx, updates) = mpsc::unbounded_channel();
+    let discovery = wf::refresh::spawn_discovery(repos, cache_path, tx.clone());
+    let survey = spawn_reading(&tx);
+    let picker = Picker::new(app, tx, updates);
+    run(terminal, keys, picker, discovery, survey).await
 }
 
 /// Everything `wf` with no arguments does: register the checkout, put the
@@ -327,11 +414,11 @@ pub async fn run_picker() -> Result<()> {
     let mut terminal = ratatui::init();
     crate::spawn_terminal_guard();
 
-    let (tx, updates) = mpsc::unbounded_channel();
-    let discovery = wf::refresh::spawn_discovery(repos, cache_path.clone(), tx.clone());
-    let survey = spawn_reading(&tx);
-    let picker = Picker::new(app, tx, updates);
-    let ending = run(&mut terminal, picker, discovery, survey).await;
+    // Everything from here to the ending is [`session`], which the probe drives
+    // for real against a `TestBackend` and a scripted keyboard. What is left
+    // outside it is this terminal and the handover below, neither of which a
+    // test can stand up.
+    let ending = session(&mut terminal, &mut Typed, app, repos, cache_path.clone()).await;
 
     // The one ordering that matters, and the reason the exec is here rather
     // than in the loop: the terminal must be back in the shell's hands before
@@ -427,40 +514,100 @@ fn refresh_skills(agent: Agent) {
 mod tests {
     use super::*;
     use crate::probe;
+    use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 
-    /// How long the probe lets a spawned task run before it reads the log.
+    /// How long the loop runs on after the reading has reached the screen.
     ///
-    /// The reason this is not zero. `#[tokio::test]`'s current-thread runtime
-    /// polls a spawned task only at an await point, so a probe body that stops
-    /// awaiting after the work it is watching gives `tokio::spawn(async move {
-    /// reap::remove(&id, true).await })` a window of exactly nothing — the task
-    /// is dropped unpolled and the deletion "did not happen". In the real event
-    /// loop that window is seconds. This is the window this probe gives it, and
-    /// it is generous on purpose: what is being watched is a `/bin/sh` shim.
-    const SETTLE: std::time::Duration = std::time::Duration::from_millis(400);
+    /// The reason this is not zero. A current-thread runtime polls a spawned
+    /// task only at an await point, so a probe that stopped the moment it had
+    /// what it came for would give `tokio::spawn(async move { … })` in a fold
+    /// arm a window of exactly nothing — the task is dropped unpolled and the
+    /// deletion "did not happen". In the real event loop that window is
+    /// seconds. This is the window this probe gives it, and it is generous on
+    /// purpose: what is being watched is a `/bin/sh` shim.
+    const SETTLE: Duration = Duration::from_millis(400);
 
     /// How long the probe will wait for the background reading to arrive
-    /// before giving up and drawing whatever it has. A reading that never lands
-    /// leaves the screen without the count line the assertions want, which is a
-    /// failure with a readable message rather than a hang.
-    const LANDING: std::time::Duration = std::time::Duration::from_secs(10);
+    /// before quitting anyway. A reading that never lands leaves the screen
+    /// without the count line the assertions want, which is a failure with a
+    /// readable message rather than a hang.
+    const LANDING: Duration = Duration::from_secs(10);
 
-    /// A whole `run`-style tick, driven for real in a child process whose `dl`
-    /// and `gh` are recording shims.
+    /// A scripted keyboard, and the only thing about the probe's run that is
+    /// not the real thing.
     ///
-    /// This is the assembly, not a value handed to one function of it: the
-    /// composition site starts the real [`wf::reclaim::survey_live`], the real
-    /// channel carries the real reading, [`Picker::tick`]'s drain loop folds it
-    /// and the real [`wf::ui::draw`] paints it. Everything any of that reaches
-    /// for is written down as argv, in order, whatever module it was spelt in
-    /// and whatever the function was called.
+    /// It drives the loop the way a person does: watch the screen, wait for
+    /// what you came for, then quit. The first time it is asked for a key the
+    /// first frame has just been painted and nothing else has happened yet, so
+    /// that is where the ordering note goes.
+    struct Script {
+        /// When to quit regardless, so a reading that never lands ends the run.
+        deadline: std::time::Instant,
+        /// When the reading first reached the app. The loop runs on for
+        /// [`SETTLE`] past this — see there.
+        landed: Option<std::time::Instant>,
+        /// Whether the first frame has been noted yet.
+        noted: bool,
+    }
+
+    impl Script {
+        fn new() -> Self {
+            Self {
+                deadline: std::time::Instant::now() + LANDING,
+                landed: None,
+                noted: false,
+            }
+        }
+    }
+
+    impl Keys for Script {
+        async fn next_press(&mut self, app: &App, timeout: Duration) -> Result<Option<KeyEvent>> {
+            if !self.noted {
+                self.noted = true;
+                // The first frame is painted and nothing has been awaited
+                // since: on a current-thread runtime the reading spawned at the
+                // composition site cannot have been polled yet, so anything
+                // already in the log above this note was waited for by the
+                // frame. That is the whole of what
+                // `the_first_frame_is_drawn_before_anything_is_asked` reads.
+                probe::note("the first frame");
+            }
+            if self.landed.is_none() && app.reclaimable.is_some() {
+                self.landed = Some(std::time::Instant::now());
+            }
+            let seen_enough = self.landed.is_some_and(|at| at.elapsed() >= SETTLE);
+            if seen_enough || std::time::Instant::now() >= self.deadline {
+                return Ok(Some(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)));
+            }
+            // Far shorter than the real `TICK`, because this is the probe's own
+            // cadence and a probe that took a quarter of a second per frame
+            // would cost seconds per assertion. It is an `await`, which is what
+            // matters: it is the only point in the loop at which anything
+            // spawned gets to run.
+            tokio::time::sleep(timeout / 25).await;
+            Ok(None)
+        }
+    }
+
+    /// A whole session, driven for real in a child process whose `dl` and `gh`
+    /// are recording shims and whose `HOME` is a scratch machine with the
+    /// fixture's workspaces on it.
     ///
-    /// The runtime is built by hand rather than by `#[tokio::test]` so the
-    /// probe can hold it open past the tick and let anything spawned during the
-    /// tick actually run — see [`SETTLE`].
+    /// This is the assembly and not an imitation of it: [`session`] is the
+    /// function `run_picker` calls, it starts the real
+    /// [`wf::reclaim::survey_live`] and the real discovery, the real channel
+    /// carries the real reading, [`run`]'s own loop turns, [`Picker::tick`]
+    /// drains and the real [`wf::ui::draw`] paints. Everything any of that
+    /// reaches for is written down — as argv if it ran a command, as a
+    /// disturbed path if it touched the scratch home — whatever module it was
+    /// spelt in, under whatever name, from whatever submodule.
+    ///
+    /// The runtime is built by hand rather than by `#[tokio::test]` so that it
+    /// is current-thread: that is what makes the ordering above deterministic
+    /// rather than a race between the first frame and a worker thread.
     #[test]
     #[ignore = "run by `probe::record` from the tests below, under recording shims"]
-    fn picker_tick_probe() {
+    fn picker_session_probe() {
         if !probe::is_child() {
             return;
         }
@@ -470,35 +617,24 @@ mod tests {
             .expect("a runtime for the probe");
         let backend = ratatui::backend::TestBackend::new(100, 12);
         let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut keys = Script::new();
 
-        // One `block_on` around the whole thing, so that every tick runs inside
-        // the runtime exactly as `run`'s does. A tick driven from outside one
-        // would make `tokio::spawn` in a fold arm *panic* rather than run, and
-        // a probe that cannot observe the escape it exists for is a probe that
-        // reports the wrong reason.
-        runtime.block_on(async {
-            let (tx, updates) = mpsc::unbounded_channel();
-            let survey = spawn_reading(&tx);
-            let mut picker = Picker::new(App::empty(), tx, updates);
-            // The first frame, with nothing awaited between the spawn above and
-            // this line — exactly as `run_picker` has nothing between them. On
-            // a current-thread runtime that is what makes the ordering a fact
-            // rather than a race: the spawned reading cannot have been polled,
-            // so anything in the log above the note was awaited by the frame.
-            picker.tick(&mut terminal).expect("the first frame");
-            probe::note("the first frame");
-
-            // Now let it land, the way the loop does: tick again each time
-            // round, until the reading is on screen.
-            let deadline = std::time::Instant::now() + LANDING;
-            while picker.app.reclaimable.is_none() && std::time::Instant::now() < deadline {
-                tokio::time::sleep(SETTLE / 20).await;
-                picker.tick(&mut terminal).expect("a later frame");
-            }
-            // And give whatever the ticks spawned the window a real loop would.
-            tokio::time::sleep(SETTLE).await;
-            drop(survey);
-        });
+        // No repos, so the map search answers immediately without asking `gh`
+        // anything — the reading is what this run is about, and a discovery
+        // that fetched would only add noise to the log. The cache it writes
+        // goes in the probe's own scratch directory rather than under `HOME`,
+        // because `HOME` is the thing being watched for changes.
+        let ending = runtime.block_on(session(
+            &mut terminal,
+            &mut keys,
+            App::empty(),
+            Vec::new(),
+            probe::child_scratch().join("projects.json"),
+        ));
+        assert!(
+            matches!(ending.expect("the session"), Ending::Quit),
+            "the scripted keyboard quits, and nothing else ends this loop"
+        );
 
         let buf = terminal.backend().buffer();
         for y in 0..buf.area.height {
@@ -510,32 +646,34 @@ mod tests {
         }
     }
 
-    /// One recorded run of [`picker_tick_probe`], for the assertions below to
-    /// share. Each of them calls this rather than the probe directly, because
-    /// the child costs a process and a `SETTLE`.
-    fn a_tick() -> probe::Recording {
+    /// One recorded run of [`picker_session_probe`], for the assertions below
+    /// to share. Each of them calls this rather than the probe directly,
+    /// because the child costs a process and a `SETTLE`.
+    fn a_session() -> probe::Recording {
         probe::record(
-            "picker::tests::picker_tick_probe",
+            "picker::tests::picker_session_probe",
             probe::DL_LISTING,
             probe::GH_FACTS,
         )
     }
 
     #[test]
-    fn no_deletion_survives_a_whole_tick_of_the_real_assembly() {
+    fn no_deletion_survives_a_whole_session_of_the_real_assembly() {
         // #137's safety claim as a fact about a run, over the assembly rather
         // than over one expression in it. Between the composition site and the
-        // painted frame there is exactly one thing this may ask of the machine:
+        // last frame there is exactly one thing this may ask of the machine:
         // what exists, and what the tracker says about it. A `dl <ws> rm` added
-        // anywhere in that span — in the drain loop, inside a `tokio::spawn`,
-        // behind a helper named nothing anyone thought to forbid — is recorded
-        // here, because destroying a workspace means running `dl`.
-        let run = a_tick();
+        // anywhere in that span — in `run`'s loop, in the drain loop, inside a
+        // `tokio::spawn`, behind a helper in another file named nothing anyone
+        // thought to forbid — is recorded here, because destroying a workspace
+        // means running `dl`. And a destruction that runs no command at all is
+        // caught by the scratch home, which must come back untouched.
+        let run = a_session();
         run.destroyed_nothing();
         assert_eq!(
             run.argv.len(),
             3,
-            "a tick asks for the listing and the tracker, and nothing else: {:?}",
+            "a session asks for the listing and the tracker, and nothing else: {:?}",
             run.argv
         );
         assert_eq!(run.argv[1], "dl <--ls> <--json>");
@@ -550,11 +688,13 @@ mod tests {
     fn the_first_frame_is_drawn_before_anything_is_asked() {
         // #137's other property, pinned rather than asserted. The reading costs
         // a subprocess and a round trip; the first frame must not be behind
-        // either. The probe writes its note the instant the frame is painted,
-        // into the same log the shims append to, so the ordering is a recorded
-        // fact: awaiting the reading at the composition site — which *does*
-        // compile — puts `dl <--ls> <--json>` above the note and fails here.
-        let run = a_tick();
+        // either. The script writes its note the first time the loop asks it
+        // for a key, which is the instant after the first frame is painted,
+        // into the same log the shims append to — so the ordering is a recorded
+        // fact: awaiting the reading anywhere in `session` before the loop
+        // starts, which *does* compile, puts `dl <--ls> <--json>` above the
+        // note and fails here.
+        let run = a_session();
         assert_eq!(
             run.argv.first().map(String::as_str),
             Some("note <the first frame>"),
@@ -571,7 +711,7 @@ mod tests {
         // dropped the payload on the floor — `Reclaimable(_) => {}` — leaves
         // every other test in this tree green, because every other test hands
         // the reading to the thing it is testing.
-        let run = a_tick();
+        let run = a_session();
         let screen = run.printed();
         let line = screen
             .iter()
@@ -586,37 +726,33 @@ mod tests {
     }
 
     #[test]
-    fn no_deletion_is_reachable_from_the_picker() {
-        // The structural half, which the run above cannot cover: a subprocess
-        // is observable and `std::fs::remove_dir_all` is not. So argv is
-        // watched at run time and the means of destruction that leave no argv
-        // are pinned here, over the *whole* file — the composition site, the
-        // drain loop, every arm of the fold and the loop around them. This
-        // module drains a channel, writes app state and paints a buffer, and
-        // has no business naming any of these.
+    fn the_picker_names_no_way_of_running_a_command() {
+        // What is left for source text to say, now that the deletion itself is
+        // out of reach by construction — `wf::reap`'s `remove` is private to
+        // its module, in a *different crate* from this one, so no helper, no
+        // alias and no submodule of the binary can call it and the edit that
+        // tries is a compile error rather than a test failure.
         //
-        // `reap` is on the list bare, not as `reap::`, and that is the point:
-        // `use wf::reap as tidy;` spells no `::` and would then reach the
-        // deletion side under a name nobody forbade. Every route to that module
-        // has to say the word somewhere, so the word is what is forbidden.
-        // `tokio::spawn` is on it because a spawned task is how an `.await`
-        // gets into a function that has none, which is the one way round
-        // [`Picker::tick`] and [`fold`] not being async.
+        // This is much narrower than the list it replaces, and it is worth
+        // being exact about what it is for. Shelling out to `dl` is caught by
+        // the run above, over the whole loop, whatever file it is spelt in.
+        // What that run cannot catch is a subprocess this file starts *after*
+        // the probe stops watching — so `Command` and `process::` stay
+        // forbidden here, where a screen-painting module has no use for either.
+        // `tokio::spawn` is on the list because a spawned task is how an
+        // `.await` gets into [`Picker::tick`] and [`fold`], neither of which is
+        // async, and a task that outlives the loop outlives the probe with it.
+        //
+        // It is *not* a claim that nothing in the picker's path can delete.
+        // `std::fs::remove_dir_all` in a submodule of this module names none of
+        // these and would compile; what stops it is the scratch home the run
+        // above compares, and outside that home nothing stops it — which is
+        // true of any code in any file in any crate.
         let code = probe::code_only(include_str!("picker.rs"));
-        for forbidden in [
-            "reap",
-            "remove",
-            "\"rm\"",
-            "--force",
-            "Command",
-            "process::",
-            "fs::",
-            "unsafe",
-            "tokio::spawn",
-        ] {
+        for forbidden in ["Command", "process::", "tokio::spawn"] {
             assert!(
                 !code.contains(forbidden),
-                "the picker must not be able to delete a workspace: it names {forbidden:?}"
+                "the picker draws a screen and drains a channel: it names {forbidden:?}"
             );
         }
     }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -965,9 +965,21 @@ mod tests {
         // from — the module cannot be reached without its own name being
         // written — and it was not applied here the first time. Measured:
         // `fs::` in the list is green against the alias and the bare name is
-        // bins 16/1; bare `fs` still costs this file nothing, because `fs`
+        // bins 16/1; bare `fs` costs this file nothing *today*, because `fs`
         // does not occur in its code at all, in an identifier or anywhere else.
         //
+        // That "today" is the cost, and it is worth writing down rather than
+        // discovering: this is a substring match, so bare `fs` also forbids
+        // `offset`, `refs` and `prefs`. Measured — `let offset = 0usize;` in
+        // this file is bins 16/1, reporting *it names "fs"*, which is a
+        // misleading message for an edit that reaches nothing. This is a
+        // scrolling list, so a scroll offset is a plausible future edit, and
+        // the maintainer who hits it will be told the wrong thing. It is the
+        // same class of cost `remove` already imposes (see `app.failed`
+        // above, which is written `retain` for exactly this reason); the
+        // token stays because an argv-less deletion is worse than a confusing
+        // test failure, but the next person should not have to rediscover why
+        // their `offset` is red.
         // So what this token covers is the part of this file the run does not
         // reach. It is *not* a claim that nothing on the picker's path can
         // delete, and a grep over one file could never be one. The same call

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,0 +1,657 @@
+//! The picker: the screen, the loop that feeds it, and the handover (#26/#34).
+//!
+//! A module of the `wf` binary rather than lines of [`main`](crate::main),
+//! because of what #137 needs to be able to say. The background reading of what
+//! a `wf reap` would claim flows through this assembly — spawned here, carried
+//! on the one channel, folded here, drawn from here — and "nothing on that path
+//! can delete a workspace" is a claim about *the whole assembly*, not about one
+//! expression in it. `main.rs` also owns `wf reap`, which deletes for a living,
+//! so a denylist over `main.rs` could never be more than a claim about a region
+//! of it. Over this file it is one grep with nothing carved out:
+//! [`tests::no_deletion_is_reachable_from_the_picker`].
+//!
+//! The three joints that grep covers, each of which was reachable before this
+//! file existed: [`Picker::tick`]'s drain loop, [`fold`]'s arms, and
+//! [`spawn_reading`] — the composition site where the reading becomes a task.
+//! Two of them are also watched at run time, as argv, by the probe below.
+//!
+//! The ordering that matters is at the bottom of [`run_picker`]: restore the
+//! terminal, *then* exec, because after the exec there is no `wf` left to
+//! restore anything.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use ratatui::backend::Backend;
+use ratatui::crossterm::event::{self, Event, KeyEventKind};
+use ratatui::{DefaultTerminal, Terminal};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::task::JoinHandle;
+
+use wf::app::{App, Outcome};
+use wf::launch::{Agent, Launch};
+use wf::model::{Map, MapId};
+use wf::projects::{self, ProjectsCache};
+use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup, Survey};
+use wf::skills;
+
+/// How long the loop waits on a keypress before redrawing — the cadence at
+/// which streamed load events reach the screen.
+const TICK: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Why the event loop ended — the two ways `wf` gives the terminal back.
+///
+/// A sum rather than "quit, plus maybe a launch on the side": these are the
+/// only two exits, they are mutually exclusive, and the second carries exactly
+/// what the caller needs to finish the job. Nothing here performs the launch,
+/// because performing it means the terminal must already be restored — and this
+/// value is what carries that requirement out to where it can be met.
+enum Ending {
+    /// The user quit.
+    Quit,
+    /// A ticket was picked. `wf`'s last act is to become its agent.
+    Handover(Box<Launch>),
+}
+
+/// Everything the screen is drawn from, and the arrivals that change it.
+///
+/// Held together so that [`tick`](Picker::tick) — draining the channel and
+/// drawing the result — is a single call a test can make, rather than the body
+/// of a loop only a real terminal can enter. That is what lets the probe below
+/// drive the *assembly* instead of handing a value straight to [`fold`].
+struct Picker {
+    app: App,
+    clusters: BTreeMap<MapId, Map>,
+    loaders: Loaders,
+    /// The sending end, kept because a fold can start further loads.
+    tx: UnboundedSender<LoadEvent>,
+    updates: UnboundedReceiver<LoadEvent>,
+}
+
+impl Picker {
+    /// A picker over an app that has no data yet (#27), with the cached seed's
+    /// fetches already started.
+    fn new(
+        app: App,
+        tx: UnboundedSender<LoadEvent>,
+        updates: UnboundedReceiver<LoadEvent>,
+    ) -> Self {
+        let mut loaders = Loaders::new();
+        // The cached seed starts fetching immediately (#28); the search's answer
+        // reconciles this set rather than adding to it, so a map that closed or
+        // opened is corrected in the tasks actually doing the fetching, not just
+        // in the state the screen reads.
+        loaders.reconcile(&app.open_maps, &tx);
+        Self {
+            app,
+            clusters: BTreeMap::new(),
+            loaders,
+            tx,
+            updates,
+        }
+    }
+
+    /// Drain everything that landed, then draw.
+    ///
+    /// **Deliberately not `async`**, for the reason [`fold`] is not: draining a
+    /// channel and painting a buffer read no file, run no process and wait for
+    /// nothing. This is the loop body that used to sit inside [`run`], where it
+    /// was async by inheritance — and where `reap::remove(id, false).await` was
+    /// three lines of edit away from deleting every workspace the reading had
+    /// just named, unattended. Here that edit does not compile.
+    ///
+    /// Generic over the backend so the probe can drive a real tick against a
+    /// `TestBackend`: the thing under test is the assembly, and an assembly
+    /// only a terminal can enter is one nothing observes.
+    fn tick<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<()> {
+        // A fetch swaps one map's cluster; App::replace_clusters keeps the
+        // cursor pinned to row identity, query and scope untouched.
+        while let Ok(event) = self.updates.try_recv() {
+            fold(
+                event,
+                &mut self.app,
+                &mut self.clusters,
+                &mut self.loaders,
+                &self.tx,
+            );
+        }
+        terminal.draw(|frame| wf::ui::draw(frame, &self.app))?;
+        Ok(())
+    }
+}
+
+/// Fold one arrival into what the screen draws.
+///
+/// Split out of [`Picker::tick`]'s loop so each arm is a call a test can make
+/// and a frame it can read, which is the whole difficulty with an event loop:
+/// everything between the channel and the screen used to be reachable only by
+/// standing up a terminal and driving it.
+///
+/// **Deliberately not `async`.** Folding an arrival into the app state reads no
+/// file, runs no process and waits for nothing — the work was all done by the
+/// task that sent the event. Saying so in the signature is what makes #137's
+/// separation structural at this end of the path: this is where a reap would be
+/// wired if anyone ever wired one, and a function that cannot await cannot ask
+/// `dl` to remove anything.
+fn fold(
+    event: LoadEvent,
+    app: &mut App,
+    clusters: &mut BTreeMap<MapId, Map>,
+    loaders: &mut Loaders,
+    tx: &UnboundedSender<LoadEvent>,
+) {
+    match event {
+        LoadEvent::Discovered(found) => {
+            // Reconciling the loaders *is* the load for every map the
+            // seed did not already cover: those fetches are all in
+            // flight at once and each lands on screen as it arrives.
+            loaders.reconcile(&found, tx);
+            app.startup.searched(&found);
+            // Nothing to apply here any more: the level was decided
+            // before the first frame and discovery has no say in it.
+            // A repo the search finds no map for renders its project
+            // row saying so, which is both the notice this used to
+            // post and somewhere to act on it.
+            //
+            // Maps the search dropped must stop being rendered as well as
+            // stop being fetched — their rows are as stale as their load.
+            // A map that is no longer open also stops being a *failure*:
+            // there is nothing left to have failed.
+            clusters.retain(|id, _| found.contains(id));
+            app.failed.retain(|id| found.contains(id));
+            app.open_maps = found;
+            app.replace_clusters(clusters.clone());
+        }
+        // Discovery retries, so this is a status report and not an end
+        // state: `wf` stays on screen and recovers when the search does.
+        LoadEvent::SearchFailed => {
+            app.notice = Some("map search failed — retrying".to_string());
+        }
+        LoadEvent::Fetched { id, outcome } => {
+            app.startup.record_arrival(&id);
+            match outcome {
+                MapFetch::Loaded(new_map) => {
+                    // `retain` rather than the set method that shares its name
+                    // with the thing this whole file may not do — see
+                    // [`tests::no_deletion_is_reachable_from_the_picker`]. It
+                    // also matches the two lines above it.
+                    app.failed.retain(|failed| failed != &id);
+                    clusters.insert(id, new_map);
+                    app.replace_clusters(clusters.clone());
+                }
+                // Nothing polls any more, so a failed load is not a blip
+                // the next cycle papers over — it is the final word on
+                // that map until someone asks again. Recorded as state
+                // rather than announced as a notice, because a notice
+                // is gone on the next keypress and this is not.
+                MapFetch::Failed => {
+                    app.failed.insert(id);
+                }
+            }
+        }
+        // The background reading landed (#137). A plain state write on
+        // a screen that has been up and answering keys the whole time —
+        // it changes one dim segment of the count line and nothing else,
+        // and it arrives at most once because nothing asks again.
+        LoadEvent::Reclaimable(found) => {
+            app.reclaimable = Some(found);
+        }
+    }
+}
+
+/// Start the background reading of what a `wf reap` would claim (#137).
+///
+/// The composition site, and a function rather than a line inside
+/// [`run_picker`] so that it is somewhere a probe can *call*. Wrapping the
+/// reading here — awaiting it before it is handed over, folding a deletion into
+/// it — is the edit this covers, and the reason the first frame is measured
+/// against it in [`tests::the_first_frame_is_drawn_before_anything_is_asked`].
+///
+/// Read behind the screen exactly as the map search is: a `dl --ls --json`
+/// subprocess and one batched GraphQL call, neither of them on the way to a
+/// frame. It folds into the count line when it lands, says nothing when it
+/// fails, and can delete nothing.
+fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
+    wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone())
+}
+
+/// Stop everything running behind the screen, and wait for it to be gone.
+///
+/// The last thing before a handover, and the reason it is a function of its
+/// own: "aborted *and awaited*" is a claim about two tasks that a test can now
+/// make on both at once. Nothing after this point can be drawn, and the process
+/// is about to be replaced — an in-flight `gh` or `dl` that outlives the `exec`
+/// is inherited by the agent as a child holding the terminal it just took over.
+async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
+    discovery.abort();
+    let _ = discovery.await;
+    // The reading holds a `dl` and a `gh` of its own, and the same reasoning
+    // applies — [`Survey::stop`] is where the waiting is spelt out.
+    survey.stop().await;
+}
+
+/// The event loop. It starts with **no data at all** (#27): which repos even
+/// have maps, and the maps themselves, arrive as [`LoadEvent`]s while the screen
+/// is already up and answering keys.
+async fn run(
+    terminal: &mut DefaultTerminal,
+    mut picker: Picker,
+    discovery: JoinHandle<()>,
+    survey: Survey,
+) -> Result<Ending> {
+    loop {
+        picker.tick(terminal)?;
+        if event::poll(TICK)? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match picker.app.handle_key(key) {
+                    Outcome::Quit => return Ok(Ending::Quit),
+                    // Through the loaders, not alongside them: a refetch that
+                    // raced an in-flight load used to be silently overwritten
+                    // by the older snapshot. One channel, send order, newest
+                    // write wins. Results stream in as they land, so the last
+                    // word on how it went is the count line, not this notice.
+                    Outcome::Refresh => {
+                        picker.loaders.restart(&picker.app.open_maps, &picker.tx);
+                        picker.app.startup.reloading();
+                        picker.app.failed.clear();
+                    }
+                    // Nothing after this can be drawn. Stop the background work
+                    // *and wait for it* before handing over: an in-flight `gh`
+                    // outlives the `exec` otherwise, and the agent inherits it
+                    // as a zombie holding the terminal it just took over.
+                    Outcome::Launch(launch) => {
+                        picker.loaders.shutdown().await;
+                        stop_background(discovery, survey).await;
+                        return Ok(Ending::Handover(launch));
+                    }
+                    Outcome::Continue => {}
+                }
+            }
+        }
+    }
+}
+
+/// Everything `wf` with no arguments does: register the checkout, put the
+/// screen up, run the loop, and either quit or become the agent.
+pub async fn run_picker() -> Result<()> {
+    // Accretive registration: running wf here is what makes this checkout
+    // a project. Non-checkouts and non-GitHub remotes are simply None. This
+    // is local git (<10ms) and the projects cache it writes is what the first
+    // frame is drawn from, so it stays ahead of the screen.
+    let cwd = std::env::current_dir().context("cannot resolve the working directory")?;
+    let here = projects::discover_checkout(&cwd).await;
+    let cache_path =
+        projects::default_cache_path().context("cannot resolve the XDG cache directory")?;
+    let mut cache = ProjectsCache::load_or_default(&cache_path);
+    // Accretion needs a matching forget: a checkout that has been deleted must
+    // stop offering itself as somewhere an agent could run.
+    let pruned = cache.prune_missing();
+    if let Some((path, slug)) = &here {
+        cache.register(path.clone(), slug.clone());
+        cache.save(&cache_path)?;
+    } else if pruned {
+        cache.save(&cache_path)?;
+    }
+    let repos = cache.repos();
+    // The head start (#28): the map numbers the last search found. Reading them
+    // is one local file read that has already happened, so the fetches can start
+    // before the first frame instead of after the ~2.5 s search — which is where
+    // time-to-*data* actually went. The search still runs (see
+    // [`wf::refresh::spawn_discovery`]); this only decides what `wf` fetches
+    // while waiting for it.
+    let seed = cache.map_seed();
+    let mut app = App::empty()
+        .with_checkouts(cache.checkouts.clone())
+        .with_sessions(cache.sessions.clone());
+    app.open_maps = seed.clone();
+    app.startup = Startup::seeded(&seed);
+    // cwd-open enters the project, on the first frame and unconditionally.
+    //
+    // It used to wait: the focus was only applied to a repo the cached seed
+    // already knew had a map, and otherwise handed to the loop to apply when
+    // discovery landed, because a focused repo with no maps rendered an empty
+    // screen. It cannot now — a project's screen leads with the project's own
+    // row, which is a place to stand whether or not anything has been filed in
+    // the repo, let alone fetched. So the level is decided by one local `git`
+    // call, before any network call, and nothing arriving later moves it.
+    if let Some((_, slug)) = &here {
+        app.enter(slug);
+    }
+
+    // The screen goes up *before* any network call (#27). Everything that used
+    // to run here — the map search, a serial fetch per repo — now streams into a
+    // UI that is already drawn and already reading keys.
+    let mut terminal = ratatui::init();
+    crate::spawn_terminal_guard();
+
+    let (tx, updates) = mpsc::unbounded_channel();
+    let discovery = wf::refresh::spawn_discovery(repos, cache_path.clone(), tx.clone());
+    let survey = spawn_reading(&tx);
+    let picker = Picker::new(app, tx, updates);
+    let ending = run(&mut terminal, picker, discovery, survey).await;
+
+    // The one ordering that matters, and the reason the exec is here rather
+    // than in the loop: the terminal must be back in the shell's hands before
+    // the process image is replaced, because afterwards there is no `wf` left
+    // to put it back.
+    //
+    // `show_cursor` is part of that and not a flourish. Nothing in the picker
+    // ever positions a cursor, so every `Terminal::draw` writes `ESC[?25l`, and
+    // the only thing that writes it back is `Terminal`'s `Drop` —
+    // `ratatui::restore()` is just raw-mode-off plus leave-alternate-screen.
+    // On the quit path `Drop` runs at the end of `main`; on the handover path
+    // `exec` replaces the image first and it never runs. So the agent would
+    // inherit an invisible cursor, on a terminal-global mode that outlives the
+    // alternate screen. This is the line the deleted `suspend()` had.
+    let _ = terminal.show_cursor();
+    ratatui::restore();
+    match ending? {
+        Ending::Quit => Ok(()),
+        Ending::Handover(launch) => {
+            // The launch is a use of this project, and the last chance to say
+            // so: after the exec there is no `wf` left to write anything. This
+            // is what keeps the project list ordered for someone who reaches
+            // their projects *through* it — opening `wf` in a checkout stamps
+            // it, and for everyone else launching is the only other act that
+            // means "this is what I am working on".
+            //
+            // Re-read before writing, exactly as the discovery task does: it
+            // writes the search's findings to this same file while the picker
+            // is up, so the copy loaded before the first frame is stale by
+            // now, and saving it would trade this stamp for next run's head
+            // start.
+            //
+            // Best-effort on purpose. A cache that will not write is not worth
+            // refusing a launch over, and the only cost of losing this is one
+            // project sitting lower in a list than it might have.
+            let mut cache = ProjectsCache::load_or_default(&cache_path);
+            let mut changed = cache.touch(launch.cwd());
+            // And record the conversation this launch is about to start, so a
+            // later run can offer the way back into it (#35).
+            //
+            // Written **here**, immediately before the terminal is restored
+            // and the image replaced, because this is the last moment `wf`
+            // exists — and written from the resolved launch rather than from
+            // the picker, so what is remembered is the tree the agent actually
+            // gets. A creation records nothing: it has no node to key on until
+            // its skill files one.
+            //
+            // Best-effort like the stamp above it, and for a smaller cost: a
+            // record that fails to write means the resume row is missing next
+            // time, not that anything is wrong with the launch.
+            if let Some(session) = launch.session() {
+                cache.record_session(session);
+                changed = true;
+            }
+            if changed {
+                let _ = cache.save(&cache_path);
+            }
+            // The prompts the selected agent is about to run. `wf skills
+            // install` links its skills directory at a *copy* of the bundle,
+            // and a copy is a thing that can fall behind a `pixi global update
+            // wf`. This is where it cannot: the process that refreshes it is
+            // the same one that then execs the prompt, so no launch ever gets
+            // ahead by even one release.
+            refresh_skills(launch.agent());
+            // Only ever returns an error: on success this process *is* the agent.
+            Err(launch.exec())
+        }
+    }
+}
+
+/// Bring the installed skill copies back in step with the bundle they were
+/// installed from.
+///
+/// Best-effort, and deliberately silent when there is nothing to do: a machine
+/// with no home directory to resolve, and one that never ran
+/// `wf skills install`, are not worth a word on the way into an agent. A copy
+/// that could not be *written* is different — the agent is about to run a
+/// prompt that is not the one that was installed — so that one is said out
+/// loud.
+fn refresh_skills(agent: Agent) {
+    let Ok(target) = skills::Target::resolve(agent) else {
+        return;
+    };
+    if let Err(err) = skills::refresh(&target) {
+        eprintln!(
+            "wf: could not refresh the {} skills: {err:#}",
+            agent.label()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::probe;
+
+    /// How long the probe lets a spawned task run before it reads the log.
+    ///
+    /// The reason this is not zero. `#[tokio::test]`'s current-thread runtime
+    /// polls a spawned task only at an await point, so a probe body that stops
+    /// awaiting after the work it is watching gives `tokio::spawn(async move {
+    /// reap::remove(&id, true).await })` a window of exactly nothing — the task
+    /// is dropped unpolled and the deletion "did not happen". In the real event
+    /// loop that window is seconds. This is the window this probe gives it, and
+    /// it is generous on purpose: what is being watched is a `/bin/sh` shim.
+    const SETTLE: std::time::Duration = std::time::Duration::from_millis(400);
+
+    /// How long the probe will wait for the background reading to arrive
+    /// before giving up and drawing whatever it has. A reading that never lands
+    /// leaves the screen without the count line the assertions want, which is a
+    /// failure with a readable message rather than a hang.
+    const LANDING: std::time::Duration = std::time::Duration::from_secs(10);
+
+    /// A whole `run`-style tick, driven for real in a child process whose `dl`
+    /// and `gh` are recording shims.
+    ///
+    /// This is the assembly, not a value handed to one function of it: the
+    /// composition site starts the real [`wf::reclaim::survey_live`], the real
+    /// channel carries the real reading, [`Picker::tick`]'s drain loop folds it
+    /// and the real [`wf::ui::draw`] paints it. Everything any of that reaches
+    /// for is written down as argv, in order, whatever module it was spelt in
+    /// and whatever the function was called.
+    ///
+    /// The runtime is built by hand rather than by `#[tokio::test]` so the
+    /// probe can hold it open past the tick and let anything spawned during the
+    /// tick actually run — see [`SETTLE`].
+    #[test]
+    #[ignore = "run by `probe::record` from the tests below, under recording shims"]
+    fn picker_tick_probe() {
+        if !probe::is_child() {
+            return;
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("a runtime for the probe");
+        let backend = ratatui::backend::TestBackend::new(100, 12);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        // One `block_on` around the whole thing, so that every tick runs inside
+        // the runtime exactly as `run`'s does. A tick driven from outside one
+        // would make `tokio::spawn` in a fold arm *panic* rather than run, and
+        // a probe that cannot observe the escape it exists for is a probe that
+        // reports the wrong reason.
+        runtime.block_on(async {
+            let (tx, updates) = mpsc::unbounded_channel();
+            let survey = spawn_reading(&tx);
+            let mut picker = Picker::new(App::empty(), tx, updates);
+            // The first frame, with nothing awaited between the spawn above and
+            // this line — exactly as `run_picker` has nothing between them. On
+            // a current-thread runtime that is what makes the ordering a fact
+            // rather than a race: the spawned reading cannot have been polled,
+            // so anything in the log above the note was awaited by the frame.
+            picker.tick(&mut terminal).expect("the first frame");
+            probe::note("the first frame");
+
+            // Now let it land, the way the loop does: tick again each time
+            // round, until the reading is on screen.
+            let deadline = std::time::Instant::now() + LANDING;
+            while picker.app.reclaimable.is_none() && std::time::Instant::now() < deadline {
+                tokio::time::sleep(SETTLE / 20).await;
+                picker.tick(&mut terminal).expect("a later frame");
+            }
+            // And give whatever the ticks spawned the window a real loop would.
+            tokio::time::sleep(SETTLE).await;
+            drop(survey);
+        });
+
+        let buf = terminal.backend().buffer();
+        for y in 0..buf.area.height {
+            let mut line = String::new();
+            for x in 0..buf.area.width {
+                line.push_str(buf[(x, y)].symbol());
+            }
+            println!("{}{}", probe::MARK, line.trim_end());
+        }
+    }
+
+    /// One recorded run of [`picker_tick_probe`], for the assertions below to
+    /// share. Each of them calls this rather than the probe directly, because
+    /// the child costs a process and a `SETTLE`.
+    fn a_tick() -> probe::Recording {
+        probe::record(
+            "picker::tests::picker_tick_probe",
+            probe::DL_LISTING,
+            probe::GH_FACTS,
+        )
+    }
+
+    #[test]
+    fn no_deletion_survives_a_whole_tick_of_the_real_assembly() {
+        // #137's safety claim as a fact about a run, over the assembly rather
+        // than over one expression in it. Between the composition site and the
+        // painted frame there is exactly one thing this may ask of the machine:
+        // what exists, and what the tracker says about it. A `dl <ws> rm` added
+        // anywhere in that span — in the drain loop, inside a `tokio::spawn`,
+        // behind a helper named nothing anyone thought to forbid — is recorded
+        // here, because destroying a workspace means running `dl`.
+        let run = a_tick();
+        run.destroyed_nothing();
+        assert_eq!(
+            run.argv.len(),
+            3,
+            "a tick asks for the listing and the tracker, and nothing else: {:?}",
+            run.argv
+        );
+        assert_eq!(run.argv[1], "dl <--ls> <--json>");
+        assert!(
+            run.argv[2].starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"),
+            "one batched read of the tracker: {}",
+            run.argv[2]
+        );
+    }
+
+    #[test]
+    fn the_first_frame_is_drawn_before_anything_is_asked() {
+        // #137's other property, pinned rather than asserted. The reading costs
+        // a subprocess and a round trip; the first frame must not be behind
+        // either. The probe writes its note the instant the frame is painted,
+        // into the same log the shims append to, so the ordering is a recorded
+        // fact: awaiting the reading at the composition site — which *does*
+        // compile — puts `dl <--ls> <--json>` above the note and fails here.
+        let run = a_tick();
+        assert_eq!(
+            run.argv.first().map(String::as_str),
+            Some("note <the first frame>"),
+            "the first frame waited for something: {:?}",
+            run.argv
+        );
+    }
+
+    #[test]
+    fn a_landed_reading_reaches_the_screen_through_the_loop() {
+        // The wiring #137 is, end to end at this end of it: the reading is
+        // taken behind the screen, arrives on the channel, is drained by a
+        // tick, and the count line says what a reap would claim. An arm that
+        // dropped the payload on the floor — `Reclaimable(_) => {}` — leaves
+        // every other test in this tree green, because every other test hands
+        // the reading to the thing it is testing.
+        let run = a_tick();
+        let screen = run.printed();
+        let line = screen
+            .iter()
+            .find(|line| line.contains("reclaimable"))
+            .unwrap_or_else(|| panic!("the count line must say so:\n{}", screen.join("\n")));
+        assert!(line.contains("1 reclaimable"), "{line}");
+        assert!(
+            line.contains("wf-129-closed"),
+            "it names the workspace: {line}"
+        );
+        assert!(line.contains("wf reap"), "and the command: {line}");
+    }
+
+    #[test]
+    fn no_deletion_is_reachable_from_the_picker() {
+        // The structural half, which the run above cannot cover: a subprocess
+        // is observable and `std::fs::remove_dir_all` is not. So argv is
+        // watched at run time and the means of destruction that leave no argv
+        // are pinned here, over the *whole* file — the composition site, the
+        // drain loop, every arm of the fold and the loop around them. This
+        // module drains a channel, writes app state and paints a buffer, and
+        // has no business naming any of these.
+        //
+        // `reap` is on the list bare, not as `reap::`, and that is the point:
+        // `use wf::reap as tidy;` spells no `::` and would then reach the
+        // deletion side under a name nobody forbade. Every route to that module
+        // has to say the word somewhere, so the word is what is forbidden.
+        // `tokio::spawn` is on it because a spawned task is how an `.await`
+        // gets into a function that has none, which is the one way round
+        // [`Picker::tick`] and [`fold`] not being async.
+        let code = probe::code_only(include_str!("picker.rs"));
+        for forbidden in [
+            "reap",
+            "remove",
+            "\"rm\"",
+            "--force",
+            "Command",
+            "process::",
+            "fs::",
+            "unsafe",
+            "tokio::spawn",
+        ] {
+            assert!(
+                !code.contains(forbidden),
+                "the picker must not be able to delete a workspace: it names {forbidden:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_handover_leaves_no_background_work_running() {
+        // The last thing before `exec`, and the one that cannot be seen from
+        // the outside afterwards: both tasks must be aborted *and waited for*,
+        // because it is dropping their futures that closes the `gh` and `dl`
+        // they hold. An `abort()` without the wait, a handle dropped, a handle
+        // forgotten — all three leave a child alive for the agent to inherit.
+        //
+        // Each task holds an `Arc` that cannot be released until its future is
+        // dropped, so the counts are the witness.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let witness = std::sync::Arc::new(());
+        let for_discovery = std::sync::Arc::clone(&witness);
+        let for_survey = std::sync::Arc::clone(&witness);
+        let discovery = tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            drop(for_discovery);
+        });
+        let survey = wf::refresh::spawn_survey(
+            async move {
+                std::future::pending::<()>().await;
+                drop(for_survey);
+                None
+            },
+            tx,
+        );
+        stop_background(discovery, survey).await;
+        assert_eq!(
+            std::sync::Arc::strong_count(&witness),
+            1,
+            "background work outlived the handover"
+        );
+    }
+}

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -33,19 +33,38 @@
 //!    `dl <ws> rm` reached from anywhere the loop can reach — a helper in
 //!    `app.rs`, a task spawned in a fold arm, a function named nothing anyone
 //!    thought to forbid — is written down as argv. It does not care what file
-//!    the route was spelt in. It cares about *which arm* and about *when*: all
-//!    four [`Outcome`] arms are driven, the launch one included, and the
-//!    recording runs from the composition site to a stated window past the
-//!    ending (`WATCH`, in the tests below). A cleanup deferred longer than that
-//!    is not seen. The bound is stated rather than silent because it cannot be
-//!    removed — a probe can always be outwaited.
+//!    the route was spelt in. It cares about *where*, about *which arm*, and
+//!    about *when*, and each of those three is a bound on the claim rather than
+//!    a detail of the test:
+//!
+//!    - **where**: the recording starts at [`session`], not at [`run_picker`].
+//!      `run_picker` composes the registration, the terminal, the `session`
+//!      call and the handover, and no test in this repository executes it, so
+//!      everything it does above and below that call is outside the recording.
+//!      What covers that part of this file is the denylist in (1), widened to
+//!      `fs::` for exactly this reason after a reviewer deleted a workspace
+//!      from `run_picker` with the whole selection green;
+//!    - **which arm**: all four [`Outcome`] arms are driven, the launch one
+//!      included, and so is [`fold`] — but only through the events the child's
+//!      fixtures actually produce. Its `Discovered`, `Fetched` and
+//!      `Reclaimable` arms are entered; `SearchFailed` is not, because the `gh`
+//!      shim answers the map search successfully, and a `dl <ws> rm` planted in
+//!      that one arm is green. What stands against it there is the denylist in
+//!      (1) — it has to be spelt in another file to get past that; the
+//!      recording does not reach it;
+//!    - **when**: to a stated window past the ending (`WATCH`, in the tests
+//!      below). A cleanup deferred longer than that is not seen. The bound is
+//!      stated rather than silent because it cannot be removed — a probe can
+//!      always be outwaited.
 //! 3. **Destruction that runs no command is watched where it would land.** The
 //!    same run gives the child a scratch `HOME` laid out the way this machine
 //!    is — `~/.cache/devlaunch/repos/<owner>/<repo>/<id>` for the clone,
 //!    `~/.devpod/contexts/<ctx>/workspaces/<id>` for the record — and compares
 //!    the tree before and after. An `fs::remove_dir_all` aimed at a workspace
-//!    fails it. An `fs` call aimed somewhere else is caught by nothing — as it
-//!    would be in any file of any crate, and this file claims no better.
+//!    fails it *if it runs inside `session`* — the same three bounds as (2)
+//!    apply, and the `run_picker` escape above was one of them being real. An
+//!    `fs` call aimed somewhere else is caught by nothing — as it would be in
+//!    any file of any crate, and this file claims no better.
 //!
 //! None of that says the picker deletes nothing at all. [`run_picker`] calls
 //! [`refresh_skills`] on the way into the agent, and a copy that has fallen
@@ -918,23 +937,36 @@ mod tests {
         // [`Picker::tick`] and [`fold`], neither of which is async, and a task
         // that outlives the loop outlives the probe with it.
         //
+        // `fs::` is here because the probe drives [`session`], and
+        // [`run_picker`] is the function *above* it — composed of a
+        // registration, a terminal, the `session` call and the handover, and
+        // executed by no test in this repository. A reviewer planted
+        // `std::fs::remove_dir_all` in `run_picker` aimed at the real layout
+        // (`~/.cache/devlaunch/repos/<owner>/<repo>/<id>` and
+        // `~/.devpod/contexts/default/workspaces/<id>`); it named none of the
+        // four tokens above, the whole selection was green, and driven under a
+        // pty it destroyed a workspace while the picker drew normally. So the
+        // token is what covers the part of this file the run does not reach.
+        // Adding it cost nothing: `fs::` appears nowhere in this file's code.
+        //
         // It is *not* a claim that nothing on the picker's path can delete, and
         // a grep over one file could never be one. The same call spelt in
         // `app.rs` or in a submodule of this module names none of these and
         // compiles; what stands against it there is the recorded argv and the
-        // scratch home the run above compares — and outside that home, or after
-        // that run, nothing does, which is true of any code in any file.
+        // scratch home the run above compares — and outside that home, outside
+        // [`session`], or after that run, nothing does, which is true of any
+        // code in any file.
         //
-        // Which is also why this list is shorter than the ones
-        // [`wf::reclaim`] and [`wf::refresh`] carry, rather than having drifted
-        // from them. Those are leaf modules that read and format, so `fs::` and
-        // `remove` cost them nothing and close the only spelling they have. This
-        // file is a *composition site*: it is reached by a probe that watches the
-        // filesystem directly, and banning `fs::` here would read as "the picker
-        // cannot touch a file" while a submodule of it still could. The
-        // behavioural guard is the honest one for that, so it is the one used.
-        let code = probe::code_only(include_str!("picker.rs"));
-        for forbidden in ["reap", "Command", "process::", "tokio::spawn"] {
+        // The list is still one short of the ones [`wf::reclaim`] and
+        // [`wf::refresh`] carry. Those two also forbid `remove`, and this file
+        // cannot: `app.failed.remove(&id)` is `App`'s own bookkeeping, one
+        // occurrence, and renaming a `HashMap` method to satisfy a grep is the
+        // distortion a previous round was asked to undo. `"rm"` and `--force`
+        // are absent from this file's code and could be added at no cost; they
+        // are the argv of the subprocess `Command` and `process::` already
+        // forbid spelling, and the recorded run reads argv directly.
+        let code = probe::code_only("picker.rs", include_str!("picker.rs"));
+        for forbidden in ["reap", "Command", "process::", "tokio::spawn", "fs::"] {
             assert!(
                 !code.contains(forbidden),
                 "the picker draws a screen and drains a channel: it names {forbidden:?}"

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -27,7 +27,10 @@
 //!
 //! [`note`] is what makes the log a timeline the probe body can put its own
 //! marks on, so an *ordering* — this frame was painted before that subprocess
-//! ran — is as observable as the argv itself.
+//! ran — is as observable as the argv itself. Notes are prefixed so that
+//! [`Recording::argv`] holds subprocesses and nothing else: a note is written
+//! by the probe, not by the code under test, and one that happened to contain
+//! the word `rm` would otherwise fail a deletion assertion.
 //!
 //! [`code_only`] is the smaller one: this crate's own source with the comments
 //! and the test module stripped, for the structural guards in
@@ -58,6 +61,18 @@ const LOG: &str = "WF_PROBE_LOG";
 /// the test is named for it. Everything the probe says is marked, and
 /// [`Recording::printed`] keeps only the marked part.
 pub const MARK: &str = "PROBE|";
+
+/// What [`note`] puts in front of its lines, so the one log can be read back
+/// two ways.
+///
+/// The shims and the probe body append to the same file, which is what makes
+/// an *ordering* observable — but they are not the same kind of fact. A shim
+/// line is something the code under test did; a note is something the test
+/// said about it. Without a marker the two are one list, and a probe that
+/// noted `<rm>` would fail [`Recording::destroyed_nothing`] on its own
+/// commentary. A shim writes a program name first, and a program name cannot
+/// contain a `|`.
+const NOTED: &str = "note|";
 
 /// The workspace ids [`record`] lays a scratch home out for — the three
 /// [`DL_LISTING`] names, so every workspace the code under test can *see* is
@@ -94,7 +109,15 @@ pub struct Recording {
     /// One line per subprocess the child ran, in order: the program name and
     /// then each argument in angle brackets, so an argument containing a space
     /// cannot be mistaken for two.
+    ///
+    /// Subprocesses only. The probe body's own [`note`]s share the log, so
+    /// that the two can be *ordered* against each other, but they are not
+    /// things the code under test ran and they are not counted here — see
+    /// [`Recording::timeline`] for the merged view.
     pub argv: Vec<String>,
+    /// The same log with the notes left in and in order, for the assertions
+    /// that are about *when* something happened rather than whether it did.
+    pub timeline: Vec<String>,
     /// Everything the child printed.
     pub stdout: String,
     /// Every path under the child's scratch `HOME` that was not the same
@@ -207,12 +230,17 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
         .expect("the probe child");
     let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    let argv: Vec<String> = std::fs::read_to_string(&log)
+    let timeline: Vec<String> = std::fs::read_to_string(&log)
         .expect("the log")
         .lines()
         .map(str::trim_end)
         .filter(|line| !line.is_empty())
         .map(str::to_string)
+        .collect();
+    let argv: Vec<String> = timeline
+        .iter()
+        .filter(|line| !line.starts_with(NOTED))
+        .cloned()
         .collect();
     let disturbed = differences(&before, &tree(&home));
     // Read the log and the home *before* asserting anything, so that the
@@ -234,6 +262,7 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
     );
     Recording {
         argv,
+        timeline,
         stdout,
         disturbed,
     }
@@ -369,6 +398,10 @@ fn differences(before: &[(String, Vec<u8>)], after: &[(String, Vec<u8>)]) -> Vec
 /// machine a question" is `note` sitting above every argv, and no amount of
 /// grepping the source can say that.
 ///
+/// Marked with [`NOTED`], so that a note joins [`Recording::timeline`] and not
+/// [`Recording::argv`]: what the probe said about the run is not part of what
+/// the run did.
+///
 /// Silent outside a probe child, for the same reason [`is_child`] exists.
 pub fn note(what: &str) {
     use std::io::Write;
@@ -380,7 +413,7 @@ pub fn note(what: &str) {
         .open(log)
         .expect("the probe log");
     // One write, terminator included, for the reason [`shim`] gives.
-    log.write_all(format!("note <{what}>\n").as_bytes())
+    log.write_all(format!("{NOTED} <{what}>\n").as_bytes())
         .expect("the probe log");
 }
 
@@ -488,7 +521,7 @@ fn executable(_path: &Path) {
     unimplemented!("the probe shims are `/bin/sh` scripts; `wf` targets unix");
 }
 
-/// One of this crate's source files with the comments and the whole test module
+/// One of this crate's source files with the comments and the test module
 /// stripped — what the code can *do*, rather than what the prose beside it says
 /// it does.
 ///
@@ -496,17 +529,87 @@ fn executable(_path: &Path) {
 /// stay at the call site, because its path is resolved against the file it is
 /// written in.
 ///
-/// The test module is found by its `mod tests {` line rather than by the
+/// # What is dropped, and why that is safe
+///
+/// The test module is dropped because every guard built on this reads a
+/// *denylist* — `picker.rs`'s says the file may not name `reap`, and the test
+/// that says so has to write `reap` to say it. Keeping the module would make
+/// each guard fail on itself.
+///
+/// Dropping it is only safe if the part dropped is exactly a `#[cfg(test)]`
+/// module and nothing else, so that is checked here rather than assumed. An
+/// earlier version took the lines *before* the first `mod tests {` and threw
+/// the rest away unexamined, which had two holes, both demonstrated: a helper
+/// written below the test module was invisible to all four guards (only
+/// clippy's `items_after_test_module` saw it), and a raw string containing a
+/// line reading `mod tests {` cut the file short wherever its author liked —
+/// which silenced that lint too, and made every guard green for a deletion.
+///
+/// So the whole file is read, and three things are asserted about it:
+///
+/// 1. exactly one line *starts* a `mod tests {` — a second one anywhere,
+///    including inside a string, is the decoy above;
+/// 2. it is preceded by `#[cfg(test)]` — so what is dropped is compiled out of
+///    every release, not merely named `tests`;
+/// 3. it is the file's last item — the only thing at column 0 below it is its
+///    own closing brace, on the last non-blank line.
+///
+/// What remains uncovered is the *inside* of that module, which cannot run in a
+/// shipped binary. Everything else in the file is returned and read.
+///
+/// The module is found by its `mod tests {` line rather than by the
 /// `#[cfg(test)]` above it, and that is not a detail. `main.rs` declares
 /// `#[cfg(test)] mod probe;` among its imports, so a cut at the first
 /// `#[cfg(test)]` left thirty lines of `use` statements — a guard over that
-/// file would have read no code at all and passed for it. Anything smuggled in
-/// *below* `mod tests` is caught by clippy's `items_after_test_module` instead.
+/// file would have read no code at all and passed for it.
+///
+/// # Panics
+///
+/// If any of the three does not hold, which fails the guard that called it.
 pub fn code_only(source: &str) -> String {
-    source
-        .lines()
-        .take_while(|line| !line.starts_with("mod tests {"))
+    let lines: Vec<&str> = source.lines().collect();
+    let opens: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.starts_with("mod tests {"))
+        .map(|(at, _)| at)
+        .collect();
+    assert_eq!(
+        opens.len(),
+        1,
+        "a file guarded by its source text must open exactly one test module at \
+         column 0, and this one has {} such lines (a second is how a raw string \
+         hides the rest of the file from every guard): {:?}",
+        opens.len(),
+        opens.iter().map(|at| at + 1).collect::<Vec<_>>()
+    );
+    let opens = opens[0];
+    assert_eq!(
+        opens.checked_sub(1).map(|above| lines[above].trim()),
+        Some("#[cfg(test)]"),
+        "what is dropped must be announced `#[cfg(test)]`: line {} is {:?}",
+        opens,
+        opens.checked_sub(1).map(|above| lines[above])
+    );
+    let last = lines
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .expect("a source file has a line");
+    for (at, line) in lines.iter().enumerate().skip(opens + 1) {
+        if line.trim().is_empty() || line.starts_with([' ', '\t']) {
+            continue;
+        }
+        assert!(
+            at == last && *line == "}",
+            "the test module must be this file's last item, and line {} is {line:?} \
+             — an item below it is read by no guard here",
+            at + 1
+        );
+    }
+    lines[..opens]
+        .iter()
         .filter(|line| !line.trim_start().starts_with("//"))
+        .copied()
         .collect::<Vec<_>>()
         .join("\n")
 }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -1,0 +1,239 @@
+//! Test scaffolding shared by more than one module.
+//!
+//! Two things live here, both compiled into the library's test build **and**
+//! the binary's (`#[cfg(test)] mod probe;` in `lib.rs` and in `main.rs`), which
+//! is the only way a piece of test support can be reached from both crates.
+//!
+//! [`record`] is the important one. `wf`'s dangerous edges are all subprocess
+//! calls — `dl` and `gh` — and a subprocess call is *observable*: put a
+//! recording shim first on `PATH` and every argv the code under test reached
+//! for is written down. That turns "this path cannot delete anything" from a
+//! grep over the source into a fact about a run, which is what #137 asks for
+//! and what a grep cannot give: a mutation that names none of the forbidden
+//! tokens still has to run `dl` to destroy a workspace, and running `dl` is
+//! exactly what this sees.
+//!
+//! The shims have to be first on the `PATH` of the process doing the work, and
+//! `PATH` is per-process, so the work happens in a **child**: an `#[ignore]`d
+//! test in this same binary, named by `--exact` and run with `--ignored`. That
+//! keeps the environment surgery out of the parent — where it would race every
+//! other test in the binary — and costs one process spawn.
+//!
+//! [`code_only`] is the smaller one: this crate's own source with the comments
+//! and the test module stripped, for the structural guards in
+//! [`reclaim`](crate::reclaim) and [`refresh`](crate::refresh). It was written
+//! twice, byte for byte, before it was written here.
+
+// This file is compiled into two crates and neither uses all of it — the
+// library's tests want `code_only`, the binary's do not. Without this, whatever
+// one crate does not reach is a `dead_code` warning, and CI makes a warning a
+// failure.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// The env var carrying the recording log's path down to the shims. Set on the
+/// child by [`record`]; the shims inherit it through the child's own
+/// `Command::new("dl")`, which is the whole reason it is an env var and not an
+/// argument.
+const LOG: &str = "WF_PROBE_LOG";
+
+/// What a probe body puts in front of anything it wants read back.
+///
+/// The child's stdout is shared with the test harness's own chatter, and
+/// `test tests::reclaimable_arm_probe ... ` lands on the same line as the first
+/// thing printed — a line that contains the word "reclaimable" purely because
+/// the test is named for it. Everything the probe says is marked, and
+/// [`Recording::printed`] keeps only the marked part.
+pub const MARK: &str = "PROBE|";
+
+/// What a probe run saw.
+#[derive(Debug)]
+pub struct Recording {
+    /// One line per subprocess the child ran, in order: the program name and
+    /// then each argument in angle brackets, so an argument containing a space
+    /// cannot be mistaken for two.
+    pub argv: Vec<String>,
+    /// Everything the child printed.
+    pub stdout: String,
+}
+
+impl Recording {
+    /// What the probe body itself printed, one entry per [`MARK`]ed write.
+    pub fn printed(&self) -> Vec<&str> {
+        self.stdout
+            .lines()
+            .filter_map(|line| line.split_once(MARK).map(|(_, said)| said))
+            .collect()
+    }
+
+    /// Fail unless the run reached for no external command at all.
+    ///
+    /// The assertion for the paths that are supposed to be pure — folding a
+    /// value into the app state, drawing a screen — where *any* argv is the
+    /// defect, whatever it says.
+    pub fn ran_nothing(&self) {
+        assert!(
+            self.argv.is_empty(),
+            "this path must run no external command at all, and it ran: {:?}",
+            self.argv
+        );
+    }
+
+    /// Fail if anything recorded could have destroyed a workspace.
+    ///
+    /// Deliberately not a list of function names — the point of watching argv
+    /// rather than source text is that it does not matter *how* the deletion
+    /// was spelt in Rust. `dl <ws> rm` is the only thing that removes a
+    /// workspace, `--force` the only waiver, and both are visible here however
+    /// they were reached.
+    pub fn destroyed_nothing(&self) {
+        for line in &self.argv {
+            for forbidden in ["<rm>", "<--force>", "<remove>", "<delete>"] {
+                assert!(
+                    !line.contains(forbidden),
+                    "this path must not be able to destroy a workspace, and it ran: {line}"
+                );
+            }
+        }
+    }
+}
+
+/// Run one `#[ignore]`d test of this binary in a child process whose `dl` and
+/// `gh` are recording shims, and report what it ran and what it printed.
+///
+/// `dl_stdout` and `gh_stdout` are what those shims print — the fixture
+/// listing and the fixture tracker answer. Both shims exit 0, so a path that
+/// treats a failure as "no hint" cannot pass by accident.
+///
+/// # Panics
+///
+/// If the child could not be run, or failed. A failed child is a failed probe:
+/// its assertions are the test's.
+pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
+    let dir = scratch(test);
+    std::fs::write(dir.join("dl.out"), dl_stdout).expect("the dl fixture");
+    std::fs::write(dir.join("gh.out"), gh_stdout).expect("the gh fixture");
+    let log = dir.join("argv.log");
+    std::fs::write(&log, "").expect("the log");
+    shim(&dir, "dl");
+    shim(&dir, "gh");
+
+    let exe = std::env::current_exe().expect("this test binary");
+    let path = format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let out = Command::new(exe)
+        .args([
+            "--exact",
+            test,
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("PATH", path)
+        .env(LOG, &log)
+        .output()
+        .expect("the probe child");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    assert!(
+        out.status.success(),
+        "the probe child `{test}` failed:\n{stdout}\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let argv = std::fs::read_to_string(&log)
+        .expect("the log")
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+    let _ = std::fs::remove_dir_all(&dir);
+    Recording { argv, stdout }
+}
+
+/// True when this process *is* a probe child — the guard an `#[ignore]`d probe
+/// body needs, because `cargo test -- --ignored` would otherwise run it with
+/// no shims on `PATH` and no log to write to.
+pub fn is_child() -> bool {
+    std::env::var_os(LOG).is_some()
+}
+
+/// A directory of this run's own.
+///
+/// Unique per *call*, not per test: two tests can probe the same child — one
+/// asking what it ran and one asking what it said — and the suite runs them at
+/// the same time, so a directory named for the child is a directory each of
+/// them deletes out from under the other.
+fn scratch(test: &str) -> PathBuf {
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let safe: String = test
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let dir = std::env::temp_dir().join(format!(
+        "wf-probe-{}-{}-{safe}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("the probe's scratch directory");
+    dir
+}
+
+/// Write one recording shim: append the argv to the log, then print the
+/// fixture. One line per call, with newlines inside an argument flattened —
+/// `gh api graphql`'s query is a whole multi-line document, and a record that
+/// spanned lines could not be read back as one call.
+fn shim(dir: &Path, name: &str) {
+    let path = dir.join(name);
+    let body = r#"#!/bin/sh
+{
+  printf '%s' 'PROGRAM'
+  for a in "$@"; do printf ' <%s>' "$a"; done
+} | tr '\n' ' ' >> "$LOGVAR"
+printf '\n' >> "$LOGVAR"
+cat 'FIXTURE'
+"#
+    .replace("PROGRAM", name)
+    .replace("LOGVAR", LOG)
+    .replace(
+        "FIXTURE",
+        &dir.join(format!("{name}.out")).display().to_string(),
+    );
+    std::fs::write(&path, body).expect("the shim");
+    executable(&path);
+}
+
+#[cfg(unix)]
+fn executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path).expect("the shim").permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).expect("the shim's mode");
+}
+
+#[cfg(not(unix))]
+fn executable(_path: &Path) {
+    unimplemented!("the probe shims are `/bin/sh` scripts; `wf` targets unix");
+}
+
+/// One of this crate's source files with the comments and the whole test module
+/// stripped — what the code can *do*, rather than what the prose beside it says
+/// it does.
+///
+/// Called as `code_only(include_str!("reclaim.rs"))`: the `include_str!` has to
+/// stay at the call site, because its path is resolved against the file it is
+/// written in.
+pub fn code_only(source: &str) -> String {
+    source
+        .lines()
+        .take_while(|line| !line.starts_with("#[cfg(test)]"))
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -573,15 +573,25 @@ fn executable(_path: &Path) {
 /// closed**, and that is the intended trade: an edit it cannot account for is
 /// rejected rather than waved through.
 ///
-/// The cost is real, and these three were run against `picker.rs` — each is an
-/// ordinary, security-neutral edit that now fails the guard over whichever file
-/// it is made in, with the whole rest of the selection green:
+/// The cost is real, and these four were run against `picker.rs` (the last one
+/// also against `main.rs`) — each is an ordinary, security-neutral edit that now
+/// fails the guard over whichever file it is made in, with the whole rest of the
+/// selection green:
 ///
 /// - `#[allow(clippy::too_many_lines)]` written between the `#[cfg(test)]` and
 ///   the `mod tests {` — the announcement is no longer the line above;
 /// - `#[cfg(all(test, unix))]` in place of `#[cfg(test)]` — likewise;
 /// - a second `#[cfg(test)] mod` written *below* the test module — the braces
-///   close before the end of the file, which is the whole point of (3).
+///   close before the end of the file, which is the whole point of (3);
+/// - **a `{` or a `}` that does not balance, written in a string, a char
+///   literal or a comment anywhere inside the test module.** Nothing here
+///   parses Rust, so an assertion message reading `"expected {"`, or a comment
+///   ending `and nothing else }`, moves the depth. This is the widest of the
+///   four by a long way — it is a cost on writing ordinary tests, not on
+///   arranging modules — and this repository is already paying it: the `// }`
+///   at the end of the second entry in `main.rs`'s `reap` list exists only to
+///   balance the `{` inside the string above it. Deleting that comment is bins
+///   16 / 1, on `main.rs`'s own guard, for an edit that changes nothing.
 ///
 /// Two that read like the same class and are **not** rejected, checked rather
 /// than assumed: a trailing `} // end` on the closing brace passes, because
@@ -597,9 +607,20 @@ fn executable(_path: &Path) {
 /// last in the file — and a maintainer who departs from it gets a security
 /// guard failing on an edit that has nothing to do with security. That is
 /// deliberate: the alternative is a check that can be argued out of reading
-/// part of the file, and that is how both previous versions were defeated. The
-/// panic names the file at fault so the message points at the edit rather than
-/// at this function.
+/// part of the file, and that is how both previous versions were defeated.
+///
+/// The panic names the file at fault, which is the part that was missing when
+/// this check was written — before, a `picker.rs` problem was reported as a
+/// `probe.rs` panic. It does **not** always name the line at fault, and the two
+/// halves differ: an unbalanced `}` closes the depth early, so the loop fails at
+/// the offending line and quotes it (a stray `}` in a comment above
+/// `picker.rs`'s `a_session` reported *line 802 of 1011*, which is that
+/// comment). An unbalanced `{` never brings the depth back to zero, so nothing
+/// fails until the count is checked at the end, and the message can only quote
+/// the file's **last** line — deleting `main.rs`'s balancing `// }` reports
+/// *line 644*, which is the end of `main.rs` and 200 lines from the edit. In
+/// that direction the message says which file and which guard, and the reader
+/// finds the brace.
 ///
 /// What a textual count does not reach, measured rather than reasoned: a tail
 /// whose braces are *balanced* by braces written inside string literals — one

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -7,11 +7,11 @@
 //! [`record`] is the important one. `wf`'s dangerous edges are all subprocess
 //! calls — `dl` and `gh` — and a subprocess call is *observable*: put a
 //! recording shim first on `PATH` and every argv the code under test reached
-//! for is written down. That turns "this path cannot delete anything" from a
-//! grep over the source into a fact about a run, which is what #137 asks for
-//! and what a grep cannot give: a mutation that names none of the forbidden
-//! tokens still has to run `dl` to destroy a workspace, and running `dl` is
-//! exactly what this sees.
+//! for is written down. That is weaker than "this path cannot delete anything"
+//! and stronger than a grep: it covers the branches the probe actually drives,
+//! for as long as it watches, and within that it does not care how the deletion
+//! was spelt. A mutation that names none of the forbidden tokens still has to
+//! run `dl` to destroy a workspace, and running `dl` is exactly what this sees.
 //!
 //! The shims have to be first on the `PATH` of the process doing the work, and
 //! `PATH` is per-process, so the work happens in a **child**: an `#[ignore]`d
@@ -64,9 +64,28 @@ pub const MARK: &str = "PROBE|";
 /// also a directory it can be caught destroying.
 const LAID_OUT: [&str; 3] = ["wf-129-closed", "wf-138-unstarted", "wf-137-open"];
 
-/// What each of those directories holds. The name is the point: this stands in
-/// for the one thing `dl`'s own guard exists to protect — a clone holding work
-/// that exists nowhere else.
+/// The repo those three belong to in [`DL_LISTING`], which is also the
+/// directory `dl` files their clones under.
+const LAID_OUT_REPO: &str = "blooop/wayfinder";
+
+/// Where `dl` keeps the clone of each workspace, relative to `HOME`, and where
+/// it keeps the registry naming them all.
+///
+/// Read off a real machine rather than invented: `dl` clones a bare repo to
+/// `~/.cache/devlaunch/repos/<owner>/<repo>/.bare` and adds one worktree
+/// directory per workspace beside it, with `~/.cache/devlaunch/metadata.json`
+/// recording where each one went.
+const CLONES: &str = ".cache/devlaunch/repos";
+const REGISTRY: &str = ".cache/devlaunch/metadata.json";
+
+/// Where devpod keeps its own record of each workspace, relative to `HOME`.
+/// `default` is the context name on a machine nobody has configured a second
+/// one on, which is every machine `wf` has run on.
+const RECORDS: &str = ".devpod/contexts/default/workspaces";
+
+/// What each clone holds. The name is the point: this stands in for the one
+/// thing `dl`'s own guard exists to protect — a checkout holding work that
+/// exists nowhere else.
 const PRECIOUS: &str = "work that exists nowhere else\n";
 
 /// What a probe run saw.
@@ -115,15 +134,19 @@ impl Recording {
     /// visible here however they were reached.
     ///
     /// **In process.** A `std::fs::remove_dir_all` runs no command and leaves
-    /// no argv, so the child is given a scratch `HOME` laid out as a machine
-    /// with the fixture's workspaces on it, and the whole tree is compared
-    /// before and after. Any path under it that was removed, added or
-    /// rewritten fails here, whatever module or alias or submodule did it.
+    /// no argv, so the child is given a scratch `HOME` laid out the way a real
+    /// machine keeps its workspaces — see [`lay_out_a_home`] for the paths and
+    /// where they were read from — and the whole tree is compared before and
+    /// after. Any path under it that was removed, added or rewritten fails
+    /// here, whatever module or alias or submodule did it.
     ///
     /// What that does **not** reach is a path outside the scratch home: a
     /// `remove_dir_all("/etc")` is caught by nothing here, as it would be in
-    /// any code in any file. The claim is about the thing a deletion on this
-    /// path would actually be aimed at — the workspaces the reading names.
+    /// any code in any file. Nor does it reach a deletion the run never gets
+    /// to — the recording ends when the probe body does, so a cleanup deferred
+    /// past that is invisible here. Both limits are real and neither is
+    /// closable by a test; what this covers is a destruction aimed at the
+    /// workspaces the reading names, during the run.
     pub fn destroyed_nothing(&self) {
         for line in &self.argv {
             for forbidden in ["<rm>", "<--force>", "<remove>", "<delete>"] {
@@ -217,19 +240,56 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
 }
 
 /// A scratch `HOME` for the child: a machine with the fixture's workspaces on
-/// it, each holding a file worth keeping.
+/// it, at the paths a real machine keeps them, each holding a file worth
+/// keeping.
 ///
-/// The layout stands in for `dl`'s rather than reproducing it — what matters is
-/// that a directory named for every workspace the code under test can see is
-/// *there*, so an in-process deletion aimed at one has something to hit and
-/// [`Recording::destroyed_nothing`] has something to miss.
+/// The layout is copied from a real machine and not invented, and that is the
+/// whole of why this is worth doing. An earlier version of this laid the
+/// workspaces out at `$HOME/workspaces/<id>` — a path that exists nowhere, so
+/// the tree comparison was watching a directory no deletion would ever be
+/// aimed at, and a `remove_dir_all` pointed at the *real* clone passed it. What
+/// a cleanup on this path would actually reach for is here instead:
+///
+/// - `~/.cache/devlaunch/repos/<owner>/<repo>/<id>` — the worktree `dl` clones,
+///   which is where uncommitted work lives and the thing `dl`'s own unsaved-work
+///   guard exists to protect;
+/// - `~/.cache/devlaunch/metadata.json` — the registry that says where each of
+///   those went, which a cleanup rewrites rather than removes;
+/// - `~/.devpod/contexts/default/workspaces/<id>` — devpod's record of the
+///   container, which is what `dl <id> rm` deletes when there is no clone.
+///
+/// [`tree`] compares contents as well as names, so the rewritten registry is as
+/// visible as the removed clone.
 fn lay_out_a_home(dir: &Path) -> PathBuf {
     let home = dir.join("home");
+    let mut worktrees = Vec::new();
     for id in LAID_OUT {
-        let workspace = home.join("workspaces").join(id);
-        std::fs::create_dir_all(&workspace).expect("the scratch home");
-        std::fs::write(workspace.join("PRECIOUS.txt"), PRECIOUS).expect("the scratch home");
+        let clone = home.join(CLONES).join(LAID_OUT_REPO).join(id);
+        std::fs::create_dir_all(&clone).expect("the scratch home");
+        std::fs::write(clone.join("PRECIOUS.txt"), PRECIOUS).expect("the scratch home");
+        let record = home.join(RECORDS).join(id);
+        std::fs::create_dir_all(&record).expect("the scratch home");
+        std::fs::write(
+            record.join("workspace.json"),
+            format!("{{\"id\":\"{id}\",\"context\":\"default\"}}\n"),
+        )
+        .expect("the scratch home");
+        worktrees.push(format!(
+            "\"{LAID_OUT_REPO}/{id}\":{{\"local_path\":\"{}\"}}",
+            clone.display()
+        ));
     }
+    let registry = home.join(REGISTRY);
+    std::fs::create_dir_all(registry.parent().expect("the registry's directory"))
+        .expect("the scratch home");
+    std::fs::write(
+        &registry,
+        format!(
+            "{{\"version\":2,\"worktrees\":{{{}}}}}\n",
+            worktrees.join(",")
+        ),
+    )
+    .expect("the scratch home");
     home
 }
 
@@ -319,7 +379,9 @@ pub fn note(what: &str) {
         .append(true)
         .open(log)
         .expect("the probe log");
-    writeln!(log, "note <{what}>").expect("the probe log");
+    // One write, terminator included, for the reason [`shim`] gives.
+    log.write_all(format!("note <{what}>\n").as_bytes())
+        .expect("the probe log");
 }
 
 /// A `dl --ls --json` listing over three workspaces of this repo, in the shape
@@ -387,14 +449,20 @@ fn scratch(test: &str) -> PathBuf {
 /// fixture. One line per call, with newlines inside an argument flattened —
 /// `gh api graphql`'s query is a whole multi-line document, and a record that
 /// spanned lines could not be read back as one call.
+///
+/// The line is assembled first and appended **once**, terminator included.
+/// Written as two appends — the text, then the newline — two shims running at
+/// the same time interleave into one log line, and every assertion that counts
+/// the lines becomes a race. An `O_APPEND` write this small is atomic; two are
+/// not.
 fn shim(dir: &Path, name: &str) {
     let path = dir.join(name);
     let body = r#"#!/bin/sh
-{
+line=$({
   printf '%s' 'PROGRAM'
   for a in "$@"; do printf ' <%s>' "$a"; done
-} | tr '\n' ' ' >> "$LOGVAR"
-printf '\n' >> "$LOGVAR"
+} | tr '\n' ' ')
+printf '%s\n' "$line" >> "$LOGVAR"
 cat 'FIXTURE'
 "#
     .replace("PROGRAM", name)

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -614,11 +614,11 @@ fn executable(_path: &Path) {
 /// `probe.rs` panic. It does **not** always name the line at fault, and the two
 /// halves differ: an unbalanced `}` closes the depth early, so the loop fails at
 /// the offending line and quotes it (a stray `}` in a comment above
-/// `picker.rs`'s `a_session` reported *line 802 of 1011*, which is that
+/// `picker.rs`'s `a_session` reported *line 809 of 1037*, which is that
 /// comment). An unbalanced `{` never brings the depth back to zero, so nothing
 /// fails until the count is checked at the end, and the message can only quote
 /// the file's **last** line — deleting `main.rs`'s balancing `// }` reports
-/// *line 644*, which is the end of `main.rs` and 200 lines from the edit. In
+/// *line 680*, which is the end of `main.rs` and 183 lines from the edit. In
 /// that direction the message says which file and which guard, and the reader
 /// finds the brace.
 ///

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -145,6 +145,14 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
         "the probe child `{test}` failed:\n{stdout}\n{}",
         String::from_utf8_lossy(&out.stderr)
     );
+    // A name that matches nothing leaves a child that ran no tests, exited 0
+    // and recorded no argv — and every assertion about what the probe did *not*
+    // do would then pass vacuously. This is what makes those assertions mean
+    // something: the probe ran.
+    assert!(
+        stdout.contains("test result: ok. 1 passed"),
+        "the probe child `{test}` ran no test — is that name still right?\n{stdout}"
+    );
     let argv = std::fs::read_to_string(&log)
         .expect("the log")
         .lines()

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -525,9 +525,10 @@ fn executable(_path: &Path) {
 /// stripped — what the code can *do*, rather than what the prose beside it says
 /// it does.
 ///
-/// Called as `code_only(include_str!("reclaim.rs"))`: the `include_str!` has to
-/// stay at the call site, because its path is resolved against the file it is
-/// written in.
+/// Called as `code_only("reclaim.rs", include_str!("reclaim.rs"))`: the
+/// `include_str!` has to stay at the call site, because its path is resolved
+/// against the file it is written in, and the name is written beside it so a
+/// panic from here names the file at fault rather than this one.
 ///
 /// # What is dropped, and why that is safe
 ///
@@ -537,13 +538,18 @@ fn executable(_path: &Path) {
 /// each guard fail on itself.
 ///
 /// Dropping it is only safe if the part dropped is exactly a `#[cfg(test)]`
-/// module and nothing else, so that is checked here rather than assumed. An
-/// earlier version took the lines *before* the first `mod tests {` and threw
-/// the rest away unexamined, which had two holes, both demonstrated: a helper
-/// written below the test module was invisible to all four guards (only
-/// clippy's `items_after_test_module` saw it), and a raw string containing a
-/// line reading `mod tests {` cut the file short wherever its author liked —
-/// which silenced that lint too, and made every guard green for a deletion.
+/// module and nothing else, so that is checked here rather than assumed. Two
+/// earlier versions of this check were each defeated by a reviewer, and both
+/// are worth recording because the second looked like the fix for the first.
+/// The first took the lines *before* the first `mod tests {` and threw the rest
+/// away unexamined: a helper written below the test module was invisible to all
+/// four guards (only clippy's `items_after_test_module` saw it), and a raw
+/// string containing a line reading `mod tests {` cut the file short wherever
+/// its author liked — which silenced that lint too. The second read the tail,
+/// but only at column 0: it skipped every line starting with a space or a tab,
+/// so indenting each item below a raw-string decoy by one space dropped the
+/// whole tail out of all four guards again, and only `cargo fmt --check`
+/// objected.
 ///
 /// So the whole file is read, and three things are asserted about it:
 ///
@@ -551,11 +557,59 @@ fn executable(_path: &Path) {
 ///    including inside a string, is the decoy above;
 /// 2. it is preceded by `#[cfg(test)]` — so what is dropped is compiled out of
 ///    every release, not merely named `tests`;
-/// 3. it is the file's last item — the only thing at column 0 below it is its
-///    own closing brace, on the last non-blank line.
+/// 3. counting braces from that line, the depth reaches zero only on the file's
+///    last non-blank line. Depth rather than indentation: an item written below
+///    the module closes the module's brace above the end of the file, wherever
+///    the item itself is indented to.
 ///
 /// What remains uncovered is the *inside* of that module, which cannot run in a
-/// shipped binary. Everything else in the file is returned and read.
+/// shipped binary. The lines above it are returned; the lines below it are what
+/// (3) is about, and it is (3) that makes returning only the prefix safe.
+///
+/// # The braces are counted as text, and the four files pay for that
+///
+/// Nothing here parses Rust. A `{` or `}` inside a string, a char literal or a
+/// comment counts exactly like one in code. That makes this check **fail
+/// closed**, and that is the intended trade: an edit it cannot account for is
+/// rejected rather than waved through.
+///
+/// The cost is real, and these three were run against `picker.rs` — each is an
+/// ordinary, security-neutral edit that now fails the guard over whichever file
+/// it is made in, with the whole rest of the selection green:
+///
+/// - `#[allow(clippy::too_many_lines)]` written between the `#[cfg(test)]` and
+///   the `mod tests {` — the announcement is no longer the line above;
+/// - `#[cfg(all(test, unix))]` in place of `#[cfg(test)]` — likewise;
+/// - a second `#[cfg(test)] mod` written *below* the test module — the braces
+///   close before the end of the file, which is the whole point of (3).
+///
+/// Two that read like the same class and are **not** rejected, checked rather
+/// than assumed: a trailing `} // end` on the closing brace passes, because
+/// what is counted is the brace and not the shape of the line; and a second
+/// `#[cfg(test)] mod` written *above* the test module passes, because it is
+/// above, which means the denylists read it like any other code. A file with no
+/// `mod tests {` line at all fails the first assertion by construction — zero
+/// is not one — and that is a shape this repository does not have, so it is
+/// stated from the code rather than from a run.
+///
+/// So `main.rs`, `picker.rs`, `reclaim.rs` and `refresh.rs` are held to one
+/// test-module convention — a single `#[cfg(test)] mod tests {` at column 0,
+/// last in the file — and a maintainer who departs from it gets a security
+/// guard failing on an edit that has nothing to do with security. That is
+/// deliberate: the alternative is a check that can be argued out of reading
+/// part of the file, and that is how both previous versions were defeated. The
+/// panic names the file at fault so the message points at the edit rather than
+/// at this function.
+///
+/// What a textual count does not reach, measured rather than reasoned: a tail
+/// whose braces are *balanced* by braces written inside string literals — one
+/// stray `{` in a literal inside the module and one stray `}` in a literal
+/// inside the item below it — leaves the depth at zero only on the last line,
+/// and all four guards pass, `cargo fmt --check` included. What refuses that
+/// edit is clippy's `items_after_test_module`, which CI runs under
+/// `-D warnings`; an item below a test module is exactly what that lint is for.
+/// So the honest statement is that this function catches the tail written at
+/// any indentation, and clippy catches the tail that hand-balances its braces.
 ///
 /// The module is found by its `mod tests {` line rather than by the
 /// `#[cfg(test)]` above it, and that is not a detail. `main.rs` declares
@@ -566,7 +620,7 @@ fn executable(_path: &Path) {
 /// # Panics
 ///
 /// If any of the three does not hold, which fails the guard that called it.
-pub fn code_only(source: &str) -> String {
+pub fn code_only(file: &str, source: &str) -> String {
     let lines: Vec<&str> = source.lines().collect();
     let opens: Vec<usize> = lines
         .iter()
@@ -577,9 +631,9 @@ pub fn code_only(source: &str) -> String {
     assert_eq!(
         opens.len(),
         1,
-        "a file guarded by its source text must open exactly one test module at \
-         column 0, and this one has {} such lines (a second is how a raw string \
-         hides the rest of the file from every guard): {:?}",
+        "{file}: a file guarded by its source text must open exactly one test \
+         module at column 0, and this one has {} such lines (a second is how a \
+         raw string hides the rest of the file from every guard): {:?}",
         opens.len(),
         opens.iter().map(|at| at + 1).collect::<Vec<_>>()
     );
@@ -587,7 +641,7 @@ pub fn code_only(source: &str) -> String {
     assert_eq!(
         opens.checked_sub(1).map(|above| lines[above].trim()),
         Some("#[cfg(test)]"),
-        "what is dropped must be announced `#[cfg(test)]`: line {} is {:?}",
+        "{file}: what is dropped must be announced `#[cfg(test)]`: line {} is {:?}",
         opens,
         opens.checked_sub(1).map(|above| lines[above])
     );
@@ -595,17 +649,29 @@ pub fn code_only(source: &str) -> String {
         .iter()
         .rposition(|line| !line.trim().is_empty())
         .expect("a source file has a line");
-    for (at, line) in lines.iter().enumerate().skip(opens + 1) {
-        if line.trim().is_empty() || line.starts_with([' ', '\t']) {
-            continue;
-        }
+    // Brace depth, not column. The version this replaced skipped every line
+    // starting with a space or a tab, so one space of indentation on each item
+    // below a decoy hid the whole tail from all four guards.
+    let mut depth = 0usize;
+    for (at, line) in lines.iter().enumerate().skip(opens) {
+        depth = (depth + line.matches('{').count()).saturating_sub(line.matches('}').count());
         assert!(
-            at == last && *line == "}",
-            "the test module must be this file's last item, and line {} is {line:?} \
-             — an item below it is read by no guard here",
-            at + 1
+            depth > 0 || at == last,
+            "{file}: the test module must be this file's last item, and its braces \
+             close at line {} of {} — whatever is written below that line is read \
+             by no guard here, at any indentation",
+            at + 1,
+            last + 1
         );
     }
+    assert_eq!(
+        depth,
+        0,
+        "{file}: the test module's braces are still {depth} deep at line {}, the \
+         file's last — the guards below read only what is above the module, so \
+         this file's shape has to be checkable",
+        last + 1
+    );
     lines[..opens]
         .iter()
         .filter(|line| !line.trim_start().starts_with("//"))

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -19,6 +19,10 @@
 //! keeps the environment surgery out of the parent — where it would race every
 //! other test in the binary — and costs one process spawn.
 //!
+//! [`note`] is what makes the log a timeline the probe body can put its own
+//! marks on, so an *ordering* — this frame was painted before that subprocess
+//! ran — is as observable as the argv itself.
+//!
 //! [`code_only`] is the smaller one: this crate's own source with the comments
 //! and the test module stripped, for the structural guards in
 //! [`reclaim`](crate::reclaim) and [`refresh`](crate::refresh). It was written
@@ -140,10 +144,22 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
         .output()
         .expect("the probe child");
     let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    let argv: Vec<String> = std::fs::read_to_string(&log)
+        .expect("the log")
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+    // Read the log *before* asserting anything, so that the scratch directory
+    // is swept on the way out of a failing run too — a probe that leaked a
+    // directory per failure would fill `/tmp` on exactly the day someone is
+    // running it in a loop.
+    let _ = std::fs::remove_dir_all(&dir);
     assert!(
         out.status.success(),
-        "the probe child `{test}` failed:\n{stdout}\n{}",
-        String::from_utf8_lossy(&out.stderr)
+        "the probe child `{test}` failed:\n{stdout}\n{stderr}"
     );
     // A name that matches nothing leaves a child that ran no tests, exited 0
     // and recorded no argv — and every assertion about what the probe did *not*
@@ -153,16 +169,58 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
         stdout.contains("test result: ok. 1 passed"),
         "the probe child `{test}` ran no test — is that name still right?\n{stdout}"
     );
-    let argv = std::fs::read_to_string(&log)
-        .expect("the log")
-        .lines()
-        .map(str::trim_end)
-        .filter(|line| !line.is_empty())
-        .map(str::to_string)
-        .collect();
-    let _ = std::fs::remove_dir_all(&dir);
     Recording { argv, stdout }
 }
+
+/// Write a marked line into the recording log from inside a probe body.
+///
+/// The log is a *timeline*, not a set: the shims append to it as they are run,
+/// so a line the probe writes itself lands between the subprocesses that ran
+/// before it and the ones that ran after. That is what lets a probe pin an
+/// **ordering** — "the first frame was painted before anything asked the
+/// machine a question" is `note` sitting above every argv, and no amount of
+/// grepping the source can say that.
+///
+/// Silent outside a probe child, for the same reason [`is_child`] exists.
+pub fn note(what: &str) {
+    use std::io::Write;
+    let Some(log) = std::env::var_os(LOG) else {
+        return;
+    };
+    let mut log = std::fs::OpenOptions::new()
+        .append(true)
+        .open(log)
+        .expect("the probe log");
+    writeln!(log, "note <{what}>").expect("the probe log");
+}
+
+/// A `dl --ls --json` listing over three workspaces of this repo, in the shape
+/// devlaunch 0.0.21 and newer emit — one finished ticket, one the planner warns
+/// about, one in use.
+///
+/// Here rather than beside either probe that uses it: the reading's own probe
+/// and the picker's drive the same two reads, and a fixture written twice is a
+/// fixture that can disagree with itself about what the machine looks like.
+pub const DL_LISTING: &str = r#"[
+  {"id":"wf-129-closed","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-129","state":"Stopped"},
+  {"id":"wf-138-unstarted","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-138","state":"Stopped"},
+  {"id":"wf-137-open","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-137","state":"Running"}
+]"#;
+
+/// The tracker's answer to the batched question those three nodes raise:
+/// #129 closed (a reap), #138 open with nobody on it and no PR (a warning),
+/// #137 open and claimed (a keep).
+pub const GH_FACTS: &str = r#"{"data":{"repository":{
+  "i129":{"state":"CLOSED","assignees":{"nodes":[]},
+          "closedByPullRequestsReferences":{"nodes":[]}},
+  "i137":{"state":"OPEN","assignees":{"nodes":[{"login":"blooop"}]},
+          "closedByPullRequestsReferences":{"nodes":[]}},
+  "i138":{"state":"OPEN","assignees":{"nodes":[]},
+          "closedByPullRequestsReferences":{"nodes":[]}}
+}}}"#;
 
 /// True when this process *is* a probe child — the guard an `#[ignore]`d probe
 /// body needs, because `cargo test -- --ignored` would otherwise run it with
@@ -237,10 +295,17 @@ fn executable(_path: &Path) {
 /// Called as `code_only(include_str!("reclaim.rs"))`: the `include_str!` has to
 /// stay at the call site, because its path is resolved against the file it is
 /// written in.
+///
+/// The test module is found by its `mod tests {` line rather than by the
+/// `#[cfg(test)]` above it, and that is not a detail. `main.rs` declares
+/// `#[cfg(test)] mod probe;` among its imports, so a cut at the first
+/// `#[cfg(test)]` left thirty lines of `use` statements — a guard over that
+/// file would have read no code at all and passed for it. Anything smuggled in
+/// *below* `mod tests` is caught by clippy's `items_after_test_module` instead.
 pub fn code_only(source: &str) -> String {
     source
         .lines()
-        .take_while(|line| !line.starts_with("#[cfg(test)]"))
+        .take_while(|line| !line.starts_with("mod tests {"))
         .filter(|line| !line.trim_start().starts_with("//"))
         .collect::<Vec<_>>()
         .join("\n")

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -19,6 +19,12 @@
 //! keeps the environment surgery out of the parent — where it would race every
 //! other test in the binary — and costs one process spawn.
 //!
+//! The child also gets a scratch `HOME` laid out as a machine with the
+//! fixture's workspaces on it, and the whole tree is compared before and
+//! after. That is the other half of the same idea, for the destruction that
+//! runs no command: `std::fs::remove_dir_all` leaves no argv, but it does
+//! leave a hole.
+//!
 //! [`note`] is what makes the log a timeline the probe body can put its own
 //! marks on, so an *ordering* — this frame was painted before that subprocess
 //! ran — is as observable as the argv itself.
@@ -53,6 +59,16 @@ const LOG: &str = "WF_PROBE_LOG";
 /// [`Recording::printed`] keeps only the marked part.
 pub const MARK: &str = "PROBE|";
 
+/// The workspace ids [`record`] lays a scratch home out for — the three
+/// [`DL_LISTING`] names, so every workspace the code under test can *see* is
+/// also a directory it can be caught destroying.
+const LAID_OUT: [&str; 3] = ["wf-129-closed", "wf-138-unstarted", "wf-137-open"];
+
+/// What each of those directories holds. The name is the point: this stands in
+/// for the one thing `dl`'s own guard exists to protect — a clone holding work
+/// that exists nowhere else.
+const PRECIOUS: &str = "work that exists nowhere else\n";
+
 /// What a probe run saw.
 #[derive(Debug)]
 pub struct Recording {
@@ -62,6 +78,10 @@ pub struct Recording {
     pub argv: Vec<String>,
     /// Everything the child printed.
     pub stdout: String,
+    /// Every path under the child's scratch `HOME` that was not the same
+    /// afterwards as before — removed, added or rewritten. Empty is the
+    /// expected reading; see [`Recording::destroyed_nothing`].
+    disturbed: Vec<String>,
 }
 
 impl Recording {
@@ -86,13 +106,24 @@ impl Recording {
         );
     }
 
-    /// Fail if anything recorded could have destroyed a workspace.
+    /// Fail if the run destroyed anything, by either of the two means it has.
     ///
-    /// Deliberately not a list of function names — the point of watching argv
-    /// rather than source text is that it does not matter *how* the deletion
-    /// was spelt in Rust. `dl <ws> rm` is the only thing that removes a
-    /// workspace, `--force` the only waiver, and both are visible here however
-    /// they were reached.
+    /// **Out of process.** Deliberately not a list of function names — the
+    /// point of watching argv rather than source text is that it does not
+    /// matter *how* the deletion was spelt in Rust. `dl <ws> rm` is the only
+    /// thing that removes a workspace, `--force` the only waiver, and both are
+    /// visible here however they were reached.
+    ///
+    /// **In process.** A `std::fs::remove_dir_all` runs no command and leaves
+    /// no argv, so the child is given a scratch `HOME` laid out as a machine
+    /// with the fixture's workspaces on it, and the whole tree is compared
+    /// before and after. Any path under it that was removed, added or
+    /// rewritten fails here, whatever module or alias or submodule did it.
+    ///
+    /// What that does **not** reach is a path outside the scratch home: a
+    /// `remove_dir_all("/etc")` is caught by nothing here, as it would be in
+    /// any code in any file. The claim is about the thing a deletion on this
+    /// path would actually be aimed at — the workspaces the reading names.
     pub fn destroyed_nothing(&self) {
         for line in &self.argv {
             for forbidden in ["<rm>", "<--force>", "<remove>", "<delete>"] {
@@ -102,6 +133,11 @@ impl Recording {
                 );
             }
         }
+        assert!(
+            self.disturbed.is_empty(),
+            "this path must leave the machine as it found it, and it changed: {:?}",
+            self.disturbed
+        );
     }
 }
 
@@ -124,6 +160,8 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
     std::fs::write(&log, "").expect("the log");
     shim(&dir, "dl");
     shim(&dir, "gh");
+    let home = lay_out_a_home(&dir);
+    let before = tree(&home);
 
     let exe = std::env::current_exe().expect("this test binary");
     let path = format!(
@@ -140,6 +178,7 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
             "--test-threads=1",
         ])
         .env("PATH", path)
+        .env("HOME", &home)
         .env(LOG, &log)
         .output()
         .expect("the probe child");
@@ -152,10 +191,11 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
         .filter(|line| !line.is_empty())
         .map(str::to_string)
         .collect();
-    // Read the log *before* asserting anything, so that the scratch directory
-    // is swept on the way out of a failing run too — a probe that leaked a
-    // directory per failure would fill `/tmp` on exactly the day someone is
-    // running it in a loop.
+    let disturbed = differences(&before, &tree(&home));
+    // Read the log and the home *before* asserting anything, so that the
+    // scratch directory is swept on the way out of a failing run too — a probe
+    // that leaked a directory per failure would fill `/tmp` on exactly the day
+    // someone is running it in a loop.
     let _ = std::fs::remove_dir_all(&dir);
     assert!(
         out.status.success(),
@@ -169,7 +209,95 @@ pub fn record(test: &str, dl_stdout: &str, gh_stdout: &str) -> Recording {
         stdout.contains("test result: ok. 1 passed"),
         "the probe child `{test}` ran no test — is that name still right?\n{stdout}"
     );
-    Recording { argv, stdout }
+    Recording {
+        argv,
+        stdout,
+        disturbed,
+    }
+}
+
+/// A scratch `HOME` for the child: a machine with the fixture's workspaces on
+/// it, each holding a file worth keeping.
+///
+/// The layout stands in for `dl`'s rather than reproducing it — what matters is
+/// that a directory named for every workspace the code under test can see is
+/// *there*, so an in-process deletion aimed at one has something to hit and
+/// [`Recording::destroyed_nothing`] has something to miss.
+fn lay_out_a_home(dir: &Path) -> PathBuf {
+    let home = dir.join("home");
+    for id in LAID_OUT {
+        let workspace = home.join("workspaces").join(id);
+        std::fs::create_dir_all(&workspace).expect("the scratch home");
+        std::fs::write(workspace.join("PRECIOUS.txt"), PRECIOUS).expect("the scratch home");
+    }
+    home
+}
+
+/// The directory the probe child may write its own scratch state into — the
+/// one holding the log, which is [`record`]'s and is swept with it.
+///
+/// A probe that needs a path to hand the code under test (a projects cache, a
+/// checkout) uses this rather than `HOME`, because `HOME` is the thing being
+/// watched for changes and a legitimate write there would read as destruction.
+///
+/// # Panics
+///
+/// Outside a probe child, where there is no such directory. Guard with
+/// [`is_child`].
+pub fn child_scratch() -> PathBuf {
+    let log = std::env::var_os(LOG).expect("a probe child has a log");
+    PathBuf::from(log)
+        .parent()
+        .expect("the log lives in the scratch directory")
+        .to_path_buf()
+}
+
+/// Every file under `root`, by path relative to it, with its contents.
+///
+/// Contents and not merely names: a workspace whose files were emptied in place
+/// is as destroyed as one that was removed, and `rename` shows up as both a
+/// disappearance and an appearance.
+fn tree(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn walk(root: &Path, at: &Path, into: &mut Vec<(String, Vec<u8>)>) {
+        let Ok(entries) = std::fs::read_dir(at) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(root, &path, into);
+            } else if let Ok(bytes) = std::fs::read(&path) {
+                let name = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string();
+                into.push((name, bytes));
+            }
+        }
+    }
+    let mut found = Vec::new();
+    walk(root, root, &mut found);
+    found.sort();
+    found
+}
+
+/// What changed between two [`tree`] readings, as one line per path.
+fn differences(before: &[(String, Vec<u8>)], after: &[(String, Vec<u8>)]) -> Vec<String> {
+    let mut changed = Vec::new();
+    for (path, bytes) in before {
+        match after.iter().find(|(name, _)| name == path) {
+            None => changed.push(format!("{path} was removed")),
+            Some((_, now)) if now != bytes => changed.push(format!("{path} was rewritten")),
+            Some(_) => {}
+        }
+    }
+    for (path, _) in after {
+        if !before.iter().any(|(name, _)| name == path) {
+            changed.push(format!("{path} appeared"));
+        }
+    }
+    changed
 }
 
 /// Write a marked line into the recording log from inside a probe body.
@@ -201,6 +329,10 @@ pub fn note(what: &str) {
 /// Here rather than beside either probe that uses it: the reading's own probe
 /// and the picker's drive the same two reads, and a fixture written twice is a
 /// fixture that can disagree with itself about what the machine looks like.
+///
+/// The three ids are also [`LAID_OUT`] as directories in the child's scratch
+/// home, so what the code under test can see is exactly what it can be caught
+/// destroying.
 pub const DL_LISTING: &str = r#"[
   {"id":"wf-129-closed","devlaunch":true,"repo":"blooop/wayfinder",
    "branch":"wayfinder/wayfinder-129","state":"Stopped"},

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -28,6 +28,12 @@
 //! left alone. A suspicion is worth printing and never worth acting on, which
 //! is why [`Verdict::Warn`] exists and why [`doomed`] is the single place that
 //! decides what actually goes.
+//!
+//! The *deciding* is all here; the *noticing* is [`reclaim`](crate::reclaim),
+//! which calls [`plan`] and [`doomed`] behind the picker so `wf` can say what a
+//! reap would claim without being asked (#137). It adds no deletion path — it
+//! reads these two functions and renders a sentence, and everything that
+//! destroys anything is still reached only by a human typing `wf reap`.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Stdio;

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -571,6 +571,17 @@ fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap
 
 /// Hand one finished workspace back to `dl`.
 ///
+/// **Private to this module, and that is the whole of #137's separation.** The
+/// picker is a module of the *binary*; this is the library. A deletion the
+/// binary crate cannot name is a deletion no line of the picker — nor a helper
+/// it calls, in any file, under any alias, from any submodule — can reach: the
+/// edit is a compile error rather than a thing a test has to notice. Three
+/// review rounds each found a different way past a source-text denylist over
+/// the picker's own file, and each of those routes ended at this function.
+///
+/// The one caller is [`run`] below, which is `wf reap` — a human typing the
+/// command, reading the plan and answering the prompt.
+///
 /// `insist` passes `dl`'s own `--force`, and is only ever the human's `-f`
 /// reaching this far: without it, `dl` refuses when a clone holds work that
 /// exists nowhere else, and that refusal is load-bearing — [`plan`] already
@@ -582,7 +593,7 @@ fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap
 ///
 /// No `dl` on PATH, or a `dl <ws> rm` that failed — including the refusal
 /// above, which is a failure `wf` reports rather than quietly overrides.
-pub async fn remove(id: &str, insist: bool) -> Result<()> {
+async fn remove(id: &str, insist: bool) -> Result<()> {
     let mut args = vec![id, "rm"];
     if insist {
         args.push("--force");
@@ -599,6 +610,110 @@ pub async fn remove(id: &str, insist: bool) -> Result<()> {
             "`dl {id} rm` failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         );
+    }
+    Ok(())
+}
+
+/// `wf reap`: remove the workspaces whose nodes the tracker calls finished.
+///
+/// The whole command, here rather than in the binary, because `remove` above
+/// is private to this module and this is the only thing that may call it. What
+/// `main.rs` keeps is the argv that chooses this — `wf reap [-y] [-f]` — and
+/// nothing else; the picker, in the same crate as that argv, can no more reach
+/// a deletion than it can reach a private function of a library it depends on,
+/// which is exactly what it now is.
+///
+/// The division of labour is the one the launch already draws — `dl` owns the
+/// containers, `wf` owns the tickets — so this asks `dl` what exists, asks the
+/// tracker what has become of those nodes, prints the plan, and hands the
+/// finished ones back to `dl`. No terminal is taken: this is a stream command
+/// like `wf skills`, not a second TUI.
+///
+/// The plan is printed **before** the prompt and includes what is being kept,
+/// because a workspace someone expected to go and that stayed is the thing they
+/// most need told about, and a reason they disagree with ("still running" when
+/// they thought they had stopped it) is only actionable while no is an answer.
+///
+/// `warn` rows are the same argument pointed the other way: workspaces `wf`
+/// suspects are dead weight on evidence too weak to act on — a superseded
+/// ticket, or a node nothing has come of. They are printed and never counted
+/// into the prompt, because the only safe thing to do with a suspicion is say
+/// it out loud.
+///
+/// # Errors
+///
+/// A listing or a tracker query that failed, an unreadable answer to the
+/// prompt, or one or more workspaces `dl` would not remove.
+pub async fn run(yes: bool, insist: bool) -> Result<()> {
+    use std::fmt::Write;
+    use std::io::Write as _;
+
+    use crate::emit;
+
+    let workspaces = workspaces().await?;
+    let nodes: BTreeSet<Node> = workspaces.iter().filter_map(node_of).collect();
+    if nodes.is_empty() {
+        emit("no wayfinder workspaces on this machine — nothing to reap\n");
+        return Ok(());
+    }
+    let known = node_facts(&nodes).await?;
+    let verdicts = plan(&workspaces, &known, insist);
+
+    // The deletion set is asked for rather than re-derived here: `doomed` is
+    // the one definition of what goes, so a warning row cannot become a
+    // deletion by way of a partition written twice.
+    let going = doomed(&verdicts);
+    // Grouped rather than in listing order, and in this order: what stays,
+    // then what `wf` is uneasy about, then — last, immediately above the
+    // prompt — what the y/N is actually about.
+    let mut out = String::new();
+    for label in ["keep", "warn", "reap"] {
+        for verdict in &verdicts {
+            let row = match verdict {
+                Verdict::Keep { .. } => "keep",
+                Verdict::Warn { .. } => "warn",
+                Verdict::Reap { .. } => "reap",
+            };
+            if row == label {
+                let _ = writeln!(out, "  {label}  {}  ({})", verdict.id(), verdict.reason());
+            }
+        }
+    }
+    emit(&out);
+    if going.is_empty() {
+        emit("nothing to reap\n");
+        return Ok(());
+    }
+
+    if !yes {
+        emit(&format!("\ndelete {} workspace(s)? [y/N] ", going.len()));
+        let _ = std::io::stdout().flush();
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("cannot read the answer")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            emit("aborted\n");
+            return Ok(());
+        }
+    }
+
+    // One at a time, reporting each: `dl <ws> rm` tears down a container, and a
+    // failure part-way through leaves a set the next run has to be able to make
+    // sense of. Failures are collected rather than propagated at the first one,
+    // so a single wedged workspace does not strand the rest.
+    let mut failed = Vec::new();
+    for verdict in &going {
+        match remove(verdict.id(), insist).await {
+            Ok(()) => emit(&format!("removed {}\n", verdict.id())),
+            Err(e) => {
+                emit(&format!("could not remove {}: {e}\n", verdict.id()));
+                failed.push(verdict.id().to_string());
+            }
+        }
+    }
+    if !failed.is_empty() {
+        bail!("{} workspace(s) could not be removed", failed.len());
     }
     Ok(())
 }

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -571,13 +571,19 @@ fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap
 
 /// Hand one finished workspace back to `dl`.
 ///
-/// **Private to this module, and that is the whole of #137's separation.** The
-/// picker is a module of the *binary*; this is the library. A deletion the
-/// binary crate cannot name is a deletion no line of the picker — nor a helper
-/// it calls, in any file, under any alias, from any submodule — can reach: the
-/// edit is a compile error rather than a thing a test has to notice. Three
-/// review rounds each found a different way past a source-text denylist over
-/// the picker's own file, and each of those routes ended at this function.
+/// **Private to this module, and that is the strongest part of #137's
+/// separation.** The picker is a module of the *binary*; this is the library.
+/// No line of the binary can name this function — not under an alias, not from
+/// a submodule, not through a helper in another of its files — and the edit
+/// that tries is a compile error rather than a thing a test has to notice.
+/// Three review rounds each found a different way past a source-text denylist
+/// over the picker's own file, and each of those routes ended here.
+///
+/// What privacy does *not* close is [`run`] below: it is public because `main`
+/// must dispatch `wf reap`, it calls this, and the binary may name it from
+/// anywhere. That half is guarded by greps over two of the binary's files and
+/// by a recorded run of the picker — weaker things, and described as such where
+/// they live.
 ///
 /// The one caller is [`run`] below, which is `wf reap` — a human typing the
 /// command, reading the plan and answering the prompt.

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -40,6 +40,37 @@ use crate::reap::{self, Node, NodeFact, Verdict, Workspace};
 /// three because this shares one line with the load state and the match count.
 const NAMED: usize = 3;
 
+/// The shortest workspace name worth printing.
+///
+/// Below this an abbreviation has eaten the name — `de…c8` identifies nothing —
+/// and the line is better spent on the command, which is the half a reader can
+/// act on. Eight characters is enough for both ends of a `dl` id to show.
+const READABLE: usize = 8;
+
+/// The two fixed halves of the sentence. The pointer is what makes the hint
+/// actionable and the aside is #128's whole posture, so neither is ever what
+/// gets clipped: the names are budgeted around them.
+const POINTER: &str = " — wf reap";
+
+/// One id, shortened in the middle to `max` characters if it is longer.
+///
+/// Both ends survive because both carry meaning: `dl` puts the tool and the
+/// repo at the front and the ticket number at the back, and the number is what
+/// tells two workspaces of one project apart. The tail therefore gets the odd
+/// character when the budget is odd.
+fn abbreviate(id: &str, max: usize) -> String {
+    let len = id.chars().count();
+    if len <= max {
+        return id.to_string();
+    }
+    let keep = max.saturating_sub(1);
+    let tail = keep.div_ceil(2);
+    let head = keep - tail;
+    let front: String = id.chars().take(head).collect();
+    let back: String = id.chars().skip(len - tail).collect();
+    format!("{front}…{back}")
+}
+
 /// What a reap would claim, ready to say on one line.
 ///
 /// Constructible only from a set of [`Verdict`]s, through the private `read`
@@ -103,25 +134,56 @@ impl Reclaimable {
         self.warned
     }
 
-    /// The count-line segment: how many, which ones, and what to type.
+    /// The count-line segment, in `width` characters: how many, which ones,
+    /// and what to type.
     ///
     /// The warned count is a parenthesised aside so the leading number cannot
     /// be read as including it — the whole point of the `Warn` arm is that
     /// those rows are not part of what would go.
-    pub fn hint(&self) -> String {
-        let mut named: Vec<String> = self.ids.iter().take(NAMED).cloned().collect();
-        if self.ids.len() > NAMED {
-            named.push(format!("+{} more", self.ids.len() - NAMED));
-        }
+    ///
+    /// **The width is a budget, not a suggestion.** This shares one line with
+    /// the load state and the match count, and a real `dl` id is ~40
+    /// characters, so three of them written out unconditionally push the
+    /// `wf reap` pointer and the warned aside off the end of an 80-column
+    /// terminal — leaving a hint that names things and says nothing about what
+    /// to do with them, which is the one shape #137 rules out. So the two ends
+    /// of the sentence are laid down first and the names take what is left:
+    /// as many whole ones as fit, then one shortened in the middle, then —
+    /// only on a screen too narrow for any readable name — none.
+    pub fn hint(&self, width: usize) -> String {
+        let head = format!("· {} reclaimable", self.ids.len());
         let aside = match self.warned {
             0 => String::new(),
             n => format!(" (+{n} to check by hand)"),
         };
-        format!(
-            "· {} reclaimable: {}{aside} — wf reap",
-            self.ids.len(),
-            named.join(", ")
-        )
+        let fixed = head.chars().count() + aside.chars().count() + POINTER.chars().count();
+        // ": " is the cost of naming anything at all.
+        let room = width.saturating_sub(fixed + 2);
+        let say = |names: &str| format!("{head}: {names}{aside}{POINTER}");
+
+        // Whole names, as many as the room allows.
+        for count in (1..=NAMED.min(self.ids.len())).rev() {
+            let mut spelt: Vec<String> = self.ids.iter().take(count).cloned().collect();
+            if self.ids.len() > count {
+                spelt.push(format!("+{} more", self.ids.len() - count));
+            }
+            let names = spelt.join(", ");
+            if names.chars().count() <= room {
+                return say(&names);
+            }
+        }
+
+        // Not even one whole name. One shortened one still says which project
+        // and which ticket, which is what the reader is checking.
+        let rest = match self.ids.len() {
+            1 => String::new(),
+            n => format!(", +{} more", n - 1),
+        };
+        let left = room.saturating_sub(rest.chars().count());
+        if left >= READABLE {
+            return say(&format!("{}{rest}", abbreviate(&self.ids[0], left)));
+        }
+        format!("{head}{aside}{POINTER}")
     }
 }
 
@@ -292,18 +354,40 @@ mod tests {
         // The `Warn` count is allowed (#128 lets warnings be counted) and must
         // stay on its own side of the sentence: the reclaimable list is the
         // doomed ids, and the warning is an aside the leading number excludes.
+        //
+        // The three `Keep`s are not scenery. "How many did we warn about" and
+        // "how many did we not reap" are different numbers, and the second one
+        // — every healthy workspace on the machine — is much the larger. An
+        // aside computed as `verdicts.len() - doomed.len()` would read `+4` on
+        // this fixture and tell the user to go and inspect four workspaces, of
+        // which three are simply in use.
         let workspaces = vec![
             workspace("doomed", "blooop/devlaunch", 80),
             workspace("warned", "blooop/devlaunch", 96),
+            workspace("claimed", "blooop/devlaunch", 97),
+            workspace("in-flight", "blooop/devlaunch", 98),
+            {
+                let mut dirty = workspace("dirty", "blooop/devlaunch", 99);
+                dirty.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+                dirty
+            },
         ];
         let known = facts([
             (node("blooop/devlaunch", 80), NodeFact::Closed),
             (node("blooop/devlaunch", 96), NodeFact::Unstarted),
+            (node("blooop/devlaunch", 97), NodeFact::Claimed),
+            (node("blooop/devlaunch", 98), NodeFact::InFlight { pr: 9 }),
+            (node("blooop/devlaunch", 99), NodeFact::Closed),
         ]);
         let reading = reading(&workspaces, &known).expect("one workspace is doomed");
         assert_eq!(reading.ids(), ["doomed"]);
-        assert_eq!(reading.warned(), 1);
-        let hint = reading.hint();
+        assert_eq!(
+            reading.warned(),
+            1,
+            "one row was warned about; the other three are kept, which is not \
+             the same thing and is not a person's problem"
+        );
+        let hint = reading.hint(120);
         assert!(
             hint.starts_with("· 1 reclaimable: doomed"),
             "the count and the names are the doomed set's alone: {hint}"
@@ -363,7 +447,7 @@ mod tests {
         ]);
         let reading = reading(&workspaces, &known).expect("five closed tickets");
         assert_eq!(
-            reading.hint(),
+            reading.hint(120),
             "· 5 reclaimable: ws-0, ws-1, ws-2, +2 more — wf reap"
         );
         // One is spelt outright, with no count of the unspelt.
@@ -371,7 +455,88 @@ mod tests {
             ids: vec!["only".to_string()],
             warned: 0,
         };
-        assert_eq!(one.hint(), "· 1 reclaimable: only — wf reap");
+        assert_eq!(one.hint(120), "· 1 reclaimable: only — wf reap");
+    }
+
+    /// Three workspaces named the way `dl` actually names them: 41 characters
+    /// each, because the id carries the host, the owner, the repo and the
+    /// ticket. Every width claim below is measured against these rather than
+    /// against `ws-0`, which fits anywhere and therefore proves nothing.
+    fn realistic() -> Reclaimable {
+        Reclaimable {
+            ids: vec![
+                "devlaunch-github-com-blooop-wayfinder-129".to_string(),
+                "devlaunch-github-com-blooop-wayfinder-127".to_string(),
+                "devlaunch-github-com-blooop-wayfinder-80x".to_string(),
+            ],
+            warned: 1,
+        }
+    }
+
+    #[test]
+    fn the_pointer_and_the_aside_survive_real_workspace_names_on_a_narrow_screen() {
+        // The failure this exists for: three 41-character ids written out
+        // unconditionally are 123 characters before the sentence reaches
+        // `— wf reap`, so on an 80-column terminal the hint named some
+        // workspaces and then stopped — no aside, no command, nothing to do.
+        // Whatever the width, the reader can still see how many, how many need
+        // a human, and what to type.
+        for width in [60, 70, 80, 100, 120] {
+            let hint = realistic().hint(width);
+            assert!(
+                hint.chars().count() <= width,
+                "{width}: the hint must fit the budget it was given: {hint:?}"
+            );
+            assert!(
+                hint.starts_with("· 3 reclaimable"),
+                "{width}: the count leads: {hint:?}"
+            );
+            assert!(
+                hint.ends_with("(+1 to check by hand) — wf reap"),
+                "{width}: the aside and the pointer are never what gets cut: {hint:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_name_too_long_for_the_line_is_shortened_at_both_ends_rather_than_dropped() {
+        // 80 columns has no room for a whole 41-character id beside the aside
+        // and the pointer, and a bare "3 reclaimable" is exactly the
+        // unjudgeable count #137 rules out. So one name is kept, shortened in
+        // the middle — the front says whose it is, the back says which ticket.
+        let hint = realistic().hint(80);
+        assert!(hint.contains('…'), "{hint}");
+        assert!(
+            hint.contains("devlaunch"),
+            "the front of the name survives: {hint}"
+        );
+        assert!(
+            hint.contains("129"),
+            "so does the ticket number, which is what identifies it: {hint}"
+        );
+        assert!(
+            hint.contains("+2 more"),
+            "and the two it could not name are still counted: {hint}"
+        );
+    }
+
+    #[test]
+    fn a_screen_too_narrow_for_any_readable_name_keeps_the_command() {
+        // The last resort, and the right one: half a name is not something a
+        // reader can check, while `wf reap` is still something they can run.
+        let hint = realistic().hint(45);
+        assert_eq!(hint, "· 3 reclaimable (+1 to check by hand) — wf reap");
+    }
+
+    #[test]
+    fn abbreviating_keeps_both_ends_and_never_grows_a_name() {
+        assert_eq!(abbreviate("short", 20), "short", "it already fits");
+        assert_eq!(abbreviate("short", 5), "short", "exactly, and still whole");
+        assert_eq!(abbreviate("devlaunch-wayfinder-127", 12), "devla…er-127");
+        for max in 2..30 {
+            let out = abbreviate("devlaunch-github-com-blooop-wayfinder-127", max);
+            assert_eq!(out.chars().count(), max, "{max}: {out}");
+        }
     }
 
     #[tokio::test]
@@ -453,33 +618,105 @@ mod tests {
         );
     }
 
-    /// This module's own source, with the comments and the tests stripped —
-    /// the guard below is about what the code can do, not about what the prose
-    /// says it does.
-    fn code_only() -> String {
-        include_str!("reclaim.rs")
-            .lines()
-            .take_while(|line| !line.starts_with("#[cfg(test)]"))
-            .filter(|line| !line.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n")
+    /// A `dl --ls --json` listing over three workspaces of this repo, in the
+    /// shape devlaunch 0.0.21 and newer emit — one finished ticket, one the
+    /// planner warns about, one in use.
+    const DL_LISTING: &str = r#"[
+      {"id":"wf-129-closed","devlaunch":true,"repo":"blooop/wayfinder",
+       "branch":"wayfinder/wayfinder-129","state":"Stopped"},
+      {"id":"wf-138-unstarted","devlaunch":true,"repo":"blooop/wayfinder",
+       "branch":"wayfinder/wayfinder-138","state":"Stopped"},
+      {"id":"wf-137-open","devlaunch":true,"repo":"blooop/wayfinder",
+       "branch":"wayfinder/wayfinder-137","state":"Running"}
+    ]"#;
+
+    /// The tracker's answer to the batched question those three nodes raise:
+    /// #129 closed (a reap), #138 open with nobody on it and no PR (a warning),
+    /// #137 open and claimed (a keep).
+    const GH_FACTS: &str = r#"{"data":{"repository":{
+      "i129":{"state":"CLOSED","assignees":{"nodes":[]},
+              "closedByPullRequestsReferences":{"nodes":[]}},
+      "i137":{"state":"OPEN","assignees":{"nodes":[{"login":"blooop"}]},
+              "closedByPullRequestsReferences":{"nodes":[]}},
+      "i138":{"state":"OPEN","assignees":{"nodes":[]},
+              "closedByPullRequestsReferences":{"nodes":[]}}
+    }}}"#;
+
+    /// The reading taken for real, in a child process whose `dl` and `gh` are
+    /// the fixtures above and whose every invocation is written down. The
+    /// `#[ignore]` is what keeps it out of an ordinary run: without the shims
+    /// on `PATH` it would be asking this machine about its actual workspaces.
+    #[tokio::test]
+    #[ignore = "run by `probe::record` from the two tests below, under recording shims"]
+    async fn survey_live_probe() {
+        if !crate::probe::is_child() {
+            return;
+        }
+        let said = match survey_live().await {
+            Some(found) => found.hint(120),
+            None => "no reading at all".to_string(),
+        };
+        println!("{}{said}", crate::probe::MARK);
+    }
+
+    #[test]
+    fn the_surfacing_path_runs_two_reads_and_nothing_else() {
+        // #137's safety claim, as a fact about a run rather than a grep over
+        // the source. `reap::workspaces` and `reap::node_facts` both reach a
+        // PATH-resolved binary, so everything this path is *capable* of doing
+        // to a workspace shows up here as argv — whatever it was spelt as in
+        // Rust, in whichever module, and whether or not it named any word a
+        // reader thought to forbid. A `dl <ws> rm` added anywhere between
+        // `survey_live` and the reading it returns fails this test.
+        let run = crate::probe::record("reclaim::tests::survey_live_probe", DL_LISTING, GH_FACTS);
+        run.destroyed_nothing();
+        assert_eq!(
+            run.argv.len(),
+            2,
+            "one listing and one batched query, and nothing else: {:?}",
+            run.argv
+        );
+        assert_eq!(
+            run.argv[0], "dl <--ls> <--json>",
+            "the only thing this path asks `dl` for is what exists"
+        );
+        assert!(
+            run.argv[1].starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"),
+            "one batched read of the tracker: {}",
+            run.argv[1]
+        );
+    }
+
+    #[test]
+    fn the_reading_over_a_real_dl_and_gh_says_what_a_reap_would_claim() {
+        // The other half of the same run: not just that it destroyed nothing,
+        // but that it did the work. A `survey_live` that answered `None`, or a
+        // reading that never reached the sentence, leaves this with nothing to
+        // match — which is the point, because "surfaces nothing, ever" is the
+        // failure mode a guard on capability alone would call a pass.
+        let run = crate::probe::record("reclaim::tests::survey_live_probe", DL_LISTING, GH_FACTS);
+        assert_eq!(
+            run.printed(),
+            ["· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap"],
+            "the live reading is the same sentence the offline tests pin"
+        );
     }
 
     #[test]
     fn no_deletion_is_reachable_from_the_surfacing_path() {
-        // The whole safety claim of #137, asserted structurally because there
-        // is no behaviour to observe: this module must have no way to destroy
-        // anything, so what is pinned is that it does not name the means.
-        // `reap::remove` is the one function that deletes, `dl <ws> rm` the one
-        // command, `--force` the one waiver, and a `Command` of its own would
-        // be a way around all three.
-        let code = code_only();
+        // The structural half, which the run above cannot cover: a subprocess
+        // is observable, and `std::fs::remove_dir_all` is not. So argv is
+        // watched at run time and the means of destruction that leave no argv
+        // are pinned here — this module reads two functions and formats a
+        // sentence, and has no business naming any of these.
+        let code = crate::probe::code_only(include_str!("reclaim.rs"));
         for forbidden in [
             "remove",
             "\"rm\"",
             "--force",
             "Command",
             "process::",
+            "fs::",
             "unsafe",
         ] {
             assert!(
@@ -493,15 +730,11 @@ mod tests {
             code.contains("reap::plan(workspaces, known, false)"),
             "the reading must plan without insisting"
         );
-    }
-
-    #[test]
-    fn the_surfaced_set_comes_from_doomed_rather_than_a_partition_written_twice() {
         // #129's single definition, pinned at the one site that could quietly
         // grow a second one. A `matches!(v, Verdict::Reap { .. })` here would
-        // pass every behavioural test in this file on the day it was written
-        // and drift the first time `doomed` changed.
-        let code = code_only();
+        // agree with `doomed` on the day it was written — so every behavioural
+        // test in this file passes over it — and drift the first time `doomed`
+        // changed. Nothing but source text can see a duplicate that agrees.
         assert!(
             code.contains("reap::doomed(verdicts)"),
             "the doomed set must be asked for, not re-derived"

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -792,8 +792,16 @@ mod tests {
         // `use std::fs as sys;`, which is a one-line edit that a reviewer used
         // to reopen an escape this PR had already closed once. The bare name
         // catches both spellings and costs nothing — `fs` occurs nowhere in
-        // this file's code. Measured: the alias in this module's reading is
-        // lib 356/1 against the bare name.
+        // this file's code. What the bare name adds here is narrower than it
+        // first looks, and the measurement is worth stating precisely: an
+        // aliased `remove_dir_all` is caught either way, because `remove` is
+        // already on this list — two reviewers measured that row at different
+        // sites and got 356/1 and 355/2, the difference being how many guards
+        // fire, not whether one does. The bare name earns its place on the
+        // calls `remove` does not name: an aliased `fs::write` truncating a
+        // file is red at `fs` and **fully green** at `fs::`. Note this is a
+        // substring match, so it also forbids `offset`, `refs` and `prefs`
+        // here — see the same note in [`crate::picker`].
         let code = crate::probe::code_only("reclaim.rs", include_str!("reclaim.rs"));
         for forbidden in ["remove", "\"rm\"", "--force", "Command", "process::", "fs"] {
             assert!(

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -141,15 +141,23 @@ impl Reclaimable {
     /// be read as including it — the whole point of the `Warn` arm is that
     /// those rows are not part of what would go.
     ///
-    /// **The width is a budget, not a suggestion.** This shares one line with
-    /// the load state and the match count, and a real `dl` id is ~40
-    /// characters, so three of them written out unconditionally push the
-    /// `wf reap` pointer and the warned aside off the end of an 80-column
-    /// terminal — leaving a hint that names things and says nothing about what
-    /// to do with them, which is the one shape #137 rules out. So the two ends
-    /// of the sentence are laid down first and the names take what is left:
-    /// as many whole ones as fit, then one shortened in the middle, then —
-    /// only on a screen too narrow for any readable name — none.
+    /// **The width is a budget, not a suggestion**, at every width and not
+    /// merely at the comfortable ones. This shares one line with the load state
+    /// and the match count, and a real `dl` id is ~40 characters, so three of
+    /// them written out unconditionally push the `wf reap` pointer and the
+    /// warned aside off the end of an 80-column terminal — leaving a hint that
+    /// names things and says nothing about what to do with them, which is the
+    /// one shape #137 rules out. So the two ends of the sentence are laid down
+    /// first and the names take what is left: as many whole ones as fit, then
+    /// one shortened in the middle, then — on a screen too narrow for any
+    /// readable name — none.
+    ///
+    /// Below that the fixed halves themselves stop fitting, and the same
+    /// argument decides the order they go in. The aside is a count of rows
+    /// nobody has to act on today; the pointer is the half a reader can act on,
+    /// the same reason a name below `READABLE` characters is dropped. So the
+    /// aside is dropped before the pointer, and only a width too narrow for
+    /// even `· N reclaimable` clips anything at all.
     pub fn hint(&self, width: usize) -> String {
         let head = format!("· {} reclaimable", self.ids.len());
         let aside = match self.warned {
@@ -183,7 +191,19 @@ impl Reclaimable {
         if left >= READABLE {
             return say(&format!("{}{rest}", abbreviate(&self.ids[0], left)));
         }
-        format!("{head}{aside}{POINTER}")
+
+        // No name at all, so the fixed halves are all there is — and they are
+        // measured too, in the order that keeps the actionable one. The last
+        // arm is the count alone; a width even that does not fit gets what
+        // there is room for, because overflowing the budget is what clips the
+        // *neighbouring* segments of the count line.
+        for tail in [format!("{aside}{POINTER}"), POINTER.to_string()] {
+            let line = format!("{head}{tail}");
+            if line.chars().count() <= width {
+                return line;
+            }
+        }
+        head.chars().take(width).collect()
     }
 }
 
@@ -524,8 +544,59 @@ mod tests {
     fn a_screen_too_narrow_for_any_readable_name_keeps_the_command() {
         // The last resort, and the right one: half a name is not something a
         // reader can check, while `wf reap` is still something they can run.
-        let hint = realistic().hint(45);
+        // 47 characters is what the count, the aside and the pointer cost
+        // together, so that is the narrowest screen all three survive on.
+        let hint = realistic().hint(47);
         assert_eq!(hint, "· 3 reclaimable (+1 to check by hand) — wf reap");
+        // One character narrower and something has to go. The aside counts
+        // rows nobody has to act on today; the pointer is the only thing on
+        // this line anyone can do — so the aside is what goes.
+        assert_eq!(realistic().hint(46), "· 3 reclaimable — wf reap");
+        assert_eq!(realistic().hint(25), "· 3 reclaimable — wf reap");
+    }
+
+    #[test]
+    fn the_hint_fits_its_budget_at_every_width() {
+        // The doc says the width is a budget and not a suggestion, and this is
+        // the sentence that says it at *every* width rather than at the five
+        // comfortable ones the test above picks. The count line is shared: a
+        // hint that overruns does not merely lose its own tail, it clips the
+        // segments beside it.
+        for warned in [0, 1, 12] {
+            for count in 1..=4 {
+                let found = Reclaimable {
+                    ids: (0..count)
+                        .map(|i| format!("devlaunch-github-com-blooop-wayfinder-12{i}"))
+                        .collect(),
+                    warned,
+                };
+                for width in 0..=140 {
+                    let hint = found.hint(width);
+                    assert!(
+                        hint.chars().count() <= width,
+                        "{count} ids, {warned} warned, width {width}: {hint:?} is \
+                         {} characters",
+                        hint.chars().count()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn the_command_is_the_last_thing_the_budget_gives_up() {
+        // The ordering the last-resort branch encodes, stated as its own
+        // claim: as the screen narrows, the names go, then the aside, and
+        // `wf reap` survives every width that can hold it at all.
+        let found = realistic();
+        let widest_without_the_command = (0..=140)
+            .filter(|w| !found.hint(*w).contains("wf reap"))
+            .max()
+            .expect("some width is too narrow for the pointer");
+        assert_eq!(
+            widest_without_the_command, 24,
+            "the pointer must survive every width `· N reclaimable — wf reap` fits in"
+        );
     }
 
     #[test]
@@ -618,30 +689,6 @@ mod tests {
         );
     }
 
-    /// A `dl --ls --json` listing over three workspaces of this repo, in the
-    /// shape devlaunch 0.0.21 and newer emit — one finished ticket, one the
-    /// planner warns about, one in use.
-    const DL_LISTING: &str = r#"[
-      {"id":"wf-129-closed","devlaunch":true,"repo":"blooop/wayfinder",
-       "branch":"wayfinder/wayfinder-129","state":"Stopped"},
-      {"id":"wf-138-unstarted","devlaunch":true,"repo":"blooop/wayfinder",
-       "branch":"wayfinder/wayfinder-138","state":"Stopped"},
-      {"id":"wf-137-open","devlaunch":true,"repo":"blooop/wayfinder",
-       "branch":"wayfinder/wayfinder-137","state":"Running"}
-    ]"#;
-
-    /// The tracker's answer to the batched question those three nodes raise:
-    /// #129 closed (a reap), #138 open with nobody on it and no PR (a warning),
-    /// #137 open and claimed (a keep).
-    const GH_FACTS: &str = r#"{"data":{"repository":{
-      "i129":{"state":"CLOSED","assignees":{"nodes":[]},
-              "closedByPullRequestsReferences":{"nodes":[]}},
-      "i137":{"state":"OPEN","assignees":{"nodes":[{"login":"blooop"}]},
-              "closedByPullRequestsReferences":{"nodes":[]}},
-      "i138":{"state":"OPEN","assignees":{"nodes":[]},
-              "closedByPullRequestsReferences":{"nodes":[]}}
-    }}}"#;
-
     /// The reading taken for real, in a child process whose `dl` and `gh` are
     /// the fixtures above and whose every invocation is written down. The
     /// `#[ignore]` is what keeps it out of an ordinary run: without the shims
@@ -668,7 +715,11 @@ mod tests {
         // Rust, in whichever module, and whether or not it named any word a
         // reader thought to forbid. A `dl <ws> rm` added anywhere between
         // `survey_live` and the reading it returns fails this test.
-        let run = crate::probe::record("reclaim::tests::survey_live_probe", DL_LISTING, GH_FACTS);
+        let run = crate::probe::record(
+            "reclaim::tests::survey_live_probe",
+            crate::probe::DL_LISTING,
+            crate::probe::GH_FACTS,
+        );
         run.destroyed_nothing();
         assert_eq!(
             run.argv.len(),
@@ -694,7 +745,11 @@ mod tests {
         // reading that never reached the sentence, leaves this with nothing to
         // match — which is the point, because "surfaces nothing, ever" is the
         // failure mode a guard on capability alone would call a pass.
-        let run = crate::probe::record("reclaim::tests::survey_live_probe", DL_LISTING, GH_FACTS);
+        let run = crate::probe::record(
+            "reclaim::tests::survey_live_probe",
+            crate::probe::DL_LISTING,
+            crate::probe::GH_FACTS,
+        );
         assert_eq!(
             run.printed(),
             ["· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap"],
@@ -726,8 +781,19 @@ mod tests {
         }
         // And the one call it *does* make into reap's planning is never the
         // insisting one — the waiver stays with the human reading the plan.
-        assert!(
-            code.contains("reap::plan(workspaces, known, false)"),
+        // Read as "whatever the last argument is, it is `false`" rather than as
+        // the whole call written out: renaming a parameter is not a change to
+        // this claim, and a test that broke on one would be a test about
+        // spelling.
+        let insist = code
+            .split("reap::plan(")
+            .nth(1)
+            .and_then(|call| call.split(')').next())
+            .and_then(|args| args.rsplit(',').next())
+            .map(str::trim);
+        assert_eq!(
+            insist,
+            Some("false"),
             "the reading must plan without insisting"
         );
         // #129's single definition, pinned at the one site that could quietly

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -772,12 +772,16 @@ mod tests {
     }
 
     #[test]
-    fn no_deletion_is_reachable_from_the_surfacing_path() {
+    fn the_surfacing_module_names_no_means_of_destruction() {
         // The structural half, which the run above cannot cover: a subprocess
         // is observable, and `std::fs::remove_dir_all` is not. So argv is
         // watched at run time and the means of destruction that leave no argv
         // are pinned here — this module reads two functions and formats a
         // sentence, and has no business naming any of these.
+        //
+        // A fact about this file's text, and named as one: it says nothing
+        // about what a function it calls in another file may do. That is what
+        // the recorded run above is for, within the bounds that run states.
         //
         // `unsafe` used to be on this list and is not: `unsafe_code = "deny"`
         // in `Cargo.toml` covers every target in the crate, so a copy here was

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -16,8 +16,10 @@
 //!
 //! **Nothing here can delete.** `plan` is asked with `insist` false, so a
 //! workspace holding work that exists nowhere else is not surfaced at all; and
-//! the whole module reads facts and returns a sentence. It spawns no process of
-//! its own, and never reaches `reap`'s deletion side. The reading is the
+//! the whole module reads facts and returns a sentence. It cannot reach
+//! `reap`'s deletion side even by trying: the function that removes a workspace
+//! is private to `reap`'s own module, so `reap::remove(id, true).await` written
+//! anywhere in this file is `E0603`, not a test failure. The reading is the
 //! product; the waiver, the prompt and the deletion all stay with the human
 //! typing `wf reap`.
 //!
@@ -158,6 +160,18 @@ impl Reclaimable {
     /// the same reason a name below `READABLE` characters is dropped. So the
     /// aside is dropped before the pointer, and only a width too narrow for
     /// even `· N reclaimable` clips anything at all.
+    ///
+    /// **The cost of that order, named rather than hidden.** The aside is
+    /// treated as fixed while the names are being budgeted, so it is only ever
+    /// dropped *after* naming has already been given up. With one warning that
+    /// costs 22 characters, and below about 78 columns the segment is the bare
+    /// count — while spending those 22 characters on a name instead would have
+    /// left room for an abbreviated one and a `+N more`. Both readings are
+    /// defensible and this one is deliberate: `(+N to check by hand)` is the
+    /// whole of #128's posture on the screen, and a reader who cannot see it
+    /// has no way to know those rows were considered at all, whereas a reader
+    /// who cannot see a name still has `wf reap`, which prints every name.
+    /// A future that disagrees should change the order here, not the budget.
     pub fn hint(&self, width: usize) -> String {
         let head = format!("· {} reclaimable", self.ids.len());
         let aside = match self.warned {
@@ -764,6 +778,10 @@ mod tests {
         // watched at run time and the means of destruction that leave no argv
         // are pinned here — this module reads two functions and formats a
         // sentence, and has no business naming any of these.
+        //
+        // `unsafe` used to be on this list and is not: `unsafe_code = "deny"`
+        // in `Cargo.toml` covers every target in the crate, so a copy here was
+        // a second, weaker statement of a rule the compiler already enforces.
         let code = crate::probe::code_only(include_str!("reclaim.rs"));
         for forbidden in [
             "remove",
@@ -772,7 +790,6 @@ mod tests {
             "Command",
             "process::",
             "fs::",
-            "unsafe",
         ] {
             assert!(
                 !code.contains(forbidden),

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -786,7 +786,7 @@ mod tests {
         // `unsafe` used to be on this list and is not: `unsafe_code = "deny"`
         // in `Cargo.toml` covers every target in the crate, so a copy here was
         // a second, weaker statement of a rule the compiler already enforces.
-        let code = crate::probe::code_only(include_str!("reclaim.rs"));
+        let code = crate::probe::code_only("reclaim.rs", include_str!("reclaim.rs"));
         for forbidden in [
             "remove",
             "\"rm\"",

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -786,15 +786,16 @@ mod tests {
         // `unsafe` used to be on this list and is not: `unsafe_code = "deny"`
         // in `Cargo.toml` covers every target in the crate, so a copy here was
         // a second, weaker statement of a rule the compiler already enforces.
+        //
+        // `fs` bare rather than `fs::`, matching `picker.rs` and
+        // [`crate::refresh`]: written `fs::`, the token is defeated by
+        // `use std::fs as sys;`, which is a one-line edit that a reviewer used
+        // to reopen an escape this PR had already closed once. The bare name
+        // catches both spellings and costs nothing — `fs` occurs nowhere in
+        // this file's code. Measured: the alias in this module's reading is
+        // lib 356/1 against the bare name.
         let code = crate::probe::code_only("reclaim.rs", include_str!("reclaim.rs"));
-        for forbidden in [
-            "remove",
-            "\"rm\"",
-            "--force",
-            "Command",
-            "process::",
-            "fs::",
-        ] {
+        for forbidden in ["remove", "\"rm\"", "--force", "Command", "process::", "fs"] {
             assert!(
                 !code.contains(forbidden),
                 "the surfacing path must not be able to delete: it names {forbidden:?}"

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -1,0 +1,515 @@
+//! Noticing what [`reap`] would claim, without being asked (#137).
+//!
+//! `wf reap` already decides what is finished. What it lacks is a trigger: it
+//! fires only when a person remembers to type it. This module is that trigger
+//! for the **noticing** and deliberately not for the deleting — the picker says
+//! what a reap would claim and points at the command, and a human still runs it.
+//!
+//! Three properties, and each one is why this module is shaped the way it is.
+//!
+//! **One vocabulary.** The surfaced set is [`reap::doomed`] over
+//! [`reap::plan`], called rather than reimplemented. `doomed` stays the single
+//! place that decides what goes (#129), so a display cannot drift into a
+//! second, unaudited definition of "finished", and a [`Verdict::Warn`] row
+//! keeps its never-acted-on posture (#128) — counted here, never named as
+//! reclaimable.
+//!
+//! **Nothing here can delete.** `plan` is asked with `insist` false, so a
+//! workspace holding work that exists nowhere else is not surfaced at all; and
+//! the whole module reads facts and returns a sentence. It spawns no process of
+//! its own, and never reaches `reap`'s deletion side. The reading is the
+//! product; the waiver, the prompt and the deletion all stay with the human
+//! typing `wf reap`.
+//!
+//! **It fails silent.** [`survey`] answers `Option`, not `Result`. No `dl` on
+//! PATH, a `dl --ls --json` that failed, a GraphQL error, no network: the hint
+//! is simply absent. A cleanup convenience is never worth an error, a stall, or
+//! a degraded launcher.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+
+use anyhow::Result;
+
+use crate::reap::{self, Node, NodeFact, Verdict, Workspace};
+
+/// How many workspaces the hint spells before it starts counting.
+///
+/// A bare count cannot be judged — "3 reclaimable" is a number a reader has no
+/// way to agree or disagree with — so the hint names what it means. It stops at
+/// three because this shares one line with the load state and the match count.
+const NAMED: usize = 3;
+
+/// What a reap would claim, ready to say on one line.
+///
+/// Constructible only from a set of [`Verdict`]s, through the private `read`
+/// below — which answers `None` when [`reap::doomed`] is empty. So "there is nothing
+/// to reclaim" is the absence of this value rather than a value claiming zero,
+/// and no code path can render a hint about an empty set.
+///
+/// `warned` is a count and nothing more. The ids are the doomed set's, so a
+/// warning has no way to reach the reclaimable list even by accident: it is
+/// carried in a different field of a different type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reclaimable {
+    /// The doomed workspaces' ids, in listing order. Never empty.
+    ids: Vec<String>,
+    /// How many rows `plan` warned about — printed as a separate clause,
+    /// never counted into the reclaimable set (#128).
+    warned: usize,
+}
+
+impl Reclaimable {
+    /// The reading over one plan: [`reap::doomed`]'s ids, and the warnings
+    /// counted beside them.
+    ///
+    /// `None` when nothing is doomed, which is the ordinary case and the one
+    /// that must draw nothing at all.
+    fn read(verdicts: &[Verdict]) -> Option<Self> {
+        let ids: Vec<String> = reap::doomed(verdicts)
+            .into_iter()
+            .map(|verdict| verdict.id().to_string())
+            .collect();
+        if ids.is_empty() {
+            return None;
+        }
+        let warned = verdicts
+            .iter()
+            .filter(|verdict| matches!(verdict, Verdict::Warn { .. }))
+            .count();
+        Some(Self { ids, warned })
+    }
+
+    /// A reading with these ids on it, for the tests of the screen and the
+    /// channel that carry one. Test-only so that production has exactly one
+    /// way in — [`Reclaimable::read`], over a plan.
+    #[cfg(test)]
+    pub(crate) fn for_test(ids: &[&str], warned: usize) -> Self {
+        assert!(!ids.is_empty(), "a reading is never empty");
+        Self {
+            ids: ids.iter().map(|id| (*id).to_string()).collect(),
+            warned,
+        }
+    }
+
+    /// The workspaces a reap would claim, by the id `wf reap` and `dl` both
+    /// name them by.
+    pub fn ids(&self) -> &[String] {
+        &self.ids
+    }
+
+    /// How many rows `wf` is uneasy about but will not act on.
+    pub fn warned(&self) -> usize {
+        self.warned
+    }
+
+    /// The count-line segment: how many, which ones, and what to type.
+    ///
+    /// The warned count is a parenthesised aside so the leading number cannot
+    /// be read as including it — the whole point of the `Warn` arm is that
+    /// those rows are not part of what would go.
+    pub fn hint(&self) -> String {
+        let mut named: Vec<String> = self.ids.iter().take(NAMED).cloned().collect();
+        if self.ids.len() > NAMED {
+            named.push(format!("+{} more", self.ids.len() - NAMED));
+        }
+        let aside = match self.warned {
+            0 => String::new(),
+            n => format!(" (+{n} to check by hand)"),
+        };
+        format!(
+            "· {} reclaimable: {}{aside} — wf reap",
+            self.ids.len(),
+            named.join(", ")
+        )
+    }
+}
+
+/// What a reap would claim, given what `dl` listed and what the tracker said.
+///
+/// The one place the surfaced set is decided, and it decides nothing itself:
+/// [`reap::plan`] then [`reap::doomed`], the same two calls `wf reap` makes.
+///
+/// `insist` is **false**, always. `-f` waives `dl`'s unsaved-work guard, and
+/// that waiver is a human's to grant while looking at the plan — a hint that
+/// quietly counted the workspaces `-f` would reach would be naming work that
+/// exists nowhere else as disposable.
+pub fn reading(workspaces: &[Workspace], known: &BTreeMap<Node, NodeFact>) -> Option<Reclaimable> {
+    Reclaimable::read(&reap::plan(workspaces, known, false))
+}
+
+/// Take the reading, silently.
+///
+/// Generic over its two reads so the whole fail-silent path is exercisable
+/// without `dl`, `gh` or a network — [`survey_live`] is the one-line binding to
+/// the real pair.
+///
+/// Every failure is the same answer: no hint. A listing that would not run, a
+/// tracker that would not answer, a repo slug that will not parse — none of
+/// them is a fact about a workspace, and the only honest thing to show for one
+/// is nothing.
+pub async fn survey<L, LFut, F, FFut>(listing: L, facts: F) -> Option<Reclaimable>
+where
+    L: FnOnce() -> LFut,
+    LFut: Future<Output = Result<Vec<Workspace>>>,
+    F: FnOnce(BTreeSet<Node>) -> FFut,
+    FFut: Future<Output = Result<BTreeMap<Node, NodeFact>>>,
+{
+    let workspaces = listing().await.ok()?;
+    let nodes: BTreeSet<Node> = workspaces.iter().filter_map(reap::node_of).collect();
+    if nodes.is_empty() {
+        // Nothing of `wf`'s on this machine. Not a question worth a round trip,
+        // and not a hint worth drawing.
+        return None;
+    }
+    let known = facts(nodes).await.ok()?;
+    reading(&workspaces, &known)
+}
+
+/// [`survey`] against the real `dl` listing and the real batched tracker query
+/// — one subprocess and one GraphQL round trip, both `reap`'s own.
+pub async fn survey_live() -> Option<Reclaimable> {
+    survey(reap::workspaces, |nodes| async move {
+        reap::node_facts(&nodes).await
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+
+    fn workspace(id: &str, repo: &str, number: u64) -> Workspace {
+        Workspace {
+            id: id.to_string(),
+            devlaunch: true,
+            repo: Some(repo.to_string()),
+            branch: Some(format!("wayfinder/{}-{number}", short(repo))),
+            state: Some("Stopped".to_string()),
+            unsaved: None,
+        }
+    }
+
+    fn short(repo: &str) -> &str {
+        repo.split('/').next_back().unwrap_or(repo)
+    }
+
+    fn node(repo: &str, number: u64) -> Node {
+        Node {
+            repo: repo.to_string(),
+            number,
+        }
+    }
+
+    fn facts<const N: usize>(entries: [(Node, NodeFact); N]) -> BTreeMap<Node, NodeFact> {
+        entries.into_iter().collect()
+    }
+
+    /// Every arm of `NodeFact`, so the table below cannot quietly stop covering
+    /// one when a seventh is added — the match makes that a compile error.
+    fn every_node_fact() -> Vec<NodeFact> {
+        let all = vec![
+            NodeFact::Closed,
+            NodeFact::DoneByMerge { pr: 97 },
+            NodeFact::Superseded { pr: 98 },
+            NodeFact::InFlight { pr: 99 },
+            NodeFact::Claimed,
+            NodeFact::Unstarted,
+        ];
+        for fact in &all {
+            match fact {
+                NodeFact::Closed
+                | NodeFact::DoneByMerge { .. }
+                | NodeFact::Superseded { .. }
+                | NodeFact::InFlight { .. }
+                | NodeFact::Claimed
+                | NodeFact::Unstarted => {}
+            }
+        }
+        all
+    }
+
+    #[test]
+    fn the_surfaced_set_is_exactly_the_doomed_set_over_every_node_fact() {
+        // The guard against a second definition of "finished". The expectation
+        // is not a literal list: it is `doomed(plan(…))` computed right here,
+        // so a display that started deciding for itself — including one that
+        // merely re-derived the same answer — fails the moment the two drift.
+        for fact in every_node_fact() {
+            for unsaved in [None, Some("1 uncommitted change(s) (pixi.lock)")] {
+                for state in ["Stopped", "Running"] {
+                    let mut ws = workspace("solo", "blooop/devlaunch", 80);
+                    ws.unsaved = unsaved.map(str::to_string);
+                    ws.state = Some(state.to_string());
+                    let known = facts([(node("blooop/devlaunch", 80), fact.clone())]);
+                    let listed = std::slice::from_ref(&ws);
+
+                    let verdicts = reap::plan(listed, &known, false);
+                    let expected: Vec<String> = reap::doomed(&verdicts)
+                        .into_iter()
+                        .map(|v| v.id().to_string())
+                        .collect();
+                    let surfaced: Vec<String> = reading(listed, &known)
+                        .map(|r| r.ids().to_vec())
+                        .unwrap_or_default();
+
+                    assert_eq!(
+                        surfaced, expected,
+                        "{fact:?} / unsaved={unsaved:?} / {state}: the surfaced set \
+                         must be `doomed(plan(…))` and nothing else"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_warned_workspace_is_never_surfaced_as_reclaimable() {
+        // The mirror of reap's own
+        // `a_warned_workspace_never_reaches_the_doomed_set_even_with_y_and_f`,
+        // pointed at the display: the safety property of the whole `Warn` arm
+        // is that no path turns a suspicion into something offered up for
+        // deletion. There are no flags to vary here — that is the point, the
+        // reading has none — so the variation is the two warning facts and
+        // whether the clone holds work.
+        for fact in [NodeFact::Superseded { pr: 97 }, NodeFact::Unstarted] {
+            for unsaved in [None, Some("1 uncommitted change(s) (pixi.lock)")] {
+                let mut ws = workspace("warned", "blooop/devlaunch", 80);
+                ws.unsaved = unsaved.map(str::to_string);
+                let known = facts([(node("blooop/devlaunch", 80), fact.clone())]);
+                assert_eq!(
+                    reading(std::slice::from_ref(&ws), &known),
+                    None,
+                    "{fact:?} / unsaved={unsaved:?} was surfaced as reclaimable"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_warning_beside_a_real_one_is_counted_and_still_not_named() {
+        // The `Warn` count is allowed (#128 lets warnings be counted) and must
+        // stay on its own side of the sentence: the reclaimable list is the
+        // doomed ids, and the warning is an aside the leading number excludes.
+        let workspaces = vec![
+            workspace("doomed", "blooop/devlaunch", 80),
+            workspace("warned", "blooop/devlaunch", 96),
+        ];
+        let known = facts([
+            (node("blooop/devlaunch", 80), NodeFact::Closed),
+            (node("blooop/devlaunch", 96), NodeFact::Unstarted),
+        ]);
+        let reading = reading(&workspaces, &known).expect("one workspace is doomed");
+        assert_eq!(reading.ids(), ["doomed"]);
+        assert_eq!(reading.warned(), 1);
+        let hint = reading.hint();
+        assert!(
+            hint.starts_with("· 1 reclaimable: doomed"),
+            "the count and the names are the doomed set's alone: {hint}"
+        );
+        assert!(
+            !hint.contains("warned"),
+            "a warned workspace must never be named as reclaimable: {hint}"
+        );
+        assert!(
+            hint.contains("(+1 to check by hand)"),
+            "the warning is counted, in its own clause: {hint}"
+        );
+    }
+
+    #[test]
+    fn the_reading_never_waives_the_guard_that_keeps_unpushed_work() {
+        // `-f` is the human's to grant in front of the plan. A workspace whose
+        // clone holds work that exists nowhere else is kept by `plan`, and the
+        // hint must inherit that keep rather than quietly count it — otherwise
+        // the picker is advertising a reap that would throw work away.
+        let mut ws = workspace("dirty", "blooop/devlaunch", 80);
+        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
+        assert_eq!(reading(std::slice::from_ref(&ws), &known), None);
+        // And the same node with a clean clone *is* surfaced, so the assertion
+        // above is about the unsaved work and not about the fixture.
+        ws.unsaved = None;
+        assert_eq!(
+            reading(&[ws], &known).map(|r| r.ids().to_vec()),
+            Some(vec!["dirty".to_string()])
+        );
+    }
+
+    #[test]
+    fn nothing_to_reclaim_is_no_value_at_all_rather_than_a_zero() {
+        let ws = workspace("live", "blooop/devlaunch", 80);
+        let known = facts([(node("blooop/devlaunch", 80), NodeFact::InFlight { pr: 9 })]);
+        assert_eq!(reading(&[ws], &known), None);
+        // The same claim at the constructor, which is the only way in.
+        assert_eq!(Reclaimable::read(&[]), None);
+    }
+
+    #[test]
+    fn the_hint_names_what_it_found_and_the_command_that_acts_on_it() {
+        // A count alone cannot be judged. The names are what make the hint
+        // something a reader can disagree with, and `wf reap` is the only
+        // action it points at.
+        let workspaces: Vec<Workspace> = (0..5)
+            .map(|i| workspace(&format!("ws-{i}"), "blooop/devlaunch", 80 + i))
+            .collect();
+        let known = facts([
+            (node("blooop/devlaunch", 80), NodeFact::Closed),
+            (node("blooop/devlaunch", 81), NodeFact::Closed),
+            (node("blooop/devlaunch", 82), NodeFact::Closed),
+            (node("blooop/devlaunch", 83), NodeFact::Closed),
+            (node("blooop/devlaunch", 84), NodeFact::Closed),
+        ]);
+        let reading = reading(&workspaces, &known).expect("five closed tickets");
+        assert_eq!(
+            reading.hint(),
+            "· 5 reclaimable: ws-0, ws-1, ws-2, +2 more — wf reap"
+        );
+        // One is spelt outright, with no count of the unspelt.
+        let one = Reclaimable {
+            ids: vec!["only".to_string()],
+            warned: 0,
+        };
+        assert_eq!(one.hint(), "· 1 reclaimable: only — wf reap");
+    }
+
+    #[tokio::test]
+    async fn a_failing_dl_listing_produces_no_hint_and_no_error() {
+        // No `dl` on PATH, a `dl` too old for `--json`, a listing that will not
+        // parse: all the same answer. The signature carries half the claim —
+        // there is no `Result` to propagate — and this pins the other half,
+        // that the failure is not a panic either.
+        let surfaced = survey(
+            || async {
+                Err(anyhow!(
+                    "failed to run `dl` — is devlaunch installed and on PATH?"
+                ))
+            },
+            |_| async { unreachable!("the tracker must not be asked about a listing that failed") },
+        )
+        .await;
+        assert_eq!(surfaced, None);
+    }
+
+    #[tokio::test]
+    async fn a_failing_node_facts_query_produces_no_hint_and_no_error() {
+        // The listing worked and the tracker did not: a GraphQL error, an
+        // unauthenticated `gh`, no network. Same answer, and in particular not
+        // a reading taken from the half of the evidence that did arrive.
+        let surfaced = survey(
+            || async { Ok(vec![workspace("doomed", "blooop/devlaunch", 80)]) },
+            |_| async { Err(anyhow!("GraphQL error: Bad credentials")) },
+        )
+        .await;
+        assert_eq!(surfaced, None);
+    }
+
+    #[tokio::test]
+    async fn a_machine_with_no_wayfinder_workspaces_asks_the_tracker_nothing() {
+        // The listing is `dl`'s whole machine, most of which is not `wf`'s. No
+        // node means no question worth a round trip — and the `unreachable!`
+        // is what pins that rather than merely observing an empty answer.
+        let mut foreign = workspace("theirs", "blooop/devlaunch", 80);
+        foreign.devlaunch = false;
+        let surfaced = survey(
+            || async { Ok(vec![foreign]) },
+            |_| async { unreachable!("no nodes means no tracker query") },
+        )
+        .await;
+        assert_eq!(surfaced, None);
+    }
+
+    #[tokio::test]
+    async fn a_survey_that_lands_reads_exactly_what_a_reap_would_claim() {
+        let listed = vec![
+            workspace("doomed", "blooop/devlaunch", 80),
+            workspace("alive", "blooop/devlaunch", 81),
+        ];
+        let known = facts([
+            (node("blooop/devlaunch", 80), NodeFact::Closed),
+            (node("blooop/devlaunch", 81), NodeFact::InFlight { pr: 9 }),
+        ]);
+        let asked = std::cell::RefCell::new(BTreeSet::new());
+        let surfaced = survey(
+            || async { Ok(listed.clone()) },
+            |nodes| {
+                *asked.borrow_mut() = nodes;
+                async { Ok(known.clone()) }
+            },
+        )
+        .await;
+        assert_eq!(
+            surfaced,
+            reading(&listed, &known),
+            "the survey's answer is the reading over what the two reads returned"
+        );
+        assert_eq!(
+            asked.into_inner(),
+            [node("blooop/devlaunch", 80), node("blooop/devlaunch", 81)]
+                .into_iter()
+                .collect::<BTreeSet<_>>(),
+            "one batched question, covering every node the listing named"
+        );
+    }
+
+    /// This module's own source, with the comments and the tests stripped —
+    /// the guard below is about what the code can do, not about what the prose
+    /// says it does.
+    fn code_only() -> String {
+        include_str!("reclaim.rs")
+            .lines()
+            .take_while(|line| !line.starts_with("#[cfg(test)]"))
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn no_deletion_is_reachable_from_the_surfacing_path() {
+        // The whole safety claim of #137, asserted structurally because there
+        // is no behaviour to observe: this module must have no way to destroy
+        // anything, so what is pinned is that it does not name the means.
+        // `reap::remove` is the one function that deletes, `dl <ws> rm` the one
+        // command, `--force` the one waiver, and a `Command` of its own would
+        // be a way around all three.
+        let code = code_only();
+        for forbidden in [
+            "remove",
+            "\"rm\"",
+            "--force",
+            "Command",
+            "process::",
+            "unsafe",
+        ] {
+            assert!(
+                !code.contains(forbidden),
+                "the surfacing path must not be able to delete: it names {forbidden:?}"
+            );
+        }
+        // And the one call it *does* make into reap's planning is never the
+        // insisting one — the waiver stays with the human reading the plan.
+        assert!(
+            code.contains("reap::plan(workspaces, known, false)"),
+            "the reading must plan without insisting"
+        );
+    }
+
+    #[test]
+    fn the_surfaced_set_comes_from_doomed_rather_than_a_partition_written_twice() {
+        // #129's single definition, pinned at the one site that could quietly
+        // grow a second one. A `matches!(v, Verdict::Reap { .. })` here would
+        // pass every behavioural test in this file on the day it was written
+        // and drift the first time `doomed` changed.
+        let code = code_only();
+        assert!(
+            code.contains("reap::doomed(verdicts)"),
+            "the doomed set must be asked for, not re-derived"
+        );
+        assert!(
+            !code.contains("Verdict::Reap"),
+            "nothing here may decide what a reap would take: {}",
+            "that is `doomed`'s job alone"
+        );
+    }
+}

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -533,6 +533,10 @@ mod tests {
         // `std::fs::remove_dir_all` inside the spawned task passed both this
         // and the argv probe, because a directory removed in-process runs no
         // command for a shim to write down.
+        //
+        // `unsafe` used to be on this list and is not, for the reason its
+        // sibling gives: `unsafe_code = "deny"` in `Cargo.toml` already covers
+        // every target in the crate.
         let code = crate::probe::code_only(include_str!("refresh.rs"));
         for forbidden in [
             "reap::",
@@ -542,7 +546,6 @@ mod tests {
             "Command",
             "process::",
             "fs::",
-            "unsafe",
         ] {
             assert!(
                 !code.contains(forbidden),

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -549,10 +549,14 @@ mod tests {
         //
         // `fs` is bare for the same reason, and that took a second round to
         // notice: written `fs::`, it was reopened by `use std::fs as sys;`.
-        // Measured here rather than assumed for the two library files as well
-        // as for `picker.rs` — that alias inside the spawned task is lib 356/1
-        // against the bare name, and `fs` occurs in none of the four guarded
-        // files' code.
+        // Measured, not assumed, that it costs nothing: `fs` occurs in none of
+        // the four guarded files' code. What it buys here is not the aliased
+        // `remove_dir_all` inside the spawned task — `remove` catches that at
+        // either spelling — but the calls `remove` does not name; see
+        // [`crate::reclaim`], where an aliased `fs::write` is red at `fs` and
+        // green at `fs::`. That pair was measured there and not here, so this
+        // list carries the bare name by the same argument rather than by its
+        // own row.
         let code = crate::probe::code_only("refresh.rs", include_str!("refresh.rs"));
         for forbidden in [
             "reap",

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -540,9 +540,15 @@ mod tests {
         // `unsafe` used to be on this list and is not, for the reason its
         // sibling gives: `unsafe_code = "deny"` in `Cargo.toml` already covers
         // every target in the crate.
+        //
+        // `reap` bare rather than `reap::`, matching `picker.rs`: this file has
+        // no business naming the module at all, and the module cannot be
+        // reached without its name being written, so `use crate::reap as tidy;`
+        // is caught here too. It costs nothing — nothing in this file's code
+        // says the word.
         let code = crate::probe::code_only(include_str!("refresh.rs"));
         for forbidden in [
-            "reap::",
+            "reap",
             "remove",
             "\"rm\"",
             "--force",

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -531,7 +531,7 @@ mod tests {
         // this file, not about everything a future handed to it might do — the
         // reading itself is guarded in [`crate::reclaim`] and the loop that
         // consumes it in the binary's `picker`.
-        // The same list its sibling in [`crate::reclaim`] carries, and for the
+        // Its sibling in [`crate::reclaim`]'s list plus `reap`, and for the
         // same reason: a shorter one here was a door in the same wall. A
         // `std::fs::remove_dir_all` inside the spawned task passed both this
         // and the argv probe, because a directory removed in-process runs no
@@ -546,6 +546,13 @@ mod tests {
         // reached without its name being written, so `use crate::reap as tidy;`
         // is caught here too. It costs nothing — nothing in this file's code
         // says the word.
+        //
+        // `fs` is bare for the same reason, and that took a second round to
+        // notice: written `fs::`, it was reopened by `use std::fs as sys;`.
+        // Measured here rather than assumed for the two library files as well
+        // as for `picker.rs` — that alias inside the spawned task is lib 356/1
+        // against the bare name, and `fs` occurs in none of the four guarded
+        // files' code.
         let code = crate::probe::code_only("refresh.rs", include_str!("refresh.rs"));
         for forbidden in [
             "reap",
@@ -554,7 +561,7 @@ mod tests {
             "--force",
             "Command",
             "process::",
-            "fs::",
+            "fs",
         ] {
             assert!(
                 !code.contains(forbidden),

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -20,6 +20,7 @@
 //! failed load leaves the picker up with a notice rather than taking it down.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -29,6 +30,7 @@ use tokio::task::JoinHandle;
 use crate::fetch;
 use crate::model::{Map, MapId, MapSet};
 use crate::projects::ProjectsCache;
+use crate::reclaim::Reclaimable;
 
 /// How long the map search waits before trying again. The only recurring timer
 /// left: nothing polls, but a search that never answers would leave `wf`
@@ -59,6 +61,12 @@ pub enum LoadEvent {
     SearchFailed,
     /// One map's load reported.
     Fetched { id: MapId, outcome: MapFetch },
+    /// The background reading found workspaces a `wf reap` would claim (#137).
+    ///
+    /// Only ever sent when there is something to say: a reading that failed and
+    /// a reading that found nothing are the same silence, because neither is
+    /// anything the screen should draw.
+    Reclaimable(Reclaimable),
 }
 
 /// Has the `wayfinder:map` label search answered yet?
@@ -324,6 +332,38 @@ pub fn spawn_discovery(
     })
 }
 
+/// Take the background reading of what a `wf reap` would claim, off the path to
+/// the first frame (#137).
+///
+/// The same shape as [`spawn_discovery`] and for the same reason: the reading
+/// costs a `dl --ls --json` subprocess and one batched GraphQL call, and the
+/// picker is already drawn and answering keys. Nothing on the way to the first
+/// frame waits for this — it folds into the view when it lands, through the one
+/// channel everything else arrives on.
+///
+/// The reading is handed in as a *future* rather than taken as a capability
+/// this could invoke: what reaches the screen is a value, and nothing in this
+/// module can ask for a deletion or perform one.
+///
+/// Silent by construction: the future answers `Option`, and a `None` — no `dl`,
+/// a listing that failed, a tracker that would not answer, nothing to reclaim —
+/// sends nothing at all. There is no failure event because there is no failure
+/// worth a word.
+///
+/// Returns its handle so the launch path can stop it and wait, exactly as it
+/// does for the map loads: the reading holds child processes of its own, and an
+/// in-flight one outliving the `exec` would be inherited by the agent.
+pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()>
+where
+    S: Future<Output = Option<Reclaimable>> + Send + 'static,
+{
+    tokio::spawn(async move {
+        if let Some(found) = survey.await {
+            let _ = tx.send(LoadEvent::Reclaimable(found));
+        }
+    })
+}
+
 /// Where the cursor lands after a load or a refresh swaps the ticket list.
 ///
 /// Identity wins over position: if the previously selected row still exists
@@ -350,6 +390,85 @@ pub fn preserve_cursor<K: PartialEq>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// This module's source with the comments stripped, for the structural
+    /// guard below — what the code can do, not what the prose says it does.
+    fn code_only() -> String {
+        include_str!("refresh.rs")
+            .lines()
+            .take_while(|line| !line.starts_with("#[cfg(test)]"))
+            .filter(|line| !line.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// A reading that never answers — the reading `wf` must be able to draw
+    /// over. A `pending` future rather than a long sleep, so "the picker did
+    /// not wait" is a fact about the code and not about a timer.
+    async fn never() -> Option<Reclaimable> {
+        std::future::pending().await
+    }
+
+    #[tokio::test]
+    async fn the_picker_never_waits_on_the_reading() {
+        // The claim that keeps this off the critical path: spawning the reading
+        // hands back control immediately, and the loop that draws the first
+        // frame finds an empty channel rather than a value it had to wait for.
+        // The reading here *never* completes, so anything that awaited it would
+        // hang this test rather than slow it.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let handle = spawn_survey(never(), tx.clone());
+            assert!(
+                rx.try_recv().is_err(),
+                "nothing may be on the channel before the reading lands"
+            );
+            handle.abort();
+        })
+        .await
+        .expect("the picker must not wait for the reading");
+    }
+
+    #[tokio::test]
+    async fn a_reading_that_lands_folds_in_through_the_one_channel() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let found = Reclaimable::for_test(&["ws-a"], 0);
+        spawn_survey(std::future::ready(Some(found.clone())), tx.clone())
+            .await
+            .expect("the reading task");
+        match rx.try_recv() {
+            Ok(LoadEvent::Reclaimable(got)) => assert_eq!(got, found),
+            other => panic!("the reading must arrive as its own event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_reading_that_found_nothing_says_nothing() {
+        // No `dl`, a failed listing, a tracker that would not answer, or simply
+        // nothing to reclaim: one silence, no event, and above all no error.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        spawn_survey(std::future::ready(None), tx.clone())
+            .await
+            .expect("the reading task");
+        assert!(
+            rx.try_recv().is_err(),
+            "a reading with nothing to say must send nothing"
+        );
+    }
+
+    #[test]
+    fn the_background_reading_carries_a_value_and_never_a_capability() {
+        // #137's safety claim, at the seam that spawns the work: this module
+        // takes a future that answers with a reading. It cannot reach `reap`'s
+        // deletion side, because it cannot reach `reap` at all.
+        let code = code_only();
+        for forbidden in ["reap::", "\"rm\"", "--force", "Command"] {
+            assert!(
+                !code.contains(forbidden),
+                "the background reading must not be able to delete: it names {forbidden:?}"
+            );
+        }
+    }
 
     const A: (&str, u64) = ("wayfinder", 6);
     const B: (&str, u64) = ("wayfinder", 7);

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -369,13 +369,21 @@ where
 /// A `JoinHandle` would do the job and did, until the guard on "the picker
 /// never waits for this" turned out to be a grep over `main.rs` — which passes
 /// happily for `let _ = survey.await;` written any of the several ways that
-/// spelling admits. A handle nobody can await is a stronger statement than a
-/// test that nobody awaited it: the only thing this type offers is
-/// [`stop`](Survey::stop), and waiting for the reading before the first frame
-/// stops being a thing that compiles.
+/// spelling admits. The only thing this type offers is
+/// [`stop`](Survey::stop), so *this handle* cannot be waited on.
 ///
-/// Which leaves exactly one hazard, and [`stop`](Survey::stop) is where it is
-/// answered.
+/// It is worth being exact about how far that goes, because the obvious
+/// stronger claim is false and was made here: it does **not** put the reading
+/// off limits before the first frame. The reading is a separate value, and
+/// `let found = survey_live().await;` above the call compiles, is green, and
+/// puts a subprocess and a round trip in front of the screen. What rules that
+/// out is a fact about a run —
+/// `picker::tests::the_first_frame_is_drawn_before_anything_is_asked`, which
+/// records the frame and the subprocesses into one ordered log and reads the
+/// order off it.
+///
+/// Which leaves exactly one hazard this type does answer, and
+/// [`stop`](Survey::stop) is where it is.
 #[derive(Debug)]
 pub struct Survey(JoinHandle<()>);
 
@@ -520,8 +528,22 @@ mod tests {
         // #137's safety claim, at the seam that spawns the work: this module
         // takes a future that answers with a reading. It cannot reach `reap`'s
         // deletion side, because it cannot reach `reap` at all.
+        // The same list its sibling in [`crate::reclaim`] carries, and for the
+        // same reason: a shorter one here was a door in the same wall. A
+        // `std::fs::remove_dir_all` inside the spawned task passed both this
+        // and the argv probe, because a directory removed in-process runs no
+        // command for a shim to write down.
         let code = crate::probe::code_only(include_str!("refresh.rs"));
-        for forbidden in ["reap::", "\"rm\"", "--force", "Command"] {
+        for forbidden in [
+            "reap::",
+            "remove",
+            "\"rm\"",
+            "--force",
+            "Command",
+            "process::",
+            "fs::",
+            "unsafe",
+        ] {
             assert!(
                 !code.contains(forbidden),
                 "the background reading must not be able to delete: it names {forbidden:?}"

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -546,7 +546,7 @@ mod tests {
         // reached without its name being written, so `use crate::reap as tidy;`
         // is caught here too. It costs nothing — nothing in this file's code
         // says the word.
-        let code = crate::probe::code_only(include_str!("refresh.rs"));
+        let code = crate::probe::code_only("refresh.rs", include_str!("refresh.rs"));
         for forbidden in [
             "reap",
             "remove",

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -350,18 +350,59 @@ pub fn spawn_discovery(
 /// sends nothing at all. There is no failure event because there is no failure
 /// worth a word.
 ///
-/// Returns its handle so the launch path can stop it and wait, exactly as it
+/// Returns a [`Survey`] so the launch path can stop it and wait, exactly as it
 /// does for the map loads: the reading holds child processes of its own, and an
 /// in-flight one outliving the `exec` would be inherited by the agent.
-pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()>
+pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>) -> Survey
 where
     S: Future<Output = Option<Reclaimable>> + Send + 'static,
 {
-    tokio::spawn(async move {
+    Survey(tokio::spawn(async move {
         if let Some(found) = survey.await {
             let _ = tx.send(LoadEvent::Reclaimable(found));
         }
-    })
+    }))
+}
+
+/// The running reading, as something that can only be **stopped**.
+///
+/// A `JoinHandle` would do the job and did, until the guard on "the picker
+/// never waits for this" turned out to be a grep over `main.rs` — which passes
+/// happily for `let _ = survey.await;` written any of the several ways that
+/// spelling admits. A handle nobody can await is a stronger statement than a
+/// test that nobody awaited it: the only thing this type offers is
+/// [`stop`](Survey::stop), and waiting for the reading before the first frame
+/// stops being a thing that compiles.
+///
+/// Which leaves exactly one hazard, and [`stop`](Survey::stop) is where it is
+/// answered.
+#[derive(Debug)]
+pub struct Survey(JoinHandle<()>);
+
+impl Survey {
+    /// Stop the reading and wait until it is really gone.
+    ///
+    /// Both halves matter, and only on the launch path. `abort` asks; the
+    /// `await` is what waits for the task's future to be *dropped*, and
+    /// dropping it is what closes the `dl` or `gh` this reading may have in
+    /// flight (`kill_on_drop`). Skipping the wait — or dropping the handle, or
+    /// forgetting it — leaves a live child that outlives the `exec`, and the
+    /// agent that replaces `wf` inherits it holding the terminal it just took
+    /// over.
+    pub async fn stop(self) {
+        self.0.abort();
+        let _ = self.0.await;
+    }
+
+    /// Wait for the reading to finish of its own accord.
+    ///
+    /// Test-only, and that is the whole point of the type: production has no
+    /// way to wait for this, so the tests below can wait for a reading that
+    /// answers immediately without opening the door `main.rs` must not have.
+    #[cfg(test)]
+    pub(crate) async fn settle(self) {
+        self.0.await.expect("the reading task");
+    }
 }
 
 /// Where the cursor lands after a load or a refresh swaps the ticket list.
@@ -391,17 +432,6 @@ pub fn preserve_cursor<K: PartialEq>(
 mod tests {
     use super::*;
 
-    /// This module's source with the comments stripped, for the structural
-    /// guard below — what the code can do, not what the prose says it does.
-    fn code_only() -> String {
-        include_str!("refresh.rs")
-            .lines()
-            .take_while(|line| !line.starts_with("#[cfg(test)]"))
-            .filter(|line| !line.trim_start().starts_with("//"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     /// A reading that never answers — the reading `wf` must be able to draw
     /// over. A `pending` future rather than a long sleep, so "the picker did
     /// not wait" is a fact about the code and not about a timer.
@@ -418,12 +448,12 @@ mod tests {
         // hang this test rather than slow it.
         let (tx, mut rx) = mpsc::unbounded_channel();
         tokio::time::timeout(Duration::from_secs(5), async {
-            let handle = spawn_survey(never(), tx.clone());
+            let survey = spawn_survey(never(), tx.clone());
             assert!(
                 rx.try_recv().is_err(),
                 "nothing may be on the channel before the reading lands"
             );
-            handle.abort();
+            survey.stop().await;
         })
         .await
         .expect("the picker must not wait for the reading");
@@ -434,8 +464,8 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let found = Reclaimable::for_test(&["ws-a"], 0);
         spawn_survey(std::future::ready(Some(found.clone())), tx.clone())
-            .await
-            .expect("the reading task");
+            .settle()
+            .await;
         match rx.try_recv() {
             Ok(LoadEvent::Reclaimable(got)) => assert_eq!(got, found),
             other => panic!("the reading must arrive as its own event, got {other:?}"),
@@ -448,11 +478,40 @@ mod tests {
         // nothing to reclaim: one silence, no event, and above all no error.
         let (tx, mut rx) = mpsc::unbounded_channel();
         spawn_survey(std::future::ready(None), tx.clone())
-            .await
-            .expect("the reading task");
+            .settle()
+            .await;
         assert!(
             rx.try_recv().is_err(),
             "a reading with nothing to say must send nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn stopping_the_reading_waits_for_it_to_be_gone() {
+        // `abort` on its own only *asks*. What the launch path needs is that
+        // the task's future has been dropped by the time this returns, because
+        // dropping it is what kills the `dl` or `gh` the reading may still have
+        // in flight — an `abort` without the wait, or a handle simply forgotten,
+        // leaves that child alive to be inherited by the agent `wf` execs.
+        //
+        // The witness is an `Arc` the task holds: the future cannot be dropped
+        // while the count is above one, and cannot survive once it is one.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let witness = std::sync::Arc::new(());
+        let held = std::sync::Arc::clone(&witness);
+        let survey = spawn_survey(
+            async move {
+                std::future::pending::<()>().await;
+                drop(held);
+                None
+            },
+            tx,
+        );
+        survey.stop().await;
+        assert_eq!(
+            std::sync::Arc::strong_count(&witness),
+            1,
+            "the reading is still running after it was stopped"
         );
     }
 
@@ -461,7 +520,7 @@ mod tests {
         // #137's safety claim, at the seam that spawns the work: this module
         // takes a future that answers with a reading. It cannot reach `reap`'s
         // deletion side, because it cannot reach `reap` at all.
-        let code = code_only();
+        let code = crate::probe::code_only(include_str!("refresh.rs"));
         for forbidden in ["reap::", "\"rm\"", "--force", "Command"] {
             assert!(
                 !code.contains(forbidden),

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -526,8 +526,11 @@ mod tests {
     #[test]
     fn the_background_reading_carries_a_value_and_never_a_capability() {
         // #137's safety claim, at the seam that spawns the work: this module
-        // takes a future that answers with a reading. It cannot reach `reap`'s
-        // deletion side, because it cannot reach `reap` at all.
+        // takes a future that answers with a reading, and its own text names
+        // neither `reap` nor any means of destruction. That is a fact about
+        // this file, not about everything a future handed to it might do — the
+        // reading itself is guarded in [`crate::reclaim`] and the loop that
+        // consumes it in the binary's `picker`.
         // The same list its sibling in [`crate::reclaim`] carries, and for the
         // same reason: a shorter one here was a door in the same wall. A
         // `std::fs::remove_dir_all` inside the spawned task passed both this

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,6 +17,7 @@ use crate::app::{App, Overlay};
 use crate::filter;
 use crate::launch::{Agent, Candidate, Launch, Staged};
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
+use crate::reclaim::Reclaimable;
 use crate::view::{Branch, Fold, GroupKind, Item, Plan, ProjectRow};
 
 /// One colour per glyph meaning, shared by the row column and the rollup
@@ -573,6 +574,24 @@ pub fn failure_note(app: &App) -> String {
     }
 }
 
+/// The `· N reclaimable: …` segment on the count line (#137): what a
+/// `wf reap` would claim, once the background reading has landed.
+///
+/// Empty while the reading is out, and empty forever if it failed or found
+/// nothing — the three are one silence on purpose, because none of them is
+/// something a person picking a ticket needs told about.
+///
+/// It names the workspaces rather than only counting them: a bare number is
+/// something a reader has no way to agree or disagree with, and the point of
+/// surfacing this at all is that `wf reap` is then a decision rather than an
+/// errand. The picker does nothing with it — the segment *is* the feature.
+pub fn reclaim_note(app: &App) -> String {
+    app.reclaimable
+        .as_ref()
+        .map(Reclaimable::hint)
+        .unwrap_or_default()
+}
+
 /// The `· N idle maps hidden` segment on the count line (#51): the leverage
 /// view drops a map with nothing takeable from the body, and the count is the
 /// only trace of it — silence would read as the map not existing at all. The
@@ -856,11 +875,16 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     // staged — the staged launch is a modal now (#62's line became
     // [`draw_launch_picker`]), and a modal does not need the row it covers to
     // move out of its way.
-    let status = [app.startup.hint(), failure_note(app), idle_note(&plan)]
-        .into_iter()
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let status = [
+        app.startup.hint(),
+        failure_note(app),
+        idle_note(&plan),
+        reclaim_note(app),
+    ]
+    .into_iter()
+    .filter(|part| !part.is_empty())
+    .collect::<Vec<_>>()
+    .join(" ");
     let (shown, total) = app.counts();
     let mut count_spans = vec![
         Span::raw(format!("  {shown}/{total}")),
@@ -1373,6 +1397,53 @@ mod tests {
             screen.contains("└─  ● #2 Choose the stack"),
             "the done ticket hangs off the group line: {screen}"
         );
+    }
+
+    #[test]
+    fn the_first_frame_says_nothing_about_reclaimable_workspaces() {
+        // The reading is a `dl` subprocess and a GraphQL call behind the
+        // screen. Until it lands — and forever, if it failed or found nothing —
+        // the picker looks exactly as it did before #137.
+        let app = fixture_app();
+        assert_eq!(app.reclaimable, None, "nothing has been read yet");
+        let screen = render(&app);
+        assert!(
+            !screen.contains("reclaimable"),
+            "the picker must not mention a reading it has not got: {screen}"
+        );
+    }
+
+    #[test]
+    fn the_count_line_names_what_a_reap_would_claim_once_the_reading_lands() {
+        // A count alone cannot be judged, so the segment names the workspaces
+        // and the command that acts on them. Nothing here deletes anything —
+        // the whole feature is this sentence.
+        let mut app = fixture_app();
+        app.reclaimable = Some(Reclaimable::for_test(&["ws-a", "ws-b"], 0));
+        let screen = render(&app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("reclaimable"))
+            .unwrap_or_else(|| panic!("the count line says so: {screen}"));
+        assert!(line.contains("2 reclaimable"), "{line}");
+        assert!(line.contains("ws-a"), "{line}");
+        assert!(line.contains("ws-b"), "{line}");
+        assert!(line.contains("wf reap"), "{line}");
+    }
+
+    #[test]
+    fn a_warned_workspace_is_never_drawn_as_reclaimable() {
+        // #128's posture, at the last place it could be lost: the warned count
+        // is an aside, and the leading number is the doomed set's alone.
+        let mut app = fixture_app();
+        app.reclaimable = Some(Reclaimable::for_test(&["ws-a"], 2));
+        let screen = render(&app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("reclaimable"))
+            .unwrap_or_else(|| panic!("the count line says so: {screen}"));
+        assert!(line.contains("1 reclaimable"), "{line}");
+        assert!(line.contains("+2 to check by hand"), "{line}");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -585,10 +585,16 @@ pub fn failure_note(app: &App) -> String {
 /// something a reader has no way to agree or disagree with, and the point of
 /// surfacing this at all is that `wf reap` is then a decision rather than an
 /// errand. The picker does nothing with it — the segment *is* the feature.
-pub fn reclaim_note(app: &App) -> String {
+///
+/// `width` is what is left of the count line once everything else on it has
+/// been laid down. Real workspace ids are ~40 characters, so this segment is
+/// the one on the line that has to be *sized* rather than written and clipped:
+/// see [`Reclaimable::hint`] for what it gives up first, and what it never
+/// gives up.
+pub fn reclaim_note(app: &App, width: usize) -> String {
     app.reclaimable
         .as_ref()
-        .map(Reclaimable::hint)
+        .map(|found| Reclaimable::hint(found, width))
         .unwrap_or_default()
 }
 
@@ -875,27 +881,44 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     // staged — the staged launch is a modal now (#62's line became
     // [`draw_launch_picker`]), and a modal does not need the row it covers to
     // move out of its way.
-    let status = [
-        app.startup.hint(),
-        failure_note(app),
-        idle_note(&plan),
-        reclaim_note(app),
-    ]
-    .into_iter()
-    .filter(|part| !part.is_empty())
-    .collect::<Vec<_>>()
-    .join(" ");
+    let mut parts: Vec<String> = [app.startup.hint(), failure_note(app), idle_note(&plan)]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect();
     let (shown, total) = app.counts();
+    let counts = format!("  {shown}/{total}");
+    let notice = app
+        .notice
+        .as_ref()
+        .map(|notice| format!("   {notice}"))
+        .unwrap_or_default();
+    // The reclaim segment is sized rather than written and clipped, because it
+    // is the only one on this line whose content is unbounded — a `dl`
+    // workspace id is ~40 characters and there can be three of them. It goes
+    // last and takes what the rest of the line has left, which is why the rest
+    // of the line is measured first.
+    let spent = counts.chars().count()
+        + 2
+        + parts
+            .iter()
+            .map(|part| part.chars().count() + 1)
+            .sum::<usize>()
+        + notice.chars().count();
+    let note = reclaim_note(app, (count_area.width as usize).saturating_sub(spent));
+    if !note.is_empty() {
+        parts.push(note);
+    }
+    let status = parts.join(" ");
     let mut count_spans = vec![
-        Span::raw(format!("  {shown}/{total}")),
+        Span::raw(counts),
         Span::styled(
             format!("  {status}"),
             Style::new().add_modifier(Modifier::DIM),
         ),
     ];
-    if let Some(notice) = &app.notice {
+    if !notice.is_empty() {
         count_spans.push(Span::styled(
-            format!("   {notice}"),
+            notice,
             Style::new().add_modifier(Modifier::DIM),
         ));
     }
@@ -984,7 +1007,13 @@ mod tests {
 
     /// Render the app through `TestBackend` and return the screen as text.
     fn render(app: &App) -> String {
-        let backend = TestBackend::new(90, 24);
+        render_at(90, app)
+    }
+
+    /// The same, on a terminal of a stated width — for the claims that are
+    /// about what survives a narrow one.
+    fn render_at(width: u16, app: &App) -> String {
+        let backend = TestBackend::new(width, 24);
         let mut terminal = Terminal::new(backend).expect("terminal");
         terminal.draw(|f| draw(f, app)).expect("draw");
         let buf = terminal.backend().buffer();
@@ -1444,6 +1473,44 @@ mod tests {
             .unwrap_or_else(|| panic!("the count line says so: {screen}"));
         assert!(line.contains("1 reclaimable"), "{line}");
         assert!(line.contains("+2 to check by hand"), "{line}");
+    }
+
+    #[test]
+    fn the_count_line_keeps_the_command_when_the_names_are_real_ones() {
+        // `ws-a` fits anywhere and proves nothing. A `dl` workspace id is ~40
+        // characters, and three of them written out unconditionally push the
+        // aside and the `wf reap` pointer past the right edge of an
+        // 80-column terminal — leaving a segment that names workspaces and
+        // says nothing about what to do with them.
+        let mut app = fixture_app();
+        app.reclaimable = Some(Reclaimable::for_test(
+            &[
+                "devlaunch-github-com-blooop-wayfinder-129",
+                "devlaunch-github-com-blooop-wayfinder-127",
+                "devlaunch-github-com-blooop-wayfinder-80x",
+            ],
+            1,
+        ));
+        for width in [80, 100, 120] {
+            let screen = render_at(width, &app);
+            let line = screen
+                .lines()
+                .find(|line| line.contains("reclaimable"))
+                .unwrap_or_else(|| panic!("{width}: the count line says so: {screen}"));
+            assert!(line.contains("3 reclaimable"), "{width}: {line}");
+            assert!(
+                line.contains("(+1 to check by hand)"),
+                "{width}: the aside is never what gets clipped: {line}"
+            );
+            assert!(
+                line.contains("wf reap"),
+                "{width}: nor is the command: {line}"
+            );
+            assert!(
+                line.contains("129"),
+                "{width}: and a workspace is still named: {line}"
+            );
+        }
     }
 
     #[test]

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -52,7 +52,11 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // The search retries, so a blip is survivable rather than fatal:
             // go round and wait for the next event.
             LoadEvent::SearchFailed => {}
-            other => {
+            // Named rather than `_`, so a seventh kind of arrival is a compile
+            // error here and a decision someone makes — this file is compiled
+            // but never run by CI, which makes a wildcard in it the least
+            // observed thing in the tree.
+            other @ (LoadEvent::Fetched { .. } | LoadEvent::Reclaimable(_)) => {
                 panic!("expected discovery first, got {other:?}")
             }
         }

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -52,7 +52,7 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // The search retries, so a blip is survivable rather than fatal:
             // go round and wait for the next event.
             LoadEvent::SearchFailed => {}
-            other @ LoadEvent::Fetched { .. } => {
+            other => {
                 panic!("expected discovery first, got {other:?}")
             }
         }


### PR DESCRIPTION
Closes #137. Map: #121.

`wf` now says, without being asked, what a `wf reap` would claim — and nothing
more. The noticing ships; the deleting is #138 and stays blocked.

```
  12/30  · 2 reclaimable: devlaunch-github-…oop-wayfinder-127, +1 more — wf reap
```

## What shipped

- **`src/reclaim.rs`** — the reading. `reading()` is `reap::doomed(&reap::plan(…))`,
  called, not reimplemented and not re-derived: `doomed` stays the single place
  that decides what goes (#129). `plan` is asked with `insist` **false**, so a
  workspace whose clone holds work that exists nowhere else is never surfaced —
  `-f` waives `dl`'s guard and that waiver stays a human's to grant in front of
  the plan. `Verdict::Warn` (`Superseded`, `Unstarted`) is *counted* and never
  named, in a `(+N to check by hand)` aside the leading number excludes (#128).
- **`survey()` answers `Option`, not `Result`.** No `dl` on PATH, a `dl --ls`
  that failed, a GraphQL error, no network, or simply nothing to reclaim: one
  silence, no event, no error, no stall. It is generic over its two reads, so
  the whole fail-silent path is exercisable without `dl`, `gh` or a network.
- **`refresh::spawn_survey`** — the same shape as `spawn_discovery`, folding into
  the view through the one channel the loop already drains between frames. It
  takes the reading as a *future*: what reaches the screen is a value. It hands
  back a **`Survey`**, a handle whose only operation is `stop()` — abort *and*
  wait, before the `exec`, for the same reason the map loads are stopped: an
  in-flight `dl`/`gh` would otherwise be inherited by the agent.
- **`App::reclaimable` / `ui::reclaim_note`** — state, not a one-shot notice, on
  the dim count-line segment beside the load hint. It names the workspaces
  rather than only counting them: a bare count is not something a reader can
  agree or disagree with. The segment is **budgeted at every width**: a `dl` id
  is ~41 characters, so the count, the aside and the `— wf reap` pointer are laid
  down first and the names take what is left — whole ones while they fit, then
  one shortened in the middle, then none; and below that the aside goes before
  the pointer, because the command is the only half a reader can act on.
- **`src/picker.rs`** — the picker assembly (screen, loop, handover) in a module
  of its own, and **`wf::reap::run`** — `wf reap` itself — in the library.
- README's Startup and `wf reap` sections document the segment, its budget and
  its silence. No `SKILL.md` describes the picker chrome, so the skills are
  unchanged.

## The safety claim, stated exactly

This is the part that has taken six review rounds, and #137 was **amended**
because of them: *"no deletion is reachable from this path at all"* is not
deliverable while the picker and `wf reap` share a binary crate. `reap::remove`
is private and provably unnameable, but `reap::run(yes, insist)` must stay
public for `main` to dispatch `wf reap`, and it *contains* the deletion.
Everything else available here is a source-text grep (which cannot cover a call
one hop away) or a runtime probe (which covers the branches it drives, for as
long as it watches, over the span it drives, against the layout it fakes). A
**crate split** — the picker in a crate that cannot depend on reap's deletion —
is the only mechanism that would deliver the original wording; it is a real
option, it is noted on #137, and it is deliberately not in this PR.

So, precisely, three things and their edges. **Only the first is a proof.**

1. **The deletion itself cannot be named.** `wf::reap`'s `remove` is private to
   its module in the library; this is the binary. A prologue in `main`, a helper
   in `main.rs`, an aliased import, a submodule of `picker.rs` — every route
   that ends at that function is `E0603`. Nothing has to notice; the build
   refuses. This also holds inside the library: the same edit from `reclaim.rs`
   does not compile.
2. **`reap::run` is public, and what stands against it is two greps over two
   files.** `picker.rs` may not write the token `reap` at all, nor `Command`,
   `process::`, `tokio::spawn`, nor `fs`. `main.rs` holds the list of every line
   **of code** in itself that writes the *word* `reap` — five lines — and may
   write neither `Command` nor `fs`.

   **Bare words, not paths, and that is the whole technique.** `use crate::reap
   as tidy;` writes no `reap::`; `use std::fs as sys;` writes no `fs::`. Both
   were live escapes against the narrower spelling, the second found at
   `663cea8` against a token this PR had added one push earlier. There is no
   spelling of a module that does not write its own name, so the name is what is
   counted — in all four guarded files, `reclaim.rs` and `refresh.rs` included.

   `main.rs`'s list is of lines **of code**: `USAGE` writes `wf reap` twice
   because that is the command it documents, and the help text is cut out before
   the list is taken — pinning its hand-wrapping made the guard fail on a rewrap
   and say something untrue when it did. The cut is now checked against
   `USAGE`'s own line count, because for one push it was not, and an unbounded
   cut is itself an escape (below).

   **They are greps, and they are worth what greps are worth.** They catch a
   cleanup wired in by accident, which is the mistake a maintainer is actually
   likely to make. They do not stop someone routing around them, and six
   rounds of review say so: a grep over two files cannot see the same call
   written in a third, and it cannot see a second name for the module
   re-exported from the library — that second one is demonstrated below,
   fully green. Closing either needs the crate split.
3. **What the run does is recorded, over a stated span.** A probe drives the
   real `session` — real `survey_live`, real channel, real loop, real `draw` —
   in a child process with recording `dl`/`gh` shims and a scratch `HOME`,
   through **all four `Outcome` arms**, and compares the home before and after.
   **Its three limits are stated rather than papered over, and each is measured
   in the table below:**

   - **where.** The recording spans `session`, not `run_picker`. `run_picker` is
     what composes the registration, the terminal, the `session` call and the
     handover, and **no test in this repository executes it** — so a deletion
     written above or below that call is outside the recording entirely. That
     was a live escape found in review at `038fca1` (a real-layout
     `remove_dir_all` in `run_picker`, fully green, destroying the fixture under
     a pty), and it was reopened at `663cea8` by a one-line alias. What stands
     there is the `fs` token in (2), not the probe, and the rows below show the
     same mutation green with the token spelt `fs::` and red with it spelt
     `fs`.
   - **when.** It watches until `WATCH` (400 ms) past the reading landing, past
     each key and past the session ending, so a deletion deferred longer is
     invisible. Demonstrated both ways below.
   - **what it reaches.** The home comparison only sees paths under that scratch
     home, and the argv recording only sees arms the child's fixtures actually
     enter. `fold`'s `SearchFailed` arm is not one of them — the `gh` shim
     succeeds — and a `dl <ws> rm --force` planted there is green. **Arbitrary
     `std::fs` is caught by nothing when it is aimed outside the watched home
     *or written outside the span* — and outside that span is the whole of
     `run_picker` and the whole of `main`.** The second kind is demonstrated
     below, both ways round: a `remove_dir_all` aimed squarely *inside* the
     watched home, written in each of those two functions, passes the whole
     suite with the `fs` token off and really destroys the fixture, and fails
     with it on. The first kind — aimed elsewhere on the disk — is round 7's
     row, carried and marked as not re-run. What catches the second kind is a
     grep over two files. Nothing catches either kind in a third.

And plainly, because the README used to say otherwise: **the picker does delete
one thing, and it is not a workspace.** `run_picker` calls `refresh_skills` on
the way into the agent, and `skills::refresh` removes and rewrites
`~/.claude/wf-skills/<skill>` when a copy has fallen behind the bundle. That is
`wf`'s copy of `wf`'s own prompts. The claim here is about workspaces, and it is
now written as one.

## What this round (round 8) changed

Round 7's review found four of five amended clauses standing where both axes
checked them, and blocked on three one-line guard defects — one of them a
regression introduced by round 7's own headline fix. Each was located and
measured free by the reviewer who found it, and each is re-measured here with a
control.

- **`fs::` is defeated by one line, so the token is now bare `fs`.**
  `use std::fs as sys;` writes no `fs::`; `sys::remove_dir_all(…)` in
  `run_picker` was **fully green** and, built and driven, really removed
  `PRECIOUS.txt` and `workspace.json` from a scratch home laid out the way this
  machine is. That is round 6's escape verbatim, reopened by an alias. The
  technique was already written down one screen away for `reap` and had not been
  applied to `fs`. Bare `fs` occurs **zero** times in the code of all four
  guarded files, so it went on `picker.rs`, `reclaim.rs` and `refresh.rs` at no
  cost.
- **`main.rs` carried no in-process deletion token at all.** A real-layout
  `remove_dir_all` prologue in `main()` was fully green; built,
  `HOME=<scratch> wf --version` printed `wf 0.14.0`, **exited 0**, and destroyed
  both the clone and the devpod record, where the head binary on the same
  command leaves them intact. Both spellings were measured: with the token at
  `fs::` the alias form is green; bare `fs` catches both.
- **`without_usage`'s cut was unbounded, and round 7 introduced it.** `closes`
  was the *first* line at or after the `const` whose `trim_end()` ends `";`,
  with nothing checking that it closed `USAGE`'s own literal. A trailing comment
  on `USAGE`'s closing line runs the cut to the next `";`-terminated line
  anywhere below, and everything between is cut out of the list — a helper
  calling `reap::run(true, true)`, reached from `main()`'s first line,
  disappeared entirely and the whole selection was green. It is now
  `assert_eq!(closes - opens, USAGE.lines().count(), …)`, and a `USAGE` rewrap
  that changes the line count stays green, so it does not put back the
  wrap-pinning round 7 removed.
- **The brace count's real cost is now enumerated.** `code_only` counts braces
  as text, so an unbalanced `{` or `}` in any string, char literal or comment
  *inside the test module* fails the guard over that file — an ordinary,
  security-neutral edit, and much the widest of the four costs, because it falls
  on writing tests rather than on arranging modules. This repository is already
  paying it: the `// }` at the end of `main.rs`'s second list entry exists only
  to balance a `{` inside the string above it, and deleting that comment is bins
  **16 / 1**. The doc's claim that the panic "points at the edit" is corrected to
  what it does: an unbalanced `}` closes the depth early and the message quotes
  the offending line; an unbalanced `{` is only noticed at the end, and the
  message can quote nothing but the file's last line.
- **`picker.rs`'s denylist comparison has its real numbers.** It said the list
  was "one short" of its siblings. Measured: picker 5, `reclaim` 6, `refresh` 7;
  picker is missing **three** that both siblings carry (`remove`, `"rm"`,
  `--force`), and carries `tokio::spawn`, which neither does.

**Corrected because execution falsified them, not tidied:** `picker.rs`'s module
doc (the `fs::` bullet and the (3) concession), `picker.rs`'s guard comment,
`picker.rs:22` and `main.rs:36` (both said "every line", where the list is of
lines *of code* with the help text cut out), `without_usage`'s `# Panics` ("a
shape this cannot locate is refused rather than skipped" — in the escape nothing
was refused), `code_only`'s cost list and its "points at the edit" sentence,
`README.md`'s grep paragraph and its `std::fs` concession, and the two limit rows
in this body above.

**No production code changed in this push** — verified by stripping `//` lines
and truncating at each `mod tests {`, across **every** `.rs` file tracked in the
repo (23 of them), against `663cea8`. Zero files differ. Every edit is inside a
`#[cfg(test)]` module, a doc comment, or the README.

## Guards proven by mutation

Every row below except the last block was run **at this head**, under the
**full CI selection** (`cargo test --locked --lib --bins --examples
--no-fail-fast`, plus `--test skill_docs`) — never a filtered run, with the tree
restored by copying a checksum-verified pristine snapshot back over it (never
`git checkout`) and every source re-`touch`ed between rows so cargo could not
serve a stale build, and with a poison row proving the harness compiles what it
edits. The rows that were **not** re-run in this push are listed as such at the
end, rather than mixed in. Fixture ids (`wf-129-closed`, `wf-137-open`,
`wf-138-unstarted`) name no workspace on any machine, and every binary driven
below ran against a scratch `HOME` built for the run.

**Baseline at this head: lib 357 / 0, bins 17 / 0, examples 0 / 0,
skill_docs 7 / 0**, clippy 0 warnings under `-D warnings`, `fmt --all --check`
clean, `cargo doc --no-deps` clean.

### The three escapes round 7 found, each with the control that isolates the fix

| # | mutation | result | what catches it |
|---|---|---|---|
| P0 | poison: `assert!(false)` in one bin guard | bins **16 / 1** | the harness compiles what it edits |
| A1 | `use std::fs as sys;` + `sys::remove_dir_all(…)` in **`run_picker`**, above the `session` call, aimed at `~/.cache/devlaunch/repos/blooop/wayfinder/<id>` and `~/.devpod/contexts/default/workspaces/<id>` | bins **16 / 1** | `picker.rs`'s denylist: *it names `"fs"`* |
| A1c | **control** — the identical escape with the token spelt `fs::`, as it stood at `663cea8` | lib **357 / 0**, bins **17 / 0**, skill_docs **7 / 0** — **fully green**. Built and run (`wf` with no arguments, no tty): the fixture's `PRECIOUS.txt` and `workspace.json` were **removed**; the head binary on the same command leaves both intact | nothing. The alias writes no `fs::` |
| A2 | round 6's plain `std::fs::remove_dir_all` in `run_picker`, same paths | bins **16 / 1** | the bare token still catches the plain spelling — no regression |
| A3 | real-layout `remove_dir_all` prologue in **`main()`** | bins **16 / 1** | `main.rs`'s guard: *deleting a directory in-process is not something it does* |
| A3a | the **alias** spelling of that prologue in `main()` | bins **16 / 1** | the same assertion |
| A3c | **control** — A3 with the `fs` assertion removed | lib **357 / 0**, bins **17 / 0**, skill_docs **7 / 0** — **fully green**. Built: `HOME=<scratch> wf --version` printed `wf 0.14.0`, **exited 0**, and destroyed both the clone and the devpod record. The head binary on the same command leaves both intact | nothing |
| A3ac | **control** — A3a with the assertion removed | **fully green** | nothing |
| A3b | **spelling control** — A3a with the token written `fs::` instead of `fs` | lib **357 / 0**, bins **17 / 0** — **green** | nothing. This is what says the *bare* name is the fix |
| B1 | trailing comment on `USAGE`'s closing line, plus `async fn wash_up() { reap::run(true, true); let _ = "swept"; }` written directly under `USAGE` and called from `main()`'s first line | bins **16 / 1** | `without_usage`: *the lines cut here are not `USAGE` … left: 31, right: 27* |
| B1c | **control** — the identical escape with the `USAGE.lines().count()` bound removed, i.e. `663cea8`'s shape | lib **357 / 0**, bins **17 / 0**, skill_docs **7 / 0**, fmt and clippy clean — **fully green**. Built and run with a recording `dl` first on `PATH`: `wf --version` printed *no wayfinder workspaces on this machine — nothing to reap* and recorded `dl <--ls> <--json>`; the head binary on the same command records **nothing** | nothing. The `reap::run` line is inside the cut |
| B2 | **vehicle control** — the same helper *without* the trailing comment | bins **16 / 1**, the list quoting `let _ = reap::run(true, true).await;` | the comment is what moved the cut |
| B3 | `USAGE`'s `wf reap` paragraph reworded **and rewrapped from eight lines to ten** | lib **357 / 0**, bins **17 / 0**, skill_docs **7 / 0** — **green** | nothing, correctly: the bound compares two things that move together, so it does not put back round 7's wrap-pinning |

### Re-run at this head to prove no regression

| # | mutation | result | what caught it |
|---|---|---|---|
| R1 | `wf::reap::remove(…)` named from `picker.rs` | **compile error** `E0603` | visibility (clause 1) |
| R2 | `wf::reap::run(true, true)` in `run_picker` | bins **16 / 1** | `picker.rs`'s bare `reap` |
| R3 | `use crate::reap as tidy;` + `tidy::run(true, true)` prologue in `main()` | bins **16 / 1** | `main.rs`'s list, quoting the new line |
| R4 | `Command::new("dl").args([id, "rm", "--force"]).output()` prologue in `main()` | bins **16 / 1** | `main.rs`'s `Command` assertion |
| R5 | raw-string `mod tests {` decoy + an **indented** `wash_up()` calling `wf::reap::run(true, true)` from `run_picker` | bins **16 / 1** | `code_only`'s brace depth |
| R6 | `use std::fs as sys;` + `sys::remove_dir_all(…)` inside `refresh::spawn_survey`'s spawned task | lib **356 / 1** | `refresh.rs`'s bare `fs` (this push widened it too) |
| R7 | the same inside `reclaim`'s reading | lib **356 / 1** | `reclaim.rs`'s bare `fs` |
| R8 | **clause (3)** — `dl <id> rm --force` from a helper in **`app.rs`** (no denylist), on the key path | bins **15 / 2** | *this path must not be able to destroy a workspace, and it ran: `dl <wf-129-closed> <rm> <--force>`* |
| R9 | **clause (5)** — real-layout `remove_dir_all` from the same `app.rs` helper | bins **15 / 2** | the scratch home: *`.cache/devlaunch/repos/blooop/wayfinder/wf-129-closed/PRECIOUS.txt was removed`, `.devpod/contexts/default/workspaces/wf-129-closed/workspace.json was removed`* |

### `code_only` fails closed: the class round 7's review added, measured

Three module-shape costs were already enumerated. This is the fourth, and it is
the widest, because it falls on writing ordinary tests rather than on arranging
modules — and this repository is already paying it.

| # | edit | result | what the message names |
|---|---|---|---|
| F1 | delete `main.rs`'s `// }` — the comment that balances the `{` inside the string on the list entry above it, and changes nothing else | bins **16 / 1** | `main.rs`, and **line 644** — the file's *last* line, 183 lines from the edit |
| F2 | an ordinary new test in `picker.rs` whose assertion string contains `"{ reclaimable"` | bins **17 / 1** | `picker.rs`, and **line 1015** — again the file's last |
| F3 | an ordinary comment ending `}` inside `picker.rs`'s test module | bins **16 / 1** | `picker.rs`, and **line 802** — which *is* the offending line |

F1/F2 versus F3 is why `code_only`'s doc no longer says the panic "points at the
edit". An unbalanced `}` closes the depth early, so the loop fails at the line
that did it; an unbalanced `{` is only noticed when the count is checked at the
end, and there is nothing to quote but the file's last line.

### Inherited from round 7 and **not** re-run in this push

Marked rather than folded in: the `Refresh`, `Continue`, `Launch` and `fold` arm
rows (bins 15/2, 16/1, 15/2, 15/2); the `WATCH` pair (deferred deletion green at
400 ms, bins 16/1 at 3 s); the fictitious-fixture control for the layout change;
the two green rows for limits *outside the home* and `fold`'s `SearchFailed`
arm; the library re-export row (`pub use reap as tidy;`, fully green — the
disclosed residual only a crate split closes); and the three module-shape
fail-closed rows with their two green near-misses. Clause (3) and clause (5)
were re-run here as **R8/R9**, which exercise the same probe against a helper in
a file that carries no denylist.

Failing closed is the intended trade — the alternative is a check that can be
argued out of reading part of the file, which is how both previous versions were
defeated — but it is a real cost, and it is now written into `code_only`'s doc as
a constraint on four files rather than left to be discovered by whoever trips it.

**Source-text guards, counted plainly: four.** Each reads its file's code from
the top down to a `#[cfg(test)] mod tests {` that has been checked to be the
file's last item, with the depth check above standing in for reading the tail
itself. `picker::the_picker_names_neither_a_subprocess_nor_reap` (5 tokens:
`reap`, `Command`, `process::`, `tokio::spawn`, `fs`).
`main::the_binary_writes_reap_only_where_it_is_listed_here` (the five code lines
writing the word, the TUI arm's shape, and neither `Command` nor `fs`).
`refresh::the_background_reading_carries_a_value_and_never_a_capability` (7) and
`reclaim::the_surfacing_module_names_no_means_of_destruction` (6) cover argv-less
destruction in the two library modules on the path; the second also pins the
*agreeing* duplicate of `doomed`, which is invisible to every behavioural test
by definition. The three lists differ, and `picker.rs`'s comment now says how
rather than calling itself "one short": picker lacks `remove`, `"rm"` and
`--force`, which both siblings carry, and carries `tokio::spawn`, which neither
does.

## Measured on this machine, by execution, at this head

- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --locked`
  under `-D warnings`, `cargo doc --no-deps`, lib 357/0, bins 17/0, examples 0/0,
  skill_docs 7/0 — all clean.
- **Every row in the first three tables above**, under the full unfiltered CI
  selection, at this head — including each control, so "green without the fix,
  red with it" is measured on both sides rather than argued.
- **Three binaries built and driven against a scratch `HOME`** laid out the way
  this machine is. The `fs`-in-`main()` escape: `wf --version` exited 0 and
  destroyed the clone and the devpod record. The `fs`-in-`run_picker` escape:
  `wf` with no arguments destroyed the same two before failing on the absent
  tty. The `without_usage` escape, with a recording `dl` first on `PATH`:
  `wf --version` reached `reap::run` and recorded `dl <--ls> <--json>`. The head
  binary, on each of the same three commands, leaves the fixture intact and
  records nothing.
- The "no production code changed" check, across every tracked `.rs` file,
  against `663cea8`: zero files differ.

**Not verified by execution in this push, and marked as such:** that the
`without_usage` escape *removes* a workspace when driven — the recording `dl`
answered `--ls --json` with an empty list, so `reap::run` found nothing to
claim; what was measured is that it reached `reap::run` at all, which the head
binary does not on that command. The same caveat carries over from round 7 for
the library re-export route.

**Inherited from earlier rounds, not re-measured in this push, and marked as
such** (in addition to the mutation rows named at the end of the tables above):
the pty session at 120×40 that drew
`· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap` and recorded
exactly `dl <--ls> <--json>` plus one `gh api graphql`; `wf reap` on the
identical fixture printing `keep wf-137-open` / `warn wf-138-unstarted` /
`reap wf-129-closed`; `wf reap`'s byte-identical behaviour across the move into
the library (twelve comparisons at round 4); the first frame not regressing
against the **pre-PR** base (pty, exec → first byte, n=9, alternating order,
3.8 ms median); the five fail-silent routes; and the live agreement between the
picker's reading and `wf reap`'s own plan against the real authenticated
tracker; and the pty runs of the two `fs` escapes, which were driven here
without a tty instead. Nothing in this push touches `reclaim.rs`'s reading,
`reap::plan`, or any production code path — see the byte-identity check above.

- The reclaim **rate** #121 wants before #138 is still unmeasured — there is
  nothing on this machine for `wf reap` to claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

