### PR TITLE
Read dl's three answers, and say what is running or has stopped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -901,14 +901,15 @@ invisibly absent on a fresh machine. That is what takes `wf` from ~3 MB to
 that set it. `dl <workspace> up` — start without attaching — and the
 per-workspace launch lock are what the warm-up is made of.
 
-**Use `dl` 0.0.20 or newer.** Launching several tickets at once means several
-`dl` processes preparing the same repo's cache at the same moment; 0.0.20 is
-where those runs serialize over a per-repo lock instead of racing (the loser
-of the old race could delete the winner's half-written clone). This one is
-below the isolation floor, so it now only describes what a `dl` too old to
-isolate with would have done. It is kept because `wf reap` still reads a
-listing from whichever `dl` is on PATH: older `dl` on devpod 0.26 hands
-the agent **no terminal**, and an agent with no terminal decides it was invoked
+**Two older floors, now subsumed by the one above.** Both are kept as the
+record of why a floor exists at all — they are what an older `dl` did, and
+0.0.24 is above both, so nothing `wf` will isolate with can still do either.
+
+Launching several tickets at once means several `dl` processes preparing the
+same repo's cache at the same moment; **0.0.20** is where those runs serialize
+over a per-repo lock instead of racing (the loser of the old race could delete
+the winner's half-written clone). And older `dl` on devpod 0.26 hands the agent
+**no terminal**, and an agent with no terminal decides it was invoked
 non-interactively: it prints one answer and exits, so the symptom is a session
 that never starts rather than an error. Measured here on devpod 0.26.1:
 `devpod ssh --command` (what `dl` ≤ 0.0.12 uses) gives `not a tty`, `TERM=dumb`

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ dropped the moment you press it rather than when its replacement lands: these
 are claims in the present tense, and a screen asserting last hour's containers
 beside freshly fetched tickets would be worse than one asserting nothing.
 
-Stalls also reach the [count line](#startup) as `· 2 stalled: wayfinder#133,
-+1 more`, because the row is not always on screen — the project list has no
+Stalls also reach the [count line](#startup) as
+`· 2 stalled: wayfinder#133, wayfinder#134`, because the row is not always on
+screen — the project list has no
 ticket rows at all, and a stall can be inside a fold or another map. Running
 containers stay on their rows: they are the ordinary state of a machine in use,
 and a count of them would be a status bar rather than a summons.
@@ -445,16 +446,19 @@ ask again.
 count line when it arrives:
 
 ```
-  12/30  · 1 stalled: wayfinder#133  · 2 reclaimable: devlaunch-…-127, +1 more — wf reap
+  12/30  · 1 stalled: wayfinder#133 · 2 reclaimable: devlaunch-github-…oop-wayfinder-127, +1 more — wf reap
 ```
 
 That one reading answers two questions, because the same `dl --ls --json` and
 the same tracker query settle both: what a reap would claim, and
 [what is running and what stopped](#what-is-actually-running-and-what-stopped).
-Stalls are laid down first and capped, so the two variable-length segments
-cannot fight over one line — on a terminal too narrow for both it is the reap
-pointer that goes, which is the one trade in here worth disagreeing with: work
-that has stopped moving outranks tidying that can wait.
+Stalls are laid down first, so on a narrowing terminal it is the `wf reap`
+pointer and the warned aside that go while stalls are still naming nodes — the
+one trade in here worth disagreeing with: work that has stopped moving outranks
+tidying that can wait. What stalls will not do is squeeze the reclaim note below
+its own count, because that segment clips rather than vanishing and `· 2
+reclaima` is not a word; they give up a name instead, which the rows' own `⧖`
+markings make readable anyway.
 
 It is the same reading `wf reap` prints, taken by the same code — a `dl --ls
 --json` and one batched tracker query, neither of them on the way to a frame.
@@ -775,7 +779,7 @@ an empty one.
 | `enter` | on the project list: enter that project. On a project's screen: open the launch picker — the creation rows on the project's own row, the launch modes on a ticket or a cluster header — and a second `enter` runs the agent here and exits. On a group line it folds instead, since there is no agent to run |
 | `←`/`→`, `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick Claude/Codex, pick the row, fill its field (a steering prompt, a task, or a map seed), launch — `esc` backs out with the query and cursor intact. `←`/`→` does nothing on a `resume` row, whose agent comes from the record |
 | `⏎` in a row | a previous launch left a conversation on this node: its picker leads with `resume`, and `enter enter` rejoins it |
-| `▣` in a row | a container of this node's is up — [something is very likely working here](#what-is-actually-running-and-what-stopped) |
+| `▣` in a row | [a container of this node's is up](#what-is-actually-running-and-what-stopped) — which is not the same as an agent being alive in it |
 | `⧖` in a row | claimed, nothing pushed, and nothing of its running: a run that stopped between its stages |
 | `ctrl-r` | refetch every map in place, keeping your query, level and cursor |
 | `esc` | clear the query; on an empty query, quit |

--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ short — it says a launch *happened*.
 reading that finds [reclaimable workspaces](#startup) reads it too, and two
 markings come out of the join:
 
-- **`▣` a container of this node's is up.** Something is very likely working
-  here.
+- **`▣` a container of this node's is up.**
 - **`⧖` claimed, nothing pushed, and nothing of its running.** Somebody — almost
   always an agent — took this ticket and is no longer on it.
 
@@ -293,6 +292,11 @@ container on its own is the ordinary look of work that finished. It is the
 *pair* that means a lifecycle went down between its stages. It reads against the
 stage glyph beside it, and that contrast is the finding: `◐ #133 … ⧖` is the
 tracker saying *building* and the machine saying *nothing is*.
+
+`ctrl-r` retakes the reading along with everything else, and what it said is
+dropped the moment you press it rather than when its replacement lands: these
+are claims in the present tense, and a screen asserting last hour's containers
+beside freshly fetched tickets would be worse than one asserting nothing.
 
 Stalls also reach the [count line](#startup) as `· 2 stalled: wayfinder#133,
 +1 more`, because the row is not always on screen — the project list has no
@@ -308,12 +312,19 @@ narrower than the useful-sounding one:
   then. `▣` covers a session you left, a session that exited an hour ago inside
   a container nobody stopped, and a `WF_PREWARM` container never entered. It is
   a floor on activity, not a reading of it.
-- **A stall is not a crash.** An agent that handed off cleanly and one that died
-  mid-slice leave the same shape. The ticket's breadcrumb trail is what tells
-  them apart, and reading it is yours.
-- **Host launches are invisible.** A checkout with no devcontainer runs on the
-  host, where there is no workspace and no state to read. Those nodes carry no
-  marking at all rather than a wrong one.
+- **A stall is not a crash**, and a reboot marks everything at once. The same
+  shape is left by an agent that died mid-slice, one that handed off cleanly, a
+  `dl <ws> stop` you ran yourself, and a restart that stopped every container on
+  the machine. None of those is a false positive — each of those runs really has
+  stopped and really does want picking up — but they arrive together, so
+  `12 stalled` the morning after a reboot is a fact about the host rather than
+  about the work. The breadcrumb trail on the ticket says which.
+- **A node launched on the host can still be marked**, and this is the one
+  outright wrong answer. `wf` cannot see host processes, so a node whose agent
+  is running on the host, but which owns a stopped workspace from some *other*
+  launch — the repo grew a `.devcontainer/` later, or `WF_PREWARM` built one at
+  a staging you backed out of — looks exactly like a stall. A node with no
+  workspace at all is genuinely unmarked rather than wrongly marked.
 - **This machine only**, the same limit [resume](#resuming-picking-a-conversation-back-up)
   carries: the listing is local, so a ticket worked on another machine looks
   unstarted here.

--- a/README.md
+++ b/README.md
@@ -270,6 +270,59 @@ open PRs — one red PR makes the node red. With no open PR, a merged one means
 done; with no PR at all it falls back to unclaimed → ready, claimed → building,
 closed → done.
 
+### What is actually running, and what stopped
+
+Every glyph above is a **tracker** fact. That is the right vocabulary for what
+the work *is*, and it is silent about the half `wf` itself created: a launch
+`exec`s an agent into a container and exits, so nothing has ever reported back
+whether that agent is still there. `⏎` comes closest and deliberately stops
+short — it says a launch *happened*.
+
+`dl` knows the missing half and already publishes it, so the same background
+reading that finds [reclaimable workspaces](#startup) reads it too, and two
+markings come out of the join:
+
+- **`▣` a container of this node's is up.** Something is very likely working
+  here.
+- **`⧖` claimed, nothing pushed, and nothing of its running.** Somebody — almost
+  always an agent — took this ticket and is no longer on it.
+
+`⧖` is the one that needed both halves, and it is why this is a join rather than
+a field. A claim on its own is the ordinary look of work in progress; a stopped
+container on its own is the ordinary look of work that finished. It is the
+*pair* that means a lifecycle went down between its stages. It reads against the
+stage glyph beside it, and that contrast is the finding: `◐ #133 … ⧖` is the
+tracker saying *building* and the machine saying *nothing is*.
+
+Stalls also reach the [count line](#startup) as `· 2 stalled: wayfinder#133,
++1 more`, because the row is not always on screen — the project list has no
+ticket rows at all, and a stall can be inside a fold or another map. Running
+containers stay on their rows: they are the ordinary state of a machine in use,
+and a count of them would be a status bar rather than a summons.
+
+Four things this deliberately does not claim, because the honest version is
+narrower than the useful-sounding one:
+
+- **A container being up is not an agent being alive.** `dl` reports the
+  container; nobody reports the process inside it, and `wf` is long gone by
+  then. `▣` covers a session you left, a session that exited an hour ago inside
+  a container nobody stopped, and a `WF_PREWARM` container never entered. It is
+  a floor on activity, not a reading of it.
+- **A stall is not a crash.** An agent that handed off cleanly and one that died
+  mid-slice leave the same shape. The ticket's breadcrumb trail is what tells
+  them apart, and reading it is yours.
+- **Host launches are invisible.** A checkout with no devcontainer runs on the
+  host, where there is no workspace and no state to read. Those nodes carry no
+  marking at all rather than a wrong one.
+- **This machine only**, the same limit [resume](#resuming-picking-a-conversation-back-up)
+  carries: the listing is local, so a ticket worked on another machine looks
+  unstarted here.
+
+Nothing is done about any of it. `wf reap` still keeps a claimed workspace — a
+stale claim is a person's stated intent and reap does not overrule it — which is
+exactly why the stall was worth drawing: it was the one thing on the machine
+that nothing pointed at.
+
 `↑`/`↓` prefer **siblings at the cursor's depth**, so on the default screen they
 move between tickets you can actually take and step over the blocked context
 hanging beneath them; `→` reveals what the cursor is on and `←` closes it again.
@@ -381,8 +434,16 @@ ask again.
 count line when it arrives:
 
 ```
-  12/30  · 2 reclaimable: devlaunch-github-…oop-wayfinder-127, +1 more — wf reap
+  12/30  · 1 stalled: wayfinder#133  · 2 reclaimable: devlaunch-…-127, +1 more — wf reap
 ```
+
+That one reading answers two questions, because the same `dl --ls --json` and
+the same tracker query settle both: what a reap would claim, and
+[what is running and what stopped](#what-is-actually-running-and-what-stopped).
+Stalls are laid down first and capped, so the two variable-length segments
+cannot fight over one line — on a terminal too narrow for both it is the reap
+pointer that goes, which is the one trade in here worth disagreeing with: work
+that has stopped moving outranks tidying that can wait.
 
 It is the same reading `wf reap` prints, taken by the same code — a `dl --ls
 --json` and one batched tracker query, neither of them on the way to a frame.
@@ -703,6 +764,8 @@ an empty one.
 | `enter` | on the project list: enter that project. On a project's screen: open the launch picker — the creation rows on the project's own row, the launch modes on a ticket or a cluster header — and a second `enter` runs the agent here and exits. On a group line it folds instead, since there is no agent to run |
 | `←`/`→`, `↑`/`↓` or `tab`, *type*, then `enter`* | in the launch picker: pick Claude/Codex, pick the row, fill its field (a steering prompt, a task, or a map seed), launch — `esc` backs out with the query and cursor intact. `←`/`→` does nothing on a `resume` row, whose agent comes from the record |
 | `⏎` in a row | a previous launch left a conversation on this node: its picker leads with `resume`, and `enter enter` rejoins it |
+| `▣` in a row | a container of this node's is up — [something is very likely working here](#what-is-actually-running-and-what-stopped) |
+| `⧖` in a row | claimed, nothing pushed, and nothing of its running: a run that stopped between its stages |
 | `ctrl-r` | refetch every map in place, keeping your query, level and cursor |
 | `esc` | clear the query; on an empty query, quit |
 | `q` | quit — on an empty query only, since mid-query it types |

--- a/README.md
+++ b/README.md
@@ -875,23 +875,39 @@ over its index. (Isolated launches used to run in the picked tree itself, which
 meant every launch of a repo shared one tree and one container — serial by
 construction.)
 
-Two things have to be true for a Claude launch to be isolated, and otherwise it
-runs on the host exactly as it always has:
+Three things have to be true for a Claude launch to be isolated, and otherwise
+it runs on the host exactly as it always has:
 
-1. the checkout declares one of those two configs, and
-2. `dl` is on PATH.
+1. the checkout declares one of those two configs,
+2. `dl` is on PATH, and
+3. that `dl` is **0.0.24 or newer**.
 
-**`WF_PREWARM=1` needs `dl` 0.0.24 or newer.** `dl <workspace> up` — start
-without attaching — and the per-workspace launch lock are what the warm-up is
-made of; on an older `dl` the background spawn fails silently and the launch
-simply pays the cold start at the second enter, as it always did.
+The third is there because "installed" and "speaks this binary's command line"
+are different questions, and asking only the first moved the failure past the
+point where it could still degrade: the prewarm below fires `dl <workspace> up`,
+which no release before 0.0.24 had, so a machine with everything up to date
+satisfied both of the old conditions and then failed *inside* the launch. `wf`
+asks `dl --version` once per run instead. A `dl` that is installed and cannot be
+used says so in the launch notice, because that is the fixable case — an absent
+`dl` stays quiet, since a repo may carry a `devcontainer.json` for its editor
+users on a machine that never wanted containers.
+
+Installing `wf` from the channel brings a conforming `dl` with it: the recipe
+declares `devlaunch >=0.0.24`, so the container half of the binary is not
+invisibly absent on a fresh machine. That is what takes `wf` from ~3 MB to
+~370 MB where devlaunch is not already present.
+
+**`WF_PREWARM=1` needs `dl` 0.0.24 or newer** — the same floor, and the release
+that set it. `dl <workspace> up` — start without attaching — and the
+per-workspace launch lock are what the warm-up is made of.
 
 **Use `dl` 0.0.20 or newer.** Launching several tickets at once means several
 `dl` processes preparing the same repo's cache at the same moment; 0.0.20 is
 where those runs serialize over a per-repo lock instead of racing (the loser
-of the old race could delete the winner's half-written clone). The older floor
-still matters too: `wf` pins no version and never will — the launch
-is one `exec` of a program found on PATH — but older `dl` on devpod 0.26 hands
+of the old race could delete the winner's half-written clone). This one is
+below the isolation floor, so it now only describes what a `dl` too old to
+isolate with would have done. It is kept because `wf reap` still reads a
+listing from whichever `dl` is on PATH: older `dl` on devpod 0.26 hands
 the agent **no terminal**, and an agent with no terminal decides it was invoked
 non-interactively: it prints one answer and exits, so the symptom is a session
 that never starts rather than an error. Measured here on devpod 0.26.1:
@@ -973,6 +989,16 @@ their branch looks like), branches that are not `wayfinder/<repo>-<n>` for that
 repo, tickets with an open or draft PR (in review is where review fixes happen),
 tickets someone has claimed, and anything **running** — a ticket closing is no
 evidence that the session in the container ended.
+
+**A `dl` that says nothing is not a `dl` saying nothing is at risk.** From
+devlaunch **0.0.24** the listing answers `unsaved` for every clone `dl` made,
+and leaves it null only on workspaces it did not make. So on 0.0.24 and newer a
+missing answer about one of `wf`'s own workspaces means `dl`'s inspection fell
+over, and the row is kept saying so rather than collected as clean. Releases
+before that wrote null for a clean clone, and are still read that way. No single
+row can tell the two apart, so `wf` asks `dl --version` once per run and reads
+the listing accordingly; a `dl` it cannot place is read the older, permissive
+way, so the worst case is the behaviour that shipped before the floor existed.
 
 One `gh api graphql` call per repo answers all of this, however many workspaces
 that repo has — which is also what makes the picker's background reading cheap

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.15.1"
+  version: "0.16.0"
 
 package:
   name: wf

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
+use crate::liveness::{Life, Liveness};
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::{self, Checkout, Resume, Session};
 use crate::reclaim::Reclaimable;
@@ -258,6 +259,15 @@ pub struct App {
     /// cleared would be gone before it was read. Nothing in the picker acts on
     /// it — it is a sentence naming a command a person may choose to type.
     pub reclaimable: Option<Reclaimable>,
+    /// What is running on this machine, and what stopped without finishing —
+    /// the other half of the same background reading (#137's survey, read for
+    /// a second question).
+    ///
+    /// Not an `Option`: an empty [`Liveness`] and one that has not arrived draw
+    /// exactly the same nothing, and every reader of it asks about one node at
+    /// a time. A second layer of "have we looked yet" would be a distinction no
+    /// caller can act on.
+    pub liveness: Liveness,
     pub overlay: Overlay,
     /// The structural screen `tab` toggles (#51). Only the lens is stored;
     /// whether the body is currently *flattened* is derived from the query in
@@ -290,6 +300,7 @@ impl App {
             failed: BTreeSet::new(),
             startup: Startup::loaded(),
             reclaimable: None,
+            liveness: Liveness::default(),
             overlay: Overlay::None,
             lens: Lens::Leverage,
             expanded: Expanded::new(),
@@ -330,6 +341,13 @@ impl App {
     pub fn with_sessions(mut self, sessions: Vec<Session>) -> Self {
         self.sessions = sessions;
         self
+    }
+
+    /// What this machine says about the node, if anything — beside
+    /// [`App::resume`] because the row asks them together and they are the two
+    /// facts on a row that come from outside the tracker.
+    pub fn life(&self, repo: &str, number: u64) -> Option<Life> {
+        self.liveness.of(repo, number)
     }
 
     /// The conversation a previous launch of this node left, if any.

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
-use crate::liveness::{Life, Liveness};
+use crate::liveness::Liveness;
 use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
 use crate::projects::{self, Checkout, Resume, Session};
 use crate::reclaim::Reclaimable;
@@ -341,13 +341,6 @@ impl App {
     pub fn with_sessions(mut self, sessions: Vec<Session>) -> Self {
         self.sessions = sessions;
         self
-    }
-
-    /// What this machine says about the node, if anything — beside
-    /// [`App::resume`] because the row asks them together and they are the two
-    /// facts on a row that come from outside the tracker.
-    pub fn life(&self, repo: &str, number: u64) -> Option<Life> {
-        self.liveness.of(repo, number)
     }
 
     /// The conversation a previous launch of this node left, if any.

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1228,6 +1228,33 @@ impl Devlaunch {
             )),
         }
     }
+
+    /// Does this `dl` say what every clone it made would lose?
+    ///
+    /// [`reap`](crate::reap) asks, because a missing answer means opposite
+    /// things either side of [`UNSAVED_IS_AN_OBJECT`]: before it, `null` on
+    /// `dl`'s own clone was the ordinary *clean* case; from it, `null` appears
+    /// exactly where `devlaunch` is false, so a `null` on a clone `dl` made
+    /// means `dl`'s own inspection fell over. Reaping is right in the first
+    /// reading and destroys work in the second, and no single row can tell them
+    /// apart — only the version can, which is why this is asked here rather
+    /// than guessed in the parser.
+    ///
+    /// The two states with no version to compare answer `false`, so anything
+    /// this binary cannot place reads the old, permissive way. The failure mode
+    /// is then "behaves as it did before the floor existed" rather than
+    /// "refuses every workspace on a machine `wf` could not probe".
+    fn answers_unsaved(self) -> bool {
+        match self {
+            Devlaunch::Usable => true,
+            // Too old for the *floor* is not too old for this question: a `dl`
+            // that answers `unsaved` but lacks some later subcommand still
+            // answered. Compared rather than assumed, so raising the floor
+            // cannot quietly restate a fact about a past release.
+            Devlaunch::TooOld(found) => found >= UNSAVED_IS_AN_OBJECT,
+            Devlaunch::Absent | Devlaunch::Unreadable => false,
+        }
+    }
 }
 
 /// Ask `dl` its version, once per process.
@@ -1254,6 +1281,31 @@ fn devlaunch_on_path() -> Devlaunch {
             Err(_) => Devlaunch::Absent,
         }
     })
+}
+
+/// The release where `--ls --json` began answering `unsaved` for every clone
+/// `dl` made.
+///
+/// devlaunch 0.0.24 replaced a string-or-null field with a one-key object, and
+/// from there `unsaved` is null *exactly* where `devlaunch` is false — there is
+/// no clone of `dl`'s own to inspect. That is the same release [`prewarm`]'s
+/// `up` arrived in, so this equals [`DEVLAUNCH_FLOOR`] today.
+///
+/// Two constants for one release anyway, because they answer two questions.
+/// Raising the floor is about what `wf` may *ask* `dl` to do; this is about how
+/// to read what `dl` already said, and [`reap`](crate::reap) reads listings
+/// from whatever `dl` is on PATH rather than only from one a launch would
+/// accept. Collapsing them would make a future floor bump silently restate a
+/// fact about a past release.
+const UNSAVED_IS_AN_OBJECT: DlVersion = DlVersion(0, 0, 24);
+
+/// Does the `dl` on this machine say what every clone it made would lose?
+///
+/// Split from the probe for the same reason [`Devlaunch::from_version_output`]
+/// is — the rule is the part worth testing, and it is testable without a `dl`
+/// on the machine running the tests.
+pub(crate) fn devlaunch_answers_unsaved() -> bool {
+    devlaunch_on_path().answers_unsaved()
 }
 
 /// Wrap one argument so a POSIX shell hands it back unchanged.
@@ -3561,6 +3613,30 @@ mod tests {
         // Unreadable, not usable: a `dl` whose answer cannot be compared is a
         // `dl` whose command line cannot be relied on.
         assert_eq!(Devlaunch::from_version_output("???"), Devlaunch::Unreadable);
+    }
+
+    #[test]
+    fn the_unsaved_reading_follows_the_release_that_changed_it_not_the_floor() {
+        // Usable is the ordinary yes. It is only sound because the floor is at
+        // or above the release that changed the field — assert that, so raising
+        // the floor below it can never make `Usable` claim an answer that
+        // release did not give.
+        assert!(DEVLAUNCH_FLOOR >= UNSAVED_IS_AN_OBJECT);
+
+        // The case the two constants exist for: a `dl` below a future floor
+        // that still answers `unsaved`. Read as answering, because it does.
+        assert!(Devlaunch::TooOld(DlVersion(0, 0, 24)).answers_unsaved());
+        assert!(Devlaunch::TooOld(DlVersion(0, 1, 0)).answers_unsaved());
+
+        // 0.0.23 is the release whose `null` meant clean. Reading it as an
+        // unanswered question would refuse every workspace on that machine.
+        assert!(!Devlaunch::TooOld(DlVersion(0, 0, 23)).answers_unsaved());
+
+        // No version to compare: read the old, permissive way rather than
+        // refusing everything.
+        assert!(!Devlaunch::Absent.answers_unsaved());
+        assert!(!Devlaunch::Unreadable.answers_unsaved());
+        assert!(Devlaunch::Usable.answers_unsaved());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod app;
 pub mod fetch;
 pub mod filter;
 pub mod launch;
+pub mod liveness;
 pub mod model;
 /// Test scaffolding shared by more than one module, and by both crates —
 /// `src/probe.rs` is declared here *and* in `src/main.rs`, which is the only

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -39,20 +39,29 @@
 //! prewarmed and was never entered. It is a floor on activity, not a reading of
 //! it.
 //!
-//! **A stall is not a crash.** The same shape is left by an agent that handed
-//! off cleanly and by one that died mid-slice; the ticket's breadcrumb trail is
-//! what tells those apart, and reading it is a person's job. The claim here is
-//! only that nothing is moving.
+//! **A stall is not a crash.** The same shape is left by an agent that died
+//! mid-slice, by one that handed off cleanly, by a `dl <ws> stop` you ran
+//! yourself, and by a reboot — which stops every container on the machine at
+//! once, so the morning after one, every claimed node with a workspace is
+//! marked. Those are not false positives: each of those runs really has
+//! stopped, and each really does want picking up. But they arrive together, so
+//! the count line can read `12 stalled` for a reason that is about the host and
+//! not about the work. The ticket's breadcrumb trail is what says which; the
+//! claim here is only that nothing is moving.
 //!
-//! **Host launches are invisible.** A checkout with no devcontainer runs the
-//! agent on the host, where there is no workspace and so no `state` to read.
-//! Those nodes have no liveness at all rather than a false negative — `of`
-//! answers `None`, and the stall count never includes them.
+//! **A node launched on the host can still be marked**, and this is the one
+//! outright false positive. A checkout with no devcontainer runs the agent on
+//! the host, where there is no container to report — but if that node has a
+//! workspace from *some other* launch (the repo grew a `.devcontainer/` later,
+//! or `WF_PREWARM` built one at a staging you backed out of), the stopped
+//! workspace and the live claim look exactly like a stall. `wf` cannot see host
+//! processes, so it cannot tell. A node with no workspace at all is genuinely
+//! invisible here rather than wrongly marked.
 //!
 //! **This machine only.** The listing is local, the same limit the resume
 //! record carries. A ticket worked on another machine looks unstarted here.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::reap::{node_of, Node, NodeFact, Workspace};
 
@@ -81,15 +90,15 @@ pub enum Life {
 
 /// The machine's half of the picture, per node.
 ///
-/// Sets rather than a map because both arms are *presence*: a node either
-/// answers one of them or has no liveness at all. `running` wins where a node
-/// could somehow satisfy both — a stall is defined by the absence of a running
-/// container, so the two are disjoint by construction and the ordering is
-/// belt-and-braces stated as a test.
+/// **One map, not a set per arm.** A node has at most one liveness, and two
+/// parallel sets can represent it having two — which then forces a precedence
+/// rule at every read, to resolve a state that is not supposed to exist. The
+/// map makes the question unaskable instead: the arms are values, so the
+/// precedence lives once, in [`Liveness::read`], where the facts that decide it
+/// are actually in hand.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Liveness {
-    running: BTreeSet<Node>,
-    stalled: BTreeSet<Node>,
+    life: BTreeMap<Node, Life>,
 }
 
 impl Liveness {
@@ -97,27 +106,29 @@ impl Liveness {
     ///
     /// Takes the same two values [`reap::plan`](crate::reap::plan) does, from
     /// the same reading, and reads different fields of them. Nothing here can
-    /// delete: it consumes two borrowed slices and returns sets of numbers.
+    /// delete: it consumes two borrowed slices and returns a map of numbers.
+    ///
+    /// Running is settled first and wins, because a node can own more than one
+    /// workspace: with one container up and another down, the node is being
+    /// worked on, and the down one is not evidence of anything.
     pub fn read(workspaces: &[Workspace], known: &BTreeMap<Node, NodeFact>) -> Self {
-        let mut running = BTreeSet::new();
-        let mut has_workspace = BTreeSet::new();
-        for workspace in workspaces {
-            let Some(node) = node_of(workspace) else {
-                // Not one of `wf`'s — its branch is not a name `wf` minted, so
-                // nothing about it is a fact about a node.
-                continue;
-            };
-            if workspace.state.as_deref() == Some("Running") {
-                running.insert(node.clone());
-            }
-            has_workspace.insert(node);
-        }
-        let stalled = has_workspace
-            .into_iter()
-            .filter(|node| !running.contains(node))
-            .filter(|node| matches!(known.get(node), Some(NodeFact::Claimed)))
+        // Not one of `wf`'s — a branch it never minted is no fact about a node.
+        let ours = || workspaces.iter().filter_map(|w| Some((node_of(w)?, w)));
+        let mut life: BTreeMap<Node, Life> = ours()
+            .filter(|(_, w)| w.is_running())
+            .map(|(node, _)| (node, Life::Running))
             .collect();
-        Self { running, stalled }
+        for (node, workspace) in ours() {
+            // `is_stopped`, not `!is_running`: a state neither predicate knows
+            // is a state `wf` has no business turning into a claim on a row.
+            if !workspace.is_stopped() || life.contains_key(&node) {
+                continue;
+            }
+            if matches!(known.get(&node), Some(NodeFact::Claimed)) {
+                life.insert(node, Life::Stalled);
+            }
+        }
+        Self { life }
     }
 
     /// What to mark this node with, if anything.
@@ -126,17 +137,12 @@ impl Liveness {
     /// `(repo, number)`. Same shape as [`App::resume`](crate::app::App::resume),
     /// because it is answering the same kind of question about the same rows.
     pub fn of(&self, repo: &str, number: u64) -> Option<Life> {
-        let node = Node {
-            repo: repo.to_string(),
-            number,
-        };
-        if self.running.contains(&node) {
-            return Some(Life::Running);
-        }
-        if self.stalled.contains(&node) {
-            return Some(Life::Stalled);
-        }
-        None
+        self.life
+            .get(&Node {
+                repo: repo.to_string(),
+                number,
+            })
+            .copied()
     }
 
     /// Is there anything here worth carrying to the screen at all?
@@ -144,19 +150,28 @@ impl Liveness {
     /// The reading is only sent when something has something to say, so this is
     /// what keeps an empty join from waking the draw path.
     pub fn is_empty(&self) -> bool {
-        self.running.is_empty() && self.stalled.is_empty()
+        self.life.is_empty()
+    }
+
+    /// The nodes at one arm, in a stable order — `BTreeMap`'s, so the count
+    /// line never reshuffles between frames.
+    fn at(&self, arm: Life) -> impl Iterator<Item = &Node> {
+        self.life
+            .iter()
+            .filter(move |(_, life)| **life == arm)
+            .map(|(node, _)| node)
     }
 
     /// How many nodes are stalled — the count the line leads with.
     pub fn stalled(&self) -> usize {
-        self.stalled.len()
+        self.at(Life::Stalled).count()
     }
 
     /// How many nodes have a container up. Never drawn on the count line (see
     /// [`Liveness::hint`]); this is what the probe reads to prove the live path
     /// produces liveness at all.
     pub fn running(&self) -> usize {
-        self.running.len()
+        self.at(Life::Running).count()
     }
 
     /// The count-line segment: how many are stalled, and which.
@@ -182,11 +197,11 @@ impl Liveness {
     /// first — deliberate, and the one trade in here worth disagreeing with:
     /// work that has stopped moving outranks tidying that can wait.
     pub fn hint(&self, width: usize) -> String {
-        if self.stalled.is_empty() {
+        if self.stalled() == 0 {
             return String::new();
         }
-        let head = format!("· {} stalled", self.stalled.len());
-        let names: Vec<String> = self.stalled.iter().map(Node::name).collect();
+        let head = format!("· {} stalled", self.stalled());
+        let names: Vec<String> = self.at(Life::Stalled).map(Node::name).collect();
         for count in (1..=NAMED.min(names.len())).rev() {
             let rest = names.len() - count;
             let more = if rest == 0 {
@@ -209,18 +224,25 @@ impl Liveness {
     /// channel that carry one.
     #[cfg(test)]
     pub(crate) fn for_test(running: &[(&str, u64)], stalled: &[(&str, u64)]) -> Self {
-        let set = |nodes: &[(&str, u64)]| {
+        fn arm(nodes: &[(&str, u64)], life: Life) -> Vec<(Node, Life)> {
             nodes
                 .iter()
-                .map(|(repo, number)| Node {
-                    repo: (*repo).to_string(),
-                    number: *number,
+                .map(|(repo, number)| {
+                    (
+                        Node {
+                            repo: (*repo).to_string(),
+                            number: *number,
+                        },
+                        life,
+                    )
                 })
                 .collect()
-        };
+        }
         Self {
-            running: set(running),
-            stalled: set(stalled),
+            life: arm(running, Life::Running)
+                .into_iter()
+                .chain(arm(stalled, Life::Stalled))
+                .collect(),
         }
     }
 }
@@ -330,6 +352,43 @@ mod tests {
         let live = Liveness::read(&workspaces, &BTreeMap::new());
         assert_eq!(live.stalled(), 0);
         assert!(live.is_empty());
+    }
+
+    /// This module is on the picker's reading path, so it carries the path's
+    /// denylist too.
+    ///
+    /// [`reclaim`](crate::reclaim), [`refresh`](crate::refresh),
+    /// [`picker`](crate::picker) and `main` each hold one, and the point of
+    /// having them in every file is stated in `reclaim`'s own module doc: a
+    /// grep over N files cannot see the same call written in the N+1th. This
+    /// module *is* that N+1th file — new, importing `reap`, and reached from
+    /// the survey the picker spawns — so it arrived owing the guard rather than
+    /// being exempt from it.
+    ///
+    /// `tokio::spawn` is the one worth spelling out here, and it is on this
+    /// list for `picker`'s reason rather than `reclaim`'s: a task spawned in a
+    /// derivation like this one outlives the run that recorded it, and the
+    /// runtime probes watch a bounded window. `--force` and `"rm"` are the argv
+    /// of a subprocess this file has no means to start, and cost nothing to
+    /// forbid anyway. Substring match, as everywhere else: `fs` here also
+    /// forbids `refs` and `offset`, which this file has no occasion to write.
+    #[test]
+    fn deriving_liveness_can_delete_nothing() {
+        let code = crate::probe::code_only("liveness.rs", include_str!("liveness.rs"));
+        for forbidden in [
+            "remove",
+            "\"rm\"",
+            "--force",
+            "Command",
+            "process::",
+            "tokio::spawn",
+            "fs",
+        ] {
+            assert!(
+                !code.contains(forbidden),
+                "reading liveness is a join over two borrowed slices: it names {forbidden:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -1,0 +1,374 @@
+//! Liveness: what is actually running, and what stopped without finishing.
+//!
+//! Every glyph on the picker until now was a **tracker** fact — the issue's
+//! state, its assignees, its linked PRs. That is the right vocabulary for what
+//! the work *is*, and it is silent about the half `wf` itself created: a launch
+//! `exec`s an agent into a container and exits, so nothing has ever reported
+//! back whether that agent is still there. `⏎` comes closest and deliberately
+//! stops short — it records that a launch *happened*, which is the strongest
+//! thing the launch record can honestly claim.
+//!
+//! `dl` knows the missing half and already publishes it. The reaper reads
+//! `state` to protect a running container from deletion and then throws it
+//! away; this module keeps it, and joins it to the tracker fact the same
+//! reading already fetched.
+//!
+//! Two observations come out of that join, and the second is the one that
+//! needed both halves:
+//!
+//! - **Running** — a container is up for this node.
+//! - **Stalled** — the tracker says [`NodeFact::Claimed`] (open, assigned,
+//!   nothing pushed) while no container of that node's is up. Somebody, almost
+//!   always an agent, took this ticket and is no longer working on it.
+//!
+//! Neither half can say that alone, which is why this lives here rather than in
+//! the fetch. A claim on its own is the ordinary look of work in progress. A
+//! stopped container on its own is the ordinary look of work that finished. It
+//! is the pair — claimed, nothing to show for it, and nothing running — that
+//! means a lifecycle went down between its stages, and that is exactly the
+//! state [`reap`](crate::reap) is right to refuse to collect and wrong to leave
+//! unmentioned: a stale claim keeps a workspace, so the run that died is the
+//! one thing on the machine nothing was pointing at.
+//!
+//! ## What this deliberately does not claim
+//!
+//! **A container being up is not an agent being alive.** `dl` reports the
+//! container; nobody reports the process inside it, and `wf` is long gone by
+//! then. `Running` means a container is up — a session you left, a session that
+//! exited an hour ago inside a container nobody stopped, a `dl <ws> up` that
+//! prewarmed and was never entered. It is a floor on activity, not a reading of
+//! it.
+//!
+//! **A stall is not a crash.** The same shape is left by an agent that handed
+//! off cleanly and by one that died mid-slice; the ticket's breadcrumb trail is
+//! what tells those apart, and reading it is a person's job. The claim here is
+//! only that nothing is moving.
+//!
+//! **Host launches are invisible.** A checkout with no devcontainer runs the
+//! agent on the host, where there is no workspace and so no `state` to read.
+//! Those nodes have no liveness at all rather than a false negative — `of`
+//! answers `None`, and the stall count never includes them.
+//!
+//! **This machine only.** The listing is local, the same limit the resume
+//! record carries. A ticket worked on another machine looks unstarted here.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::reap::{node_of, Node, NodeFact, Workspace};
+
+/// How many stalled nodes the count line names before it starts counting.
+///
+/// Two, where the reclaim hint allows three, because a node's name is the
+/// short repo and its number — `wayfinder#133` — and two of those plus the
+/// lead-in is already most of what a shared line can spare. The rows carry the
+/// same marking, so the line is a summons rather than the full list.
+const NAMED: usize = 2;
+
+/// What this machine says about a node, beyond what the tracker knows.
+///
+/// Two arms and no `Idle`: a node with no workspace and a node whose workspace
+/// is merely stopped are both "nothing to report", and giving that a name would
+/// invite a marker on almost every row — `⏎` already says a launch happened
+/// here, and a second badge repeating it in different words is noise on the one
+/// screen whose whole job is picking out the rows that want you.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Life {
+    /// A container of this node's is up.
+    Running,
+    /// Claimed, nothing pushed, and nothing of its running.
+    Stalled,
+}
+
+/// The machine's half of the picture, per node.
+///
+/// Sets rather than a map because both arms are *presence*: a node either
+/// answers one of them or has no liveness at all. `running` wins where a node
+/// could somehow satisfy both — a stall is defined by the absence of a running
+/// container, so the two are disjoint by construction and the ordering is
+/// belt-and-braces stated as a test.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Liveness {
+    running: BTreeSet<Node>,
+    stalled: BTreeSet<Node>,
+}
+
+impl Liveness {
+    /// Join `dl`'s listing to the tracker's answers.
+    ///
+    /// Takes the same two values [`reap::plan`](crate::reap::plan) does, from
+    /// the same reading, and reads different fields of them. Nothing here can
+    /// delete: it consumes two borrowed slices and returns sets of numbers.
+    pub fn read(workspaces: &[Workspace], known: &BTreeMap<Node, NodeFact>) -> Self {
+        let mut running = BTreeSet::new();
+        let mut has_workspace = BTreeSet::new();
+        for workspace in workspaces {
+            let Some(node) = node_of(workspace) else {
+                // Not one of `wf`'s — its branch is not a name `wf` minted, so
+                // nothing about it is a fact about a node.
+                continue;
+            };
+            if workspace.state.as_deref() == Some("Running") {
+                running.insert(node.clone());
+            }
+            has_workspace.insert(node);
+        }
+        let stalled = has_workspace
+            .into_iter()
+            .filter(|node| !running.contains(node))
+            .filter(|node| matches!(known.get(node), Some(NodeFact::Claimed)))
+            .collect();
+        Self { running, stalled }
+    }
+
+    /// What to mark this node with, if anything.
+    ///
+    /// The per-row lookup, keyed the way the screen has a node to hand:
+    /// `(repo, number)`. Same shape as [`App::resume`](crate::app::App::resume),
+    /// because it is answering the same kind of question about the same rows.
+    pub fn of(&self, repo: &str, number: u64) -> Option<Life> {
+        let node = Node {
+            repo: repo.to_string(),
+            number,
+        };
+        if self.running.contains(&node) {
+            return Some(Life::Running);
+        }
+        if self.stalled.contains(&node) {
+            return Some(Life::Stalled);
+        }
+        None
+    }
+
+    /// Is there anything here worth carrying to the screen at all?
+    ///
+    /// The reading is only sent when something has something to say, so this is
+    /// what keeps an empty join from waking the draw path.
+    pub fn is_empty(&self) -> bool {
+        self.running.is_empty() && self.stalled.is_empty()
+    }
+
+    /// How many nodes are stalled — the count the line leads with.
+    pub fn stalled(&self) -> usize {
+        self.stalled.len()
+    }
+
+    /// How many nodes have a container up. Never drawn on the count line (see
+    /// [`Liveness::hint`]); this is what the probe reads to prove the live path
+    /// produces liveness at all.
+    pub fn running(&self) -> usize {
+        self.running.len()
+    }
+
+    /// The count-line segment: how many are stalled, and which.
+    ///
+    /// Named rather than counted for the reason the reclaim hint gives for
+    /// naming its workspaces: `2 stalled` is a number nobody can agree or
+    /// disagree with, and a name is what makes it checkable against what the
+    /// reader already believes about their own work.
+    ///
+    /// **Only stalls reach this line.** Running containers are on their rows
+    /// and nowhere else — they are the ordinary state of a machine in use, and
+    /// a count of them is a status bar, not a summons. A stall is the anomaly,
+    /// and the anomaly is what a shared line is for.
+    ///
+    /// No pointer clause, unlike the reclaim hint's ` — wf reap`: that one
+    /// names a command a reader would otherwise have to remember, and the move
+    /// here is `enter` on the row, which is the picker's whole verb. Telling
+    /// somebody to press enter in a list is spending the scarcest characters on
+    /// the line saying nothing.
+    ///
+    /// The width is a budget. This segment is laid down before the reclaim
+    /// note, so on a line too narrow for both it is the reap pointer that goes
+    /// first — deliberate, and the one trade in here worth disagreeing with:
+    /// work that has stopped moving outranks tidying that can wait.
+    pub fn hint(&self, width: usize) -> String {
+        if self.stalled.is_empty() {
+            return String::new();
+        }
+        let head = format!("· {} stalled", self.stalled.len());
+        let names: Vec<String> = self.stalled.iter().map(Node::name).collect();
+        for count in (1..=NAMED.min(names.len())).rev() {
+            let rest = names.len() - count;
+            let more = if rest == 0 {
+                String::new()
+            } else {
+                format!(", +{rest} more")
+            };
+            let line = format!("{head}: {}{more}", names[..count].join(", "));
+            if line.chars().count() <= width {
+                return line;
+            }
+        }
+        if head.chars().count() <= width {
+            return head;
+        }
+        String::new()
+    }
+
+    /// A liveness with these nodes on it, for the tests of the screen and the
+    /// channel that carry one.
+    #[cfg(test)]
+    pub(crate) fn for_test(running: &[(&str, u64)], stalled: &[(&str, u64)]) -> Self {
+        let set = |nodes: &[(&str, u64)]| {
+            nodes
+                .iter()
+                .map(|(repo, number)| Node {
+                    repo: (*repo).to_string(),
+                    number: *number,
+                })
+                .collect()
+        };
+        Self {
+            running: set(running),
+            stalled: set(stalled),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace(id: &str, repo: &str, number: u64, state: &str) -> Workspace {
+        let short = repo.split('/').next_back().unwrap();
+        Workspace {
+            id: id.to_string(),
+            devlaunch: true,
+            repo: Some(repo.to_string()),
+            branch: Some(format!("wayfinder/{short}-{number}")),
+            state: Some(state.to_string()),
+            unsaved: None,
+        }
+    }
+
+    fn node(repo: &str, number: u64) -> Node {
+        Node {
+            repo: repo.to_string(),
+            number,
+        }
+    }
+
+    fn facts<const N: usize>(entries: [(Node, NodeFact); N]) -> BTreeMap<Node, NodeFact> {
+        entries.into_iter().collect()
+    }
+
+    const REPO: &str = "blooop/wayfinder";
+
+    #[test]
+    fn a_claimed_node_whose_container_is_down_is_the_stall_neither_half_could_name() {
+        let workspaces = [workspace("a", REPO, 133, "Stopped")];
+        let known = facts([(node(REPO, 133), NodeFact::Claimed)]);
+        let live = Liveness::read(&workspaces, &known);
+        assert_eq!(live.of(REPO, 133), Some(Life::Stalled));
+        assert_eq!(live.stalled(), 1);
+    }
+
+    #[test]
+    fn the_same_claim_with_its_container_up_is_work_in_progress_and_not_a_stall() {
+        let workspaces = [workspace("a", REPO, 133, "Running")];
+        let known = facts([(node(REPO, 133), NodeFact::Claimed)]);
+        let live = Liveness::read(&workspaces, &known);
+        assert_eq!(live.of(REPO, 133), Some(Life::Running));
+        assert_eq!(live.stalled(), 0, "a container that is up is not a stall");
+    }
+
+    /// The discriminator has to be the pair, so each half alone must stay
+    /// quiet: this is the test that fails if either condition is dropped.
+    #[test]
+    fn neither_half_alone_makes_a_stall() {
+        // Claimed, but nothing of `wf`'s on this machine at all — a host
+        // launch, or another machine's work.
+        let known = facts([(node(REPO, 133), NodeFact::Claimed)]);
+        assert_eq!(Liveness::read(&[], &known).stalled(), 0);
+        assert_eq!(Liveness::read(&[], &known).of(REPO, 133), None);
+
+        // A stopped container under every other fact the tracker can report.
+        // Only `Claimed` is a stall; `InFlight` in particular is not, because
+        // the PR is the thing the run left behind and the screen already shows
+        // it.
+        let workspaces = [workspace("a", REPO, 133, "Stopped")];
+        for fact in [
+            NodeFact::Closed,
+            NodeFact::DoneByMerge { pr: 1 },
+            NodeFact::Superseded { pr: 1 },
+            NodeFact::InFlight { pr: 1 },
+            NodeFact::Unstarted,
+        ] {
+            let known = facts([(node(REPO, 133), fact.clone())]);
+            assert_eq!(
+                Liveness::read(&workspaces, &known).stalled(),
+                0,
+                "{fact:?} is not a stall"
+            );
+        }
+    }
+
+    #[test]
+    fn a_node_with_two_workspaces_is_running_if_either_of_them_is() {
+        let workspaces = [
+            workspace("a", REPO, 133, "Stopped"),
+            workspace("b", REPO, 133, "Running"),
+        ];
+        let known = facts([(node(REPO, 133), NodeFact::Claimed)]);
+        let live = Liveness::read(&workspaces, &known);
+        assert_eq!(live.of(REPO, 133), Some(Life::Running));
+        assert_eq!(live.stalled(), 0);
+    }
+
+    #[test]
+    fn a_workspace_wf_did_not_mint_is_no_fact_about_any_node() {
+        let mut foreign = workspace("x", REPO, 133, "Running");
+        foreign.branch = Some("hotfix/urgent".to_string());
+        let known = facts([(node(REPO, 133), NodeFact::Claimed)]);
+        let live = Liveness::read(&[foreign], &known);
+        assert!(live.is_empty(), "a branch wf never named says nothing");
+    }
+
+    #[test]
+    fn a_node_the_tracker_did_not_answer_for_is_not_read_as_claimed() {
+        let workspaces = [workspace("a", REPO, 133, "Stopped")];
+        let live = Liveness::read(&workspaces, &BTreeMap::new());
+        assert_eq!(live.stalled(), 0);
+        assert!(live.is_empty());
+    }
+
+    #[test]
+    fn the_hint_names_what_it_can_and_counts_the_rest() {
+        let live = Liveness::for_test(&[], &[(REPO, 90), (REPO, 133), (REPO, 134)]);
+        assert_eq!(
+            live.hint(80),
+            "· 3 stalled: wayfinder#90, wayfinder#133, +1 more"
+        );
+    }
+
+    /// The ladder, width by width. A segment that overran its budget would push
+    /// the reclaim note — or the match count — off the end of the line.
+    #[test]
+    fn the_hint_never_overruns_its_budget_at_any_width() {
+        let live = Liveness::for_test(&[], &[(REPO, 90), (REPO, 133), (REPO, 134)]);
+        for width in 0..60 {
+            let hint = live.hint(width);
+            assert!(
+                hint.chars().count() <= width,
+                "width {width} produced {} characters: {hint:?}",
+                hint.chars().count()
+            );
+        }
+        assert_eq!(live.hint(0), "", "no room is no segment, not a clipped one");
+        assert_eq!(
+            live.hint(12),
+            "· 3 stalled",
+            "the count survives after the names are gone"
+        );
+    }
+
+    #[test]
+    fn nothing_stalled_is_no_segment_however_much_room_there_is() {
+        let live = Liveness::for_test(&[(REPO, 133)], &[]);
+        assert_eq!(live.hint(200), "");
+        assert!(
+            !live.is_empty(),
+            "but a running container is still worth carrying"
+        );
+    }
+}

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -106,7 +106,8 @@ impl Liveness {
     ///
     /// Takes the same two values [`reap::plan`](crate::reap::plan) does, from
     /// the same reading, and reads different fields of them. Nothing here can
-    /// delete: it consumes two borrowed slices and returns a map of numbers.
+    /// delete: it borrows a listing and a set of tracker answers, and returns a
+    /// map of numbers.
     ///
     /// Running is settled first and wins, because a node can own more than one
     /// workspace: with one container up and another down, the node is being
@@ -192,10 +193,17 @@ impl Liveness {
     /// somebody to press enter in a list is spending the scarcest characters on
     /// the line saying nothing.
     ///
-    /// The width is a budget. This segment is laid down before the reclaim
-    /// note, so on a line too narrow for both it is the reap pointer that goes
-    /// first — deliberate, and the one trade in here worth disagreeing with:
-    /// work that has stopped moving outranks tidying that can wait.
+    /// The width is a budget, and this segment is laid down before the reclaim
+    /// note — so on a narrowing line the reap pointer and the warned aside go
+    /// while stalls are still naming nodes. Deliberate, and the one trade in
+    /// here worth disagreeing with: work that has stopped moving outranks
+    /// tidying that can wait.
+    ///
+    /// The caller holds back [`Reclaimable::min_width`](crate::reclaim::Reclaimable::min_width)
+    /// before asking, which is where that priority stops. Below its own count
+    /// the reclaim note clips rather than disappearing, so taking those last
+    /// characters would not buy the line a stall name — it would spend them
+    /// turning the neighbouring segment into a fragment.
     pub fn hint(&self, width: usize) -> String {
         if self.stalled() == 0 {
             return String::new();
@@ -386,7 +394,7 @@ mod tests {
         ] {
             assert!(
                 !code.contains(forbidden),
-                "reading liveness is a join over two borrowed slices: it names {forbidden:?}"
+                "reading liveness is a join over what it was handed: it names {forbidden:?}"
             );
         }
     }

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -120,9 +120,10 @@ impl Liveness {
             .map(|(node, _)| (node, Life::Running))
             .collect();
         for (node, workspace) in ours() {
-            // `is_stopped`, not `!is_running`: a state neither predicate knows
-            // is a state `wf` has no business turning into a claim on a row.
-            if !workspace.is_stopped() || life.contains_key(&node) {
+            // `is_down`, not `!is_running`: a container mid-start, or a state
+            // this `wf` cannot read, is not something to turn into a claim on
+            // a row. A container devpod cannot find at all *is* down.
+            if !workspace.is_down() || life.contains_key(&node) {
                 continue;
             }
             if matches!(known.get(&node), Some(NodeFact::Claimed)) {
@@ -331,6 +332,40 @@ mod tests {
                 "{fact:?} is not a stall"
             );
         }
+    }
+
+    /// The states that settle, and the states that say nothing.
+    ///
+    /// `NotFound` is the one worth pinning: a container devpod cannot find has
+    /// certainly stopped, and reading only `Stopped` left the most definitely
+    /// dead workspace on the machine unmarked.
+    #[test]
+    fn a_container_that_is_gone_is_as_down_as_one_that_is_stopped() {
+        let known = facts([(node(REPO, 133), NodeFact::Claimed)]);
+        for state in ["Stopped", "NotFound"] {
+            let workspaces = [workspace("a", REPO, 133, state)];
+            assert_eq!(
+                Liveness::read(&workspaces, &known).of(REPO, 133),
+                Some(Life::Stalled),
+                "{state} is a stall"
+            );
+        }
+        // Mid-transition, and a state dl could not read. Neither is a claim.
+        for state in ["Busy", "SomethingDevpodAddedLater"] {
+            let workspaces = [workspace("a", REPO, 133, state)];
+            assert_eq!(
+                Liveness::read(&workspaces, &known).of(REPO, 133),
+                None,
+                "{state} asserts nothing"
+            );
+        }
+        let mut unanswered = workspace("a", REPO, 133, "Stopped");
+        unanswered.state = None;
+        assert_eq!(
+            Liveness::read(&[unanswered], &known).of(REPO, 133),
+            None,
+            "a state dl would not answer for asserts nothing"
+        );
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -182,6 +182,10 @@ struct Picker {
     /// The sending end, kept because a fold can start further loads.
     tx: UnboundedSender<LoadEvent>,
     updates: UnboundedReceiver<LoadEvent>,
+    /// Which reading the screen is currently asking for — bumped by every
+    /// `ctrl-r`, so an answer to a question already withdrawn can be told from
+    /// the answer to the live one. See [`LoadEvent::Surveyed`].
+    reading: u64,
 }
 
 impl Picker {
@@ -204,6 +208,9 @@ impl Picker {
             loaders,
             tx,
             updates,
+            // The reading `session` starts alongside this picker. They agree by
+            // both being the first, which is the only coupling between them.
+            reading: 0,
         }
     }
 
@@ -226,6 +233,7 @@ impl Picker {
                 &mut self.clusters,
                 &mut self.loaders,
                 &self.tx,
+                self.reading,
             );
         }
         terminal.draw(|frame| wf::ui::draw(frame, &self.app))?;
@@ -258,6 +266,7 @@ fn fold(
     clusters: &mut BTreeMap<MapId, Map>,
     loaders: &mut Loaders,
     tx: &UnboundedSender<LoadEvent>,
+    reading: u64,
 ) {
     match event {
         LoadEvent::Discovered(found) => {
@@ -310,7 +319,13 @@ fn fold(
         // line, and — through `app.liveness` — a marking on any row whose
         // node this machine has something to say about. And it arrives
         // more than once, because `ctrl-r` asks again.
-        LoadEvent::Surveyed(found) => {
+        // An answer to a question the screen has since withdrawn. Dropping it
+        // is the whole reason the event says which reading it is: `ctrl-r`
+        // clears what is held and asks again, and a stale answer folded after
+        // that clear would restore it with nothing able to correct it — a
+        // fresh reading that finds nothing is silent by design.
+        LoadEvent::Surveyed { taken, .. } if taken != reading => {}
+        LoadEvent::Surveyed { reading: found, .. } => {
             let (reclaimable, liveness) = found.into_parts();
             app.reclaimable = reclaimable;
             app.liveness = liveness;
@@ -330,8 +345,8 @@ fn fold(
 /// subprocess and one batched GraphQL call, neither of them on the way to a
 /// frame. What lands folds into the count line and into the rows' own
 /// markings; a reading that fails says nothing at all.
-fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
-    wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone())
+fn spawn_reading(tx: &UnboundedSender<LoadEvent>, taken: u64) -> Survey {
+    wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone(), taken)
 }
 
 /// Take the reading again, on `ctrl-r`.
@@ -341,9 +356,9 @@ fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
 /// its own, and two overlapping ones would race to write the same two fields
 /// with answers taken at different moments — the older one landing last, which
 /// is exactly the bug `Loaders::restart` exists to avoid on the map side.
-async fn restart_reading(previous: Survey, tx: &UnboundedSender<LoadEvent>) -> Survey {
+async fn restart_reading(previous: Survey, tx: &UnboundedSender<LoadEvent>, taken: u64) -> Survey {
     previous.stop().await;
-    spawn_reading(tx)
+    spawn_reading(tx, taken)
 }
 
 /// Stop everything running behind the screen, and wait for it to be gone.
@@ -411,7 +426,8 @@ async fn run<B: Backend, K: Keys>(
                 // hour's containers with nothing able to correct it.
                 picker.app.reclaimable = None;
                 picker.app.liveness = wf::liveness::Liveness::default();
-                survey = restart_reading(survey, &picker.tx).await;
+                picker.reading += 1;
+                survey = restart_reading(survey, &picker.tx, picker.reading).await;
             }
             // Nothing after this can be drawn. Stop the background work
             // *and wait for it* before handing over: an in-flight `gh`
@@ -445,7 +461,7 @@ async fn session<B: Backend, K: Keys>(
 ) -> Result<Ending> {
     let (tx, updates) = mpsc::unbounded_channel();
     let discovery = wf::refresh::spawn_discovery(repos, cache_path, tx.clone());
-    let survey = spawn_reading(&tx);
+    let survey = spawn_reading(&tx, 0);
     let picker = Picker::new(app, tx, updates);
     run(terminal, keys, picker, discovery, survey).await
 }
@@ -931,6 +947,18 @@ mod tests {
             );
         }
         assert_eq!(run.argv[0], "dl <--ls> <--json>");
+        // Bounded as well as filtered. A predicate over each call says nothing
+        // about how many there are, and "nothing extra" is a claim about the
+        // count — fifty tracker reads on the launch path would satisfy every
+        // assertion above. Not pinned to an exact number, because this script
+        // presses `ctrl-r` and the second reading is racing `stop_background`:
+        // its `dl` may or may not have run by the time the arm aborts it. Two
+        // readings, two calls each, is the ceiling either way.
+        assert!(
+            run.argv.len() <= 4,
+            "at most the two readings this script asks for: {:?}",
+            run.argv
+        );
     }
 
     #[test]
@@ -975,6 +1003,106 @@ mod tests {
             "it names the workspace: {line}"
         );
         assert!(line.contains("wf reap"), "and the command: {line}");
+    }
+
+    /// A reading answering a question the screen has withdrawn is dropped.
+    ///
+    /// The window is real rather than theoretical: `Picker::tick` drains the
+    /// channel once per turn and then parks in `next_press`, so a reading that
+    /// lands while the loop is parked waits there. Press `ctrl-r` in that
+    /// window and the clear happens *first*; without the tag, the next drain
+    /// folds the withdrawn answer straight back over it.
+    ///
+    /// What makes that unrecoverable rather than merely brief is the silence
+    /// this event is designed around: a fresh reading that finds nothing sends
+    /// nothing, so if the containers really did stop, no later event exists to
+    /// correct the restored markings. They would sit there until the session
+    /// ended.
+    #[tokio::test]
+    async fn an_answer_to_a_withdrawn_reading_is_dropped_rather_than_folded() {
+        let (tx, updates) = mpsc::unbounded_channel();
+        let mut picker = Picker::new(App::new(BTreeMap::new()), tx.clone(), updates);
+        // A real reading, taken through the real derivation with the two reads
+        // stubbed — the test-only constructors live in the library's own test
+        // build and this is the binary. Going through `survey` is the better
+        // seam anyway: the value folded below is one the production path can
+        // actually produce.
+        let node = wf::reap::Node {
+            repo: "blooop/wayfinder".to_string(),
+            number: 7,
+        };
+        let other = wf::reap::Node {
+            repo: node.repo.clone(),
+            number: 8,
+        };
+        let workspace = |number: u64, state: &str| wf::reap::Workspace {
+            id: format!("wf-{number}"),
+            devlaunch: true,
+            repo: Some(node.repo.clone()),
+            branch: Some(format!("wayfinder/wayfinder-{number}")),
+            state: Some(state.to_string()),
+            unsaved: None,
+        };
+        // One finished node whose container is down — a reap would claim it —
+        // and one whose container is up, so the reading carries both halves.
+        let listed = vec![workspace(7, "Stopped"), workspace(8, "Running")];
+        let known: BTreeMap<_, _> = [
+            (node.clone(), wf::reap::NodeFact::Closed),
+            (other, wf::reap::NodeFact::Closed),
+        ]
+        .into_iter()
+        .collect();
+        let stale = wf::reclaim::survey(
+            || async { Ok(listed.clone()) },
+            |_| async { Ok(known.clone()) },
+        )
+        .await
+        .expect("a finished workspace and a live container are both worth reporting");
+        assert!(
+            !stale.liveness().is_empty(),
+            "the fixture must carry a marking for the drop to be about anything"
+        );
+
+        // The reading the screen is waiting for lands: it is folded.
+        fold(
+            LoadEvent::Surveyed {
+                taken: 0,
+                reading: stale.clone(),
+            },
+            &mut picker.app,
+            &mut picker.clusters,
+            &mut picker.loaders,
+            &picker.tx,
+            picker.reading,
+        );
+        assert!(picker.app.reclaimable.is_some(), "the live answer is taken");
+        assert!(!picker.app.liveness.is_empty(), "markings and all");
+
+        // `ctrl-r`: what is held goes, and the question is asked again.
+        picker.app.reclaimable = None;
+        picker.app.liveness = wf::liveness::Liveness::default();
+        picker.reading += 1;
+
+        // The previous reading's answer, already queued when the key landed.
+        fold(
+            LoadEvent::Surveyed {
+                taken: 0,
+                reading: stale,
+            },
+            &mut picker.app,
+            &mut picker.clusters,
+            &mut picker.loaders,
+            &picker.tx,
+            picker.reading,
+        );
+        assert_eq!(
+            picker.app.reclaimable, None,
+            "a withdrawn reading must not restore the hint"
+        );
+        assert!(
+            picker.app.liveness.is_empty(),
+            "nor the row markings it came with"
+        );
     }
 
     #[test]
@@ -1097,6 +1225,7 @@ mod tests {
                 None
             },
             tx,
+            0,
         );
         stop_background(discovery, survey).await;
         assert_eq!(

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -305,9 +305,11 @@ fn fold(
             }
         }
         // The background reading landed (#137). A plain state write on
-        // a screen that has been up and answering keys the whole time —
-        // it changes one dim segment of the count line and nothing else,
-        // and it arrives at most once because nothing asks again.
+        // a screen that has been up and answering keys the whole time.
+        // It reaches further than it once did: a dim segment of the count
+        // line, and — through `app.liveness` — a marking on any row whose
+        // node this machine has something to say about. And it arrives
+        // more than once, because `ctrl-r` asks again.
         LoadEvent::Surveyed(found) => {
             let (reclaimable, liveness) = found.into_parts();
             app.reclaimable = reclaimable;
@@ -326,8 +328,8 @@ fn fold(
 ///
 /// Read behind the screen exactly as the map search is: a `dl --ls --json`
 /// subprocess and one batched GraphQL call, neither of them on the way to a
-/// frame. It folds into the count line when it lands and says nothing when it
-/// fails.
+/// frame. What lands folds into the count line and into the rows' own
+/// markings; a reading that fails says nothing at all.
 fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
     wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone())
 }
@@ -1043,9 +1045,13 @@ mod tests {
         // The list is five tokens, against six in [`wf::reclaim`], seven in
         // [`wf::refresh`] and seven in [`wf::liveness`], and the difference is
         // worth writing down rather than rounding off. `liveness` is the newest
-        // and holds the union: it is a pure join over two borrowed slices, so
-        // every token is free there and none of them constrains anything it had
-        // occasion to write. Both siblings forbid `remove`, `"rm"` and `--force`;
+        // and forbids seven of the eight tokens the four lists use between
+        // them. The exception is the interesting one: `liveness` cannot forbid
+        // `reap`, because it is written on `use crate::reap::{node_of, Node,
+        // NodeFact, Workspace}` — it reads that module's *types*. What stands
+        // there instead is the same thing that stands in `reclaim`, which calls
+        // `reap::plan` by name for the same reason: `reap`'s deletion is
+        // private to `reap`, so no import can reach it. Both siblings forbid `remove`, `"rm"` and `--force`;
         // this file forbids none of the three. `remove` it cannot:
         // `app.failed.remove(&id)` is `App`'s own bookkeeping, one occurrence,
         // and renaming a `HashMap` method to satisfy a grep is the distortion a

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -54,7 +54,7 @@
 //!    - **which arm**: all four [`Outcome`] arms are driven, the launch one
 //!      included, and so is [`fold`] — but only through the events the child's
 //!      fixtures actually produce. Its `Discovered`, `Fetched` and
-//!      `Read` arms are entered; `SearchFailed` is not, because the `gh`
+//!      `Surveyed` arms are entered; `SearchFailed` is not, because the `gh`
 //!      shim answers the map search successfully, and a `dl <ws> rm` planted in
 //!      that one arm is green. What stands against it there is the denylist in
 //!      (1) — it has to be spelt in another file to get past that; the
@@ -308,7 +308,7 @@ fn fold(
         // a screen that has been up and answering keys the whole time —
         // it changes one dim segment of the count line and nothing else,
         // and it arrives at most once because nothing asks again.
-        LoadEvent::Read(found) => {
+        LoadEvent::Surveyed(found) => {
             let (reclaimable, liveness) = found.into_parts();
             app.reclaimable = reclaimable;
             app.liveness = liveness;
@@ -330,6 +330,18 @@ fn fold(
 /// fails.
 fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
     wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone())
+}
+
+/// Take the reading again, on `ctrl-r`.
+///
+/// The previous one is stopped **and waited for** before a second is started,
+/// for the reason the handover does it: a reading holds a `dl` and a `gh` of
+/// its own, and two overlapping ones would race to write the same two fields
+/// with answers taken at different moments — the older one landing last, which
+/// is exactly the bug `Loaders::restart` exists to avoid on the map side.
+async fn restart_reading(previous: Survey, tx: &UnboundedSender<LoadEvent>) -> Survey {
+    previous.stop().await;
+    spawn_reading(tx)
 }
 
 /// Stop everything running behind the screen, and wait for it to be gone.
@@ -363,7 +375,7 @@ async fn run<B: Backend, K: Keys>(
     keys: &mut K,
     mut picker: Picker,
     discovery: JoinHandle<()>,
-    survey: Survey,
+    mut survey: Survey,
 ) -> Result<Ending> {
     loop {
         picker.tick(terminal)?;
@@ -381,6 +393,23 @@ async fn run<B: Backend, K: Keys>(
                 picker.loaders.restart(&picker.app.open_maps, &picker.tx);
                 picker.app.startup.reloading();
                 picker.app.failed.clear();
+                // The reading is refetched with everything else, and what it
+                // said is dropped *now* rather than when its replacement lands.
+                // It was one dim segment naming a command when it could be read
+                // once at startup and left; it now also marks rows with claims
+                // in the present tense — which container is up, which run has
+                // stopped — and those go stale the moment anything starts or
+                // stops. A stale `▣` on a node whose container this session's
+                // own launch picker just built is the version of it a person
+                // would actually hit.
+                //
+                // Clearing before the refetch is the honest order: a reading
+                // that finds nothing sends no event, so keeping the old one
+                // until it is replaced would leave a screen asserting last
+                // hour's containers with nothing able to correct it.
+                picker.app.reclaimable = None;
+                picker.app.liveness = wf::liveness::Liveness::default();
+                survey = restart_reading(survey, &picker.tx).await;
             }
             // Nothing after this can be drawn. Stop the background work
             // *and wait for it* before handing over: an in-flight `gh`
@@ -845,17 +874,34 @@ mod tests {
         // does is not here.
         let run = a_session();
         run.destroyed_nothing();
+        // Stated as a rule over every call rather than as a fixed list, because
+        // the *number* of readings is a property of the keys pressed — this
+        // script presses `ctrl-r` — while "these two questions and no others"
+        // is the safety claim, and it must hold however many times the run
+        // asks them.
+        for argv in &run.argv {
+            assert!(
+                argv == "dl <--ls> <--json>"
+                    || argv.starts_with(
+                        "gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"
+                    ),
+                "a session asks for the listing and the tracker, and nothing else: {argv}"
+            );
+        }
+        // And the refresh really does ask again. `ctrl-r` is documented as
+        // refetching everything in place, and the reading became a per-row
+        // claim in the present tense — so a refresh that left it at its startup
+        // value would be drawing an hour-old container state beside freshly
+        // fetched tickets. Read off the run rather than from the call site: the
+        // pair repeats.
         assert_eq!(
-            run.argv.len(),
-            2,
-            "a session asks for the listing and the tracker, and nothing else: {:?}",
             run.argv
-        );
-        assert_eq!(run.argv[0], "dl <--ls> <--json>");
-        assert!(
-            run.argv[1].starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"),
-            "one batched read of the tracker: {}",
-            run.argv[1]
+                .iter()
+                .filter(|argv| *argv == "dl <--ls> <--json>")
+                .count(),
+            2,
+            "the reading is taken at startup and again on ctrl-r: {:?}",
+            run.argv
         );
     }
 
@@ -873,12 +919,15 @@ mod tests {
         // in flight would land in this log after the reading did.
         let run = a_launching_session();
         run.destroyed_nothing();
-        assert_eq!(
-            run.argv.len(),
-            2,
-            "launching asks nothing extra of the machine: {:?}",
-            run.argv
-        );
+        for argv in &run.argv {
+            assert!(
+                argv == "dl <--ls> <--json>"
+                    || argv.starts_with(
+                        "gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"
+                    ),
+                "launching asks nothing extra of the machine: {argv}"
+            );
+        }
         assert_eq!(run.argv[0], "dl <--ls> <--json>");
     }
 
@@ -991,9 +1040,12 @@ mod tests {
         // outside [`session`], or after that run, nothing does, which is true
         // of any code in any file.
         //
-        // The list is five tokens, against six in [`wf::reclaim`] and seven in
-        // [`wf::refresh`], and the difference is worth writing down rather than
-        // rounding off. Both siblings forbid `remove`, `"rm"` and `--force`;
+        // The list is five tokens, against six in [`wf::reclaim`], seven in
+        // [`wf::refresh`] and seven in [`wf::liveness`], and the difference is
+        // worth writing down rather than rounding off. `liveness` is the newest
+        // and holds the union: it is a pure join over two borrowed slices, so
+        // every token is free there and none of them constrains anything it had
+        // occasion to write. Both siblings forbid `remove`, `"rm"` and `--force`;
         // this file forbids none of the three. `remove` it cannot:
         // `app.failed.remove(&id)` is `App`'s own bookkeeping, one occurrence,
         // and renaming a `HashMap` method to satisfy a grep is the distortion a

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -54,7 +54,7 @@
 //!    - **which arm**: all four [`Outcome`] arms are driven, the launch one
 //!      included, and so is [`fold`] — but only through the events the child's
 //!      fixtures actually produce. Its `Discovered`, `Fetched` and
-//!      `Reclaimable` arms are entered; `SearchFailed` is not, because the `gh`
+//!      `Read` arms are entered; `SearchFailed` is not, because the `gh`
 //!      shim answers the map search successfully, and a `dl <ws> rm` planted in
 //!      that one arm is green. What stands against it there is the denylist in
 //!      (1) — it has to be spelt in another file to get past that; the
@@ -308,8 +308,10 @@ fn fold(
         // a screen that has been up and answering keys the whole time —
         // it changes one dim segment of the count line and nothing else,
         // and it arrives at most once because nothing asks again.
-        LoadEvent::Reclaimable(found) => {
-            app.reclaimable = Some(found);
+        LoadEvent::Read(found) => {
+            let (reclaimable, liveness) = found.into_parts();
+            app.reclaimable = reclaimable;
+            app.liveness = liveness;
         }
     }
 }
@@ -660,7 +662,7 @@ mod tests {
                 // `the_first_frame_is_drawn_before_anything_is_asked` reads.
                 probe::note("the first frame");
             }
-            if self.due.is_none() && app.reclaimable.is_some() {
+            if self.due.is_none() && (app.reclaimable.is_some() || !app.liveness.is_empty()) {
                 self.due = Some(now + WATCH);
             }
             let ready = self.due.is_some_and(|at| now >= at);

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -866,6 +866,25 @@ mod tests {
         )
     }
 
+    /// Is this recorded call one of the questions a session is allowed to ask?
+    ///
+    /// Shared by the two safety assertions so they cannot drift apart, and
+    /// written as "what may be asked" rather than "what must not be run": a
+    /// denylist of destructive spellings is exactly the thing a new `dl`
+    /// subcommand walks around. What makes all three safe is that none of them
+    /// names a workspace, which is where every destructive `dl` takes its
+    /// target.
+    ///
+    /// `--version` is on the list because reading a listing now depends on
+    /// knowing which `dl` wrote it (`reap::answered_where_dl_answers`). It is
+    /// asked once per process and answers nothing about any particular
+    /// workspace.
+    fn asked_a_question(argv: &str) -> bool {
+        argv == "dl <--ls> <--json>"
+            || argv == "dl <--version>"
+            || argv.starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>")
+    }
+
     /// The same, for the run that ends in a launch.
     fn a_launching_session() -> probe::Recording {
         probe::record(
@@ -899,10 +918,7 @@ mod tests {
         // asks them.
         for argv in &run.argv {
             assert!(
-                argv == "dl <--ls> <--json>"
-                    || argv.starts_with(
-                        "gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"
-                    ),
+                asked_a_question(argv),
                 "a session asks for the listing and the tracker, and nothing else: {argv}"
             );
         }
@@ -939,10 +955,7 @@ mod tests {
         run.destroyed_nothing();
         for argv in &run.argv {
             assert!(
-                argv == "dl <--ls> <--json>"
-                    || argv.starts_with(
-                        "gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"
-                    ),
+                asked_a_question(argv),
                 "launching asks nothing extra of the machine: {argv}"
             );
         }
@@ -953,10 +966,23 @@ mod tests {
         // assertion above. Not pinned to an exact number, because this script
         // presses `ctrl-r` and the second reading is racing `stop_background`:
         // its `dl` may or may not have run by the time the arm aborts it. Two
-        // readings, two calls each, is the ceiling either way.
+        // readings, two calls each, plus the one `dl <--version>` the process
+        // asks once however many readings it takes, is the ceiling either way.
         assert!(
-            run.argv.len() <= 4,
+            run.argv.len() <= 5,
             "at most the two readings this script asks for: {:?}",
+            run.argv
+        );
+        // The version is the part that must not scale with the readings — it is
+        // memoized per process precisely so a refresh does not pay for another
+        // Python start, and nothing else in this run would notice if it did.
+        assert!(
+            run.argv
+                .iter()
+                .filter(|argv| *argv == "dl <--version>")
+                .count()
+                <= 1,
+            "the version is asked once per process, not once per reading: {:?}",
             run.argv
         );
     }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -422,9 +422,14 @@ pub fn note(what: &str) {
         .expect("the probe log");
 }
 
-/// A `dl --ls --json` listing over four workspaces of this repo, in the shape
-/// devlaunch 0.0.21 and newer emit — one finished ticket, one the planner warns
-/// about, one in use, and one whose run stopped between its stages.
+/// A `dl --ls --json` listing over four workspaces of this repo, as devlaunch
+/// 0.0.24 writes them — one finished ticket, one the planner warns about, one
+/// in use, and one whose run stopped between its stages.
+///
+/// The newest shape on purpose: this is the fixture the *whole reading* is
+/// driven through, so it should look like the `dl` this `wf` will be run
+/// against next. Every older spelling of `unsaved` has its own row in
+/// [`DL_LISTING_UNSAVED`], which is where that field is the subject.
 ///
 /// The fourth exists so the live path can produce a **stall**, not just be
 /// asserted to derive one from hand-built state: it is the only row whose
@@ -435,7 +440,7 @@ pub fn note(what: &str) {
 /// and the picker's drive the same two reads, and a fixture written twice is a
 /// fixture that can disagree with itself about what the machine looks like.
 ///
-/// The three ids are also [`LAID_OUT`] as directories in the child's scratch
+/// The four ids are also [`LAID_OUT`] as directories in the child's scratch
 /// home, so what the code under test can see is exactly what it can be caught
 /// destroying.
 pub const DL_LISTING: &str = r#"[

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -74,12 +74,17 @@ pub const MARK: &str = "PROBE|";
 /// contain a `|`.
 const NOTED: &str = "note|";
 
-/// The workspace ids [`record`] lays a scratch home out for — the three
+/// The workspace ids [`record`] lays a scratch home out for — the four
 /// [`DL_LISTING`] names, so every workspace the code under test can *see* is
 /// also a directory it can be caught destroying.
-const LAID_OUT: [&str; 3] = ["wf-129-closed", "wf-138-unstarted", "wf-137-open"];
+const LAID_OUT: [&str; 4] = [
+    "wf-129-closed",
+    "wf-138-unstarted",
+    "wf-137-open",
+    "wf-134-stalled",
+];
 
-/// The repo those three belong to in [`DL_LISTING`], which is also the
+/// The repo those four belong to in [`DL_LISTING`], which is also the
 /// directory `dl` files their clones under.
 const LAID_OUT_REPO: &str = "blooop/wayfinder";
 
@@ -417,9 +422,14 @@ pub fn note(what: &str) {
         .expect("the probe log");
 }
 
-/// A `dl --ls --json` listing over three workspaces of this repo, in the shape
+/// A `dl --ls --json` listing over four workspaces of this repo, in the shape
 /// devlaunch 0.0.21 and newer emit — one finished ticket, one the planner warns
-/// about, one in use.
+/// about, one in use, and one whose run stopped between its stages.
+///
+/// The fourth exists so the live path can produce a **stall**, not just be
+/// asserted to derive one from hand-built state: it is the only row whose
+/// container is down while its ticket is claimed, and it is what makes the
+/// recorded reading say `stalled 1`.
 ///
 /// Here rather than beside either probe that uses it: the reading's own probe
 /// and the picker's drive the same two reads, and a fixture written twice is a
@@ -437,16 +447,26 @@ pub const DL_LISTING: &str = r#"[
    "unsaved":{"nothingToLose":true}},
   {"id":"wf-137-open","devlaunch":true,"repo":"blooop/wayfinder",
    "branch":"wayfinder/wayfinder-137","state":"Running",
+   "unsaved":{"nothingToLose":true}},
+  {"id":"wf-134-stalled","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-134","state":"Stopped",
    "unsaved":{"nothingToLose":true}}
 ]"#;
 
 /// Every shape `dl` has ever emitted for `unsaved`, in one listing.
 ///
 /// The top three rows are devlaunch **0.0.24 and newer**: an object with
-/// exactly one key. The bottom two are **0.0.23 and older**, whose field was a
+/// exactly one key. The next two are **0.0.23 and older**, whose field was a
 /// bare sentence or `null` — still on real machines, because `wf` pins no `dl`
-/// version. The last row is a workspace `dl` did not create, where the field is
-/// absent altogether.
+/// version. Then two rows no `dl` has ever emitted: a key from a *later* `dl`
+/// than this binary, and the documented key carrying an undocumented payload.
+/// The last row is a workspace `dl` did not create, where the field is absent
+/// altogether.
+///
+/// Those two invented rows are the ones that matter most. `parse_workspaces` is
+/// all or nothing, so a listing this `wf` cannot fully read is a listing it
+/// reads *none* of — and a fixture containing only the shapes already shipped
+/// would prove nothing about the release after this one.
 ///
 /// This is a transcription of `dl`'s own documented output rather than
 /// something `wf` finds convenient to parse: the object arms and their spelling
@@ -469,18 +489,27 @@ pub const DL_LISTING_UNSAVED: &str = r#"[
    "unsaved":"1 uncommitted change(s) (pixi.lock)"},
   {"id":"wf-5-legacy-clean","devlaunch":true,"repo":"blooop/wayfinder",
    "branch":"wayfinder/wayfinder-5","state":"Stopped","unsaved":null},
+  {"id":"wf-6-newer-dl","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-6","state":"Stopped",
+   "unsaved":{"someAnswerFromALaterDl":"whatever it means"}},
+  {"id":"wf-7-odd-payload","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-7","state":"Stopped",
+   "unsaved":{"nothingToLose":false}},
   {"id":"not-ours","devlaunch":false,"state":"Stopped"}
 ]"#;
 
-/// The tracker's answer to the batched question those three nodes raise:
+/// The tracker's answer to the batched question those four nodes raise:
 /// #129 closed (a reap), #138 open with nobody on it and no PR (a warning),
-/// #137 open and claimed (a keep).
+/// #137 open and claimed (a keep, and — its container being up — a `▣`),
+/// #134 open and claimed with its container down (a keep, and a `⧖`).
 pub const GH_FACTS: &str = r#"{"data":{"repository":{
   "i129":{"state":"CLOSED","assignees":{"nodes":[]},
           "closedByPullRequestsReferences":{"nodes":[]}},
   "i137":{"state":"OPEN","assignees":{"nodes":[{"login":"blooop"}]},
           "closedByPullRequestsReferences":{"nodes":[]}},
   "i138":{"state":"OPEN","assignees":{"nodes":[]},
+          "closedByPullRequestsReferences":{"nodes":[]}},
+  "i134":{"state":"OPEN","assignees":{"nodes":[{"login":"blooop"}]},
           "closedByPullRequestsReferences":{"nodes":[]}}
 }}}"#;
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -430,11 +430,46 @@ pub fn note(what: &str) {
 /// destroying.
 pub const DL_LISTING: &str = r#"[
   {"id":"wf-129-closed","devlaunch":true,"repo":"blooop/wayfinder",
-   "branch":"wayfinder/wayfinder-129","state":"Stopped"},
+   "branch":"wayfinder/wayfinder-129","state":"Stopped",
+   "unsaved":{"nothingToLose":true}},
   {"id":"wf-138-unstarted","devlaunch":true,"repo":"blooop/wayfinder",
-   "branch":"wayfinder/wayfinder-138","state":"Stopped"},
+   "branch":"wayfinder/wayfinder-138","state":"Stopped",
+   "unsaved":{"nothingToLose":true}},
   {"id":"wf-137-open","devlaunch":true,"repo":"blooop/wayfinder",
-   "branch":"wayfinder/wayfinder-137","state":"Running"}
+   "branch":"wayfinder/wayfinder-137","state":"Running",
+   "unsaved":{"nothingToLose":true}}
+]"#;
+
+/// Every shape `dl` has ever emitted for `unsaved`, in one listing.
+///
+/// The top three rows are devlaunch **0.0.24 and newer**: an object with
+/// exactly one key. The bottom two are **0.0.23 and older**, whose field was a
+/// bare sentence or `null` — still on real machines, because `wf` pins no `dl`
+/// version. The last row is a workspace `dl` did not create, where the field is
+/// absent altogether.
+///
+/// This is a transcription of `dl`'s own documented output rather than
+/// something `wf` finds convenient to parse: the object arms and their spelling
+/// come from devlaunch's `--ls --json` table, and the whole reason this fixture
+/// exists is that the two repos had no executed agreement about this field at
+/// all — only prose on each side, which is how the string→object change was
+/// able to land unnoticed.
+pub const DL_LISTING_UNSAVED: &str = r#"[
+  {"id":"wf-1-clean","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-1","state":"Stopped",
+   "unsaved":{"nothingToLose":true}},
+  {"id":"wf-2-dirty","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-2","state":"Stopped",
+   "unsaved":{"wouldLose":"2 uncommitted change(s) (pixi.lock, notes.md) and 1 unpushed commit(s)"}},
+  {"id":"wf-3-unreadable","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-3","state":"Stopped",
+   "unsaved":{"couldNotTell":"fatal: not a git repository"}},
+  {"id":"wf-4-legacy-dirty","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-4","state":"Stopped",
+   "unsaved":"1 uncommitted change(s) (pixi.lock)"},
+  {"id":"wf-5-legacy-clean","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-5","state":"Stopped","unsaved":null},
+  {"id":"not-ours","devlaunch":false,"state":"Stopped"}
 ]"#;
 
 /// The tracker's answer to the batched question those three nodes raise:

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -563,17 +563,35 @@ fn scratch(test: &str) -> PathBuf {
 /// the same time interleave into one log line, and every assertion that counts
 /// the lines becomes a race. An `O_APPEND` write this small is atomic; two are
 /// not.
+/// The release the shimmed `dl` claims to be, and it must match what the
+/// fixtures are written as.
+///
+/// [`DL_LISTING`] answers `unsaved` with the one-key object, which is a 0.0.24
+/// listing, and `reap` reads a *missing* answer differently either side of that
+/// release. A shim that listed like 0.0.24 and versioned like 0.0.23 would be
+/// evidence about a machine that cannot exist, which is worse than no probe.
+const SHIMMED_DL: &str = "0.0.24";
+
 fn shim(dir: &Path, name: &str) {
     let path = dir.join(name);
+    // `--version` is answered before the fixture, because `dl` answers it with
+    // a version rather than with a listing, and a shim that returned the
+    // listing to both would be a `dl` that exists nowhere. The recording still
+    // happens first, so the call is counted either way.
+    //
+    // The answer is [`SHIMMED_DL`] for the same reason the fixtures name a
+    // release: a probe is only evidence about a machine it could be.
     let body = r#"#!/bin/sh
 line=$({
   printf '%s' 'PROGRAM'
   for a in "$@"; do printf ' <%s>' "$a"; done
 } | tr '\n' ' ')
 printf '%s\n' "$line" >> "$LOGVAR"
+if [ "$1" = "--version" ]; then printf '%s\n' 'PROGRAM VERSION'; exit 0; fi
 cat 'FIXTURE'
 "#
     .replace("PROGRAM", name)
+    .replace("VERSION", SHIMMED_DL)
     .replace("LOGVAR", LOG)
     .replace(
         "FIXTURE",

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -465,8 +465,11 @@ pub const DL_LISTING: &str = r#"[
 /// bare sentence or `null` — still on real machines, because `wf` pins no `dl`
 /// version. Then two rows no `dl` has ever emitted: a key from a *later* `dl`
 /// than this binary, and the documented key carrying an undocumented payload.
-/// The last row is a workspace `dl` did not create, where the field is absent
-/// altogether.
+/// One of those carries a documented key **beside** an undocumented sibling,
+/// which is the shape a later `dl` produces by adding one field: it must go on
+/// being read, because the alternative is every row in the listing refusing at
+/// once. The last row is a workspace `dl` did not create, where the field is
+/// absent altogether.
 ///
 /// Those two invented rows are the ones that matter most. `parse_workspaces` is
 /// all or nothing, so a listing this `wf` cannot fully read is a listing it
@@ -500,6 +503,9 @@ pub const DL_LISTING_UNSAVED: &str = r#"[
   {"id":"wf-7-odd-payload","devlaunch":true,"repo":"blooop/wayfinder",
    "branch":"wayfinder/wayfinder-7","state":"Stopped",
    "unsaved":{"nothingToLose":false}},
+  {"id":"wf-8-sibling-key","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-8","state":"Stopped",
+   "unsaved":{"nothingToLose":true,"checkedAt":"2026-08-10T00:00:00Z"}},
   {"id":"not-ours","devlaunch":false,"state":"Stopped"}
 ]"#;
 

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -43,6 +43,7 @@ use serde::Deserialize;
 use tokio::process::Command;
 
 use crate::fetch::{is_open, parse_pr, Assignee, GraphQlResponse, Nodes, PrNode};
+use crate::launch::devlaunch_answers_unsaved;
 use crate::model::PrStatus;
 
 /// The branch prefix `wf` mints its workspaces under (#106): the full branch is
@@ -73,20 +74,21 @@ pub struct Workspace {
     pub state: Option<String>,
     /// What deleting would destroy, in `dl`'s words.
     ///
-    /// `None` is "no answer": the field was `null` or absent. **It permits a
-    /// reap, and that is a compromise rather than a reading.** On devlaunch
-    /// ≤ 0.0.23 — the release actually installed on most machines today —
-    /// `null` on a workspace `dl` made *is* the ordinary clean case, so
-    /// refusing it would make `wf reap` collect nothing at all there. On 0.0.24
-    /// and newer the same `null` should only ever appear on a workspace `dl`
-    /// did not create, which [`node_of`] has already dropped before the guard
-    /// runs — so a `null` reaching it means `dl`'s own guard fell over, and
-    /// treating that as "clean" is the wrong direction.
+    /// `None` is "no answer": the field was `null` or absent, and what that
+    /// means depends on which `dl` wrote it. On devlaunch ≤ 0.0.23 `null` on a
+    /// workspace `dl` made *is* the ordinary clean case. From 0.0.24 the same
+    /// `null` appears exactly where `devlaunch` is false, so one on a clone
+    /// `dl` made means `dl`'s own inspection fell over — and reading that as
+    /// "clean" is devlaunch#171's bug, which is the bug the object form was a
+    /// breaking change to prevent.
     ///
-    /// The two are indistinguishable from one row, and nothing here asks `dl`
-    /// its version. What the arms below *do* retire is the other half of the
-    /// old sentinel: a clean clone now says so in its own name, so "no answer"
-    /// is at least no longer the same value as "nothing to lose".
+    /// No single row can tell the two apart, so the version is asked instead:
+    /// `answered_where_dl_answers` turns the second reading into
+    /// [`Unsaved::Unanswered`] before [`plan`] ever sees the row, and leaves
+    /// the first alone. A `None` still standing here is therefore a `dl` whose
+    /// version said the field was allowed to be empty, or one `wf` could not
+    /// probe at all — and it permits a reap, which is what those releases meant
+    /// by it.
     #[serde(default)]
     pub unsaved: Option<Unsaved>,
 }
@@ -166,6 +168,22 @@ pub enum Unsaved {
     /// is `wf` failing on `dl`, and a row that said the first when it meant the
     /// second would send somebody to look at the wrong thing.
     Unrecognized(String),
+    /// `dl` made this clone and then said nothing about what it holds.
+    ///
+    /// **Never parsed from the wire** — there is no spelling of it, because it
+    /// is the *absence* of one. It is put here by `answered_where_dl_answers`
+    /// after asking the `dl` on PATH its version, and only for a `dl` that
+    /// documents an answer on every clone of its own. On such a release `null`
+    /// appears exactly where `devlaunch` is false, so a `null` on a clone `dl`
+    /// made is `dl`'s own inspection having fallen over — which is
+    /// devlaunch#171's bug, the one the object form exists to prevent, and
+    /// reaping on it would walk straight back into it.
+    ///
+    /// Separate from [`Unsaved::CouldNotTell`] because `dl` saying "I could not
+    /// read this clone" and `dl` saying nothing at all are different failures
+    /// with different places to look: the first is a broken clone, the second
+    /// is a broken `dl`.
+    Unanswered,
 }
 
 impl Unsaved {
@@ -183,6 +201,9 @@ impl Unsaved {
             Self::Unrecognized(said) => Some(format!(
                 "this wf cannot read what dl said about it ({said}) — newer dl?"
             )),
+            Self::Unanswered => {
+                Some("dl made this clone but did not say what it holds".to_string())
+            }
         }
     }
 
@@ -195,16 +216,24 @@ impl Unsaved {
             Self::Unrecognized(said) => Some(format!(
                 ", discarding a clone this wf cannot read dl's answer about ({said})"
             )),
+            Self::Unanswered => {
+                Some(", discarding a clone dl did not say anything about".to_string())
+            }
         }
     }
 }
 
 /// `dl`'s two spellings of the same field, both accepted.
 ///
-/// `wf` pins no `dl` version and never will — the launch is one `exec` of a
-/// program found on `PATH` — so both are live on real machines: devlaunch
-/// through 0.0.23 emits a bare sentence or `null`, and 0.0.24 emits the
-/// one-key object.
+/// Both are live on real machines: devlaunch through 0.0.23 emits a bare
+/// sentence or `null`, and 0.0.24 emits the one-key object.
+///
+/// `wf` does now hold `dl` to a floor, but that floor governs what a *launch*
+/// may ask of it, and reaping is the other direction — it reads a listing from
+/// whichever `dl` is on `PATH`, including one too old to isolate with. A
+/// machine can also have reaped its workspaces with an older `dl` and upgraded
+/// since. Refusing to read the older spelling would strand exactly the
+/// workspaces most in need of collecting.
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum UnsavedWire {
@@ -649,13 +678,45 @@ pub async fn workspaces() -> Result<Vec<Workspace>> {
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-    parse_workspaces(&output.stdout)
+    let mut workspaces = parse_workspaces(&output.stdout)?;
+    answered_where_dl_answers(&mut workspaces, devlaunch_answers_unsaved());
+    Ok(workspaces)
 }
 
 /// The parse boundary for `dl`'s listing, kept apart from the process call so
 /// it is testable without devlaunch installed.
 fn parse_workspaces(body: &[u8]) -> Result<Vec<Workspace>> {
     serde_json::from_slice(body).context("unparseable workspace listing from `dl --ls --json`")
+}
+
+/// Give a missing answer its meaning, once the `dl` that wrote it is known.
+///
+/// The one place a `dl` version reaches this module, and it is applied here —
+/// at the boundary that already ran the process — so that [`plan`] stays a pure
+/// function of rows it is handed. A version probe inside the parser or the
+/// planner would make every test of either depend on what is installed on the
+/// machine running it.
+///
+/// `answers` is [`devlaunch_answers_unsaved`] in production and both values in
+/// the tests. When it is false nothing happens at all: on those releases `null`
+/// on `dl`'s own clone is the ordinary clean case, and rewriting it would make
+/// `wf reap` refuse every workspace on the machine.
+///
+/// Keyed on `devlaunch` rather than on [`node_of`] because that is the
+/// distinction `dl` documents — `unsaved` is null exactly where `devlaunch` is
+/// false — and reading a row `dl` disclaims as an unanswered question would
+/// invent a failure out of a workspace that was never `dl`'s to inspect. Rows
+/// that are `dl`'s but not `wf`'s are left marked anyway; [`plan`] drops them
+/// for not being ours, and this function has no business knowing that.
+fn answered_where_dl_answers(workspaces: &mut [Workspace], answers: bool) {
+    if !answers {
+        return;
+    }
+    for workspace in workspaces {
+        if workspace.devlaunch && workspace.unsaved.is_none() {
+            workspace.unsaved = Some(Unsaved::Unanswered);
+        }
+    }
 }
 
 /// What the tracker says about each of `nodes`.
@@ -1702,6 +1763,99 @@ mod tests {
 
     /// Only the arm that says the clone is clean lets a finished ticket go.
     ///
+    /// The same `null`, read as the two opposite things it means either side of
+    /// devlaunch 0.0.24.
+    ///
+    /// `wf-5-legacy-clean` is the row that carries the whole argument: on the
+    /// release that wrote it, `null` on `dl`'s own clone is *clean* and it must
+    /// reap, and on a release that answers every clone it made, the same `null`
+    /// is `dl`'s inspection having fallen over and it must not. One row cannot
+    /// say which, which is why the version is asked once and applied here.
+    ///
+    /// `not-ours` pins the other edge: `unsaved` is null on it under every
+    /// release, because there is no clone of `dl`'s own there to inspect. It is
+    /// never an unanswered question, and marking it as one would invent a
+    /// failure out of a workspace `dl` explicitly disclaims.
+    #[test]
+    fn a_missing_answer_reads_as_clean_or_as_a_broken_dl_depending_on_which_dl_wrote_it() {
+        let read = |answers| {
+            let mut workspaces =
+                parse_workspaces(crate::probe::DL_LISTING_UNSAVED.as_bytes()).unwrap();
+            answered_where_dl_answers(&mut workspaces, answers);
+            workspaces
+        };
+        let unsaved_of = |workspaces: &[Workspace], id: &str| {
+            workspaces
+                .iter()
+                .find(|w| w.id == id)
+                .expect("the fixture row")
+                .unsaved
+                .clone()
+        };
+
+        // A `dl` that documents an answer on every clone of its own.
+        let answering = read(true);
+        assert_eq!(
+            unsaved_of(&answering, "wf-5-legacy-clean"),
+            Some(Unsaved::Unanswered),
+            "a clone dl made and said nothing about is a question it failed to answer"
+        );
+        assert_eq!(
+            unsaved_of(&answering, "not-ours"),
+            None,
+            "a workspace dl did not make is not one it failed to answer for"
+        );
+
+        // A `dl` from before the field changed, or one `wf` could not probe.
+        // Nothing is rewritten: on those releases the `null` meant clean, and
+        // reading it as a failure would refuse every workspace on the machine.
+        let legacy = read(false);
+        assert_eq!(unsaved_of(&legacy, "wf-5-legacy-clean"), None);
+        assert_eq!(unsaved_of(&legacy, "not-ours"), None);
+
+        // Rows that did answer are untouched by either reading — the upgrade
+        // fills a gap and never overwrites what `dl` actually said.
+        for answers in [true, false] {
+            let workspaces = read(answers);
+            assert_eq!(
+                unsaved_of(&workspaces, "wf-1-clean"),
+                Some(Unsaved::NothingToLose)
+            );
+            assert_eq!(
+                unsaved_of(&workspaces, "wf-3-unreadable"),
+                Some(Unsaved::CouldNotTell("fatal: not a git repository".into()))
+            );
+        }
+
+        // And the whole point, at the level the human sees: the same listing
+        // reaps that workspace under one `dl` and refuses it under the other.
+        let known: BTreeMap<Node, NodeFact> = (1..=5)
+            .map(|n| (node("blooop/wayfinder", n), NodeFact::Closed))
+            .collect();
+        assert!(
+            doomed(&plan(&legacy, &known, false))
+                .into_iter()
+                .any(|v| v.id() == "wf-5-legacy-clean"),
+            "the release that meant clean by it still collects it"
+        );
+        let refused = plan(&answering, &known, false);
+        assert!(
+            !doomed(&refused)
+                .into_iter()
+                .any(|v| v.id() == "wf-5-legacy-clean"),
+            "the release that promised an answer does not get a reap out of silence"
+        );
+        assert!(
+            refused.iter().any(|v| matches!(
+                v,
+                Verdict::Keep { id, reason }
+                    if id == "wf-5-legacy-clean"
+                        && reason == "dl made this clone but did not say what it holds"
+            )),
+            "and it says which of dl and the clone is the thing to go and look at: {refused:?}"
+        );
+    }
+
     /// `couldNotTell` refusing is the point: those files are still on disk and
     /// nothing has established they exist anywhere else, so it is `wouldLose`'s
     /// neighbour and not `nothingToLose`'s. Flattening the three answers back

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -343,6 +343,17 @@ pub struct Node {
     pub number: u64,
 }
 
+impl Node {
+    /// How a node is named to a human — `wayfinder#133`.
+    ///
+    /// One spelling, shared by the reap plan's rows and the picker's stall
+    /// segment, because they are naming the same things on the same terminal
+    /// and two formats would read as two kinds of object.
+    pub fn name(&self) -> String {
+        format!("{}#{}", short_repo(&self.repo), self.number)
+    }
+}
+
 /// Which node a workspace is for, or `None` if it is not one of `wf`'s.
 ///
 /// Strict on purpose, and every clause is a way for this to be someone else's
@@ -414,7 +425,7 @@ pub fn plan(
             continue;
         };
         let id = workspace.id.clone();
-        let name = format!("{}#{}", short_repo(&node.repo), node.number);
+        let name = node.name();
         // Naming the waived work in the acted-on line, not only in the keep
         // line it replaced: this is the row the human is about to approve, and
         // "and discarding …" is the part they might stop at.

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -71,9 +71,109 @@ pub struct Workspace {
     /// devpod's state: `Running`, `Stopped`, …
     #[serde(default)]
     pub state: Option<String>,
-    /// What deleting would destroy, in `dl`'s words, or `None`.
+    /// What deleting would destroy, in `dl`'s words.
+    ///
+    /// `None` is "`dl` said nothing about it", which is exactly the workspaces
+    /// it did not create — never "the clone is clean". That distinction is the
+    /// whole of [`Unsaved`], and reading it back off an `Option` alone is what
+    /// this field used to get wrong.
     #[serde(default)]
-    pub unsaved: Option<String>,
+    pub unsaved: Option<Unsaved>,
+}
+
+/// What deleting a workspace's clone would destroy, as `dl` reports it.
+///
+/// Three arms because `dl` has three answers, and the third is not a flavour of
+/// either other one: **it could not tell.** A clone whose `.git` is half-removed
+/// or truncated is still full of files, and nothing has established that those
+/// files exist anywhere else — so "could not read it" has to refuse a reap
+/// exactly as "would lose work" does, and for a reason that reads differently
+/// on the plan. `dl` learned that distinction the hard way (devlaunch#171,
+/// where the guard walked out of the clone into an ancestor repository and
+/// reported *its* cleanliness); `wf` is the caller that has to not re-flatten
+/// it.
+///
+/// The old sentinel is what this replaces. `unsaved` was a string-or-null, and
+/// null carried two unrelated meanings — "clean" and "not `dl`'s clone" — with
+/// the reaper reading both as *go ahead*. The arm that says nothing is at risk
+/// now says so in its own name, and the absence of an answer is the `Option`
+/// around this type rather than a value inside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Unsaved {
+    /// Every byte of the clone exists on a remote too. Deleting costs nothing.
+    NothingToLose,
+    /// Uncommitted changes, unpushed commits, or both — named, not counted.
+    WouldLose(String),
+    /// `git` could not read the clone as a repository, and says why.
+    CouldNotTell(String),
+}
+
+impl Unsaved {
+    /// Why this workspace is kept, or `None` when it is no obstacle to a reap.
+    ///
+    /// The two refusing arms phrase themselves rather than sharing one
+    /// "holds …" sentence: a clone `dl` could not read holds nothing anybody
+    /// has established, and saying it *holds* something would be inventing the
+    /// very reading that failed.
+    fn refusal(&self) -> Option<String> {
+        match self {
+            Self::NothingToLose => None,
+            Self::WouldLose(what) => Some(format!("holds {what}")),
+            Self::CouldNotTell(why) => Some(format!("dl cannot read its clone: {why}")),
+        }
+    }
+
+    /// What a `-f` row appends to say what the reap it advises throws away.
+    fn discard(&self) -> Option<String> {
+        match self {
+            Self::NothingToLose => None,
+            Self::WouldLose(what) => Some(format!(", discarding {what}")),
+            Self::CouldNotTell(why) => Some(format!(", discarding a clone dl cannot read: {why}")),
+        }
+    }
+}
+
+/// `dl`'s two spellings of the same field, both accepted.
+///
+/// `wf` pins no `dl` version and never will — the launch is one `exec` of a
+/// program found on `PATH` — so both are live on real machines: devlaunch
+/// through 0.0.23 emits a bare sentence or `null`, and 0.0.24 emits the
+/// one-key object. Refusing either would be `wf` deciding which `dl` you may
+/// have installed, and a listing that fails to parse fails the *whole* reading
+/// (see [`parse_workspaces`]) — one unrecognised field would take the reap and
+/// the picker's hint down with it.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum UnsavedWire {
+    /// devlaunch ≤ 0.0.23. A sentence was only ever written when there was
+    /// something to lose, so it maps onto exactly one arm; the "clean" case
+    /// was `null` there, and stays [`None`] here.
+    Sentence(String),
+    /// devlaunch ≥ 0.0.24: an object with exactly one key, which is the tag.
+    Reported(UnsavedReported),
+}
+
+/// The object form, externally tagged — the key *is* the answer.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum UnsavedReported {
+    /// The payload is documented as `true` and read as nothing: the key has
+    /// already said everything, and a `false` under it would be `dl`
+    /// contradicting itself in a field `wf` would then have to arbitrate.
+    NothingToLose(serde::de::IgnoredAny),
+    WouldLose(String),
+    CouldNotTell(String),
+}
+
+impl<'de> Deserialize<'de> for Unsaved {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(match UnsavedWire::deserialize(deserializer)? {
+            UnsavedWire::Sentence(what)
+            | UnsavedWire::Reported(UnsavedReported::WouldLose(what)) => Self::WouldLose(what),
+            UnsavedWire::Reported(UnsavedReported::NothingToLose(_)) => Self::NothingToLose,
+            UnsavedWire::Reported(UnsavedReported::CouldNotTell(why)) => Self::CouldNotTell(why),
+        })
+    }
 }
 
 /// What `wf` decided about one workspace. Three arms, each carrying a reason,
@@ -319,15 +419,17 @@ pub fn plan(
         // line it replaced: this is the row the human is about to approve, and
         // "and discarding …" is the part they might stop at.
         let discard = match (&workspace.unsaved, insist) {
-            (Some(unsaved), true) => format!(", discarding {unsaved}"),
+            (Some(unsaved), true) => unsaved.discard().unwrap_or_default(),
             _ => String::new(),
         };
         if let (Some(unsaved), false) = (&workspace.unsaved, insist) {
-            verdicts.push(Verdict::Keep {
-                id,
-                reason: format!("holds {unsaved}"),
-            });
-            continue;
+            if let Some(refusal) = unsaved.refusal() {
+                verdicts.push(Verdict::Keep {
+                    id,
+                    reason: refusal,
+                });
+                continue;
+            }
         }
         if workspace.state.as_deref() == Some("Running") {
             verdicts.push(Verdict::Keep {
@@ -1085,7 +1187,9 @@ mod tests {
         // the prompt, so `-f` is the whole flag surface plan can even see.
         for fact in [NodeFact::Superseded { pr: 97 }, NodeFact::Unstarted] {
             let mut ws = workspace("warned", "blooop/devlaunch", "wayfinder/devlaunch-80");
-            ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+            ws.unsaved = Some(Unsaved::WouldLose(
+                "1 uncommitted change(s) (pixi.lock)".to_string(),
+            ));
             let known = facts([(node("blooop/devlaunch", 80), fact)]);
             for insist in [false, true] {
                 let verdicts = plan(std::slice::from_ref(&ws), &known, insist);
@@ -1105,7 +1209,9 @@ mod tests {
         // sits — and the wording is the same for both warning facts.
         for fact in [NodeFact::Superseded { pr: 97 }, NodeFact::Unstarted] {
             let mut ws = workspace("warned", "blooop/devlaunch", "wayfinder/devlaunch-80");
-            ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+            ws.unsaved = Some(Unsaved::WouldLose(
+                "1 uncommitted change(s) (pixi.lock)".to_string(),
+            ));
             let known = facts([(node("blooop/devlaunch", 80), fact)]);
             let quiet = plan(std::slice::from_ref(&ws), &known, false);
             assert!(!quiet[0].reason().contains("discarding"));
@@ -1123,7 +1229,9 @@ mod tests {
         // doing its job, and the deliberate direction: the advisory row is the
         // one that can afford to be missed.
         let mut ws = workspace("ghost", "blooop/devlaunch", "wayfinder/devlaunch-80");
-        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose(
+            "1 uncommitted change(s) (pixi.lock)".to_string(),
+        ));
         let known = facts([(node("blooop/devlaunch", 80), NodeFact::Unstarted)]);
         assert_eq!(
             plan(std::slice::from_ref(&ws), &known, false),
@@ -1171,7 +1279,7 @@ mod tests {
             NodeFact::DoneByMerge { pr: 97 },
         )]);
         let mut dirty = workspace("merged", "blooop/devlaunch", "wayfinder/devlaunch-80");
-        dirty.unsaved = Some("2 uncommitted change(s)".to_string());
+        dirty.unsaved = Some(Unsaved::WouldLose("2 uncommitted change(s)".to_string()));
         assert_eq!(
             plan(&[dirty], &known, false),
             vec![Verdict::Keep {
@@ -1195,7 +1303,9 @@ mod tests {
     #[test]
     fn insisting_on_done_by_merge_names_the_discard() {
         let mut ws = workspace("merged", "blooop/devlaunch", "wayfinder/devlaunch-80");
-        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose(
+            "1 uncommitted change(s) (pixi.lock)".to_string(),
+        ));
         let known = facts([(
             node("blooop/devlaunch", 80),
             NodeFact::DoneByMerge { pr: 97 },
@@ -1264,7 +1374,7 @@ mod tests {
         // and a caller that walks into a refusal it could have anticipated is
         // one that eventually learns to pass --force.
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
-        ws.unsaved = Some("2 uncommitted change(s)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose("2 uncommitted change(s)".to_string()));
         let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         let verdicts = plan(&[ws], &known, false);
         assert_eq!(
@@ -1295,7 +1405,7 @@ mod tests {
     fn unsaved_work_outranks_a_running_container_so_the_worse_news_is_the_one_shown() {
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.state = Some("Running".to_string());
-        ws.unsaved = Some("1 unpushed commit(s)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose("1 unpushed commit(s)".to_string()));
         let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert!(plan(&[ws], &known, false)[0].reason().contains("unpushed"));
     }
@@ -1334,6 +1444,117 @@ mod tests {
         assert_eq!(node_of(&parsed[1]), None);
     }
 
+    /// The two `dl` releases are read the same way, arm for arm.
+    ///
+    /// This is the assertion whose absence let the field change under `wf`:
+    /// both sides documented `unsaved` in prose and neither ever executed the
+    /// other's output, so the string→object change in devlaunch 0.0.24 was
+    /// invisible until a listing failed to parse — which takes the reap *and*
+    /// the picker's hint down together, since [`parse_workspaces`] is all or
+    /// nothing.
+    #[test]
+    fn every_shape_dl_has_emitted_for_unsaved_is_read_back_as_the_arm_it_means() {
+        let parsed = parse_workspaces(crate::probe::DL_LISTING_UNSAVED.as_bytes())
+            .expect("dl's listing parses, in either release's shape");
+        let read: Vec<(&str, Option<&Unsaved>)> = parsed
+            .iter()
+            .map(|w| (w.id.as_str(), w.unsaved.as_ref()))
+            .collect();
+        assert_eq!(
+            read,
+            vec![
+                ("wf-1-clean", Some(&Unsaved::NothingToLose)),
+                (
+                    "wf-2-dirty",
+                    Some(&Unsaved::WouldLose(
+                        "2 uncommitted change(s) (pixi.lock, notes.md) and 1 unpushed commit(s)"
+                            .to_string()
+                    ))
+                ),
+                (
+                    "wf-3-unreadable",
+                    Some(&Unsaved::CouldNotTell(
+                        "fatal: not a git repository".to_string()
+                    ))
+                ),
+                // 0.0.23 and older wrote a sentence only when there was
+                // something to lose, so it lands on the one arm it can mean.
+                (
+                    "wf-4-legacy-dirty",
+                    Some(&Unsaved::WouldLose(
+                        "1 uncommitted change(s) (pixi.lock)".to_string()
+                    ))
+                ),
+                // `null` on either release: no answer, which is not the same
+                // fact as `nothingToLose` and must not become it.
+                ("wf-5-legacy-clean", None),
+                ("not-ours", None),
+            ]
+        );
+    }
+
+    /// Only the arm that says the clone is clean lets a finished ticket go.
+    ///
+    /// `couldNotTell` refusing is the point: those files are still on disk and
+    /// nothing has established they exist anywhere else, so it is `wouldLose`'s
+    /// neighbour and not `nothingToLose`'s. Flattening the three answers back
+    /// onto "is it `Some`?" would reap the unreadable clone.
+    #[test]
+    fn a_clean_clone_reaps_and_an_unreadable_one_refuses_like_dirty_work_does() {
+        let workspaces = parse_workspaces(crate::probe::DL_LISTING_UNSAVED.as_bytes()).unwrap();
+        let known: BTreeMap<Node, NodeFact> = (1..=5)
+            .map(|n| (node("blooop/wayfinder", n), NodeFact::Closed))
+            .collect();
+
+        let verdicts = plan(&workspaces, &known, false);
+        let reaped: Vec<&str> = doomed(&verdicts).into_iter().map(Verdict::id).collect();
+        assert_eq!(
+            reaped,
+            vec!["wf-1-clean", "wf-5-legacy-clean"],
+            "a clean clone and an unanswered one go; nothing else does"
+        );
+        let refusals: Vec<&str> = verdicts
+            .iter()
+            .filter_map(|v| match v {
+                Verdict::Keep { id, reason } if id.starts_with("wf-3") => Some(reason.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            refusals,
+            vec!["dl cannot read its clone: fatal: not a git repository"],
+            "the unreadable clone says so, rather than claiming to hold work"
+        );
+
+        // `-f` waives both refusing arms, because that is what it hands `dl`:
+        // the flag exists so a lockfile every container dirties cannot make a
+        // workspace unreapable forever, and `dl rm --force` overrides its own
+        // guard in both cases too. What changes is that the row says which.
+        let insisted = plan(&workspaces, &known, true);
+        let claimed: Vec<&str> = doomed(&insisted).into_iter().map(Verdict::id).collect();
+        assert_eq!(
+            claimed,
+            vec![
+                "wf-1-clean",
+                "wf-2-dirty",
+                "wf-3-unreadable",
+                "wf-4-legacy-dirty",
+                "wf-5-legacy-clean"
+            ]
+        );
+        let unreadable = insisted
+            .iter()
+            .find(|v| v.id().starts_with("wf-3"))
+            .expect("the unreadable clone is planned");
+        assert!(
+            unreadable
+                .reason()
+                .contains("discarding a clone dl cannot read: fatal: not a git repository"),
+            "a forced reap names what it cannot account for: {}",
+            unreadable.reason()
+        );
+    }
+
     #[test]
     fn insisting_waives_the_unsaved_guard_and_says_what_it_is_discarding() {
         // The case this exists for: a devcontainer that installs packages in
@@ -1342,7 +1563,9 @@ mod tests {
         // forever. The reap line has to name what is being thrown away, since
         // that is the row being approved.
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
-        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose(
+            "1 uncommitted change(s) (pixi.lock)".to_string(),
+        ));
         let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert_eq!(
             plan(std::slice::from_ref(&ws), &known, true),
@@ -1369,7 +1592,9 @@ mod tests {
         // given an answer to.
         let mut ws = workspace("done", "blooop/devlaunch", "wayfinder/devlaunch-80");
         ws.state = Some("Running".to_string());
-        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose(
+            "1 uncommitted change(s) (pixi.lock)".to_string(),
+        ));
         let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert_eq!(
             plan(&[ws], &known, true),

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -143,7 +143,11 @@ pub enum Unsaved {
     CouldNotTell(String),
     /// `dl` answered something this `wf` does not understand, quoted back.
     ///
-    /// A newer `dl` than this binary, in other words. It refuses a reap for the
+    /// Two things reach here: a key from a `dl` newer than this binary, and the
+    /// documented `nothingToLose` carrying a payload it is not documented to
+    /// carry. Both are `wf` failing to read `dl` rather than `dl` failing to
+    /// read a clone, which is why the row's wording hedges at a newer `dl`
+    /// rather than asserting one. It refuses a reap for the
     /// same reason [`Unsaved::CouldNotTell`] does — nothing has established
     /// that this clone exists anywhere else — and it is a separate arm because
     /// the two are separate facts: one is `git` failing on the clone, the other
@@ -219,12 +223,14 @@ enum UnsavedWire {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 enum UnsavedReported {
-    /// The payload `dl` documents is `true`. It is read rather than ignored:
-    /// this is the one key that *permits* a delete, so anything but the
-    /// documented `true` under it falls through to [`UnsavedWire::Unknown`] and
-    /// refuses. An unrecognised key failing loudly while an unrecognised
-    /// payload under the permissive key quietly unlocked deletion would be the
-    /// asymmetry the wrong way round.
+    /// The payload `dl` documents is `true`. It is read rather than ignored,
+    /// because this is the one key that *permits* a delete: `false` is matched
+    /// here and mapped to [`Unsaved::Unrecognized`] below, and a payload that
+    /// is not a boolean at all misses this variant entirely and lands on
+    /// [`UnsavedWire::Unknown`]. Two routes, one outcome — refuse. Ignoring the
+    /// payload would have left an unrecognised *key* failing loudly while an
+    /// unrecognised value under the permissive key quietly unlocked deletion,
+    /// which is the asymmetry the wrong way round.
     NothingToLose(bool),
     WouldLose(String),
     CouldNotTell(String),

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -73,12 +73,47 @@ pub struct Workspace {
     pub state: Option<String>,
     /// What deleting would destroy, in `dl`'s words.
     ///
-    /// `None` is "`dl` said nothing about it", which is exactly the workspaces
-    /// it did not create — never "the clone is clean". That distinction is the
-    /// whole of [`Unsaved`], and reading it back off an `Option` alone is what
-    /// this field used to get wrong.
+    /// `None` is "no answer": the field was `null` or absent. **It permits a
+    /// reap, and that is a compromise rather than a reading.** On devlaunch
+    /// ≤ 0.0.23 — the release actually installed on most machines today —
+    /// `null` on a workspace `dl` made *is* the ordinary clean case, so
+    /// refusing it would make `wf reap` collect nothing at all there. On 0.0.24
+    /// and newer the same `null` should only ever appear on a workspace `dl`
+    /// did not create, which [`node_of`] has already dropped before the guard
+    /// runs — so a `null` reaching it means `dl`'s own guard fell over, and
+    /// treating that as "clean" is the wrong direction.
+    ///
+    /// The two are indistinguishable from one row, and nothing here asks `dl`
+    /// its version. What the arms below *do* retire is the other half of the
+    /// old sentinel: a clean clone now says so in its own name, so "no answer"
+    /// is at least no longer the same value as "nothing to lose".
     #[serde(default)]
     pub unsaved: Option<Unsaved>,
+}
+
+impl Workspace {
+    /// Is devpod holding a container up for this workspace?
+    ///
+    /// One predicate, because two decisions turn on it — [`plan`] keeps a
+    /// running workspace, and [`Liveness`](crate::liveness::Liveness) marks its
+    /// node — and they were spelt as the same string literal in two files. A
+    /// state `dl` renamed would then have made `reap` quietly stop protecting
+    /// containers *and* the picker quietly call every claimed node stalled,
+    /// with no test able to notice because both sides hardcoded the same word.
+    pub fn is_running(&self) -> bool {
+        self.state.as_deref() == Some("Running")
+    }
+
+    /// Is it *definitely* down — a state `dl` named, not one `wf` cannot read?
+    ///
+    /// Deliberately not `!is_running()`. devpod has more states than these two
+    /// (`Busy`, `NotFound`, and whatever it adds next), and "not running" would
+    /// silently absorb all of them. For a guard that is the safe direction; for
+    /// a marking that *asserts* something on a row it is not, so a state
+    /// neither predicate recognises produces no claim at all.
+    pub fn is_stopped(&self) -> bool {
+        self.state.as_deref() == Some("Stopped")
+    }
 }
 
 /// What deleting a workspace's clone would destroy, as `dl` reports it.
@@ -106,6 +141,15 @@ pub enum Unsaved {
     WouldLose(String),
     /// `git` could not read the clone as a repository, and says why.
     CouldNotTell(String),
+    /// `dl` answered something this `wf` does not understand, quoted back.
+    ///
+    /// A newer `dl` than this binary, in other words. It refuses a reap for the
+    /// same reason [`Unsaved::CouldNotTell`] does — nothing has established
+    /// that this clone exists anywhere else — and it is a separate arm because
+    /// the two are separate facts: one is `git` failing on the clone, the other
+    /// is `wf` failing on `dl`, and a row that said the first when it meant the
+    /// second would send somebody to look at the wrong thing.
+    Unrecognized(String),
 }
 
 impl Unsaved {
@@ -120,6 +164,9 @@ impl Unsaved {
             Self::NothingToLose => None,
             Self::WouldLose(what) => Some(format!("holds {what}")),
             Self::CouldNotTell(why) => Some(format!("dl cannot read its clone: {why}")),
+            Self::Unrecognized(said) => Some(format!(
+                "this wf cannot read what dl said about it ({said}) — newer dl?"
+            )),
         }
     }
 
@@ -129,6 +176,9 @@ impl Unsaved {
             Self::NothingToLose => None,
             Self::WouldLose(what) => Some(format!(", discarding {what}")),
             Self::CouldNotTell(why) => Some(format!(", discarding a clone dl cannot read: {why}")),
+            Self::Unrecognized(said) => Some(format!(
+                ", discarding a clone this wf cannot read dl's answer about ({said})"
+            )),
         }
     }
 }
@@ -145,33 +195,62 @@ impl Unsaved {
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum UnsavedWire {
-    /// devlaunch ≤ 0.0.23. A sentence was only ever written when there was
-    /// something to lose, so it maps onto exactly one arm; the "clean" case
-    /// was `null` there, and stays [`None`] here.
+    /// devlaunch ≤ 0.0.23. A sentence there was written when `git` reported
+    /// something; `wf` reads it as work at risk, which is the safe direction if
+    /// that release ever wrote a sentence for another reason. The "clean" case
+    /// was `null`, and stays [`None`] here.
     Sentence(String),
     /// devlaunch ≥ 0.0.24: an object with exactly one key, which is the tag.
     Reported(UnsavedReported),
+    /// Anything else `dl` might one day put here.
+    ///
+    /// **This arm is the point of the type.** Without it, a fourth answer, a
+    /// sibling key inside the object, or a payload of a shape `wf` did not
+    /// expect makes the *whole listing* fail to parse — [`parse_workspaces`] is
+    /// all or nothing, so one such row takes `wf reap` and the picker's reading
+    /// down with it. That is the exact failure this field already caused once,
+    /// and pinning two known spellings would only have moved the next one a
+    /// release away. The value is kept rather than ignored so the refusal can
+    /// quote what it did not understand.
+    Unknown(serde_json::Value),
 }
 
 /// The object form, externally tagged — the key *is* the answer.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 enum UnsavedReported {
-    /// The payload is documented as `true` and read as nothing: the key has
-    /// already said everything, and a `false` under it would be `dl`
-    /// contradicting itself in a field `wf` would then have to arbitrate.
-    NothingToLose(serde::de::IgnoredAny),
+    /// The payload `dl` documents is `true`. It is read rather than ignored:
+    /// this is the one key that *permits* a delete, so anything but the
+    /// documented `true` under it falls through to [`UnsavedWire::Unknown`] and
+    /// refuses. An unrecognised key failing loudly while an unrecognised
+    /// payload under the permissive key quietly unlocked deletion would be the
+    /// asymmetry the wrong way round.
+    NothingToLose(bool),
     WouldLose(String),
     CouldNotTell(String),
 }
+
+/// How much of an unrecognised value to quote back. Enough to recognise, short
+/// enough to sit in a plan row beside a workspace id.
+const UNKNOWN_QUOTED: usize = 60;
 
 impl<'de> Deserialize<'de> for Unsaved {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(match UnsavedWire::deserialize(deserializer)? {
             UnsavedWire::Sentence(what)
             | UnsavedWire::Reported(UnsavedReported::WouldLose(what)) => Self::WouldLose(what),
-            UnsavedWire::Reported(UnsavedReported::NothingToLose(_)) => Self::NothingToLose,
+            UnsavedWire::Reported(UnsavedReported::NothingToLose(true)) => Self::NothingToLose,
             UnsavedWire::Reported(UnsavedReported::CouldNotTell(why)) => Self::CouldNotTell(why),
+            UnsavedWire::Reported(UnsavedReported::NothingToLose(false)) => {
+                Self::Unrecognized("nothingToLose: false".to_string())
+            }
+            UnsavedWire::Unknown(value) => {
+                let mut quoted = value.to_string();
+                if quoted.chars().count() > UNKNOWN_QUOTED {
+                    quoted = quoted.chars().take(UNKNOWN_QUOTED).collect::<String>() + "…";
+                }
+                Self::Unrecognized(quoted)
+            }
         })
     }
 }
@@ -442,7 +521,7 @@ pub fn plan(
                 continue;
             }
         }
-        if workspace.state.as_deref() == Some("Running") {
+        if workspace.is_running() {
             verdicts.push(Verdict::Keep {
                 id,
                 reason: "still running — stop it first".to_string(),
@@ -1499,9 +1578,66 @@ mod tests {
                 // `null` on either release: no answer, which is not the same
                 // fact as `nothingToLose` and must not become it.
                 ("wf-5-legacy-clean", None),
+                // A key this wf has never heard of, and the one key that
+                // permits a delete carrying a payload dl does not document.
+                // Both land on the arm that refuses, and — the whole point —
+                // neither stops the six rows around them from parsing.
+                (
+                    "wf-6-newer-dl",
+                    Some(&Unsaved::Unrecognized(
+                        r#"{"someAnswerFromALaterDl":"whatever it means"}"#.to_string()
+                    ))
+                ),
+                (
+                    "wf-7-odd-payload",
+                    Some(&Unsaved::Unrecognized("nothingToLose: false".to_string()))
+                ),
                 ("not-ours", None),
             ]
         );
+    }
+
+    /// The failure this whole type exists to prevent, stated as a fact about
+    /// the boundary rather than about one value.
+    ///
+    /// `unsaved` broke `wf` once by changing shape. Accepting the two shapes
+    /// `dl` has shipped would have fixed that one incident and left the next
+    /// one identical: [`parse_workspaces`] is all or nothing, so one row `wf`
+    /// cannot read costs every row — `wf reap` aborts, and the picker's reading
+    /// fails silently, taking the reclaim hint and every liveness marking with
+    /// it and saying nothing on screen about why.
+    #[test]
+    fn an_answer_from_a_later_dl_costs_that_row_a_reap_and_costs_the_others_nothing() {
+        let workspaces = parse_workspaces(crate::probe::DL_LISTING_UNSAVED.as_bytes())
+            .expect("a field this wf cannot read must not take the listing down with it");
+        assert_eq!(
+            workspaces.len(),
+            8,
+            "every row survives one unreadable field"
+        );
+
+        let known: BTreeMap<Node, NodeFact> = (1..=7)
+            .map(|n| (node("blooop/wayfinder", n), NodeFact::Closed))
+            .collect();
+        let verdicts = plan(&workspaces, &known, false);
+        let kept: Vec<&str> = verdicts
+            .iter()
+            .filter_map(|v| match v {
+                Verdict::Keep { id, reason } if id.starts_with("wf-6") => Some(reason.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            kept,
+            vec![concat!(
+                "this wf cannot read what dl said about it ",
+                r#"({"someAnswerFromALaterDl":"whatever it means"}) — newer dl?"#
+            )],
+            "the row says dl is ahead of this wf, not that the clone is broken"
+        );
+        // And the rows either side of it are decided on their own merits.
+        let reaped: Vec<&str> = doomed(&verdicts).into_iter().map(Verdict::id).collect();
+        assert_eq!(reaped, vec!["wf-1-clean", "wf-5-legacy-clean"]);
     }
 
     /// Only the arm that says the clone is clean lets a finished ticket go.

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -104,15 +104,27 @@ impl Workspace {
         self.state.as_deref() == Some("Running")
     }
 
-    /// Is it *definitely* down — a state `dl` named, not one `wf` cannot read?
+    /// Is it *definitely* down — settled, with nothing of it running?
     ///
-    /// Deliberately not `!is_running()`. devpod has more states than these two
-    /// (`Busy`, `NotFound`, and whatever it adds next), and "not running" would
-    /// silently absorb all of them. For a guard that is the safe direction; for
-    /// a marking that *asserts* something on a row it is not, so a state
-    /// neither predicate recognises produces no claim at all.
-    pub fn is_stopped(&self) -> bool {
-        self.state.as_deref() == Some("Stopped")
+    /// Deliberately not `!is_running()`, and deliberately not `Stopped` alone
+    /// either. devpod's vocabulary is `Running`, `Busy`, `Stopped` and
+    /// `NotFound`, and `dl` writes `null` when `devpod status` will not answer:
+    ///
+    /// - `Stopped` and `NotFound` are both settled and both down. `NotFound` is
+    ///   the *stronger* of the two — the container does not exist, having been
+    ///   pruned or removed by hand — and it appears on ordinary machines; the
+    ///   listing on the one this was written on carries a `NotFound` row.
+    /// - `Busy` is a container mid-start or mid-stop, which is a transition and
+    ///   not a fact about whether work is happening.
+    /// - `null`, and any state a later devpod adds, are states `wf` cannot read.
+    ///
+    /// The last two answer `false` here *and* `false` to
+    /// [`is_running`](Workspace::is_running), which is the point of having two
+    /// predicates rather than one negation: a marking that asserts something on
+    /// a row must be silent where it does not know, and only `!is_running()`
+    /// would have quietly turned every unreadable state into a claim.
+    pub fn is_down(&self) -> bool {
+        matches!(self.state.as_deref(), Some("Stopped" | "NotFound"))
     }
 }
 
@@ -192,10 +204,7 @@ impl Unsaved {
 /// `wf` pins no `dl` version and never will — the launch is one `exec` of a
 /// program found on `PATH` — so both are live on real machines: devlaunch
 /// through 0.0.23 emits a bare sentence or `null`, and 0.0.24 emits the
-/// one-key object. Refusing either would be `wf` deciding which `dl` you may
-/// have installed, and a listing that fails to parse fails the *whole* reading
-/// (see [`parse_workspaces`]) — one unrecognised field would take the reap and
-/// the picker's hint down with it.
+/// one-key object.
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum UnsavedWire {
@@ -204,37 +213,42 @@ enum UnsavedWire {
     /// that release ever wrote a sentence for another reason. The "clean" case
     /// was `null`, and stays [`None`] here.
     Sentence(String),
-    /// devlaunch ≥ 0.0.24: an object with exactly one key, which is the tag.
-    Reported(UnsavedReported),
+    /// devlaunch ≥ 0.0.24. Read as a **map**, not as an externally-tagged enum,
+    /// and that is the whole design of this arm.
+    ///
+    /// An enum would require the object to hold exactly one key, so the day
+    /// `dl` adds a sibling — a `path`, a `checkedAt`, a count — *every* row
+    /// stops being readable at once. Every workspace then refuses, `wf reap`
+    /// collects nothing, and the picker's hint disappears without a word.
+    /// Refusing is the safe direction, but losing the whole feature to one
+    /// added field is not degradation, and this arm's job is degradation.
+    ///
+    /// Reading the keys `wf` knows and ignoring the rest costs nothing and
+    /// survives that release. What it cannot survive — a *renamed* or genuinely
+    /// new answer — is what [`UnsavedWire::Unknown`] is for.
+    Reported(serde_json::Map<String, serde_json::Value>),
     /// Anything else `dl` might one day put here.
     ///
-    /// **This arm is the point of the type.** Without it, a fourth answer, a
-    /// sibling key inside the object, or a payload of a shape `wf` did not
-    /// expect makes the *whole listing* fail to parse — [`parse_workspaces`] is
-    /// all or nothing, so one such row takes `wf reap` and the picker's reading
-    /// down with it. That is the exact failure this field already caused once,
-    /// and pinning two known spellings would only have moved the next one a
+    /// **This arm is why the field is a type and not a string.** Without it, a
+    /// value `wf` cannot read makes the *whole listing* fail to parse —
+    /// [`parse_workspaces`] is all or nothing, so one such row takes `wf reap`
+    /// and the picker's reading down with it, silently in the picker's case.
+    /// That is the exact failure this field already caused once, and pinning
+    /// the spellings that have shipped would only have moved the next one a
     /// release away. The value is kept rather than ignored so the refusal can
-    /// quote what it did not understand.
+    /// name what it did not understand.
     Unknown(serde_json::Value),
 }
 
-/// The object form, externally tagged — the key *is* the answer.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-enum UnsavedReported {
-    /// The payload `dl` documents is `true`. It is read rather than ignored,
-    /// because this is the one key that *permits* a delete: `false` is matched
-    /// here and mapped to [`Unsaved::Unrecognized`] below, and a payload that
-    /// is not a boolean at all misses this variant entirely and lands on
-    /// [`UnsavedWire::Unknown`]. Two routes, one outcome — refuse. Ignoring the
-    /// payload would have left an unrecognised *key* failing loudly while an
-    /// unrecognised value under the permissive key quietly unlocked deletion,
-    /// which is the asymmetry the wrong way round.
-    NothingToLose(bool),
-    WouldLose(String),
-    CouldNotTell(String),
-}
+/// The keys `dl` documents, in the order they are read.
+///
+/// Order is load-bearing, and only in one direction: the two refusing keys are
+/// looked for **before** the permitting one, so an object carrying both — which
+/// `dl` should never write — refuses rather than reaps. Nothing else about the
+/// order matters, because the arms are mutually exclusive in practice.
+const WOULD_LOSE: &str = "wouldLose";
+const COULD_NOT_TELL: &str = "couldNotTell";
+const NOTHING_TO_LOSE: &str = "nothingToLose";
 
 /// How much of an unrecognised value to quote back. Enough to recognise, short
 /// enough to sit in a plan row beside a workspace id.
@@ -243,21 +257,56 @@ const UNKNOWN_QUOTED: usize = 60;
 impl<'de> Deserialize<'de> for Unsaved {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(match UnsavedWire::deserialize(deserializer)? {
-            UnsavedWire::Sentence(what)
-            | UnsavedWire::Reported(UnsavedReported::WouldLose(what)) => Self::WouldLose(what),
-            UnsavedWire::Reported(UnsavedReported::NothingToLose(true)) => Self::NothingToLose,
-            UnsavedWire::Reported(UnsavedReported::CouldNotTell(why)) => Self::CouldNotTell(why),
-            UnsavedWire::Reported(UnsavedReported::NothingToLose(false)) => {
-                Self::Unrecognized("nothingToLose: false".to_string())
-            }
-            UnsavedWire::Unknown(value) => {
-                let mut quoted = value.to_string();
-                if quoted.chars().count() > UNKNOWN_QUOTED {
-                    quoted = quoted.chars().take(UNKNOWN_QUOTED).collect::<String>() + "…";
-                }
-                Self::Unrecognized(quoted)
-            }
+            UnsavedWire::Sentence(what) => Self::WouldLose(what),
+            UnsavedWire::Reported(object) => Self::from_object(&object),
+            UnsavedWire::Unknown(value) => Self::unrecognized(&value),
         })
+    }
+}
+
+impl Unsaved {
+    /// Read the object form: the first documented key that answers, and a
+    /// refusal when none does.
+    fn from_object(object: &serde_json::Map<String, serde_json::Value>) -> Self {
+        if let Some(what) = object.get(WOULD_LOSE).and_then(serde_json::Value::as_str) {
+            return Self::WouldLose(what.to_string());
+        }
+        if let Some(why) = object
+            .get(COULD_NOT_TELL)
+            .and_then(serde_json::Value::as_str)
+        {
+            return Self::CouldNotTell(why.to_string());
+        }
+        // The one key that permits a delete, and the only value it may carry.
+        // `false` is `dl` contradicting itself, and anything else is a payload
+        // it does not document: both refuse rather than being read as clean.
+        if object.get(NOTHING_TO_LOSE) == Some(&serde_json::Value::Bool(true)) {
+            return Self::NothingToLose;
+        }
+        Self::unrecognized(&serde_json::Value::Object(object.clone()))
+    }
+
+    /// Name what could not be read, short enough to sit in a plan row.
+    ///
+    /// An object is reported by its **keys**, because the key is what `wf`
+    /// failed to recognise and a reader is going to compare it against `dl`'s
+    /// own documentation. Anything else is rendered whole. Either way this is
+    /// `wf`'s re-rendering rather than `dl`'s bytes back — `serde_json` sorts
+    /// an object's keys and normalises its numbers — which is why the row says
+    /// `dl` said something *this wf* cannot read, and does not offer the text
+    /// as a quotation to grep for.
+    fn unrecognized(value: &serde_json::Value) -> Self {
+        let said = match value {
+            serde_json::Value::Object(object) if !object.is_empty() => {
+                object.keys().cloned().collect::<Vec<_>>().join(", ")
+            }
+            other => other.to_string(),
+        };
+        let mut quoted: String = said.chars().take(UNKNOWN_QUOTED).collect();
+        if said.chars().count() > UNKNOWN_QUOTED {
+            quoted.push('…');
+        }
+        Self::Unrecognized(quoted)
     }
 }
 
@@ -1588,16 +1637,21 @@ mod tests {
                 // permits a delete carrying a payload dl does not document.
                 // Both land on the arm that refuses, and — the whole point —
                 // neither stops the six rows around them from parsing.
+                // Named by its key: that is the half `wf` failed to recognise
+                // and the half a reader compares against dl's own docs.
                 (
                     "wf-6-newer-dl",
-                    Some(&Unsaved::Unrecognized(
-                        r#"{"someAnswerFromALaterDl":"whatever it means"}"#.to_string()
-                    ))
+                    Some(&Unsaved::Unrecognized("someAnswerFromALaterDl".to_string()))
                 ),
                 (
                     "wf-7-odd-payload",
-                    Some(&Unsaved::Unrecognized("nothingToLose: false".to_string()))
+                    Some(&Unsaved::Unrecognized("nothingToLose".to_string()))
                 ),
+                // A documented key beside an undocumented sibling: still read.
+                // The day `dl` adds a field to this object, every row would
+                // otherwise stop parsing at once and `wf reap` would collect
+                // nothing at all.
+                ("wf-8-sibling-key", Some(&Unsaved::NothingToLose)),
                 ("not-ours", None),
             ]
         );
@@ -1618,11 +1672,11 @@ mod tests {
             .expect("a field this wf cannot read must not take the listing down with it");
         assert_eq!(
             workspaces.len(),
-            8,
+            9,
             "every row survives one unreadable field"
         );
 
-        let known: BTreeMap<Node, NodeFact> = (1..=7)
+        let known: BTreeMap<Node, NodeFact> = (1..=8)
             .map(|n| (node("blooop/wayfinder", n), NodeFact::Closed))
             .collect();
         let verdicts = plan(&workspaces, &known, false);
@@ -1635,15 +1689,15 @@ mod tests {
             .collect();
         assert_eq!(
             kept,
-            vec![concat!(
-                "this wf cannot read what dl said about it ",
-                r#"({"someAnswerFromALaterDl":"whatever it means"}) — newer dl?"#
-            )],
+            vec!["this wf cannot read what dl said about it (someAnswerFromALaterDl) — newer dl?"],
             "the row says dl is ahead of this wf, not that the clone is broken"
         );
         // And the rows either side of it are decided on their own merits.
         let reaped: Vec<&str> = doomed(&verdicts).into_iter().map(Verdict::id).collect();
-        assert_eq!(reaped, vec!["wf-1-clean", "wf-5-legacy-clean"]);
+        assert_eq!(
+            reaped,
+            vec!["wf-1-clean", "wf-5-legacy-clean", "wf-8-sibling-key"]
+        );
     }
 
     /// Only the arm that says the clone is clean lets a finished ticket go.

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -274,6 +274,7 @@ pub async fn survey_live() -> Option<Reclaimable> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::reap::Unsaved;
     use anyhow::anyhow;
 
     fn workspace(id: &str, repo: &str, number: u64) -> Workspace {
@@ -336,7 +337,7 @@ mod tests {
             for unsaved in [None, Some("1 uncommitted change(s) (pixi.lock)")] {
                 for state in ["Stopped", "Running"] {
                     let mut ws = workspace("solo", "blooop/devlaunch", 80);
-                    ws.unsaved = unsaved.map(str::to_string);
+                    ws.unsaved = unsaved.map(|u| Unsaved::WouldLose(u.to_string()));
                     ws.state = Some(state.to_string());
                     let known = facts([(node("blooop/devlaunch", 80), fact.clone())]);
                     let listed = std::slice::from_ref(&ws);
@@ -372,7 +373,7 @@ mod tests {
         for fact in [NodeFact::Superseded { pr: 97 }, NodeFact::Unstarted] {
             for unsaved in [None, Some("1 uncommitted change(s) (pixi.lock)")] {
                 let mut ws = workspace("warned", "blooop/devlaunch", 80);
-                ws.unsaved = unsaved.map(str::to_string);
+                ws.unsaved = unsaved.map(|u| Unsaved::WouldLose(u.to_string()));
                 let known = facts([(node("blooop/devlaunch", 80), fact.clone())]);
                 assert_eq!(
                     reading(std::slice::from_ref(&ws), &known),
@@ -402,7 +403,9 @@ mod tests {
             workspace("in-flight", "blooop/devlaunch", 98),
             {
                 let mut dirty = workspace("dirty", "blooop/devlaunch", 99);
-                dirty.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+                dirty.unsaved = Some(Unsaved::WouldLose(
+                    "1 uncommitted change(s) (pixi.lock)".to_string(),
+                ));
                 dirty
             },
         ];
@@ -443,7 +446,9 @@ mod tests {
         // hint must inherit that keep rather than quietly count it — otherwise
         // the picker is advertising a reap that would throw work away.
         let mut ws = workspace("dirty", "blooop/devlaunch", 80);
-        ws.unsaved = Some("1 uncommitted change(s) (pixi.lock)".to_string());
+        ws.unsaved = Some(Unsaved::WouldLose(
+            "1 uncommitted change(s) (pixi.lock)".to_string(),
+        ));
         let known = facts([(node("blooop/devlaunch", 80), NodeFact::Closed)]);
         assert_eq!(reading(std::slice::from_ref(&ws), &known), None);
         // And the same node with a clean clone *is* surfaced, so the assertion

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -1,4 +1,5 @@
-//! Noticing what [`reap`] would claim, without being asked (#137).
+//! Noticing, without being asked: what [`reap`] would claim (#137), and what is
+//! running or has stopped ([`Liveness`](crate::liveness)).
 //!
 //! `wf reap` already decides what is finished. What it lacks is a trigger: it
 //! fires only when a person remembers to type it. This module is that trigger
@@ -16,12 +17,19 @@
 //!
 //! **Nothing here can delete.** `plan` is asked with `insist` false, so a
 //! workspace holding work that exists nowhere else is not surfaced at all; and
-//! the whole module reads facts and returns a sentence. It cannot reach
+//! the whole module reads facts and returns a description of them — a sentence
+//! for the count line, and a per-node marking beside it. It cannot reach
 //! `reap`'s deletion side even by trying: the function that removes a workspace
 //! is private to `reap`'s own module, so `reap::remove(id, true).await` written
 //! anywhere in this file is `E0603`, not a test failure. The reading is the
 //! product; the waiver, the prompt and the deletion all stay with the human
 //! typing `wf reap`.
+//!
+//! **One reading, two questions.** [`survey`] takes a single `dl --ls --json`
+//! and a single batched tracker query and derives both observations from them;
+//! [`Reading`] says why they are carried together and kept apart. The second is
+//! [`Liveness`](crate::liveness)'s own derivation, called here rather than
+//! written here.
 //!
 //! **It fails silent.** [`survey`] answers `Option`, not `Result`. No `dl` on
 //! PATH, a `dl --ls --json` that failed, a GraphQL error, no network: the hint
@@ -135,6 +143,19 @@ impl Reclaimable {
     /// How many rows `wf` is uneasy about but will not act on.
     pub fn warned(&self) -> usize {
         self.warned
+    }
+
+    /// The narrowest this segment can be and still read as a sentence.
+    ///
+    /// The last arm of [`Reclaimable::hint`] clips the count itself rather than
+    /// vanishing — deliberately, because a segment that disappears at a width
+    /// nothing else disappears at looks like a bug. But a clip is only the
+    /// right answer when the *line* has run out; a neighbouring segment that
+    /// could have yielded instead should, and it needs this number to know how
+    /// much yielding is enough. Below it the reader gets `· 2 reclaima`, which
+    /// is not a word.
+    pub fn min_width(&self) -> usize {
+        format!("· {} reclaimable", self.ids.len()).chars().count()
     }
 
     /// The count-line segment, in `width` characters: how many, which ones,

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -816,7 +816,7 @@ mod tests {
     }
 
     #[test]
-    fn the_surfacing_path_runs_two_reads_and_nothing_else() {
+    fn the_surfacing_path_asks_only_questions_and_never_names_a_workspace() {
         // #137's safety claim, as a fact about a run rather than a grep over
         // the source. `reap::workspaces` and `reap::node_facts` both reach a
         // PATH-resolved binary, so everything this path is *capable* of doing
@@ -824,26 +824,41 @@ mod tests {
         // Rust, in whichever module, and whether or not it named any word a
         // reader thought to forbid. A `dl <ws> rm` added anywhere between
         // `survey_live` and the reading it returns fails this test.
+        // Stated as a rule over every call rather than as a list, so a fourth
+        // read is not a failure but a fourth *kind* of call is. What makes a
+        // `dl` call safe here is that its argument is a question — no call on
+        // this path may name a workspace, which is where every destructive `dl`
+        // subcommand takes its target.
+        const ASKED: [&str; 2] = ["dl <--ls> <--json>", "dl <--version>"];
+
         let run = crate::probe::record(
             "reclaim::tests::survey_live_probe",
             crate::probe::DL_LISTING,
             crate::probe::GH_FACTS,
         );
         run.destroyed_nothing();
+        for call in &run.argv {
+            let asked = ASKED.contains(&call.as_str())
+                || call.starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>");
+            assert!(asked, "this path may only ask questions, and asked: {call}");
+        }
+
+        // And that it did each of them exactly once. The version probe is
+        // memoized per process, so a second one would mean the memo broke and
+        // every survey is paying for a Python start it was told not to.
+        for question in ASKED {
+            assert_eq!(
+                run.argv.iter().filter(|call| *call == question).count(),
+                1,
+                "asked exactly once: {question} in {:?}",
+                run.argv
+            );
+        }
         assert_eq!(
             run.argv.len(),
-            2,
-            "one listing and one batched query, and nothing else: {:?}",
+            3,
+            "two questions to `dl` and one batched query to `gh`: {:?}",
             run.argv
-        );
-        assert_eq!(
-            run.argv[0], "dl <--ls> <--json>",
-            "the only thing this path asks `dl` for is what exists"
-        );
-        assert!(
-            run.argv[1].starts_with("gh <api> <graphql> <-F> <owner=blooop> <-F> <name=wayfinder>"),
-            "one batched read of the tracker: {}",
-            run.argv[1]
         );
     }
 

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -33,6 +33,7 @@ use std::future::Future;
 
 use anyhow::Result;
 
+use crate::liveness::Liveness;
 use crate::reap::{self, Node, NodeFact, Verdict, Workspace};
 
 /// How many workspaces the hint spells before it starts counting.
@@ -234,6 +235,54 @@ pub fn reading(workspaces: &[Workspace], known: &BTreeMap<Node, NodeFact>) -> Op
     Reclaimable::read(&reap::plan(workspaces, known, false))
 }
 
+/// Everything one look at the machine and the tracker is worth.
+///
+/// Two observations, carried together because they come from **one** reading:
+/// the same `dl --ls --json` and the same batched tracker query answer both, so
+/// splitting them into two surveys would double the subprocess and the round
+/// trip to learn two things about the same six workspaces.
+///
+/// They stay separate values inside it rather than merging into one verdict per
+/// node, because they are answers to unrelated questions and are acted on by
+/// different parts of the screen: [`Reclaimable`] is a sentence naming a
+/// command, and [`Liveness`] is a per-row marking. A node can easily be in one
+/// and not the other, and a type that made them one field would have to invent
+/// a precedence between "this could be tidied away" and "this stopped moving"
+/// that nothing actually wants.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reading {
+    reclaimable: Option<Reclaimable>,
+    liveness: Liveness,
+}
+
+impl Reading {
+    /// `None` when neither half found anything — the ordinary quiet machine,
+    /// and the case that must not wake the draw path at all.
+    fn of(reclaimable: Option<Reclaimable>, liveness: Liveness) -> Option<Self> {
+        if reclaimable.is_none() && liveness.is_empty() {
+            return None;
+        }
+        Some(Self {
+            reclaimable,
+            liveness,
+        })
+    }
+
+    /// Hand both halves to their separate homes on the app. Consuming, because
+    /// there is exactly one consumer and nothing should be tempted to keep a
+    /// second copy of a reading that arrives once.
+    pub fn into_parts(self) -> (Option<Reclaimable>, Liveness) {
+        (self.reclaimable, self.liveness)
+    }
+
+    /// A reading with these halves on it, for the tests of the channel that
+    /// carries one.
+    #[cfg(test)]
+    pub(crate) fn for_test(reclaimable: Option<Reclaimable>, liveness: Liveness) -> Self {
+        Self::of(reclaimable, liveness).expect("a reading is never empty")
+    }
+}
+
 /// Take the reading, silently.
 ///
 /// Generic over its two reads so the whole fail-silent path is exercisable
@@ -244,7 +293,7 @@ pub fn reading(workspaces: &[Workspace], known: &BTreeMap<Node, NodeFact>) -> Op
 /// tracker that would not answer, a repo slug that will not parse — none of
 /// them is a fact about a workspace, and the only honest thing to show for one
 /// is nothing.
-pub async fn survey<L, LFut, F, FFut>(listing: L, facts: F) -> Option<Reclaimable>
+pub async fn survey<L, LFut, F, FFut>(listing: L, facts: F) -> Option<Reading>
 where
     L: FnOnce() -> LFut,
     LFut: Future<Output = Result<Vec<Workspace>>>,
@@ -259,12 +308,15 @@ where
         return None;
     }
     let known = facts(nodes).await.ok()?;
-    reading(&workspaces, &known)
+    Reading::of(
+        reading(&workspaces, &known),
+        Liveness::read(&workspaces, &known),
+    )
 }
 
 /// [`survey`] against the real `dl` listing and the real batched tracker query
 /// — one subprocess and one GraphQL round trip, both `reap`'s own.
-pub async fn survey_live() -> Option<Reclaimable> {
+pub async fn survey_live() -> Option<Reading> {
     survey(reap::workspaces, |nodes| async move {
         reap::node_facts(&nodes).await
     })
@@ -696,7 +748,7 @@ mod tests {
         .await;
         assert_eq!(
             surfaced,
-            reading(&listed, &known),
+            Reading::of(reading(&listed, &known), Liveness::read(&listed, &known)),
             "the survey's answer is the reading over what the two reads returned"
         );
         assert_eq!(
@@ -719,7 +771,18 @@ mod tests {
             return;
         }
         let said = match survey_live().await {
-            Some(found) => found.hint(120),
+            Some(found) => {
+                let (reclaimable, liveness) = found.into_parts();
+                let claim = reclaimable.map_or_else(
+                    || "nothing reclaimable".to_string(),
+                    |found| found.hint(120),
+                );
+                format!(
+                    "{claim} | running {} stalled {}",
+                    liveness.running(),
+                    liveness.stalled()
+                )
+            }
             None => "no reading at all".to_string(),
         };
         println!("{}{said}", crate::probe::MARK);
@@ -771,7 +834,7 @@ mod tests {
         );
         assert_eq!(
             run.printed(),
-            ["· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap"],
+            ["· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap | running 1 stalled 0"],
             "the live reading is the same sentence the offline tests pin"
         );
     }

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -834,7 +834,7 @@ mod tests {
         );
         assert_eq!(
             run.printed(),
-            ["· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap | running 1 stalled 0"],
+            ["· 1 reclaimable: wf-129-closed (+1 to check by hand) — wf reap | running 1 stalled 1"],
             "the live reading is the same sentence the offline tests pin"
         );
     }

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -289,6 +289,12 @@ impl Reading {
         })
     }
 
+    /// What this machine says about each node — borrowed, for a caller that
+    /// wants to look without taking the reading apart.
+    pub fn liveness(&self) -> &Liveness {
+        &self.liveness
+    }
+
     /// Hand both halves to their separate homes on the app. Consuming, because
     /// there is exactly one consumer and nothing should be tempted to keep a
     /// second copy of a reading that arrives once.

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -66,7 +66,7 @@ pub enum LoadEvent {
     /// Only ever sent when there is something to say: a reading that failed and
     /// a reading that found nothing are the same silence, because neither is
     /// anything the screen should draw.
-    Read(Reading),
+    Surveyed(Reading),
 }
 
 /// Has the `wayfinder:map` label search answered yet?
@@ -359,7 +359,7 @@ where
 {
     Survey(tokio::spawn(async move {
         if let Some(found) = survey.await {
-            let _ = tx.send(LoadEvent::Read(found));
+            let _ = tx.send(LoadEvent::Surveyed(found));
         }
     }))
 }
@@ -478,7 +478,7 @@ mod tests {
             .settle()
             .await;
         match rx.try_recv() {
-            Ok(LoadEvent::Read(got)) => assert_eq!(got, found),
+            Ok(LoadEvent::Surveyed(got)) => assert_eq!(got, found),
             other => panic!("the reading must arrive as its own event, got {other:?}"),
         }
     }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -30,7 +30,7 @@ use tokio::task::JoinHandle;
 use crate::fetch;
 use crate::model::{Map, MapId, MapSet};
 use crate::projects::ProjectsCache;
-use crate::reclaim::Reclaimable;
+use crate::reclaim::Reading;
 
 /// How long the map search waits before trying again. The only recurring timer
 /// left: nothing polls, but a search that never answers would leave `wf`
@@ -66,7 +66,7 @@ pub enum LoadEvent {
     /// Only ever sent when there is something to say: a reading that failed and
     /// a reading that found nothing are the same silence, because neither is
     /// anything the screen should draw.
-    Reclaimable(Reclaimable),
+    Read(Reading),
 }
 
 /// Has the `wayfinder:map` label search answered yet?
@@ -355,11 +355,11 @@ pub fn spawn_discovery(
 /// in-flight one outliving the `exec` would be inherited by the agent.
 pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>) -> Survey
 where
-    S: Future<Output = Option<Reclaimable>> + Send + 'static,
+    S: Future<Output = Option<Reading>> + Send + 'static,
 {
     Survey(tokio::spawn(async move {
         if let Some(found) = survey.await {
-            let _ = tx.send(LoadEvent::Reclaimable(found));
+            let _ = tx.send(LoadEvent::Read(found));
         }
     }))
 }
@@ -443,7 +443,7 @@ mod tests {
     /// A reading that never answers — the reading `wf` must be able to draw
     /// over. A `pending` future rather than a long sleep, so "the picker did
     /// not wait" is a fact about the code and not about a timer.
-    async fn never() -> Option<Reclaimable> {
+    async fn never() -> Option<Reading> {
         std::future::pending().await
     }
 
@@ -470,12 +470,15 @@ mod tests {
     #[tokio::test]
     async fn a_reading_that_lands_folds_in_through_the_one_channel() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let found = Reclaimable::for_test(&["ws-a"], 0);
+        let found = Reading::for_test(
+            Some(crate::reclaim::Reclaimable::for_test(&["ws-a"], 0)),
+            crate::liveness::Liveness::default(),
+        );
         spawn_survey(std::future::ready(Some(found.clone())), tx.clone())
             .settle()
             .await;
         match rx.try_recv() {
-            Ok(LoadEvent::Reclaimable(got)) => assert_eq!(got, found),
+            Ok(LoadEvent::Read(got)) => assert_eq!(got, found),
             other => panic!("the reading must arrive as its own event, got {other:?}"),
         }
     }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -61,12 +61,22 @@ pub enum LoadEvent {
     SearchFailed,
     /// One map's load reported.
     Fetched { id: MapId, outcome: MapFetch },
-    /// The background reading found workspaces a `wf reap` would claim (#137).
+    /// The background reading landed (#137) — what a `wf reap` would claim,
+    /// and what is running or has stopped.
     ///
     /// Only ever sent when there is something to say: a reading that failed and
     /// a reading that found nothing are the same silence, because neither is
     /// anything the screen should draw.
-    Surveyed(Reading),
+    ///
+    /// `taken` says *which* reading this is, and it exists because that silence
+    /// breaks newest-write-wins. `ctrl-r` clears what the screen holds and asks
+    /// again; an answer to the *previous* question can already be sitting in
+    /// the channel at that moment, and folding it would put the cleared state
+    /// back — with nothing to correct it, since a fresh reading that finds
+    /// nothing sends no event at all. Every other `LoadEvent` reports either
+    /// way, so send order is enough for them; this one is answered only when
+    /// the answer is interesting, so it says which question it answers.
+    Surveyed { taken: u64, reading: Reading },
 }
 
 /// Has the `wayfinder:map` label search answered yet?
@@ -353,13 +363,13 @@ pub fn spawn_discovery(
 /// Returns a [`Survey`] so the launch path can stop it and wait, exactly as it
 /// does for the map loads: the reading holds child processes of its own, and an
 /// in-flight one outliving the `exec` would be inherited by the agent.
-pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>) -> Survey
+pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>, taken: u64) -> Survey
 where
     S: Future<Output = Option<Reading>> + Send + 'static,
 {
     Survey(tokio::spawn(async move {
-        if let Some(found) = survey.await {
-            let _ = tx.send(LoadEvent::Surveyed(found));
+        if let Some(reading) = survey.await {
+            let _ = tx.send(LoadEvent::Surveyed { taken, reading });
         }
     }))
 }
@@ -456,7 +466,7 @@ mod tests {
         // hang this test rather than slow it.
         let (tx, mut rx) = mpsc::unbounded_channel();
         tokio::time::timeout(Duration::from_secs(5), async {
-            let survey = spawn_survey(never(), tx.clone());
+            let survey = spawn_survey(never(), tx.clone(), 0);
             assert!(
                 rx.try_recv().is_err(),
                 "nothing may be on the channel before the reading lands"
@@ -474,11 +484,14 @@ mod tests {
             Some(crate::reclaim::Reclaimable::for_test(&["ws-a"], 0)),
             crate::liveness::Liveness::default(),
         );
-        spawn_survey(std::future::ready(Some(found.clone())), tx.clone())
+        spawn_survey(std::future::ready(Some(found.clone())), tx.clone(), 7)
             .settle()
             .await;
         match rx.try_recv() {
-            Ok(LoadEvent::Surveyed(got)) => assert_eq!(got, found),
+            Ok(LoadEvent::Surveyed { taken, reading }) => {
+                assert_eq!(reading, found);
+                assert_eq!(taken, 7, "the event says which reading answered");
+            }
             other => panic!("the reading must arrive as its own event, got {other:?}"),
         }
     }
@@ -488,7 +501,7 @@ mod tests {
         // No `dl`, a failed listing, a tracker that would not answer, or simply
         // nothing to reclaim: one silence, no event, and above all no error.
         let (tx, mut rx) = mpsc::unbounded_channel();
-        spawn_survey(std::future::ready(None), tx.clone())
+        spawn_survey(std::future::ready(None), tx.clone(), 0)
             .settle()
             .await;
         assert!(
@@ -517,6 +530,7 @@ mod tests {
                 None
             },
             tx,
+            0,
         );
         survey.stop().await;
         assert_eq!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -620,15 +620,6 @@ pub fn idle_note(plan: &Plan) -> String {
 /// (#35) — the same glyph as the key that rejoins it.
 const RESUME_BADGE: &str = "  ⏎";
 
-/// The most of one line the stall segment may take.
-///
-/// It goes down before the reclaim note, so without a ceiling a machine with
-/// six stalled nodes could spend the whole line on them and leave the `wf reap`
-/// pointer nowhere to go. Two names and their lead-in fit inside this; a third
-/// would not, which is the same budget [`Liveness::hint`] states in its own
-/// terms.
-const STALL_BUDGET: usize = 44;
-
 /// The badge a node carries when a container of its is up.
 ///
 /// A square, where every stage glyph is round, because it is not a stage: the
@@ -668,7 +659,7 @@ impl Marks {
     fn of(app: &App, repo: &str, number: u64) -> Self {
         Self {
             resumable: app.resume(repo, number).is_some(),
-            life: app.life(repo, number),
+            life: app.liveness.of(repo, number),
         }
     }
 
@@ -1003,11 +994,13 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
             .sum::<usize>()
         + notice.chars().count();
     let mut left = (count_area.width as usize).saturating_sub(spent);
-    // Stalls are laid down before the reclaim note and capped, so the two
-    // unbounded segments cannot fight over one line. The cap is what keeps this
-    // one from being unbounded in practice: it names at most two nodes, and a
-    // node's name is short where a `dl` workspace id is not.
-    let stalled = app.liveness.hint(left.min(STALL_BUDGET));
+    // Stalls are laid down before the reclaim note, and what bounds them is
+    // `Liveness::hint`'s own `NAMED` — at most two nodes, each a short repo and
+    // a number — rather than a ceiling written here. A second cap on top of
+    // that only ever cost a name: an extra constant tuned to a width buys two
+    // columns and drops the segment from two names to one at exactly the sizes
+    // where both would have fitted.
+    let stalled = app.liveness.hint(left);
     if !stalled.is_empty() {
         left = left.saturating_sub(stalled.chars().count() + 1);
         parts.push(stalled);
@@ -1571,8 +1564,9 @@ mod tests {
 
     #[test]
     fn the_first_frame_marks_no_row_and_names_no_stall() {
+        // No reading has landed, which is the state every run starts in and
+        // stays in when `dl` is absent or the listing failed.
         let app = fixture_app();
-        assert!(app.liveness.is_empty(), "nothing has been read yet");
         let screen = render(&app);
         assert!(!screen.contains('▣'), "{screen}");
         assert!(!screen.contains('⧖'), "{screen}");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -994,13 +994,23 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
             .sum::<usize>()
         + notice.chars().count();
     let mut left = (count_area.width as usize).saturating_sub(spent);
-    // Stalls are laid down before the reclaim note, and what bounds them is
-    // `Liveness::hint`'s own `NAMED` — at most two nodes, each a short repo and
-    // a number — rather than a ceiling written here. A second cap on top of
-    // that only ever cost a name: an extra constant tuned to a width buys two
-    // columns and drops the segment from two names to one at exactly the sizes
-    // where both would have fitted.
-    let stalled = app.liveness.hint(left);
+    // Stalls are laid down before the reclaim note, but not at any price: what
+    // is held back for the reclaim note is exactly the width at which it stops
+    // being a word (`Reclaimable::min_width`), because its own last arm clips
+    // the count rather than vanishing. Without that, two named stalls on a
+    // 60-column terminal left it three characters short and it rendered
+    // `· 2 reclaima`.
+    //
+    // Yielding is the whole of the concession. Stalls still outrank the reap
+    // pointer and the warned aside — both of those go while `· N stalled` is
+    // still naming nodes — and `Liveness::hint`'s own ladder does the yielding
+    // gracefully, dropping to one name and then to the bare count, which the
+    // rows' own `⧖` markings make readable anyway.
+    let reserved = app
+        .reclaimable
+        .as_ref()
+        .map_or(0, |found| found.min_width() + 1);
+    let stalled = app.liveness.hint(left.saturating_sub(reserved));
     if !stalled.is_empty() {
         left = left.saturating_sub(stalled.chars().count() + 1);
         parts.push(stalled);
@@ -1592,9 +1602,9 @@ mod tests {
         assert!(line.contains("wayfinder#9"), "{line}");
     }
 
-    /// The two unbounded segments share one line, and the stall cap is what
-    /// keeps the earlier one from spending it all: the `wf reap` pointer is the
-    /// half of the reclaim hint a reader can act on, and it still fits.
+    /// The two variable-length segments share one line, and neither may leave
+    /// the other unreadable: the `wf reap` pointer is the half of the reclaim
+    /// hint a reader can act on, and it still fits.
     #[test]
     fn a_stall_segment_leaves_the_reclaim_pointer_its_room() {
         let mut app = fixture_app();
@@ -1617,6 +1627,53 @@ mod tests {
             line.contains("wf reap"),
             "the command survives beside the stalls: {line}"
         );
+    }
+
+    /// Neither segment is ever clipped to a fragment, at any width.
+    ///
+    /// The regression this pins was visible only on a rendered screen: with two
+    /// stalls named on a 60-column terminal, the reclaim note was left three
+    /// characters short of its own count and its last arm — which clips rather
+    /// than vanishing — put `· 2 reclaima` on the line. Every assertion about
+    /// these two segments passed, because each was measured on its own.
+    ///
+    /// Fragments are also how an *overrun* shows up here, and deliberately the
+    /// only way it can: the frame buffer is the area's width by construction,
+    /// so a line that asked for more was already truncated by the time it can
+    /// be read back, and `inner.len() <= width` is a fact about `ratatui`
+    /// rather than about this code. What a truncation leaves behind is a
+    /// partial word at the end of the line, which is what is asserted.
+    #[test]
+    fn neither_count_line_segment_can_clip_the_other_into_a_fragment() {
+        let mut app = fixture_app();
+        app.liveness = crate::liveness::Liveness::for_test(
+            &[],
+            &[("blooop/wayfinder", 9), ("blooop/wayfinder", 14)],
+        );
+        app.reclaimable = Some(Reclaimable::for_test(
+            &["devlaunch-github-blooop-wayfinder-127-ladepomi", "wf-80-x"],
+            1,
+        ));
+        for width in 40..=130u16 {
+            let screen = render_at(width, &app);
+            let line = screen.lines().nth(2).expect("a count line");
+            let inner: String = line.chars().skip(1).take(width as usize - 2).collect();
+            // A word or nothing. Any proper prefix of "reclaimable"/"stalled"
+            // left at the end of the line is the fragment this exists to catch.
+            // From one character: `· 2 r` is as wrong as `· 2 reclaima`, and no
+            // segment ends in a letter that could be mistaken for one — the
+            // names end in digits, the asides in `)`, the pointer in `p`.
+            for whole in ["reclaimable", "stalled"] {
+                for cut in 1..whole.len() {
+                    let fragment = &whole[..cut];
+                    assert!(
+                        !inner.trim_end().ends_with(fragment),
+                        "{width}: {whole:?} was clipped to {fragment:?}: {:?}",
+                        inner.trim_end()
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,6 +16,7 @@ use ratatui::Frame;
 use crate::app::{App, Overlay};
 use crate::filter;
 use crate::launch::{Agent, Candidate, Launch, Staged};
+use crate::liveness::Life;
 use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
 use crate::reclaim::Reclaimable;
 use crate::view::{Branch, Fold, GroupKind, Item, Plan, ProjectRow};
@@ -56,7 +57,7 @@ fn cluster_header(
     map: &Map,
     lit: &[usize],
     under_cursor: bool,
-    resumable: bool,
+    marks: Marks,
 ) -> Line<'static> {
     let cyan = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
     // The cursor rides *before* the `▌`, not after it: the bar is the cluster's
@@ -65,14 +66,10 @@ fn cluster_header(
     let mut spans = vec![cursor_span(under_cursor), Span::styled("▌ ", cyan)];
     spans.extend(lit_spans(id.short_repo(), lit, cyan));
     spans.push(Span::styled(format!(" · {}", map.title), cyan));
-    // A map is a node, so a charting session is as resumable as a build one —
-    // and the header is the only place the list can say so (#35).
-    if resumable {
-        spans.push(Span::styled(
-            RESUME_BADGE,
-            Style::new().fg(Color::Cyan).add_modifier(Modifier::DIM),
-        ));
-    }
+    // A map is a node, so a charting session is as resumable as a build one,
+    // and a map's own workspace is as launchable — the header is the only place
+    // the list can say either (#35).
+    spans.extend(marks.spans());
     for (glyph, count) in map.tally() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
@@ -293,7 +290,7 @@ fn ticket_line(
     branch: &Branch,
     lit: &[usize],
     under_cursor: bool,
-    resumable: bool,
+    marks: Marks,
 ) -> Line<'static> {
     // Nested rows carry the cursor column as extra indent, so a branch begins
     // directly under the glyph of the row it hangs from instead of to its left.
@@ -319,12 +316,7 @@ fn ticket_line(
             Style::new().add_modifier(Modifier::DIM),
         ));
     }
-    if resumable {
-        spans.push(Span::styled(
-            RESUME_BADGE,
-            Style::new().fg(Color::Cyan).add_modifier(Modifier::DIM),
-        ));
-    }
+    spans.extend(marks.spans());
     for pr in &ticket.prs {
         spans.extend(pr_badge(&ticket.repo, pr));
     }
@@ -355,8 +347,22 @@ fn context_line(ticket: &Ticket, prefix: &str) -> Line<'static> {
     // No resume badge either, for the same reason it carries no cursor: a
     // context row is not somewhere `enter` can be pressed, so a badge about
     // what `enter` would do there would be an offer the row cannot honour.
-    ticket_line(ticket, prefix, &[], &Branch::Plain, &[], false, false)
-        .patch_style(Style::new().add_modifier(Modifier::DIM))
+    //
+    // No liveness marking, on the narrower ground these rows already stand on:
+    // a context row shows no PR badges either. It is drawn to say *where* the
+    // matches beneath it live, and everything it says about itself is furniture
+    // — so a stalled node reachable only as somebody else's context is not
+    // marked on a sifted screen, and is there the moment the query clears.
+    ticket_line(
+        ticket,
+        prefix,
+        &[],
+        &Branch::Plain,
+        &[],
+        false,
+        Marks::default(),
+    )
+    .patch_style(Style::new().add_modifier(Modifier::DIM))
 }
 
 /// The body as styled lines: the [`Plan`] walked in order. Shared by the live
@@ -452,7 +458,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     map,
                     &lit,
                     under_cursor,
-                    app.resume(&id.repo, id.number).is_some(),
+                    Marks::of(app, &id.repo, id.number),
                 ));
             }
             Item::Ticket {
@@ -475,7 +481,7 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
                     branch,
                     &lit,
                     under_cursor,
-                    app.resume(&ticket.repo, ticket.number).is_some(),
+                    Marks::of(app, &ticket.repo, ticket.number),
                 ));
             }
             Item::Project(project) => lines.push(project_line(project, under_cursor)),
@@ -613,6 +619,98 @@ pub fn idle_note(plan: &Plan) -> String {
 /// The badge a row carries when a previous launch left a conversation on it
 /// (#35) — the same glyph as the key that rejoins it.
 const RESUME_BADGE: &str = "  ⏎";
+
+/// The most of one line the stall segment may take.
+///
+/// It goes down before the reclaim note, so without a ceiling a machine with
+/// six stalled nodes could spend the whole line on them and leave the `wf reap`
+/// pointer nowhere to go. Two names and their lead-in fit inside this; a third
+/// would not, which is the same budget [`Liveness::hint`] states in its own
+/// terms.
+const STALL_BUDGET: usize = 44;
+
+/// The badge a node carries when a container of its is up.
+///
+/// A square, where every stage glyph is round, because it is not a stage: the
+/// row's leading glyph is what the *tracker* says the work is, and this is what
+/// the *machine* says is happening to it. Two vocabularies that must not be
+/// mistaken for one another at a glance, so they do not share a shape.
+const RUNNING_BADGE: &str = "  ▣";
+
+/// The badge a node carries when it is claimed, has nothing pushed, and nothing
+/// of its is running.
+///
+/// It sits next to a `◐ building` stage glyph, and that juxtaposition *is* the
+/// finding: the tracker believes this is in progress, and no container of its
+/// is up. An hourglass because what it reports is elapsed time and nothing else
+/// — see [`Life::Stalled`](crate::liveness::Life::Stalled) for how little that
+/// claims.
+const STALLED_BADGE: &str = "  ⧖";
+
+/// What the app knows about a row's node that the ticket itself cannot say.
+///
+/// Both fields are per-node lookups against state the tracker never supplied —
+/// one from the launch record, one from this machine — and both are decided at
+/// the same call site for the same `(repo, number)`. Carrying them as one value
+/// is what keeps a row's signature from growing a parameter every time `wf`
+/// learns something new about a node, and it puts the two badges in one place
+/// so a ticket row and a cluster header cannot drift apart about their order.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Marks {
+    /// A previous launch left a conversation on this node (#35).
+    resumable: bool,
+    /// What this machine says is happening to it, if anything.
+    life: Option<Life>,
+}
+
+impl Marks {
+    /// Everything the app has to say about one node.
+    fn of(app: &App, repo: &str, number: u64) -> Self {
+        Self {
+            resumable: app.resume(repo, number).is_some(),
+            life: app.life(repo, number),
+        }
+    }
+
+    /// The badges, in the one order both row kinds draw them: what `enter`
+    /// would rejoin, then what is happening to it now.
+    fn spans(self) -> Vec<Span<'static>> {
+        let mut spans = Vec::new();
+        if self.resumable {
+            spans.push(Span::styled(
+                RESUME_BADGE,
+                Style::new().fg(Color::Cyan).add_modifier(Modifier::DIM),
+            ));
+        }
+        spans.extend(life_span(self.life));
+        spans
+    }
+}
+
+/// The spans a row's liveness marking contributes, if any.
+///
+/// **No new colour.** Cyan is already "`wf`'s own record about this row" — it
+/// is what `⏎` is drawn in — and these two are the same kind of fact from the
+/// same background reading, so they join it rather than minting a seventh hue
+/// on a screen that deliberately spends six (see [`CURSOR_COLOR`], and the
+/// query-match modifier that was chosen over a colour for the same reason).
+///
+/// The two are told apart by weight instead: a running container is live, so it
+/// is undimmed; a stall is a session that is over, which is exactly what DIM
+/// means everywhere else here. That leaves the badge for the thing that has
+/// stopped quieter than the one still going, which is the right way round for a
+/// picker — the loud version of "stalled" belongs on the count line, where it
+/// is a summons and not a decoration.
+fn life_span(life: Option<Life>) -> Option<Span<'static>> {
+    let cyan = Style::new().fg(Color::Cyan);
+    match life? {
+        Life::Running => Some(Span::styled(RUNNING_BADGE, cyan)),
+        Life::Stalled => Some(Span::styled(
+            STALLED_BADGE,
+            cyan.add_modifier(Modifier::DIM),
+        )),
+    }
+}
 
 /// How long ago `then` was, from `now`, in the one unit that reads: `20m ago`,
 /// `3h ago`, `5d ago`.
@@ -904,7 +1002,17 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
             .map(|part| part.chars().count() + 1)
             .sum::<usize>()
         + notice.chars().count();
-    let note = reclaim_note(app, (count_area.width as usize).saturating_sub(spent));
+    let mut left = (count_area.width as usize).saturating_sub(spent);
+    // Stalls are laid down before the reclaim note and capped, so the two
+    // unbounded segments cannot fight over one line. The cap is what keeps this
+    // one from being unbounded in practice: it names at most two nodes, and a
+    // node's name is short where a `dl` workspace id is not.
+    let stalled = app.liveness.hint(left.min(STALL_BUDGET));
+    if !stalled.is_empty() {
+        left = left.saturating_sub(stalled.chars().count() + 1);
+        parts.push(stalled);
+    }
+    let note = reclaim_note(app, left);
     if !note.is_empty() {
         parts.push(note);
     }
@@ -1425,6 +1533,95 @@ mod tests {
         assert!(
             screen.contains("└─  ● #2 Choose the stack"),
             "the done ticket hangs off the group line: {screen}"
+        );
+    }
+
+    /// The two markings land on the rows they are about, and say different
+    /// things: one node has a container up, another is claimed with nothing
+    /// running. Both come from the same reading.
+    #[test]
+    fn a_running_container_and_a_stall_are_marked_on_the_rows_they_belong_to() {
+        let mut app = fixture_app();
+        app.liveness = crate::liveness::Liveness::for_test(
+            &[("blooop/wayfinder", 6)],
+            &[("blooop/wayfinder", 9)],
+        );
+        let screen = render(&app);
+        let row = |needle: &str| {
+            screen
+                .lines()
+                .find(|line| line.contains(needle))
+                .unwrap_or_else(|| panic!("no row for {needle}: {screen}"))
+                .to_string()
+        };
+        assert!(
+            row("Re-entry breadcrumbs").contains('▣'),
+            "a node with a container up says so: {screen}"
+        );
+        assert!(
+            row("Main screen design").contains('⧖'),
+            "a claimed node with nothing running says so: {screen}"
+        );
+        // The two are never the same mark, and neither leaks onto a row the
+        // reading said nothing about.
+        assert!(!row("Re-entry breadcrumbs").contains('⧖'), "{screen}");
+        assert!(!row("Supervising AFK agents").contains('▣'), "{screen}");
+        assert!(!row("Supervising AFK agents").contains('⧖'), "{screen}");
+    }
+
+    #[test]
+    fn the_first_frame_marks_no_row_and_names_no_stall() {
+        let app = fixture_app();
+        assert!(app.liveness.is_empty(), "nothing has been read yet");
+        let screen = render(&app);
+        assert!(!screen.contains('▣'), "{screen}");
+        assert!(!screen.contains('⧖'), "{screen}");
+        assert!(!screen.contains("stalled"), "{screen}");
+    }
+
+    /// A stall reaches the count line as well as the row, because the row is
+    /// not always on screen: the project list has no ticket rows at all, and a
+    /// stalled node can be inside a fold or another map.
+    #[test]
+    fn the_count_line_names_what_stopped_moving() {
+        let mut app = fixture_app();
+        app.liveness = crate::liveness::Liveness::for_test(
+            &[],
+            &[("blooop/wayfinder", 9), ("blooop/wayfinder", 14)],
+        );
+        let screen = render(&app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("stalled"))
+            .unwrap_or_else(|| panic!("no stall segment: {screen}"));
+        assert!(line.contains("2 stalled"), "{line}");
+        assert!(line.contains("wayfinder#9"), "{line}");
+    }
+
+    /// The two unbounded segments share one line, and the stall cap is what
+    /// keeps the earlier one from spending it all: the `wf reap` pointer is the
+    /// half of the reclaim hint a reader can act on, and it still fits.
+    #[test]
+    fn a_stall_segment_leaves_the_reclaim_pointer_its_room() {
+        let mut app = fixture_app();
+        app.liveness = crate::liveness::Liveness::for_test(
+            &[],
+            &[
+                ("blooop/wayfinder", 9),
+                ("blooop/wayfinder", 14),
+                ("blooop/wayfinder", 7),
+            ],
+        );
+        app.reclaimable = Some(Reclaimable::for_test(&["wf-129-closed"], 0));
+        let screen = render_at(120, &app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("stalled"))
+            .unwrap_or_else(|| panic!("no stall segment: {screen}"));
+        assert!(line.contains("3 stalled"), "{line}");
+        assert!(
+            line.contains("wf reap"),
+            "the command survives beside the stalls: {line}"
         );
     }
 

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -56,7 +56,7 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // error here and a decision someone makes — this file is compiled
             // but never run by CI, which makes a wildcard in it the least
             // observed thing in the tree.
-            other @ (LoadEvent::Fetched { .. } | LoadEvent::Surveyed(_)) => {
+            other @ (LoadEvent::Fetched { .. } | LoadEvent::Surveyed { .. }) => {
                 panic!("expected discovery first, got {other:?}")
             }
         }

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -56,7 +56,7 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // error here and a decision someone makes — this file is compiled
             // but never run by CI, which makes a wildcard in it the least
             // observed thing in the tree.
-            other @ (LoadEvent::Fetched { .. } | LoadEvent::Reclaimable(_)) => {
+            other @ (LoadEvent::Fetched { .. } | LoadEvent::Read(_)) => {
                 panic!("expected discovery first, got {other:?}")
             }
         }

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -56,7 +56,7 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // error here and a decision someone makes — this file is compiled
             // but never run by CI, which makes a wildcard in it the least
             // observed thing in the tree.
-            other @ (LoadEvent::Fetched { .. } | LoadEvent::Read(_)) => {
+            other @ (LoadEvent::Fetched { .. } | LoadEvent::Surveyed(_)) => {
                 panic!("expected discovery first, got {other:?}")
             }
         }


### PR DESCRIPTION
Three gaps in the `wf`/`dl` loop: the contract between them, and the half of a node's state that only this machine knows.

## The `unsaved` contract (a live break)

devlaunch's unreleased main changes `dl --ls --json`'s `unsaved` from a string-or-null to an object with one of three keys. `wf` declared it `Option<String>`, and `parse_workspaces` is all-or-nothing — so that listing does not parse, and one field takes `wf reap` *and* the picker's reading down together, silently in the picker's case.

The field is now a sum type over `dl`'s answers, read from both releases' spellings since `wf` pins no `dl` version:

| wire | arm | reap |
| --- | --- | --- |
| `{"nothingToLose":true}` | `NothingToLose` | passes |
| `{"wouldLose":"…"}` | `WouldLose` | keeps, `-f` waives |
| `{"couldNotTell":"…"}` | `CouldNotTell` | keeps, `-f` waives |
| `"a sentence"` (≤ 0.0.23) | `WouldLose` | keeps |
| anything unrecognised | `Unrecognized` | keeps |
| `null` / absent | `None` | passes |

`couldNotTell` refusing is the arm that earns the type: those files are on disk and nothing has established they exist anywhere else, so it belongs beside `wouldLose`, not beside `nothingToLose`. Flattening back to "is it `Some`?" reaps an unreadable clone.

The object is read as a **map**, not an externally-tagged enum, so the day `dl` adds a sibling field the known keys still answer. An enum would have made every row unreadable at once — refusing is the safe direction, but losing the whole feature to one added field is not degradation.

Pinned with a fixture of `dl`'s literal output covering every shape either release emits, plus two no `dl` has ever sent. Neither repo had one: both documented this field in prose and neither executed the other's output, which is how the change landed unnoticed.

## `▣` and `⧖` — what is running, and what stopped

Every glyph on the picker was a **tracker** fact. A launch `exec`s an agent into a container and exits, so nothing ever reported back whether that agent is still there; `⏎` says a launch *happened*, which is all the launch record can honestly claim.

`dl` knows the other half and publishes it. The reaper already read `state` to protect a running container and then threw it away — the same background reading now keeps it and joins it to the tracker facts it had already fetched:

- **`▣`** a container of this node's is up
- **`⧖`** claimed, nothing pushed, and nothing of its running

`⧖` is the one that needed both halves. A claim alone is the ordinary look of work in progress; a stopped container alone is the ordinary look of work that finished. Only the pair means a lifecycle went down between its stages — which is exactly the state `wf reap` is right to refuse to collect (a stale claim is a person's stated intent), and so the one thing on the machine nothing pointed at.

No new colour: cyan is already "`wf`'s own record about this row", which is what `⏎` uses. The two are told apart by weight.

## What it deliberately does not claim

A container being up is not an agent being alive. A stall is not a crash — a reboot marks everything at once, and those are true positives that simply arrive together. A node launched on the **host** can still be marked, if it owns a stopped workspace from some other launch; that one is an outright false positive and the README says so. Same-machine only.

## Review

Four adversarial passes (spec, standards, regression, doc-coherence). What they caught, and what changed:

- an unknown `unsaved` key killed the whole listing — now refuses one row
- `{"nothingToLose": false}` reaped
- `Liveness` was two parallel sets, so a node could be in both — now one map
- `NotFound` (on this machine's real listing) was read as "say nothing" when it is the strongest "down" there is
- an answer to a reading `ctrl-r` had withdrawn could restore what the refresh cleared, permanently — the event now says which reading it answers
- the two count-line segments could clip each other into `· 2 reclaima`, visible only on a rendered screen
- two docs asserted things the code does not do, both corrected rather than softened

## Verification

CI green: `fmt --check`, `clippy --all-targets` under `-D warnings`, 376 lib + 18 bin tests, `doc`.

Exercised end to end against the real `dl` on this machine (**0.0.23** — the legacy shape), and against shims speaking 0.0.24, a sibling-key release, and a renamed answer.

## Two open judgement calls

- **`-f` waives `CouldNotTell`**, mirroring `dl`'s own `rm --force`; refusing would make a corrupt-`.git` workspace unreapable forever. But `wf reap -f -y` then deletes one with nobody seeing the row, because `-y` skips the plan.
- `live_launch_exec` has a wall-clock deadline and is flaky under parallel load. Pre-existing; this branch adds process pressure to a suite CI does not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce liveness tracking that joins devlaunch container state with tracker facts to show which nodes are running or stalled, and harden the unsaved-work contract so future changes in devlaunch’s output don’t break reaping or hints.

New Features:
- Add per-node liveness modelling and UI badges to indicate running containers and stalled work, plus a count-line summary of stalled nodes.
- Extend the background survey to derive both reclaimable workspaces and liveness from a single devlaunch listing and tracker query, refreshing coherently on ctrl-r.
- Support devlaunch’s newer structured unsaved field while safely handling legacy and unknown shapes so listings and plans stay readable across releases.

Bug Fixes:
- Prevent a single unreadable unsaved value from breaking the entire workspace listing and picker hint.
- Ensure NotFound devpod states are treated as fully down, and avoid misclassifying states devpod or wf cannot read.
- Fix race conditions where stale background readings could restore cleared reclaim/liveness state after ctrl-r.
- Prevent UI count-line segments for stalls and reclaimable workspaces from clipping each other into unreadable fragments at narrow widths.

Enhancements:
- Refine reap planning to use a typed Unsaved enum with clearer refusal/force-discard messaging and to prioritise protecting running containers and unsaved work.
- Add shared node naming and consolidated badge handling so map headers and ticket rows consistently present resume and liveness markings.
- Document the semantics and limitations of running/stalled markings and how they relate to wf reap and multi-machine usage.

Documentation:
- Update README to explain running/stalled badges, their relationship to devlaunch and tracker facts, and how stalls and reclaim hints share the count line.

Tests:
- Add fixture listings and tracker responses for all historical and hypothetical unsaved field shapes plus liveness scenarios, with tests ensuring robust parsing, correct reaping decisions, and accurate UI markings and count-line behaviour.
- Extend live-streaming and picker tests to cover multi-reading behaviour, ctrl-r refresh semantics, and the restricted subprocess surface for surveys.

---

## Update: merged `main` (0.15.1) and re-reviewed against it

`main` grew a **`dl >= 0.0.24` floor** and a `devlaunch >=0.0.24` run dependency
while this was open. That lands directly on this PR's subject and made two of its
own docs false, so the merge is not just a fast-forward.

**The compromise this PR documented is now fixable.** `unsaved: null` was read as
permitting a reap, and the field doc said so explicitly — because 0.0.23 was "the
release actually installed on most machines today" and "nothing here asks `dl` its
version". Both statements changed on `main`. From devlaunch 0.0.24 `unsaved` is null
*exactly* where `devlaunch` is false, so a null on a clone `dl` made means `dl`'s own
inspection fell over — devlaunch#171, the bug the object form was a breaking change to
prevent. Permitting a reap there walks back into it.

So `Unsaved` gains `Unanswered`, the one arm never parsed from the wire, applied at the
boundary that already ran the process (`answered_where_dl_answers`) so `plan` stays pure
and no test of it depends on what is installed on the test machine. A `dl` too old, or
one whose version will not parse, is read the old permissive way — the worst case is the
behaviour that shipped before the floor existed.

Verified end to end against shimmed releases, not only in unit tests:

| `dl --version` | silent `wf` workspace |
|---|---|
| 0.0.23 | reaped (that release meant *clean* by it) |
| 0.0.24 / 0.0.25 | **kept** — `dl made this clone but did not say what it holds` |
| unparseable | reaped (degrades to the old reading) |

Also in this update: version → **0.16.0** with the recipe tracking it, the probe shims
answer `--version` (a shim that listed like 0.0.24 and versioned like 0.0.23 is evidence
about a machine that cannot exist), and the three recorded safety assertions become a
rule — what makes these calls safe is that none of them names a workspace, which is
where every destructive `dl` subcommand takes its target.

README carried `main`'s staleness too: it still described isolation as two conditions and
repeated "wf pins no version and never will". It now names the third condition, the run
dependency and its ~370 MB, how a missing answer is read, and that the 0.0.20/0.0.13
floors are history rather than advice.
