### PR TITLE
Say what resolve_on_path's second caller now asks it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.15.0"
+  version: "0.15.1"
 
 package:
   name: wf

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1651,9 +1651,9 @@ impl Launch {
 /// that is the caller naming a file, not `$PATH` resolution.
 ///
 /// Two callers, and the difference matters: [`Launch::exec`] resolves the
-/// program it is about to become and reports the miss, while
-/// [`Isolation::detect`] only asks whether `dl` is there and quietly answers
-/// [`Isolation::Host`] when it is not.
+/// program it is about to become and reports the miss, while the `dl` probe
+/// wants only a path to run `--version` on and treats a miss as "no `dl` here",
+/// which [`Isolation::detect`] answers with [`Isolation::Host`].
 fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
     if program.contains('/') {
         return Ok(PathBuf::from(program));


### PR DESCRIPTION
`resolve_on_path`'s doc claimed `Isolation::detect` "only asks whether `dl` is there and quietly answers `Host` when it is not". 0.15.0 made that false: detection also asks the version, so resolution is now one step of a probe rather than the whole question, and a `dl` that *is* on PATH can still answer `Host`.

Doc comment and version bump only. `cargo fmt --check`, `clippy -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc` clean; 360 lib tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the behavior of PATH resolution for `resolve_on_path` and bump the crate version for a patch release.

Enhancements:
- Clarify the documentation comment describing how `resolve_on_path` is used by `Launch::exec` and `Isolation::detect`.

Build:
- Bump crate and packaging metadata versions from 0.15.0 to 0.15.1 to align Cargo.toml, lockfile, and recipe.