### PR TITLE
Say in Installing what the recipe actually declares

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,13 +11,21 @@ below):
 pixi global install -c https://prefix.dev/blooop -c conda-forge wf
 ```
 
-The package declares no run dependencies. `wf` finds what it needs on PATH and
-says so plainly when something is missing, rather than dragging second copies
-into its own environment. It wants an authenticated `gh` and the agent CLI, and
-nothing else — there is no multiplexer to install. Add
-[`dl`](https://github.com/blooop/devlaunch) if you want the agent to run inside
-your repos' devcontainers ([Isolation](#isolation-claude-runs-in-the-repos-devcontainer));
-without it every launch runs on the host, which is what `wf` has always done.
+The package declares **one** run dependency:
+[`devlaunch`](https://github.com/blooop/devlaunch) `>=0.0.24`, so
+`pixi global install wf` is enough to get the agent running inside your repos'
+devcontainers ([Isolation](#isolation-claude-runs-in-the-repos-devcontainer)).
+That is the one thing `wf` will not leave to PATH, because isolation is not an
+error path: with no `dl` a launch silently runs on the host instead, so the
+container half of the binary would be invisibly absent rather than loudly
+missing. It costs python and devpod in the environment — roughly 370 MB once per
+machine, and ~85 MB for a second environment that wants it, since pixi hardlinks
+the rest from its package cache.
+
+Everything else `wf` finds on PATH and says so plainly when it is missing,
+rather than dragging second copies into its own environment. It wants an
+authenticated `gh` and the agent CLI, and nothing else — there is no multiplexer
+to install.
 
 Then link the skills it launches into both CLIs' skills directories:
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.17.0"
+  version: "0.17.1"
 
 package:
   name: wf

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -462,8 +462,10 @@ pub const DL_LISTING: &str = r#"[
 ///
 /// The top three rows are devlaunch **0.0.24 and newer**: an object with
 /// exactly one key. The next two are **0.0.23 and older**, whose field was a
-/// bare sentence or `null` — still on real machines, because `wf` pins no `dl`
-/// version. Then two rows no `dl` has ever emitted: a key from a *later* `dl`
+/// bare sentence or `null` — still on real machines, because the floor `wf`
+/// holds `dl` to governs what a *launch* may ask of it, while `wf reap` reads a
+/// listing from whichever `dl` is on PATH. Then two rows no `dl` has ever
+/// emitted: a key from a *later* `dl`
 /// than this binary, and the documented key carrying an undocumented payload.
 /// One of those carries a documented key **beside** an undocumented sibling,
 /// which is the shape a later `dl` produces by adding one field: it must go on


### PR DESCRIPTION
Doc-only, found while merging #142.

0.15.0 added `devlaunch >=0.0.24` to the recipe's run requirements. The
**Installing** section still said *"The package declares no run dependencies"*
and told you to add `dl` yourself if you wanted containers. #142 corrected the
Isolation section, which left the README asserting both halves of a
contradiction — and the wrong half is the one people read first, on their way to
running the install command.

The ~370 MB is also the part someone would want to know *before* running it
rather than after, so it is named here and not only in Isolation.

`0.17.1` — documentation only, carried through the release path the way 0.15.1
was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify installation documentation to reflect the devlaunch runtime dependency and release a documentation-only version bump.

Enhancements:
- Bump crate and recipe versions from 0.17.0 to 0.17.1 to publish the documentation-only update.

Documentation:
- Update the Installing section to state that devlaunch >=0.0.24 is a declared run dependency, explain its role in container isolation, and note its approximate disk footprint.