### PR TITLE
Retire the refresh key, and everything that existed to serve it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -293,10 +293,18 @@ container on its own is the ordinary look of work that finished. It is the
 stage glyph beside it, and that contrast is the finding: `◐ #133 … ⧖` is the
 tracker saying *building* and the machine saying *nothing is*.
 
-`ctrl-r` retakes the reading along with everything else, and what it said is
-dropped the moment you press it rather than when its replacement lands: these
-are claims in the present tense, and a screen asserting last hour's containers
-beside freshly fetched tickets would be worse than one asserting nothing.
+**These markings are taken once, at startup, and never again** — and that is a
+real limitation rather than an oversight. The reading is taken behind the first
+frame and there is no key that retakes it, so `▣` and `⧖` say what was true when
+`wf` started, not what is true now. Start a container from the launch picker of
+this very session and the row behind it will not learn: the marking you are
+looking at was decided before you pressed anything.
+
+They stay useful because of how short a session is — `wf` is on screen for
+seconds — and because the thing they report moves in minutes rather than
+milliseconds. But a screen you left open while a build ran is a screen making
+claims in the past tense, and the only way to bring them up to date is to quit
+and run `wf` again, which is ~0.6 s warm.
 
 Stalls also reach the [count line](#startup) as
 `· 2 stalled: wayfinder#133, wayfinder#134`, because the row is not always on
@@ -436,11 +444,12 @@ retried rather than fatal. Which project's screen is up is not the search's
 business either way: it comes from the local `git` call that registers the
 checkout, before the first frame, and nothing arriving later moves it.
 
-Each map is fetched exactly once. Nothing polls: `wf` is on screen for seconds
-and restarts warm in ~0.6 s, so there is nothing worth keeping fresh. `ctrl-r`
-refetches everything when you want it — after closing a ticket in the browser,
-say. A fetch that fails says so on the count line and stays failed until you
-ask again.
+Each map is fetched exactly once per run, and there is no key that asks again.
+Nothing polls either: `wf` is on screen for seconds and restarts warm in ~0.6 s,
+so a whole new run is the refresh — at the price of the query, the project you
+had entered and where the cursor was. A fetch that fails says so on the count
+line and stays failed for the rest of the run; the screen says `run wf again`
+rather than naming a key, because running it again is what retries.
 
 **What a `wf reap` would claim is read in the background too**, and lands on the
 count line when it arrives:
@@ -495,8 +504,8 @@ or a second name for the module exported from the library.
 
 Everything else is watched rather than proven. A test drives the real event loop
 against a recording `dl` and `gh`, through every arm the loop has — quit,
-refresh, continue, and the launch that ends the session — and reads back every
-argv the run made, plus a scratch `HOME` laid out the way this machine is
+continue, and the launch that ends the session — and reads back every argv the
+run made, plus a scratch `HOME` laid out the way this machine is
 (`~/.cache/devlaunch/repos/<owner>/<repo>/<id>` for the clone,
 `~/.devpod/contexts/<ctx>/workspaces/<id>` for the record), compared before and
 after. That catches a workspace deleted by running `dl` and one deleted
@@ -781,16 +790,21 @@ an empty one.
 | `⏎` in a row | a previous launch left a conversation on this node: its picker leads with `resume`, and `enter enter` rejoins it |
 | `▣` in a row | [a container of this node's is up](#what-is-actually-running-and-what-stopped) — which is not the same as an agent being alive in it |
 | `⧖` in a row | claimed, nothing pushed, and nothing of its running: a run that stopped between its stages |
-| `ctrl-r` | refetch every map in place, keeping your query, level and cursor |
 | `esc` | clear the query; on an empty query, quit |
 | `q` | quit — on an empty query only, since mid-query it types |
 | `ctrl-c` | quit from anywhere, including the which-checkout picker |
 | `↑`/`↓` or `j`/`k`, `enter`, `esc`/`q` | in the which-checkout picker: pick which tree the agent runs in, or cancel |
 
-`ctrl-r` is the only thing that updates the list in place. Quitting and running
-`wf` again is nearly as fast (~0.6 s warm) but throws away the query, the
-project you had entered and where the cursor was, which is the whole reason the
-key still exists now that nothing polls.
+**Nothing updates the list in place.** There was a key that refetched every map
+without losing your query, level or cursor, and it is gone: it was the only
+thing in `wf` that wrote the screen's state twice, and each of those second
+writes needed its own machinery to be safe — a load restart so a refetch could
+not be beaten by the load it replaced, a way to put the startup counter back
+into loading, and a generation tag on the background reading so an answer to a
+question you had already withdrawn could be told from a live one. One key's
+worth of freshness was not worth a second write path through everything behind
+the screen. Quitting and running `wf` again is ~0.6 s warm and costs you the
+query, the level and the cursor, and that is the trade as it now stands.
 
 That picker is the one prompt left, and only a repo with several registered
 checkouts (the `~/k1/kinisi_ros`, `~/k2/kinisi_ros` pattern) ever sees it: the

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.16.0"
+  version: "0.17.0"
 
 package:
   name: wf

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,9 +52,6 @@ pub enum Level {
 pub enum Outcome {
     Continue,
     Quit,
-    /// Force a refetch (`ctrl-r`). The loop performs it and puts the results
-    /// back via [`App::replace_clusters`].
-    Refresh,
     /// Run this ticket's agent. The last thing `wf` ever does: the loop
     /// returns, the terminal is restored, and the process becomes the agent.
     ///
@@ -218,7 +215,9 @@ pub struct App {
     /// [`App::scoped_clusters`], which leads on activity.
     pub clusters: BTreeMap<MapId, Map>,
     /// The maps believed open — the cached seed until the search answers, the
-    /// search's answer afterwards. This is what `ctrl-r` refetches.
+    /// search's answer afterwards. This is the set the loaders are reconciled
+    /// against, and with one load per run the search's answer is the last word
+    /// on it.
     pub open_maps: MapSet,
     pub query: String,
     /// Which screen is up: the project list, or one project's own.
@@ -235,11 +234,11 @@ pub struct App {
     /// Maps whose last fetch failed — **state, not a message.**
     ///
     /// A failure has to be drawn on every frame, and the one-shot `notice` is
-    /// cleared by the very next keypress. Nothing polls any more either, so a
-    /// failed fetch is the final word on that map until `ctrl-r`: with only a
-    /// notice, one keystroke turns "GitHub is down" into a screen that says
-    /// *no projects — run wf inside a checkout to register it*, which is the
-    /// exact lie [`crate::refresh::Startup`] exists to prevent for the
+    /// cleared by the very next keypress. Nothing polls and nothing asks again,
+    /// so a failed fetch is the final word on that map for the rest of the run:
+    /// with only a notice, one keystroke turns "GitHub is down" into a screen
+    /// that says *no projects — run wf inside a checkout to register it*, which
+    /// is the exact lie [`crate::refresh::Startup`] exists to prevent for the
     /// still-loading case.
     ///
     /// A set of [`MapId`]s rather than a flag, because the flag it replaces
@@ -1158,15 +1157,28 @@ impl App {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
             KeyCode::Char('c') if ctrl => Outcome::Quit,
-            KeyCode::Char('r') if ctrl => {
-                self.notice = Some("refreshing…".to_string());
-                Outcome::Refresh
-            }
-            // `ctrl-f` and `ctrl-g` are gone, not merely undocumented: focusing
-            // a project is entering it and widening is `←` out of it, so both
-            // chords named a move the arrows already make. They fall through
-            // to nothing here rather than being caught and ignored — an unbound
-            // key is unbound.
+            // `ctrl-f`, `ctrl-g` and the refresh chord are gone, not merely
+            // undocumented, and they fall through to nothing here rather than
+            // being caught and ignored — an unbound key is unbound.
+            //
+            // The first two named a move the arrows already make: focusing a
+            // project is entering it and widening is `←` out of it. Refresh
+            // named something nothing else does — refetch every map in place,
+            // keeping the query, the level and the cursor — so retiring it is a
+            // trade rather than a tidy-up. What it bought was the one screen
+            // update a session could have; what it cost was a *second write* to
+            // every piece of state behind that screen, and each of those writes
+            // needed machinery of its own: a `Loaders::restart` so a refetch
+            // could not be beaten by the load it replaced, a way to put
+            // [`crate::refresh::Startup`] back into loading, and a generation
+            // tag on the background reading so an answer to a withdrawn
+            // question could be told from a live one. All of it went with the
+            // key, and everything the loop folds is now written once.
+            //
+            // The price is paid by anyone who closes a ticket in the browser
+            // and wants to see it: run `wf` again — ~0.6 s warm — and lose the
+            // query, the project you had entered and where the cursor was.
+
             // Toggle the structural lens (#51): leverage ⇄ forest. The cursor
             // stays on its ticket if the other screen shows it; a live query
             // keeps flattening either lens until it is cleared.
@@ -3302,9 +3314,10 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_r_requests_refresh_and_replace_clusters_keeps_anchor() {
+    fn replace_clusters_keeps_the_anchor_when_the_ticket_survives() {
+        // A map arriving swaps its whole cluster, and the cursor must stay on
+        // the ticket it was on rather than on the position it happened to hold.
         let mut app = fixture_app();
-        assert_eq!(app.handle_key(ctrl('r')), Outcome::Refresh);
         go_to(&mut app, "#6");
         let same = app.clusters.clone();
         app.replace_clusters(same);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,9 @@
 //! 2. The screen goes up before any network call (#27), with the cached map
 //!    numbers (#28) already being fetched.
 //! 3. One `wayfinder:map` label search reconciles that set; every map streams
-//!    in as it lands. `ctrl-r` asks again. Nothing polls: `wf` is on screen for
-//!    seconds and restarts warm in ~0.6 s.
+//!    in as it lands, once. Nothing polls and no key asks again: `wf` is on
+//!    screen for seconds and restarts warm in ~0.6 s, so running it again is
+//!    the refresh.
 //! 4. Inside a checkout, the screen opens **on that project** and nowhere
 //!    else; run outside one and it opens on the project list, most recently
 //!    used first. Both are drawn from the cache, so neither waits on the
@@ -103,7 +104,7 @@ With no arguments: opens on the project you are standing in, or on the list of
 every registered project — most recently used first — when you are not standing
 in one. enter selects a project, or runs an agent on the picked ticket in that
 project's checkout, replacing wf — so wf is gone by the time the agent draws.
-Left backs out, ctrl-r refetches, esc quits.
+Left backs out, esc quits. Each map is fetched once per run.
 
 wf skills          report which prompt each route would actually run
 wf skills install  link this build's skills into ~/.claude/skills and ~/.codex/skills

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -51,7 +51,7 @@
 //!      green, and when the token was added as `fs::`, the next reviewer
 //!      reopened it with `use std::fs as sys;`. It is the bare name now, for
 //!      the reason `reap` is;
-//!    - **which arm**: all four [`Outcome`] arms are driven, the launch one
+//!    - **which arm**: all three [`Outcome`] arms are driven, the launch one
 //!      included, and so is [`fold`] — but only through the events the child's
 //!      fixtures actually produce. Its `Discovered`, `Fetched` and
 //!      `Surveyed` arms are entered; `SearchFailed` is not, because the `gh`
@@ -182,10 +182,6 @@ struct Picker {
     /// The sending end, kept because a fold can start further loads.
     tx: UnboundedSender<LoadEvent>,
     updates: UnboundedReceiver<LoadEvent>,
-    /// Which reading the screen is currently asking for — bumped by every
-    /// `ctrl-r`, so an answer to a question already withdrawn can be told from
-    /// the answer to the live one. See [`LoadEvent::Surveyed`].
-    reading: u64,
 }
 
 impl Picker {
@@ -208,9 +204,6 @@ impl Picker {
             loaders,
             tx,
             updates,
-            // The reading `session` starts alongside this picker. They agree by
-            // both being the first, which is the only coupling between them.
-            reading: 0,
         }
     }
 
@@ -233,7 +226,6 @@ impl Picker {
                 &mut self.clusters,
                 &mut self.loaders,
                 &self.tx,
-                self.reading,
             );
         }
         terminal.draw(|frame| wf::ui::draw(frame, &self.app))?;
@@ -266,7 +258,6 @@ fn fold(
     clusters: &mut BTreeMap<MapId, Map>,
     loaders: &mut Loaders,
     tx: &UnboundedSender<LoadEvent>,
-    reading: u64,
 ) {
     match event {
         LoadEvent::Discovered(found) => {
@@ -315,18 +306,18 @@ fn fold(
         }
         // The background reading landed (#137). A plain state write on
         // a screen that has been up and answering keys the whole time.
-        // It reaches further than it once did: a dim segment of the count
-        // line, and — through `app.liveness` — a marking on any row whose
-        // node this machine has something to say about. And it arrives
-        // more than once, because `ctrl-r` asks again.
-        // An answer to a question the screen has since withdrawn. Dropping it
-        // is the whole reason the event says which reading it is: `ctrl-r`
-        // clears what is held and asks again, and a stale answer folded after
-        // that clear would restore it with nothing able to correct it — a
-        // fresh reading that finds nothing is silent by design.
-        LoadEvent::Surveyed { taken, .. } if taken != reading => {}
-        LoadEvent::Surveyed { reading: found, .. } => {
-            let (reclaimable, liveness) = found.into_parts();
+        // It reaches further than the count line's dim segment: through
+        // `app.liveness` it marks any row whose node this machine has
+        // something to say about.
+        //
+        // It arrives exactly once. This arm used to be two — a guard
+        // dropping answers to a question the refresh key had withdrawn, and
+        // the fold proper — because the reading is silent when it finds
+        // nothing, so a stale answer folded after a clear would restore it
+        // with nothing able to correct it. With no key to clear anything
+        // there is one question and one answer, and one arm.
+        LoadEvent::Surveyed(reading) => {
+            let (reclaimable, liveness) = reading.into_parts();
             app.reclaimable = reclaimable;
             app.liveness = liveness;
         }
@@ -345,20 +336,8 @@ fn fold(
 /// subprocess and one batched GraphQL call, neither of them on the way to a
 /// frame. What lands folds into the count line and into the rows' own
 /// markings; a reading that fails says nothing at all.
-fn spawn_reading(tx: &UnboundedSender<LoadEvent>, taken: u64) -> Survey {
-    wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone(), taken)
-}
-
-/// Take the reading again, on `ctrl-r`.
-///
-/// The previous one is stopped **and waited for** before a second is started,
-/// for the reason the handover does it: a reading holds a `dl` and a `gh` of
-/// its own, and two overlapping ones would race to write the same two fields
-/// with answers taken at different moments — the older one landing last, which
-/// is exactly the bug `Loaders::restart` exists to avoid on the map side.
-async fn restart_reading(previous: Survey, tx: &UnboundedSender<LoadEvent>, taken: u64) -> Survey {
-    previous.stop().await;
-    spawn_reading(tx, taken)
+fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
+    wf::refresh::spawn_survey(wf::reclaim::survey_live(), tx.clone())
 }
 
 /// Stop everything running behind the screen, and wait for it to be gone.
@@ -382,17 +361,25 @@ async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
 ///
 /// Generic over the backend and over [`Keys`] so that the probe drives *this*
 /// function rather than a hand-written imitation of it, and it drives every one
-/// of the four arms below: a scripted keyboard that only ever sent `Esc` left
-/// `Refresh` and `Launch` unentered, which is where a fifth escape was found.
-/// Whatever the loop body reaches — a helper in another module, a task it
-/// spawns, a `dl` it shells out to — is recorded there as argv, for as long as
-/// that probe watches.
+/// of the three arms below: a scripted keyboard that only ever sent `Esc` left
+/// `Launch` unentered, which is where a fifth escape was found. Whatever the
+/// loop body reaches — a helper in another module, a task it spawns, a `dl` it
+/// shells out to — is recorded there as argv, for as long as that probe
+/// watches.
+///
+/// There were four arms until the refresh key was retired, and the fourth was
+/// the only one that ever *wrote* to the picker instead of reading it: it
+/// restarted the loads, put the startup state back into loading, cleared the
+/// failures, threw the reading away and took another. What is left only drains,
+/// draws and ends — which is why nothing here holds a generation, and why
+/// `survey` is handed straight on rather than being something this function can
+/// replace.
 async fn run<B: Backend, K: Keys>(
     terminal: &mut Terminal<B>,
     keys: &mut K,
     mut picker: Picker,
     discovery: JoinHandle<()>,
-    mut survey: Survey,
+    survey: Survey,
 ) -> Result<Ending> {
     loop {
         picker.tick(terminal)?;
@@ -401,34 +388,6 @@ async fn run<B: Backend, K: Keys>(
         };
         match picker.app.handle_key(key) {
             Outcome::Quit => return Ok(Ending::Quit),
-            // Through the loaders, not alongside them: a refetch that
-            // raced an in-flight load used to be silently overwritten
-            // by the older snapshot. One channel, send order, newest
-            // write wins. Results stream in as they land, so the last
-            // word on how it went is the count line, not this notice.
-            Outcome::Refresh => {
-                picker.loaders.restart(&picker.app.open_maps, &picker.tx);
-                picker.app.startup.reloading();
-                picker.app.failed.clear();
-                // The reading is refetched with everything else, and what it
-                // said is dropped *now* rather than when its replacement lands.
-                // It was one dim segment naming a command when it could be read
-                // once at startup and left; it now also marks rows with claims
-                // in the present tense — which container is up, which run has
-                // stopped — and those go stale the moment anything starts or
-                // stops. A stale `▣` on a node whose container this session's
-                // own launch picker just built is the version of it a person
-                // would actually hit.
-                //
-                // Clearing before the refetch is the honest order: a reading
-                // that finds nothing sends no event, so keeping the old one
-                // until it is replaced would leave a screen asserting last
-                // hour's containers with nothing able to correct it.
-                picker.app.reclaimable = None;
-                picker.app.liveness = wf::liveness::Liveness::default();
-                picker.reading += 1;
-                survey = restart_reading(survey, &picker.tx, picker.reading).await;
-            }
             // Nothing after this can be drawn. Stop the background work
             // *and wait for it* before handing over: an in-flight `gh`
             // outlives the `exec` otherwise, and the agent inherits it
@@ -461,7 +420,7 @@ async fn session<B: Backend, K: Keys>(
 ) -> Result<Ending> {
     let (tx, updates) = mpsc::unbounded_channel();
     let discovery = wf::refresh::spawn_discovery(repos, cache_path, tx.clone());
-    let survey = spawn_reading(&tx, 0);
+    let survey = spawn_reading(&tx);
     let picker = Picker::new(app, tx, updates);
     run(terminal, keys, picker, discovery, survey).await
 }
@@ -656,13 +615,13 @@ mod tests {
     /// that is where the ordering note goes.
     ///
     /// The keys it types are a *plan*, because one of them is not enough. `run`
-    /// has four [`Outcome`] arms and for three review rounds this script sent
-    /// only `Esc`, so `Refresh` and `Launch` were never entered and a deletion
-    /// written into either was green — including in `Launch`, which is both the
-    /// product's primary action and the natural home of a "free the disk on the
-    /// way out" cleanup. A plan that runs out falls back to `Esc`, so a loop
-    /// that failed to end where it was supposed to ends anyway and fails on an
-    /// assertion rather than on the suite's timeout.
+    /// has three [`Outcome`] arms and for three review rounds this script sent
+    /// only `Esc`, so `Launch` was never entered and a deletion written into it
+    /// was green — and `Launch` is both the product's primary action and the
+    /// natural home of a "free the disk on the way out" cleanup. A plan that
+    /// runs out falls back to `Esc`, so a loop that failed to end where it was
+    /// supposed to ends anyway and fails on an assertion rather than on the
+    /// suite's timeout.
     struct Script {
         /// What to type, in order, one key per [`WATCH`].
         plan: std::collections::VecDeque<KeyEvent>,
@@ -687,13 +646,13 @@ mod tests {
         }
     }
 
-    /// A key with no modifiers, and the `ctrl` variant `Refresh` needs.
+    /// A key with no modifiers, which is all this script needs. There was a
+    /// `ctrl` variant beside it for the one chord that reached an [`Outcome`]
+    /// of its own — refresh, now retired. The chords that are left either quit
+    /// (`ctrl-c`, which `Esc` already covers here) or move the cursor, and the
+    /// plain keys reach both.
     fn press(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
-    }
-
-    fn ctrl(code: KeyCode) -> KeyEvent {
-        KeyEvent::new(code, KeyModifiers::CONTROL)
     }
 
     impl Keys for Script {
@@ -785,9 +744,9 @@ mod tests {
         ending.expect("the session")
     }
 
-    /// The quit path, with the two arms that do not end the loop driven on the
-    /// way: `ctrl-r` is [`Outcome::Refresh`], `down` on a screen with nothing
-    /// on it is [`Outcome::Continue`], `esc` is [`Outcome::Quit`].
+    /// The quit path, with the one arm that does not end the loop driven on the
+    /// way: `down` on a screen with nothing on it is [`Outcome::Continue`],
+    /// `esc` is [`Outcome::Quit`].
     #[test]
     #[ignore = "run by `probe::record` from the tests below, under recording shims"]
     fn picker_session_probe() {
@@ -796,11 +755,7 @@ mod tests {
         }
         let ending = drive(
             App::empty(),
-            vec![
-                ctrl(KeyCode::Char('r')),
-                press(KeyCode::Down),
-                press(KeyCode::Esc),
-            ],
+            vec![press(KeyCode::Down), press(KeyCode::Esc)],
         );
         assert!(
             matches!(ending, Ending::Quit),
@@ -837,7 +792,6 @@ mod tests {
         let ending = drive(
             app,
             vec![
-                ctrl(KeyCode::Char('r')),
                 press(KeyCode::Enter),
                 press(KeyCode::Down),
                 press(KeyCode::Enter),
@@ -911,30 +865,29 @@ mod tests {
         // does is not here.
         let run = a_session();
         run.destroyed_nothing();
-        // Stated as a rule over every call rather than as a fixed list, because
-        // the *number* of readings is a property of the keys pressed — this
-        // script presses `ctrl-r` — while "these two questions and no others"
-        // is the safety claim, and it must hold however many times the run
-        // asks them.
+        // Stated as a rule over every call rather than as a fixed list. "These
+        // two questions and no others" is the safety claim, and it has to hold
+        // however many times the run asks them — a rule keeps saying that if
+        // anything ever asks again, which is the half of this assertion that
+        // does not depend on today's keybindings.
         for argv in &run.argv {
             assert!(
                 asked_a_question(argv),
                 "a session asks for the listing and the tracker, and nothing else: {argv}"
             );
         }
-        // And the refresh really does ask again. `ctrl-r` is documented as
-        // refetching everything in place, and the reading became a per-row
-        // claim in the present tense — so a refresh that left it at its startup
-        // value would be drawing an hour-old container state beside freshly
-        // fetched tickets. Read off the run rather than from the call site: the
-        // pair repeats.
+        // And it asks them **once**. This used to be two, because the script
+        // pressed the refresh key and it took the reading again; with that key
+        // retired there is one reading per session, and a second `dl` here
+        // would mean something started asking on its own. Read off the run
+        // rather than from the call site: the pair does not repeat.
         assert_eq!(
             run.argv
                 .iter()
                 .filter(|argv| *argv == "dl <--ls> <--json>")
                 .count(),
-            2,
-            "the reading is taken at startup and again on ctrl-r: {:?}",
+            1,
+            "one reading per session, taken at startup and never again: {:?}",
             run.argv
         );
     }
@@ -963,26 +916,16 @@ mod tests {
         // Bounded as well as filtered. A predicate over each call says nothing
         // about how many there are, and "nothing extra" is a claim about the
         // count — fifty tracker reads on the launch path would satisfy every
-        // assertion above. Not pinned to an exact number, because this script
-        // presses `ctrl-r` and the second reading is racing `stop_background`:
-        // its `dl` may or may not have run by the time the arm aborts it. Two
-        // readings, two calls each, plus the one `dl <--version>` the process
-        // asks once however many readings it takes, is the ceiling either way.
-        assert!(
-            run.argv.len() <= 5,
-            "at most the two readings this script asks for: {:?}",
-            run.argv
-        );
-        // The version is the part that must not scale with the readings — it is
-        // memoized per process precisely so a refresh does not pay for another
-        // Python start, and nothing else in this run would notice if it did.
-        assert!(
-            run.argv
-                .iter()
-                .filter(|argv| *argv == "dl <--version>")
-                .count()
-                <= 1,
-            "the version is asked once per process, not once per reading: {:?}",
+        // assertion above. One reading — a listing, the version behind it, and
+        // one batched query — and the script does not type until that reading
+        // has reached the screen, so all three have landed before the launch
+        // arm is anywhere near being entered. It was a loose ceiling while the
+        // refresh key was in the plan, because the second reading raced
+        // `stop_background`; with one reading the count is exact.
+        assert_eq!(
+            run.argv.len(),
+            3,
+            "the one reading this session takes, and nothing the launch added: {:?}",
             run.argv
         );
     }
@@ -1029,106 +972,6 @@ mod tests {
             "it names the workspace: {line}"
         );
         assert!(line.contains("wf reap"), "and the command: {line}");
-    }
-
-    /// A reading answering a question the screen has withdrawn is dropped.
-    ///
-    /// The window is real rather than theoretical: `Picker::tick` drains the
-    /// channel once per turn and then parks in `next_press`, so a reading that
-    /// lands while the loop is parked waits there. Press `ctrl-r` in that
-    /// window and the clear happens *first*; without the tag, the next drain
-    /// folds the withdrawn answer straight back over it.
-    ///
-    /// What makes that unrecoverable rather than merely brief is the silence
-    /// this event is designed around: a fresh reading that finds nothing sends
-    /// nothing, so if the containers really did stop, no later event exists to
-    /// correct the restored markings. They would sit there until the session
-    /// ended.
-    #[tokio::test]
-    async fn an_answer_to_a_withdrawn_reading_is_dropped_rather_than_folded() {
-        let (tx, updates) = mpsc::unbounded_channel();
-        let mut picker = Picker::new(App::new(BTreeMap::new()), tx.clone(), updates);
-        // A real reading, taken through the real derivation with the two reads
-        // stubbed — the test-only constructors live in the library's own test
-        // build and this is the binary. Going through `survey` is the better
-        // seam anyway: the value folded below is one the production path can
-        // actually produce.
-        let node = wf::reap::Node {
-            repo: "blooop/wayfinder".to_string(),
-            number: 7,
-        };
-        let other = wf::reap::Node {
-            repo: node.repo.clone(),
-            number: 8,
-        };
-        let workspace = |number: u64, state: &str| wf::reap::Workspace {
-            id: format!("wf-{number}"),
-            devlaunch: true,
-            repo: Some(node.repo.clone()),
-            branch: Some(format!("wayfinder/wayfinder-{number}")),
-            state: Some(state.to_string()),
-            unsaved: None,
-        };
-        // One finished node whose container is down — a reap would claim it —
-        // and one whose container is up, so the reading carries both halves.
-        let listed = vec![workspace(7, "Stopped"), workspace(8, "Running")];
-        let known: BTreeMap<_, _> = [
-            (node.clone(), wf::reap::NodeFact::Closed),
-            (other, wf::reap::NodeFact::Closed),
-        ]
-        .into_iter()
-        .collect();
-        let stale = wf::reclaim::survey(
-            || async { Ok(listed.clone()) },
-            |_| async { Ok(known.clone()) },
-        )
-        .await
-        .expect("a finished workspace and a live container are both worth reporting");
-        assert!(
-            !stale.liveness().is_empty(),
-            "the fixture must carry a marking for the drop to be about anything"
-        );
-
-        // The reading the screen is waiting for lands: it is folded.
-        fold(
-            LoadEvent::Surveyed {
-                taken: 0,
-                reading: stale.clone(),
-            },
-            &mut picker.app,
-            &mut picker.clusters,
-            &mut picker.loaders,
-            &picker.tx,
-            picker.reading,
-        );
-        assert!(picker.app.reclaimable.is_some(), "the live answer is taken");
-        assert!(!picker.app.liveness.is_empty(), "markings and all");
-
-        // `ctrl-r`: what is held goes, and the question is asked again.
-        picker.app.reclaimable = None;
-        picker.app.liveness = wf::liveness::Liveness::default();
-        picker.reading += 1;
-
-        // The previous reading's answer, already queued when the key landed.
-        fold(
-            LoadEvent::Surveyed {
-                taken: 0,
-                reading: stale,
-            },
-            &mut picker.app,
-            &mut picker.clusters,
-            &mut picker.loaders,
-            &picker.tx,
-            picker.reading,
-        );
-        assert_eq!(
-            picker.app.reclaimable, None,
-            "a withdrawn reading must not restore the hint"
-        );
-        assert!(
-            picker.app.liveness.is_empty(),
-            "nor the row markings it came with"
-        );
     }
 
     #[test]
@@ -1251,7 +1094,6 @@ mod tests {
                 None
             },
             tx,
-            0,
         );
         stop_background(discovery, survey).await;
         assert_eq!(

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -10,7 +10,18 @@
 //! 1. The cached map ids (#28) start their fetches before the first frame.
 //! 2. One `wayfinder:map` label search runs unconditionally alongside them and
 //!    reconciles that set — the cache is a head start, never a skip.
-//! 3. Each map lands on screen as it arrives; `ctrl-r` is how you ask again.
+//! 3. Each map lands on screen as it arrives, and that is the last word on it.
+//!
+//! There is **one load per run**, and no way to ask for a second. The refresh
+//! key refetched everything in place until it was retired; what it cost was a
+//! parallel path — a way to put [`Startup`] back into loading, a
+//! `Loaders::restart` that existed only so a refetch could not be beaten by the
+//! load it replaced, and a generation on the reading below so a withdrawn
+//! answer could be told from a live one. None of that is here now, because
+//! every value in this module is written once and read once. What it gave up is
+//! real and is stated where it is felt: a map that changed after `wf` started
+//! stays as it was fetched, and the only way to see the new one is to run `wf`
+//! again — ~0.6 s warm, at the price of the query, the level and the cursor.
 //!
 //! Everything is keyed by [`MapId`] rather than repo slug (#50): a repo can
 //! hold several open maps, and each is its own load, its own arrival, and its
@@ -68,15 +79,16 @@ pub enum LoadEvent {
     /// a reading that found nothing are the same silence, because neither is
     /// anything the screen should draw.
     ///
-    /// `taken` says *which* reading this is, and it exists because that silence
-    /// breaks newest-write-wins. `ctrl-r` clears what the screen holds and asks
-    /// again; an answer to the *previous* question can already be sitting in
-    /// the channel at that moment, and folding it would put the cleared state
-    /// back — with nothing to correct it, since a fresh reading that finds
-    /// nothing sends no event at all. Every other `LoadEvent` reports either
-    /// way, so send order is enough for them; this one is answered only when
-    /// the answer is interesting, so it says which question it answers.
-    Surveyed { taken: u64, reading: Reading },
+    /// It used to carry a `taken` generation saying *which* reading it was,
+    /// because that silence breaks newest-write-wins: the refresh key cleared
+    /// what it held and asked again, an answer to the *previous* question could
+    /// already be sitting in the channel at that moment, and folding it would
+    /// have put the cleared state back — with nothing able to correct it, since
+    /// a fresh reading that finds nothing sends no event at all. The tag is
+    /// gone with the key. One reading is taken per run and it is never
+    /// withdrawn, so there is no previous question an answer could belong to,
+    /// and the payload can be the reading itself.
+    Surveyed(Reading),
 }
 
 /// Has the `wayfinder:map` label search answered yet?
@@ -154,16 +166,6 @@ impl Startup {
         self.arrived.insert(id.clone());
     }
 
-    /// `ctrl-r`: every map is being fetched again, so nothing has arrived yet.
-    ///
-    /// The same state a load uses, because it is the same question — how many
-    /// of the maps we expect are in — and answering it once means the count
-    /// line reports a manual refresh exactly as it reports a start, instead of
-    /// a refresh being a silent pause with a stale hint.
-    pub fn reloading(&mut self) {
-        self.arrived.clear();
-    }
-
     /// Maps still out.
     fn pending(&self) -> impl Iterator<Item = &MapId> {
         self.expected.difference(&self.arrived)
@@ -205,6 +207,14 @@ impl Startup {
 /// set is reconciled against the truth instead. The id *is* the whole target
 /// — repo and number both — so "same repo, different map number" is simply a
 /// different key, not a number to compare.
+///
+/// Reconciling is now the *only* thing that starts a load. There used to be a
+/// `restart` beside it for the refresh key, and its reason was ordering: a load
+/// started at t₀ and a refetch started at t₁ > t₀ both write the same map's
+/// cluster, and the older one can land second, so a refetch racing the initial
+/// load was silently overwritten by the stale snapshot it was meant to replace.
+/// With the key retired there is never a second write to lose that race, and
+/// the hazard is gone rather than guarded against.
 #[derive(Debug, Default)]
 pub struct Loaders {
     running: BTreeMap<MapId, JoinHandle<()>>,
@@ -240,21 +250,6 @@ impl Loaders {
             let task = spawn_load(id.clone(), tx.clone());
             self.running.insert(id.clone(), task);
         }
-    }
-
-    /// `ctrl-r`: throw every load away and start them all again.
-    ///
-    /// The refetch has to go through *this* rather than fetching alongside it,
-    /// and the reason is ordering. A load started at t₀ and a refetch started
-    /// at t₁ > t₀ both write the same map's cluster, and the load can land
-    /// second — so a refetch racing the initial load used to be overwritten by
-    /// an older snapshot while the screen said `refreshed`. Nothing polls now,
-    /// so that stale map would be final. Restarting means every result reaches
-    /// the UI through one channel, in send order, and the newest write wins by
-    /// construction.
-    pub fn restart(&mut self, want: &MapSet, tx: &mpsc::UnboundedSender<LoadEvent>) {
-        self.abort_all();
-        self.reconcile(want, tx);
     }
 
     /// Stop every load and wait for it to actually be gone.
@@ -305,10 +300,11 @@ fn spawn_load(id: MapId, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()>
 /// Find every open `wayfinder:map` across the cached repos, off the path to
 /// the first frame (#27).
 ///
-/// It **retries** on [`RETRY_INTERVAL`] rather than giving up. A single failed
-/// search would otherwise leave `wf` permanently empty with no way back:
-/// `ctrl-r` refetches the maps it knows about, and after a failed search it
-/// knows about none.
+/// It **retries** on [`RETRY_INTERVAL`] rather than giving up, and that is now
+/// the only recovery a session has. A single failed search would otherwise
+/// leave `wf` empty for the whole run with no way back: the only other thing
+/// that fetches is the cached seed, a cold start has none, and no key asks
+/// again.
 ///
 /// It runs **unconditionally**, warm cache or cold (#28). The cache is a head
 /// start, never a skip: this is the one thing that can add a map opened since
@@ -363,13 +359,13 @@ pub fn spawn_discovery(
 /// Returns a [`Survey`] so the launch path can stop it and wait, exactly as it
 /// does for the map loads: the reading holds child processes of its own, and an
 /// in-flight one outliving the `exec` would be inherited by the agent.
-pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>, taken: u64) -> Survey
+pub fn spawn_survey<S>(survey: S, tx: mpsc::UnboundedSender<LoadEvent>) -> Survey
 where
     S: Future<Output = Option<Reading>> + Send + 'static,
 {
     Survey(tokio::spawn(async move {
         if let Some(reading) = survey.await {
-            let _ = tx.send(LoadEvent::Surveyed { taken, reading });
+            let _ = tx.send(LoadEvent::Surveyed(reading));
         }
     }))
 }
@@ -423,7 +419,7 @@ impl Survey {
     }
 }
 
-/// Where the cursor lands after a load or a refresh swaps the ticket list.
+/// Where the cursor lands after a load swaps the ticket list.
 ///
 /// Identity wins over position: if the previously selected row still exists
 /// anywhere in the new order, the cursor follows it. Only if it vanished does
@@ -466,7 +462,7 @@ mod tests {
         // hang this test rather than slow it.
         let (tx, mut rx) = mpsc::unbounded_channel();
         tokio::time::timeout(Duration::from_secs(5), async {
-            let survey = spawn_survey(never(), tx.clone(), 0);
+            let survey = spawn_survey(never(), tx.clone());
             assert!(
                 rx.try_recv().is_err(),
                 "nothing may be on the channel before the reading lands"
@@ -484,14 +480,11 @@ mod tests {
             Some(crate::reclaim::Reclaimable::for_test(&["ws-a"], 0)),
             crate::liveness::Liveness::default(),
         );
-        spawn_survey(std::future::ready(Some(found.clone())), tx.clone(), 7)
+        spawn_survey(std::future::ready(Some(found.clone())), tx.clone())
             .settle()
             .await;
         match rx.try_recv() {
-            Ok(LoadEvent::Surveyed { taken, reading }) => {
-                assert_eq!(reading, found);
-                assert_eq!(taken, 7, "the event says which reading answered");
-            }
+            Ok(LoadEvent::Surveyed(reading)) => assert_eq!(reading, found),
             other => panic!("the reading must arrive as its own event, got {other:?}"),
         }
     }
@@ -501,7 +494,7 @@ mod tests {
         // No `dl`, a failed listing, a tracker that would not answer, or simply
         // nothing to reclaim: one silence, no event, and above all no error.
         let (tx, mut rx) = mpsc::unbounded_channel();
-        spawn_survey(std::future::ready(None), tx.clone(), 0)
+        spawn_survey(std::future::ready(None), tx.clone())
             .settle()
             .await;
         assert!(
@@ -530,7 +523,6 @@ mod tests {
                 None
             },
             tx,
-            0,
         );
         survey.stop().await;
         assert_eq!(
@@ -689,9 +681,10 @@ mod tests {
 
     #[test]
     fn one_map_reporting_twice_does_not_complete_another_maps_load() {
-        // The loads are concurrent, and `ctrl-r` can make a map report again
-        // while a slow one is still out. Counting arrivals would call that
-        // done; naming who is still pending cannot.
+        // The loads are concurrent, and a map whose load was aborted mid-flight
+        // can already have queued its answer. Counting arrivals would call two
+        // reports from one map a finished load of two; naming who is still
+        // pending cannot be fooled that way, whoever reports twice and why.
         let mut startup = cold();
         startup.searched(&found(&[("fast/one", 1), ("slow/two", 2)]));
         startup.record_arrival(&MapId::new("fast/one", 1));
@@ -742,30 +735,6 @@ mod tests {
         assert_eq!(startup.hint(), "· searching for maps…");
         startup.searched(&found(&[("a/one", 1), ("b/two", 2)]));
         assert!(startup.is_loaded());
-    }
-
-    #[test]
-    fn ctrl_r_puts_the_load_back_on_the_count_line() {
-        // A refresh refetches every map, so nothing has arrived until it does.
-        // Without this the hint stays empty and `ctrl-r` is a silent pause.
-        let mut startup = cold();
-        let maps = found(&[("a/one", 1), ("b/two", 2)]);
-        startup.searched(&maps);
-        startup.record_arrival(&MapId::new("a/one", 1));
-        startup.record_arrival(&MapId::new("b/two", 2));
-        assert!(startup.is_loaded());
-
-        startup.reloading();
-        assert!(!startup.is_loaded());
-        assert_eq!(startup.hint(), "· loading maps 0/2");
-        startup.record_arrival(&MapId::new("a/one", 1));
-        assert_eq!(startup.hint(), "· loading maps 1/2");
-        startup.record_arrival(&MapId::new("b/two", 2));
-        assert!(
-            startup.is_loaded(),
-            "the search already answered; it stays answered"
-        );
-        assert_eq!(startup.hint(), "");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -507,9 +507,9 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
 /// there is somewhere to go back to.
 fn key_hints(app: &App) -> &'static str {
     if app.current_repo().is_some() {
-        "  enter launch · ←→ open · ← back · tab structure · ctrl-r refresh · esc quit"
+        "  enter launch · ←→ open · ← back · tab structure · esc quit"
     } else {
-        "  enter open · ↑↓ move · type to filter · ctrl-r refresh · esc quit"
+        "  enter open · ↑↓ move · type to filter · esc quit"
     }
 }
 
@@ -542,14 +542,20 @@ pub fn heading(app: &App) -> String {
     // Naming the map is the whole value when there is one: "GitHub is
     // unreachable" and "that project has nothing open" are different problems
     // with different fixes, and a bare count reads the same either way.
+    //
+    // This named the refresh chord as the retry until that key was retired.
+    // Naming a key that no longer exists is worse than saying nothing, and
+    // saying nothing leaves the reader on a screen with a failure and no move
+    // to make — so it names the move that is left. Restarting really is the
+    // retry now: each map is fetched once per run, and a warm start is ~0.6 s.
     if app.clusters.is_empty() && app.startup.is_loaded() {
         match app.failed.len() {
             0 => {}
             1 => {
                 let id = app.failed.iter().next().expect("len checked");
-                return format!("{}#{} — fetch failed, ctrl-r retries", id.repo, id.number);
+                return format!("{}#{} — fetch failed, run wf again", id.repo, id.number);
             }
-            n => return format!("{n} maps failed to fetch — ctrl-r retries"),
+            n => return format!("{n} maps failed to fetch — run wf again"),
         }
     }
     match projects.len() {
@@ -1908,8 +1914,11 @@ mod tests {
         assert!(screen.contains("> █"));
         assert!(screen.contains("enter launch"));
         assert!(screen.contains("tab structure"));
-        assert!(screen.contains("ctrl-r refresh"));
         assert!(screen.contains("esc quit"));
+        // The hint bar names only keys that do something. The refresh chord
+        // used to sit between `tab structure` and `esc quit`; it is unbound
+        // now, and a hint outliving its binding is a screen telling a lie.
+        assert!(!screen.contains("refresh"), "{screen}");
         assert!(screen.contains("wf · blooop/wayfinder"));
     }
 
@@ -2318,7 +2327,7 @@ mod tests {
         let screen = render(&app);
         assert!(!screen.contains("no projects"), "{screen}");
         assert!(
-            screen.contains("blooop/wayfinder#35 — fetch failed, ctrl-r retries"),
+            screen.contains("blooop/wayfinder#35 — fetch failed, run wf again"),
             "{screen}"
         );
 

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -178,52 +178,6 @@ async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
 }
 
 #[tokio::test]
-async fn restarting_the_loaders_refetches_and_cannot_be_beaten_by_the_load_it_replaced() {
-    // `ctrl-r`'s path. It goes through `Loaders` rather than fetching alongside
-    // them for one reason: a refetch started at t₁ and a load started at t₀ < t₁
-    // both write the same map's cluster, and the *older* one can land second.
-    // Nothing polls any more, so that stale map would be the last word. Every
-    // result reaching the UI through one channel in send order is what makes
-    // the newest write win, and that is what this pins.
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let live = common::a_live_map().await;
-    let seed: MapSet = [live.clone()].into_iter().collect();
-
-    let mut loaders = Loaders::new();
-    loaders.reconcile(&seed, &tx);
-    match next(&mut rx).await {
-        LoadEvent::Fetched {
-            outcome: MapFetch::Loaded(_),
-            ..
-        } => {}
-        other => panic!("the initial load must land first, got {other:?}"),
-    }
-
-    // The refresh: same map, and it must fetch again rather than skip a map it
-    // has already loaded — the `continue` in `reconcile` is exactly what
-    // `restart` exists to get past.
-    loaders.restart(&seed, &tx);
-    assert_eq!(loaders.targets(), seed);
-    match next(&mut rx).await {
-        LoadEvent::Fetched {
-            id,
-            outcome: MapFetch::Loaded(map),
-        } => {
-            assert_eq!(id, live);
-            assert!(!map.tickets.is_empty());
-        }
-        other => panic!("ctrl-r must refetch, got {other:?}"),
-    }
-
-    // And the channel is empty: exactly one result per load, so no third event
-    // is queued behind the refresh waiting to overwrite it.
-    assert!(
-        rx.try_recv().is_err(),
-        "a superseded load must not still be queued to clobber the refresh"
-    );
-}
-
-#[tokio::test]
 async fn shutdown_leaves_nothing_in_flight() {
     // The launch path awaits this immediately before `exec`. An in-flight `gh`
     // that outlives the exec is inherited by the agent as a zombie holding its


### PR DESCRIPTION
Stacked on #142 — this targets `feat/liveness-and-unsaved-contract`, not `main`.

Retires `ctrl-r` and everything that existed only to serve it.

`ctrl-r` was still fully wired: the key handler, both hint bars, the README key
table, and the failure notices reading *"fetch failed, ctrl-r retries"*. The
chord retirement in #117 unbound `ctrl-f` and `ctrl-g` and explicitly kept this
one, so it survived.

**What went with it.** The `Outcome::Refresh` arm, `Loaders::restart` and
`Startup::reloading` (both left with no callers), and the reading-generation
machinery — `LoadEvent::Surveyed { taken, reading }` collapses to
`Surveyed(Reading)`, and `Picker::reading`, `fold`'s `reading` parameter, the
stale-answer guard and `restart_reading` all go. That tag existed to drop an
answer to a withdrawn question, and with one reading per run there is no second
question to withdraw.

**The honest cost, stated in the README rather than papered over.** `▣`/`⧖` and
the reclaim hint are now taken once at startup and never retaken: they describe
the moment `wf` started, not the present, and a container this session's own
launch picker starts will not appear. They stay useful because a session is
seconds long and containers move in minutes — not because they are live.

The failure notices had to stop naming a key that no longer exists; they now say
`run wf again`, which is true, since each map is fetched once per run.

`grep -rn "ctrl-r"` returns nothing, comments included.

All five CI commands pass with `RUSTFLAGS=-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Retire the in-session refresh mechanism so all map and liveness data is fetched once per run, simplifying the event loop and background loading model.

New Features:
- Define refresh as restarting wf, with maps fetched once per run and failures retried only by rerunning the binary.

Enhancements:
- Remove the refresh Outcome arm and associated loader restart and reading generation machinery, leaving a single-pass drain/draw/end loop.
- Clarify startup and loading behavior so map discovery and reconciliation are the sole drivers of loads, eliminating secondary write paths.
- Bump the wf package version to 0.17.0 to reflect the updated behavior.

Build:
- Update recipe metadata to match the new 0.17.0 version.

Documentation:
- Update README, main help text, and UI hints to stop advertising ctrl-r, to describe one-load-per-run behavior, and to state the tradeoffs of non-live liveness markers and refresh via rerun.

Tests:
- Adjust picker, refresh, and startup tests to match the three-arm Outcome model, single reading per session, absence of ctrl-r, and updated retry/argv expectations; remove tests specific to loader restart and withdrawn-reading handling.