### PR TITLE
Close out #132: the deleting arm, and the pinning that could not see it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,8 +1010,12 @@ decides. Needs `dl` **0.0.21 or newer** for the JSON listing.
 Kept, always: workspaces `dl` did not create (they are not `wf`'s, whatever
 their branch looks like), branches that are not `wayfinder/<repo>-<n>` for that
 repo, tickets with an open or draft PR (in review is where review fixes happen),
-tickets someone has claimed, and anything **running** — a ticket closing is no
-evidence that the session in the container ended.
+tickets someone has claimed that no PR has come of, and anything **running** — a
+ticket closing is no evidence that the session in the container ended.
+
+The claim is the *last* thing read, not the first: it settles a ticket nothing
+has come of yet, and it does not outrank the PRs. A claimed ticket whose PR
+merged is finished work, and reap collects it like any other.
 
 **A `dl` that says nothing is not a `dl` saying nothing is at risk.** From
 devlaunch **0.0.24** the listing answers `unsaved` for every clone `dl` made,

--- a/README.md
+++ b/README.md
@@ -994,10 +994,12 @@ evidence too weak to act on:
   unassigned ticket is unclaimed by `wf`'s own convention, and that one bit is
   what keeps this from firing on every ticket someone is mid-way through.
 
-A stale claim therefore keeps a workspace: an agent that died leaves its ticket
-assigned, and reap does not overrule a person's stated intent. `wf` says only
-what it observed — it does not know whether anyone ever entered a container,
-and does not claim to.
+A stale claim therefore keeps a workspace *that nothing has come of*: an agent
+that died before opening a PR leaves its ticket assigned, and reap does not
+overrule a person's stated intent on no other evidence. It is the tie-breaker
+for the second case above and nothing more — a claim beside a merged PR, or on a
+closed ticket, is not read at all. `wf` says only what it observed — it does not
+know whether anyone ever entered a container, and does not claim to.
 
 This is the same division of labour the launch draws: **`dl` owns the
 containers, `wf` owns the tickets.** `dl` deliberately does not decide what is

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -214,8 +214,8 @@ pub(crate) fn parse_pr(pr: &PrNode) -> Option<PrLink> {
 }
 
 /// What the tracker's `state` string says about whether a ticket is finished
-/// with — the issue-side mirror of [`parse_pr`], and the reason an unrecognised
-/// state cannot reach a deleting arm.
+/// with — the issue-side mirror of `parse_pr` below, and the reason an
+/// unrecognised state cannot reach a deleting arm.
 ///
 /// A two-value type rather than the `bool` this used to be. The bool was read
 /// as "is it open", which made **not open** the finished condition, so every

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -213,8 +213,55 @@ pub(crate) fn parse_pr(pr: &PrNode) -> Option<PrLink> {
     })
 }
 
+/// What the tracker's `state` string says about whether a ticket is finished
+/// with — the issue-side mirror of [`parse_pr`], and the reason an unrecognised
+/// state cannot reach a deleting arm.
+///
+/// A two-value type rather than the `bool` this used to be. The bool was read
+/// as "is it open", which made **not open** the finished condition, so every
+/// state GitHub adds after this binary shipped would have arrived as a reason
+/// to call a ticket done — and on [`reap`](crate::reap)'s side, a reason to
+/// delete a workspace. Two named values force each reading to say which it is,
+/// and make the inversion that caused it a compile error rather than a `!`.
+///
+/// Here in `fetch` and not in `reap`, because the whole point is that there is
+/// **one** reading of this wire field. `reap` deriving "finished" from the same
+/// fields the badge is drawn from is a stated invariant of that module; a
+/// second copy of this rule living next to the reaper is how the screen and the
+/// reaper come to disagree about the same ticket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TicketState {
+    /// The tracker said `CLOSED`, in those letters. The only reading that may
+    /// reach `NodeFact::Closed`, which is a deleting arm.
+    Closed,
+    /// Open — or a state this binary does not recognise, which is held to the
+    /// same standard the PR reading is: the arm that stays true whatever the
+    /// new value turns out to mean is the one that keeps the workspace and
+    /// leaves the ticket on the screen. An unknown state therefore costs a
+    /// ticket that stays, never one that silently goes.
+    Live,
+}
+
+impl TicketState {
+    /// Read the tracker's `state`. Positive about *closed*, and not the
+    /// negation of "open": the two differ exactly on the values neither list
+    /// names, and that difference is whether a workspace survives them.
+    pub fn read(state: &str) -> TicketState {
+        if state == "CLOSED" {
+            TicketState::Closed
+        } else {
+            TicketState::Live
+        }
+    }
+}
+
+/// Whether a ticket is still live, for the readers that want it as a `bool`.
+///
+/// Delegates rather than restating, so the screen and the reaper cannot drift:
+/// [`model::classify`](crate::model::classify) turns `false` into
+/// `Status::Done`, which is the display-side twin of reap's deleting arm.
 pub(crate) fn is_open(state: &str) -> bool {
-    state == "OPEN"
+    TicketState::read(state) == TicketState::Live
 }
 
 /// Fetch one map live: the map issue named by `id`, its sub-issues, and their
@@ -459,6 +506,77 @@ mod tests {
              "blockedBy": {"nodes": [{"number": 18, "state": "CLOSED"}, {"number": 3, "state": "OPEN"}]}}
         ]}
     }}}}"#;
+
+    /// One map whose sub-issue and whose blocker both carry a `state` this
+    /// binary was never taught. `TRANSFERRED` is GitHub's own third issue
+    /// state; the point is that it stands for whatever the fourth turns out
+    /// to be.
+    const UNREADABLE_STATE_RESPONSE: &str = r#"{"data": {"repository": {"issue": {
+        "title": "Map: wf",
+        "state": "OPEN",
+        "labels": {"nodes": [{"name": "wayfinder:map"}]},
+        "subIssues": {"nodes": [
+            {"number": 19, "title": "Build 6", "state": "TRANSFERRED",
+             "labels": {"nodes": [{"name": "wayfinder:task"}]},
+             "assignees": {"nodes": []},
+             "blockedBy": {"nodes": []}},
+            {"number": 21, "title": "Blocked on it", "state": "OPEN",
+             "labels": {"nodes": [{"name": "wayfinder:task"}]},
+             "assignees": {"nodes": []},
+             "blockedBy": {"nodes": [{"number": 19, "state": "TRANSFERRED"}]}}
+        ]}
+    }}}}"#;
+
+    #[test]
+    fn only_the_word_closed_reads_as_closed() {
+        // The one place the tracker's `state` is turned into a fact, for the
+        // screen and for the reaper alike. `Closed` routes to `Status::Done`
+        // here and to `NodeFact::Closed` — a deletion — there, so what may
+        // produce it is a closed list of one string rather than "anything that
+        // is not the word OPEN". The states below are the shapes an answer can
+        // actually take that this binary was never taught: GitHub's own third
+        // issue state, a plausible future one, the empty string a defaulted
+        // field would leave, and a lowercasing of the real value.
+        assert_eq!(TicketState::read("CLOSED"), TicketState::Closed);
+        for unknown in ["OPEN", "TRANSFERRED", "DUPLICATE", "", "closed", "Closed"] {
+            assert_eq!(
+                TicketState::read(unknown),
+                TicketState::Live,
+                "state {unknown:?} must not read as closed"
+            );
+            assert!(
+                is_open(unknown),
+                "state {unknown:?} must still read as live"
+            );
+        }
+        assert!(!is_open("CLOSED"));
+    }
+
+    #[test]
+    fn a_state_this_binary_cannot_read_neither_finishes_a_ticket_nor_unblocks_one() {
+        // The screen's half of the same rule, and the reason the reading lives
+        // in this module rather than beside the reaper. Both directions are
+        // silent failures: a ticket wrongly shown Done drops out of the
+        // frontier and is never offered, and a blocker wrongly read as settled
+        // offers work that cannot actually be started. Neither prints an
+        // error, and until this test nothing looked at either.
+        let map = parse_map(UNREADABLE_STATE_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+
+        let unreadable = map.tickets.iter().find(|t| t.number == 19).expect("#19");
+        assert_ne!(
+            unreadable.status,
+            Status::Done,
+            "a state this binary cannot read is not evidence the ticket is finished"
+        );
+        assert_eq!(unreadable.status, Status::Frontier);
+
+        let blocked = map.tickets.iter().find(|t| t.number == 21).expect("#21");
+        assert_eq!(
+            blocked.status,
+            Status::Blocked { needs: vec![19] },
+            "an unreadable blocker still blocks"
+        );
+    }
 
     fn wf_map_id() -> MapId {
         MapId::new("blooop/wayfinder", 1)

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -39,7 +39,12 @@ use crate::model::{
 /// believed on its own (#28).
 pub const MAP_LABEL: &str = "wayfinder:map";
 
-const MAP_QUERY: &str = "\
+/// The map read, in one round trip.
+///
+/// `pub(crate)` for one reason: [`reap`](crate::reap) selects a subset of these
+/// same fields into its own batched query, and the two are held to each other
+/// by a test rather than by a comment. Nothing outside that test may read it.
+pub(crate) const MAP_QUERY: &str = "\
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     issue(number: $number) {

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -184,6 +184,20 @@ impl Recording {
                 );
             }
         }
+        self.touched_no_files();
+    }
+
+    /// Fail if the run changed anything under the child's scratch `HOME`.
+    ///
+    /// The in-process half of [`Recording::destroyed_nothing`], on its own —
+    /// for the one path that is *supposed* to destroy a workspace. `wf reap`
+    /// deletes by handing an id to `dl`, so an `<rm>` in its argv is the
+    /// feature rather than the defect, and the whole-recording assertion
+    /// cannot be used there. What must still hold is the separation `dl`'s own
+    /// guard depends on: `wf` names a workspace and `dl` decides what happens
+    /// to its clone. A reap that reached for the directory itself would run the
+    /// same commands and be caught only here.
+    pub fn touched_no_files(&self) {
         assert!(
             self.disturbed.is_empty(),
             "this path must leave the machine as it found it, and it changed: {:?}",

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -42,6 +42,9 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tokio::process::Command;
 
+/// Re-exported because `node_fact` takes one: the reading itself belongs to
+/// [`fetch`](crate::fetch), where the screen reads it too.
+pub use crate::fetch::TicketState;
 use crate::fetch::{parse_pr, Assignee, GraphQlResponse, Nodes, PrNode};
 use crate::launch::devlaunch_answers_unsaved;
 use crate::model::PrStatus;
@@ -433,9 +436,22 @@ impl PrOutcome {
 ///
 /// Derived at every read from the batch the tracker just answered — never
 /// stored, so it cannot go stale, be orphaned, or outlive the workspace it
-/// describes. `Unstarted` in particular is a *positive observation* (open, no
-/// PRs, nobody assigned) and is never reachable from a lookup that failed: a
-/// node the batch did not answer for is an error, not an `Unstarted` node.
+/// describes. `Unstarted` in particular is never reachable from a lookup that
+/// *failed*: a node the batch did not answer for is an error, not an
+/// `Unstarted` node.
+///
+/// It is a reading of an answer that arrived, then — not quite the "positive
+/// observation" this said before [`TicketState`] existed. A ticket whose state
+/// this binary cannot read, with no PRs and nobody assigned, lands here too,
+/// because `Live` is where an unrecognised state deliberately goes and this is
+/// where a live ticket with no other evidence ends up. That is the intended
+/// resolution and not a gap — every alternative is worse. An arm of its own
+/// would owe an answer at every match site for a case that has never occurred;
+/// the deleting arm is the hazard #132 exists to close; and `Warn` is where a
+/// node this binary is *unsure* about belongs. The cost is that the row says
+/// "unclaimed and no PR" about a ticket that might be closed, which overstates
+/// what was observed by one word — and it is a row that advises rather than
+/// acts, which is the arm that can afford to be wrong.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeFact {
     /// The ticket is closed.
@@ -453,42 +469,6 @@ pub enum NodeFact {
     Claimed,
     /// Open, no PRs, unclaimed: nothing has come of this node.
     Unstarted,
-}
-
-/// What the tracker's `state` string says about whether a ticket is finished
-/// with — the issue-side mirror of [`PrOutcome::project`], and the reason an
-/// unrecognised state cannot reach a deleting arm.
-///
-/// A two-value type rather than the `bool` this used to be. The bool was read
-/// as "is it open", which made **not open** the deleting condition, so every
-/// state GitHub adds after this binary shipped would have arrived as a reason
-/// to delete a workspace. Two named values force each reading to say which it
-/// is, and make the inversion that caused it a compile error rather than a
-/// `!`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TicketState {
-    /// The tracker said `CLOSED`, in those letters. The only reading that may
-    /// reach [`NodeFact::Closed`], which is a deleting arm.
-    Closed,
-    /// Open — or a state this binary does not recognise, which is held to the
-    /// same standard the PR reading is: the arm that stays true whatever the
-    /// new value turns out to mean is the one that keeps the workspace. The
-    /// node still goes on to be read by its PRs and its claim, so an unknown
-    /// state costs a workspace that stays and never one that goes.
-    Live,
-}
-
-impl TicketState {
-    /// Read the tracker's `state`. Positive, not the negation of "open": the
-    /// two differ exactly on the values neither list names, and that
-    /// difference is whether a workspace survives them.
-    pub fn read(state: &str) -> TicketState {
-        if state == "CLOSED" {
-            TicketState::Closed
-        } else {
-            TicketState::Live
-        }
-    }
 }
 
 /// Read one node the way reap decides by it — the stage lattice's table,
@@ -1216,44 +1196,44 @@ mod tests {
     }
 
     #[test]
-    fn only_the_word_closed_reads_as_closed() {
-        // #132's first item, at the reading. `Closed` is the one `NodeFact`
-        // that means "delete this" on no other evidence, so what may produce it
-        // is a closed list of one string rather than "everything that is not
-        // the word OPEN". The states below are the shapes a tracker answer can
-        // actually take that this binary was never taught: GitHub's own third
-        // issue state today, a plausible future one, the empty string a
-        // defaulted field would leave, and a lowercasing of the real value.
-        assert_eq!(TicketState::read("CLOSED"), TicketState::Closed);
-        for unknown in ["OPEN", "TRANSFERRED", "DUPLICATE", "", "closed", "Closed"] {
-            assert_eq!(
-                TicketState::read(unknown),
-                TicketState::Live,
-                "state {unknown:?} must not read as closed"
-            );
-        }
-    }
-
-    #[test]
     fn a_state_this_binary_cannot_read_is_decided_by_the_prs_and_the_claim() {
-        // Not merely "not Closed": an unknown state has to fall all the way
-        // through to the same reading an open ticket gets, or it would need an
-        // arm of its own and every match site would owe it an answer. So the
-        // claim is equality with the open reading, over the whole table.
-        for prs in [
-            vec![],
-            vec![PrOutcome::project(40, Some(&open_pr()))],
-            vec![PrOutcome::project(33, Some(&PrStatus::Merged))],
-            vec![PrOutcome::project(43, Some(&PrStatus::Closed))],
+        // The reading itself belongs to `fetch`, where `only_the_word_closed_
+        // reads_as_closed` pins it for the screen and the reaper together. What
+        // is reap's own is what an unrecognised state then *derives to*, and
+        // that is stated as literal facts rather than as equality with the
+        // `TicketState::Live` call — the two are the same call, so an assertion
+        // written that way holds under every possible mutation of `node_fact`
+        // and pins nothing at all.
+        //
+        // Every arm the derivation has, none of them `Closed`: an unknown state
+        // must fall all the way through to the reading an open ticket gets, or
+        // it would need an arm of its own and every match site would owe it an
+        // answer.
+        let unknown = TicketState::read("TRANSFERRED");
+        for (prs, claimed, unclaimed) in [
+            (vec![], NodeFact::Claimed, NodeFact::Unstarted),
+            (
+                vec![PrOutcome::project(40, Some(&open_pr()))],
+                NodeFact::InFlight { pr: 40 },
+                NodeFact::InFlight { pr: 40 },
+            ),
+            (
+                vec![PrOutcome::project(33, Some(&PrStatus::Merged))],
+                NodeFact::DoneByMerge { pr: 33 },
+                NodeFact::DoneByMerge { pr: 33 },
+            ),
+            (
+                vec![PrOutcome::project(43, Some(&PrStatus::Closed))],
+                NodeFact::Superseded { pr: 43 },
+                NodeFact::Superseded { pr: 43 },
+            ),
         ] {
-            for assigned in [true, false] {
-                assert_eq!(
-                    node_fact(TicketState::read("TRANSFERRED"), assigned, &prs),
-                    node_fact(TicketState::Live, assigned, &prs),
-                    "an unknown state reads as the open ticket it might be, \
-                     assigned={assigned}, {prs:?}"
-                );
-            }
+            assert_eq!(node_fact(unknown, true, &prs), claimed, "assigned, {prs:?}");
+            assert_eq!(
+                node_fact(unknown, false, &prs),
+                unclaimed,
+                "unassigned, {prs:?}"
+            );
         }
     }
 
@@ -2144,7 +2124,7 @@ mod tests {
         let numbers = [80, 83, 84, 85, 86];
         let known = parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &numbers)
             .expect("the batch parses");
-        let workspaces: Vec<Workspace> = numbers
+        let mut workspaces: Vec<Workspace> = numbers
             .iter()
             .map(|n| {
                 workspace(
@@ -2155,9 +2135,19 @@ mod tests {
             })
             .collect();
 
-        // `-f` too, because the question is what may be destroyed at all: the
-        // flag waives the unsaved-work guard, so a hazard that only the guard
-        // was hiding would still be a hazard for every clean clone.
+        // `-f` too, because the question is what may be destroyed at all: a
+        // hazard that only the unsaved-work guard was hiding is still a hazard
+        // the moment someone types the flag that waives it.
+        //
+        // That means one of these has to *hold* unsaved work, or the flag is
+        // read on no workspace and the second pass is the first one again:
+        // `plan` consults `insist` only inside `match (&workspace.unsaved, …)`,
+        // so with every clone clean both iterations compute the same list and
+        // the loop is decoration. #85 carries it — the unreadable state, so the
+        // waiver is being applied to precisely the node this test is about.
+        let dirty = "1 uncommitted change(s) (pixi.lock)";
+        workspaces[3].unsaved = Some(Unsaved::WouldLose(dirty.to_string()));
+
         for insist in [false, true] {
             let verdicts = plan(&workspaces, &known, insist);
             let reaped: Vec<&str> = doomed(&verdicts).into_iter().map(Verdict::id).collect();
@@ -2168,6 +2158,21 @@ mod tests {
                  and nothing else does"
             );
         }
+
+        // And the flag really did reach the node, rather than the loop above
+        // passing because nothing consulted it: under `-f` the dirty clone's
+        // row names what a by-hand reap would discard, and under neither flag
+        // it is the refusal instead. Either way #85 is not in the doomed set.
+        let forced = plan(&workspaces, &known, true);
+        let row = forced
+            .iter()
+            .find(|v| v.id() == "wf-85")
+            .expect("the unreadable node is planned");
+        assert!(
+            row.reason().contains(dirty),
+            "-f did not reach the unsaved arm: {}",
+            row.reason()
+        );
     }
 
     #[test]
@@ -2237,7 +2242,16 @@ mod tests {
                     seen_one = true;
                 }
                 '}' => {
-                    depth -= 1;
+                    // `checked_sub` rather than `-=`: on a `}` before any `{`
+                    // — what a `closedByPullRequestsReferences` reduced to a
+                    // leaf leaves behind, inside its enclosing block — a
+                    // `usize` decrement panics with "attempt to subtract with
+                    // overflow", and whoever caused that drift would get an
+                    // arithmetic panic in a test helper instead of the message
+                    // this helper exists to give them.
+                    depth = depth
+                        .checked_sub(1)
+                        .unwrap_or_else(|| panic!("unbalanced braces in {query}"));
                     if depth == 0 {
                         return Some(flattened(&query[from..=from + offset]));
                     }
@@ -2344,6 +2358,55 @@ mod tests {
     }
 
     #[test]
+    fn the_linked_pr_selection_asks_for_every_field_the_badge_reads() {
+        // The hole the two tests above leave between them. `both_queries_ask…`
+        // catches a field dropped from *one* copy of the PR selection, and the
+        // prune test below catches a field the reap parse cannot survive losing
+        // — but the badge fields are neither. `PrOutcome::project` collapses
+        // Draft, Open and unreadable into `InFlight`, so `statusCheckRollup`
+        // and `reviewDecision` are invisible to any assertion made in
+        // `NodeFact`s, and dropping either one from *both* queries at once left
+        // all 388 tests green.
+        //
+        // What reads them is `fetch::parse_pr`, so that is what this asserts
+        // against: a PR whose badge depends on every nullable field, pruned to
+        // the selection, must still produce the same badge. Both fields are
+        // nullable *with meaning* — absent is a real answer, not a parse error
+        // — which is exactly why nothing else notices them going missing, and
+        // what goes wrong is quiet: the screen draws every open PR as having
+        // no checks configured, and the reviewer trusts a green CI that was
+        // never asked about.
+        const A_PR: &str = r#"{"number": 40, "state": "OPEN", "isDraft": false,
+            "reviewDecision": "CHANGES_REQUESTED",
+            "statusCheckRollup": {"state": "FAILURE"},
+            "repository": {"nameWithOwner": "blooop/wayfinder"}}"#;
+        let full: PrNode = serde_json::from_str(A_PR).expect("the fixture is a PR node");
+        let badge = parse_pr(&full).expect("the fixture is a PR the badge parse can read");
+        assert_eq!(
+            badge.status,
+            PrStatus::Open {
+                checks: Checks::Failing,
+                review: Review::ChangesRequested,
+            },
+            "the fixture has to depend on both nullable fields, or this proves nothing"
+        );
+
+        let asked = parse_selection(NODE_FACT_SELECTION);
+        let pr_fields = &asked.0["closedByPullRequestsReferences"].0["nodes"];
+        let mut answered: serde_json::Value =
+            serde_json::from_str(A_PR).expect("the fixture is json");
+        prune(&mut answered, pr_fields);
+        let selected: PrNode = serde_json::from_value(answered)
+            .expect("a PR carrying exactly the selected fields still parses");
+
+        assert_eq!(
+            parse_pr(&selected).map(|link| link.status),
+            Some(badge.status),
+            "the selection no longer asks for a field the badge is drawn from"
+        );
+    }
+
+    #[test]
     fn the_batch_parse_reads_no_field_the_batch_forgot_to_ask_for() {
         // The other half of #132's items 2 and 3: gutting `NODE_FACT_SELECTION`
         // stayed green, because every fixture in this file is written by hand
@@ -2364,14 +2427,26 @@ mod tests {
         // filter keeps the issue's `state` on the strength of the rollup's and
         // the one mutation that matters most goes unseen. Asserted rather than
         // commented, since it is the property the whole test rests on.
-        assert_eq!(
-            asked.0.keys().collect::<Vec<_>>(),
-            ["assignees", "closedByPullRequestsReferences", "state"]
-                .iter()
-                .collect::<Vec<_>>(),
-            "the selection parse did not read the fields of an issue"
-        );
+        for field in ["state", "assignees", "closedByPullRequestsReferences"] {
+            assert!(
+                asked.0.contains_key(field),
+                "the selection parse did not read the issue's {field}: {asked:?}"
+            );
+        }
         assert!(asked.0["assignees"].0.contains_key("nodes"));
+        // The property the filter rests on, and the one a *name*-keyed filter
+        // would fail: `state` is a field of the issue and also a field of
+        // `statusCheckRollup`, so the two must be at their own depths and the
+        // rollup's must not be visible at the issue's. Asserted rather than
+        // commented, since it is what makes dropping the issue's `state` — the
+        // field that decides deletion — a red test.
+        //
+        // Presence and not an exact key set: this is a check on the parser, and
+        // a legitimate new field in the selection (`title` for a better reason
+        // line, `updatedAt` for staleness) should not fail with a message that
+        // sends its author looking for a bug in `parse_selection`.
+        let rollup = &asked.0["closedByPullRequestsReferences"].0["nodes"].0["statusCheckRollup"];
+        assert!(rollup.0.contains_key("state"), "{asked:?}");
 
         let mut body: serde_json::Value =
             serde_json::from_str(BATCH_RESPONSE).expect("the fixture is json");
@@ -2466,11 +2541,24 @@ mod tests {
         println!("{}{said}", crate::probe::MARK);
     }
 
-    /// Every `dl` call of a recorded run that names a workspace to remove.
-    fn removals(run: &crate::probe::Recording) -> Vec<&str> {
+    /// Every call of a recorded run that could destroy a workspace.
+    ///
+    /// The same four tokens [`probe::Recording::destroyed_nothing`] forbids,
+    /// and for the same reason: what matters is not how the deletion was spelt
+    /// in Rust but that *something* on this path reached for a destructive
+    /// command. The reaping probe cannot use that assertion — one `<rm>` is
+    /// the feature it exists to watch — so it uses this and then says exactly
+    /// which calls it expected. Filtering on `<rm>` alone would have let a
+    /// `devpod delete <id>` or a `dl <id> remove` through unremarked, which is
+    /// precisely the substitution the recording exists to catch.
+    fn destructive(run: &crate::probe::Recording) -> Vec<&str> {
         run.argv
             .iter()
-            .filter(|call| call.contains("<rm>"))
+            .filter(|call| {
+                ["<rm>", "<--force>", "<remove>", "<delete>"]
+                    .iter()
+                    .any(|token| call.contains(token))
+            })
             .map(String::as_str)
             .collect()
     }
@@ -2499,19 +2587,17 @@ mod tests {
             "the run reached the end: {}",
             run.stdout
         );
+        // Everything this run did that could destroy anything, as one list. A
+        // single `dl <id> rm`, no `--force` beside it — `--force` is `dl`'s own
+        // waiver of its uncommitted-work guard, and a `wf` that passed it
+        // unasked would be overriding a guard belonging to the other program —
+        // and no second spelling of a deletion anywhere.
         assert_eq!(
-            removals(&run),
+            destructive(&run),
             ["dl <wf-129-closed> <rm>"],
             "the closed ticket's workspace goes, alone and by id: {:?}",
             run.argv
         );
-        // Without `-f`, and this is where that is observable rather than
-        // asserted about a `Verdict`: `--force` is `dl`'s own waiver of its
-        // uncommitted-work guard, and a `wf` that passed it unasked would be
-        // overriding a guard belonging to the other program.
-        for call in &run.argv {
-            assert!(!call.contains("<--force>"), "unasked-for force: {call}");
-        }
         run.touched_no_files();
     }
 
@@ -2539,9 +2625,30 @@ mod tests {
             &unreadable,
         );
         run.destroyed_nothing();
+
+        // Not `stdout.contains("nothing to reap")` on its own: `run`'s
+        // no-workspaces-at-all early return prints "no wayfinder workspaces on
+        // this machine — nothing to reap", which contains that phrase too, and
+        // `destroyed_nothing` is trivially satisfied by a run that saw nothing.
+        // So a `wf reap` gone blind to every workspace on the machine would
+        // read as a pass here, which is the opposite of what this test is for.
+        //
+        // The plan rows say which it was. The workspace the sibling test above
+        // removes has to appear, and appear as a row that keeps it.
+        let rows: Vec<&str> = run
+            .stdout
+            .lines()
+            .filter(|line| line.contains("wf-129-closed"))
+            .collect();
+        assert_eq!(
+            rows,
+            ["  warn  wf-129-closed  (wayfinder#129 unclaimed and no PR — an abandoned stage? reap by hand if so)"],
+            "the run saw the workspace and kept it, rather than never seeing it: {}",
+            run.stdout
+        );
         assert!(
             run.stdout.contains("nothing to reap"),
-            "the run said what it did instead of deleting: {}",
+            "and nothing was left to delete: {}",
             run.stdout
         );
     }

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -42,7 +42,7 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use tokio::process::Command;
 
-use crate::fetch::{is_open, parse_pr, Assignee, GraphQlResponse, Nodes, PrNode};
+use crate::fetch::{parse_pr, Assignee, GraphQlResponse, Nodes, PrNode};
 use crate::launch::devlaunch_answers_unsaved;
 use crate::model::PrStatus;
 
@@ -455,6 +455,42 @@ pub enum NodeFact {
     Unstarted,
 }
 
+/// What the tracker's `state` string says about whether a ticket is finished
+/// with — the issue-side mirror of [`PrOutcome::project`], and the reason an
+/// unrecognised state cannot reach a deleting arm.
+///
+/// A two-value type rather than the `bool` this used to be. The bool was read
+/// as "is it open", which made **not open** the deleting condition, so every
+/// state GitHub adds after this binary shipped would have arrived as a reason
+/// to delete a workspace. Two named values force each reading to say which it
+/// is, and make the inversion that caused it a compile error rather than a
+/// `!`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TicketState {
+    /// The tracker said `CLOSED`, in those letters. The only reading that may
+    /// reach [`NodeFact::Closed`], which is a deleting arm.
+    Closed,
+    /// Open — or a state this binary does not recognise, which is held to the
+    /// same standard the PR reading is: the arm that stays true whatever the
+    /// new value turns out to mean is the one that keeps the workspace. The
+    /// node still goes on to be read by its PRs and its claim, so an unknown
+    /// state costs a workspace that stays and never one that goes.
+    Live,
+}
+
+impl TicketState {
+    /// Read the tracker's `state`. Positive, not the negation of "open": the
+    /// two differ exactly on the values neither list names, and that
+    /// difference is whether a workspace survives them.
+    pub fn read(state: &str) -> TicketState {
+        if state == "CLOSED" {
+            TicketState::Closed
+        } else {
+            TicketState::Live
+        }
+    }
+}
+
 /// Read one node the way reap decides by it — the stage lattice's table,
 /// applied to the same fields the map query already returns.
 ///
@@ -462,8 +498,8 @@ pub enum NodeFact {
 /// merged sibling (a multi-PR ticket between merges is still being worked), a
 /// merge outranks the closed PRs beside it, and only a node with no PR
 /// evidence at all falls through to the claim.
-pub fn node_fact(is_open: bool, is_assigned: bool, prs: &[PrOutcome]) -> NodeFact {
-    if !is_open {
+pub fn node_fact(state: TicketState, is_assigned: bool, prs: &[PrOutcome]) -> NodeFact {
+    if state == TicketState::Closed {
         return NodeFact::Closed;
     }
     let earliest = |pick: fn(&PrOutcome) -> Option<u64>| prs.iter().filter_map(pick).min();
@@ -868,7 +904,7 @@ fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap
                 number,
             },
             node_fact(
-                is_open(&issue.state),
+                TicketState::read(&issue.state),
                 !issue.assignees.nodes.is_empty(),
                 &prs,
             ),
@@ -1141,23 +1177,81 @@ mod tests {
                 NodeFact::InFlight { pr: 44 },
                 NodeFact::InFlight { pr: 44 },
             ),
+            (
+                // The rollup the table used to have no row for, and the one the
+                // precedence rule is entirely about: a merge and a rejection on
+                // the same node. Every other row has one kind of PR in it, so
+                // every other row reads the same whichever of the two arms is
+                // tried first. #132's second mutation — swapping them — lived
+                // in that gap, and it is a live difference rather than a
+                // cosmetic one: `DoneByMerge` reaps and `Superseded` only warns.
+                "a merged PR beside a closed-unmerged one",
+                vec![
+                    PrOutcome::project(33, Some(&PrStatus::Merged)),
+                    PrOutcome::project(43, Some(&PrStatus::Closed)),
+                ],
+                NodeFact::DoneByMerge { pr: 33 },
+                NodeFact::DoneByMerge { pr: 33 },
+            ),
         ];
         for (name, prs, claimed, unclaimed) in cases {
             assert_eq!(
-                node_fact(true, true, &prs),
+                node_fact(TicketState::Live, true, &prs),
                 claimed,
                 "open, assigned, {name}"
             );
             assert_eq!(
-                node_fact(true, false, &prs),
+                node_fact(TicketState::Live, false, &prs),
                 unclaimed,
                 "open, unassigned, {name}"
             );
             for assigned in [true, false] {
                 assert_eq!(
-                    node_fact(false, assigned, &prs),
+                    node_fact(TicketState::Closed, assigned, &prs),
                     NodeFact::Closed,
                     "closed, assigned={assigned}, {name}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn only_the_word_closed_reads_as_closed() {
+        // #132's first item, at the reading. `Closed` is the one `NodeFact`
+        // that means "delete this" on no other evidence, so what may produce it
+        // is a closed list of one string rather than "everything that is not
+        // the word OPEN". The states below are the shapes a tracker answer can
+        // actually take that this binary was never taught: GitHub's own third
+        // issue state today, a plausible future one, the empty string a
+        // defaulted field would leave, and a lowercasing of the real value.
+        assert_eq!(TicketState::read("CLOSED"), TicketState::Closed);
+        for unknown in ["OPEN", "TRANSFERRED", "DUPLICATE", "", "closed", "Closed"] {
+            assert_eq!(
+                TicketState::read(unknown),
+                TicketState::Live,
+                "state {unknown:?} must not read as closed"
+            );
+        }
+    }
+
+    #[test]
+    fn a_state_this_binary_cannot_read_is_decided_by_the_prs_and_the_claim() {
+        // Not merely "not Closed": an unknown state has to fall all the way
+        // through to the same reading an open ticket gets, or it would need an
+        // arm of its own and every match site would owe it an answer. So the
+        // claim is equality with the open reading, over the whole table.
+        for prs in [
+            vec![],
+            vec![PrOutcome::project(40, Some(&open_pr()))],
+            vec![PrOutcome::project(33, Some(&PrStatus::Merged))],
+            vec![PrOutcome::project(43, Some(&PrStatus::Closed))],
+        ] {
+            for assigned in [true, false] {
+                assert_eq!(
+                    node_fact(TicketState::read("TRANSFERRED"), assigned, &prs),
+                    node_fact(TicketState::Live, assigned, &prs),
+                    "an unknown state reads as the open ticket it might be, \
+                     assigned={assigned}, {prs:?}"
                 );
             }
         }
@@ -1174,7 +1268,7 @@ mod tests {
             PrOutcome::project(37, Some(&PrStatus::Draft)),
         ];
         assert_eq!(
-            node_fact(true, false, &in_flight),
+            node_fact(TicketState::Live, false, &in_flight),
             NodeFact::InFlight { pr: 37 }
         );
         let merged = [
@@ -1182,7 +1276,7 @@ mod tests {
             PrOutcome::project(91, Some(&PrStatus::Merged)),
         ];
         assert_eq!(
-            node_fact(true, false, &merged),
+            node_fact(TicketState::Live, false, &merged),
             NodeFact::DoneByMerge { pr: 91 }
         );
         let superseded = [
@@ -1190,7 +1284,7 @@ mod tests {
             PrOutcome::project(97, Some(&PrStatus::Closed)),
         ];
         assert_eq!(
-            node_fact(true, false, &superseded),
+            node_fact(TicketState::Live, false, &superseded),
             NodeFact::Superseded { pr: 97 }
         );
     }
@@ -1966,8 +2060,10 @@ mod tests {
         );
     }
 
-    /// One repo's batch, shaped exactly like the live one: five aliased
-    /// issues covering every arm the fact derivation can land on.
+    /// One repo's batch, shaped exactly like the live one: seven aliased
+    /// issues covering every arm the fact derivation can land on, plus the two
+    /// answers #132 found nothing reading — a state this binary was never
+    /// taught, and a node carrying both a merge and a rejection.
     const BATCH_RESPONSE: &str = r#"{"data": {"repository": {
         "i80": {"state": "OPEN", "assignees": {"nodes": []},
                 "closedByPullRequestsReferences": {"nodes": [
@@ -1984,6 +2080,16 @@ mod tests {
                 "closedByPullRequestsReferences": {"nodes": [
                   {"number": 44, "state": "SOMETHING_NEW", "isDraft": false,
                    "reviewDecision": null, "statusCheckRollup": null,
+                   "repository": {"nameWithOwner": "blooop/devlaunch"}}]}},
+        "i85": {"state": "TRANSFERRED", "assignees": {"nodes": []},
+                "closedByPullRequestsReferences": {"nodes": []}},
+        "i86": {"state": "OPEN", "assignees": {"nodes": []},
+                "closedByPullRequestsReferences": {"nodes": [
+                  {"number": 33, "state": "MERGED", "isDraft": false,
+                   "reviewDecision": null, "statusCheckRollup": {"state": "SUCCESS"},
+                   "repository": {"nameWithOwner": "blooop/devlaunch"}},
+                  {"number": 43, "state": "CLOSED", "isDraft": false,
+                   "reviewDecision": null, "statusCheckRollup": null,
                    "repository": {"nameWithOwner": "blooop/devlaunch"}}]}}
     }}}"#;
 
@@ -1992,7 +2098,7 @@ mod tests {
         let facts = parse_node_facts(
             BATCH_RESPONSE.as_bytes(),
             "blooop/devlaunch",
-            &[80, 81, 82, 83, 84],
+            &[80, 81, 82, 83, 84, 85, 86],
         )
         .expect("the batch parses");
         assert_eq!(
@@ -2009,8 +2115,59 @@ mod tests {
                 // fact as a PR in flight rather than being dropped on the floor
                 // and leaving #84 looking like a node nothing came of.
                 (node("blooop/devlaunch", 84), NodeFact::InFlight { pr: 44 }),
+                // A state this binary was never taught reads as the open
+                // ticket it might be, not as a closed one.
+                (node("blooop/devlaunch", 85), NodeFact::Unstarted),
+                // A merge outranks the rejection beside it.
+                (
+                    node("blooop/devlaunch", 86),
+                    NodeFact::DoneByMerge { pr: 33 }
+                ),
             ])
         );
+    }
+
+    #[test]
+    fn what_the_tracker_says_decides_deletion_all_the_way_from_the_wire() {
+        // #132's two invisible mutations, asserted where they are dangerous
+        // rather than where they are convenient. Every test above this one
+        // hands `plan` a `NodeFact` that a test author wrote down, which is
+        // precisely why both mutations survived: the derivation was covered and
+        // the *reading* was not, so nothing connected a tracker answer to a
+        // workspace being deleted.
+        //
+        // So this one starts at the bytes `gh` would print and ends at
+        // `doomed`, the single definition of what gets destroyed. Under the
+        // unknown-state hazard, #85 joins the deletion set on a word this
+        // binary cannot read; under the swapped precedence, #86 leaves it
+        // despite a merged PR. Both are one assertion here.
+        let numbers = [80, 83, 84, 85, 86];
+        let known = parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &numbers)
+            .expect("the batch parses");
+        let workspaces: Vec<Workspace> = numbers
+            .iter()
+            .map(|n| {
+                workspace(
+                    &format!("wf-{n}"),
+                    "blooop/devlaunch",
+                    &format!("wayfinder/devlaunch-{n}"),
+                )
+            })
+            .collect();
+
+        // `-f` too, because the question is what may be destroyed at all: the
+        // flag waives the unsaved-work guard, so a hazard that only the guard
+        // was hiding would still be a hazard for every clean clone.
+        for insist in [false, true] {
+            let verdicts = plan(&workspaces, &known, insist);
+            let reaped: Vec<&str> = doomed(&verdicts).into_iter().map(Verdict::id).collect();
+            assert_eq!(
+                reaped,
+                vec!["wf-80", "wf-83", "wf-86"],
+                "insist={insist}: the closed ticket and the two merged nodes go, \
+                 and nothing else does"
+            );
+        }
     }
 
     #[test]
@@ -2059,6 +2216,183 @@ mod tests {
         assert!(query.contains("i81: issue(number: 81)"), "{query}");
         assert!(query.contains("assignees(first: 5)"), "{query}");
         assert!(query.contains("includeClosedPrs: true"), "{query}");
+    }
+
+    /// Collapse every run of whitespace to one space, so two spellings of the
+    /// same selection at two indentation depths compare equal.
+    fn flattened(selection: &str) -> String {
+        selection.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// The `closedByPullRequestsReferences(…) { … }` block of a query, brace
+    /// balanced out of it, flattened. `None` if the query has no such block.
+    fn pr_selection(query: &str) -> Option<String> {
+        let from = query.find("closedByPullRequestsReferences")?;
+        let mut depth = 0usize;
+        let mut seen_one = false;
+        for (offset, ch) in query[from..].char_indices() {
+            match ch {
+                '{' => {
+                    depth += 1;
+                    seen_one = true;
+                }
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Some(flattened(&query[from..=from + offset]));
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(!seen_one, "unbalanced braces in {query}");
+        None
+    }
+
+    #[test]
+    fn both_queries_ask_for_a_linked_pr_in_exactly_the_same_words() {
+        // #132's third item. `fetch::parse_pr` and `fetch::PrNode` are one
+        // vocabulary — reap projects the badge reading rather than repeating
+        // it — but the *query text* that feeds them was copied, and a copy with
+        // nothing holding it can lose a field silently. What goes wrong is
+        // quiet in both directions: drop `statusCheckRollup` here and every
+        // reap-side PR reads as having no checks configured, which is a badge
+        // this side would never show; drop it there and the screen does the
+        // same. Neither parse fails, because both fields are nullable with
+        // meaning.
+        //
+        // Byte equality after flattening, not containment: containment would
+        // let reap's copy shrink, which is exactly the drift being forbidden.
+        let map = pr_selection(crate::fetch::MAP_QUERY).expect("the map query selects linked PRs");
+        let batch = pr_selection(NODE_FACT_SELECTION).expect("the batch selects linked PRs");
+        assert_eq!(
+            batch, map,
+            "reap's linked-PR selection has drifted from the map query's"
+        );
+    }
+
+    /// A selection text as the tree of fields it is: each name mapped to what
+    /// is selected under it, empty for a leaf. The shape a GraphQL answer to
+    /// that selection has, which is what makes it a filter.
+    #[derive(Default, Debug)]
+    struct Selected(BTreeMap<String, Selected>);
+
+    /// Read the subset of GraphQL selection syntax these two queries use:
+    /// names, optional `(arguments)`, optional nested `{ blocks }`.
+    fn parse_selection(text: &str) -> Selected {
+        let mut root = Selected::default();
+        let mut path: Vec<String> = Vec::new();
+        let mut last: Option<String> = None;
+        let mut chars = text.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '{' => path.push(last.take().expect("a block follows the field it selects")),
+                '}' => {
+                    path.pop().expect("a block was opened before it closed");
+                    last = None;
+                }
+                // Arguments say nothing about the shape of the answer.
+                '(' => {
+                    for skipped in chars.by_ref() {
+                        if skipped == ')' {
+                            break;
+                        }
+                    }
+                }
+                ch if ch.is_alphanumeric() || ch == '_' => {
+                    let mut name = String::from(ch);
+                    while chars
+                        .peek()
+                        .is_some_and(|c| c.is_alphanumeric() || *c == '_')
+                    {
+                        name.push(chars.next().expect("peeked"));
+                    }
+                    let mut at = &mut root;
+                    for step in &path {
+                        at = at.0.entry(step.clone()).or_default();
+                    }
+                    at.0.entry(name.clone()).or_default();
+                    last = Some(name);
+                }
+                _ => {}
+            }
+        }
+        assert!(path.is_empty(), "unbalanced braces in {text}");
+        root
+    }
+
+    /// Drop from `value` every field `selection` did not ask for, at the depth
+    /// it did not ask for it — the answer a server honouring that selection
+    /// would have sent back.
+    fn prune(value: &mut serde_json::Value, selection: &Selected) {
+        match value {
+            serde_json::Value::Object(fields) => {
+                fields.retain(|name, _| selection.0.contains_key(name.as_str()));
+                for (name, field) in fields.iter_mut() {
+                    prune(field, &selection.0[name]);
+                }
+            }
+            // A connection's `nodes` list: the selection under `nodes` applies
+            // to each element rather than to the list.
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    prune(item, selection);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn the_batch_parse_reads_no_field_the_batch_forgot_to_ask_for() {
+        // The other half of #132's items 2 and 3: gutting `NODE_FACT_SELECTION`
+        // stayed green, because every fixture in this file is written by hand
+        // and so carries fields the query may no longer be requesting. A test
+        // whose input is independent of the query cannot notice the query
+        // losing a field — it just keeps parsing a response the server would
+        // never have sent.
+        //
+        // So the input is derived from the query instead: the fixture is
+        // filtered down to the fields `NODE_FACT_SELECTION` actually names,
+        // which is the answer a server honouring that selection would return.
+        // Take `state` out of the selection and the issue arrives without one;
+        // take the linked-PR block out and #80 arrives looking like a node
+        // nothing came of. Both are this assertion going red.
+        let asked = parse_selection(NODE_FACT_SELECTION);
+        // The filter has to be by *path*, not by field name: `state` is a field
+        // of the issue and also a field of `statusCheckRollup`, so a name-set
+        // filter keeps the issue's `state` on the strength of the rollup's and
+        // the one mutation that matters most goes unseen. Asserted rather than
+        // commented, since it is the property the whole test rests on.
+        assert_eq!(
+            asked.0.keys().collect::<Vec<_>>(),
+            ["assignees", "closedByPullRequestsReferences", "state"]
+                .iter()
+                .collect::<Vec<_>>(),
+            "the selection parse did not read the fields of an issue"
+        );
+        assert!(asked.0["assignees"].0.contains_key("nodes"));
+
+        let mut body: serde_json::Value =
+            serde_json::from_str(BATCH_RESPONSE).expect("the fixture is json");
+        let issues = body["data"]["repository"]
+            .as_object_mut()
+            .expect("the fixture answers for a repo");
+        for issue in issues.values_mut() {
+            prune(issue, &asked);
+        }
+
+        let numbers = [80, 81, 82, 83, 84, 85, 86];
+        let from_the_selection =
+            parse_node_facts(body.to_string().as_bytes(), "blooop/devlaunch", &numbers)
+                .expect("a response carrying exactly the selected fields parses");
+        let from_the_fixture =
+            parse_node_facts(BATCH_RESPONSE.as_bytes(), "blooop/devlaunch", &numbers)
+                .expect("the fixture parses");
+        assert_eq!(
+            from_the_selection, from_the_fixture,
+            "the selection no longer asks for everything the parse reads"
+        );
     }
 
     #[test]

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -2402,4 +2402,147 @@ mod tests {
         assert!(parse_workspaces(b"not json").is_err());
         assert!(parse_workspaces(b"").is_err());
     }
+
+    #[test]
+    fn the_readme_states_the_keep_rule_the_derivation_implements() {
+        // #132's fourth item. The list of what reap keeps *always* named
+        // "tickets someone has claimed" without qualification, and that is not
+        // a rule this code has: the claim is read only after every PR arm has
+        // declined, so a claimed ticket whose PR merged is `DoneByMerge` and is
+        // collected. `AGENTS.md` makes the README part of `wf`'s interface, so
+        // a keep rule that overstates what is kept is a defect of the same kind
+        // as a wrong reason line — and a worse one to be wrong about, since it
+        // is what someone reads before deciding to trust `wf reap` with a
+        // machine.
+        //
+        // Two halves, and the pairing is the test: the derivation fact that
+        // makes the qualification necessary, and the sentence that has to carry
+        // it. The sentence is matched exactly, so rewording it fails here and
+        // whoever rewords it re-reads the rule above before saying so again.
+        let claimed_and_merged = [PrOutcome::project(33, Some(&PrStatus::Merged))];
+        assert_eq!(
+            node_fact(TicketState::Live, true, &claimed_and_merged),
+            NodeFact::DoneByMerge { pr: 33 },
+            "a claim does not outrank a merge"
+        );
+        assert_eq!(
+            node_fact(TicketState::Live, true, &[]),
+            NodeFact::Claimed,
+            "and it does settle a ticket nothing has come of"
+        );
+
+        let always = include_str!("../README.md")
+            .split_once("Kept, always:")
+            .expect("the README lists what a reap keeps unconditionally")
+            .1
+            .split_once("\n\n")
+            .expect("that list is one paragraph")
+            .0;
+        assert!(
+            always.contains("tickets someone has claimed that no PR has come of"),
+            "the keep list must qualify the claim it names: {always}"
+        );
+    }
+
+    /// `wf reap -y` taken for real, in a child process whose `dl` and `gh` are
+    /// the fixtures the parent hands it and whose every invocation is written
+    /// down. The `#[ignore]` is what keeps it out of an ordinary run: without
+    /// the shims on `PATH` this is `wf reap -y` against the machine running
+    /// the suite, and it is the one path in this crate that deletes.
+    ///
+    /// `-y` and not `-f`: the prompt is a human's, so a recorded run has to
+    /// skip it, but the unsaved-work waiver is a separate decision and the
+    /// tests below say which of them they are asking about.
+    #[tokio::test]
+    #[ignore = "run by `probe::record` from the two tests below, under recording shims"]
+    async fn reap_run_probe() {
+        if !crate::probe::is_child() {
+            return;
+        }
+        let said = match run(true, false).await {
+            Ok(()) => "the reap finished".to_string(),
+            Err(e) => format!("the reap failed: {e}"),
+        };
+        println!("{}{said}", crate::probe::MARK);
+    }
+
+    /// Every `dl` call of a recorded run that names a workspace to remove.
+    fn removals(run: &crate::probe::Recording) -> Vec<&str> {
+        run.argv
+            .iter()
+            .filter(|call| call.contains("<rm>"))
+            .map(String::as_str)
+            .collect()
+    }
+
+    #[test]
+    fn a_reap_hands_dl_the_workspaces_its_plan_doomed_and_no_others() {
+        // The deleting path as a fact about a run. Every other test of this
+        // module stops at a `Verdict`, which is a value in this process — and
+        // a plan that is right about what should go is not the same claim as a
+        // run that destroys only that. Between the two sits `run`: the loop
+        // over `doomed`, the id it passes, and the flag it does or does not
+        // add. This is the only place any of that is observed.
+        //
+        // The four workspaces in the listing are laid out as directories in the
+        // child's scratch home, so `wf` naming the wrong one would show up
+        // here as an id, and `wf` deleting one itself would show up as a
+        // disturbed path.
+        let run = crate::probe::record(
+            "reap::tests::reap_run_probe",
+            crate::probe::DL_LISTING,
+            crate::probe::GH_FACTS,
+        );
+        assert_eq!(
+            run.printed(),
+            ["the reap finished"],
+            "the run reached the end: {}",
+            run.stdout
+        );
+        assert_eq!(
+            removals(&run),
+            ["dl <wf-129-closed> <rm>"],
+            "the closed ticket's workspace goes, alone and by id: {:?}",
+            run.argv
+        );
+        // Without `-f`, and this is where that is observable rather than
+        // asserted about a `Verdict`: `--force` is `dl`'s own waiver of its
+        // uncommitted-work guard, and a `wf` that passed it unasked would be
+        // overriding a guard belonging to the other program.
+        for call in &run.argv {
+            assert!(!call.contains("<--force>"), "unasked-for force: {call}");
+        }
+        run.touched_no_files();
+    }
+
+    #[test]
+    fn a_ticket_state_this_binary_cannot_read_costs_no_workspace() {
+        // #132's first item, at the far end: not "the derivation keeps it" but
+        // "the run deletes nothing". The same fixtures as above with one word
+        // changed — the state of the one ticket whose workspace the run above
+        // removes — so the difference between the two recordings is exactly
+        // the difference between `CLOSED` and a word this binary was never
+        // taught. Before the fix this run removed `wf-129-closed` on the
+        // strength of that word.
+        let unreadable = crate::probe::GH_FACTS.replace(
+            r#""i129":{"state":"CLOSED""#,
+            r#""i129":{"state":"TRANSFERRED""#,
+        );
+        assert_ne!(
+            unreadable,
+            crate::probe::GH_FACTS,
+            "the fixture no longer says what this test edits"
+        );
+        let run = crate::probe::record(
+            "reap::tests::reap_run_probe",
+            crate::probe::DL_LISTING,
+            &unreadable,
+        );
+        run.destroyed_nothing();
+        assert!(
+            run.stdout.contains("nothing to reap"),
+            "the run said what it did instead of deleting: {}",
+            run.stdout
+        );
+    }
 }


### PR DESCRIPTION
Closes the four items #132 collected, each of which is a place where reap's *reading* was covered and its *deciding* was not.

### 1. An unrecognised issue state reached the deleting arm

`fetch::is_open` is a positive test for `OPEN`, so reap read every other state — including anything GitHub adds after this binary ships — as closed, and `NodeFact::Closed` **deletes a workspace**. That is the exact mirror of the hazard `PrOutcome::project` already resolves the safe way, pointed at the arm that destroys rather than the one that warns.

`TicketState` replaces the bool. The deleting condition is now positive at its definition, and the inversion that caused this is a compile error rather than a `!`. An unrecognised state falls all the way through to the reading an open ticket gets — asserted as equality with that reading over the whole table, not merely as "not `Closed`", so it cannot grow an arm of its own by accident.

### 2. The two mutations the suite could not see

- **Swapped `DoneByMerge`/`Superseded` precedence.** Every row in the derivation table had one *kind* of PR in it, so every row read the same whichever arm was tried first. The fixture grows a node carrying both a merge and a rejection — a live difference, since `DoneByMerge` reaps and `Superseded` only warns.
- **Gutted `NODE_FACT_SELECTION`.** Every fixture in the file is written by hand, so it carries fields the query may no longer be asking for; a test whose input is independent of the query cannot notice the query losing one. The new test derives its input *from* the selection — the fixture is pruned to the fields the selection names, by path, which is the answer a server honouring it would return.

  Field-by-field mutation of the selection: **10 of 10** caught. (The first version of this test filtered by field *name* and missed exactly one — dropping the issue-level `state`, the field that decides deletion, because `state` also appears inside `statusCheckRollup`. That is why the filter is path-aware, and the property is asserted rather than commented.)

### 3. The GraphQL selection was duplicated with nothing holding it

`fetch::parse_pr` and `fetch::PrNode` are one vocabulary, but the query text feeding them was copied into `reap`. Drift is quiet in both directions — drop `statusCheckRollup` on one side and those PRs read as having no checks configured, a badge the other side would never show, and neither parse fails because both fields are nullable with meaning. The linked-PR block is now compared for **equality** after flattening, not containment: containment would let reap's copy shrink, which is the drift being forbidden.

### 4. The README misstated the keep rule

"Kept, always" listed *tickets someone has claimed*. Not a rule this code has: the claim is read only after every PR arm declines, so a claimed ticket whose PR merged is `DoneByMerge` and is collected. Corrected, and pinned to the derivation that makes the qualification necessary.

---

### And the seam none of that would have covered: the run that deletes

Every test of this module stopped at a `Verdict` — a value in this process. Between a plan that is right about what should go and a run that destroys only that sits `run`: the loop over `doomed`, the id it passes to `dl`, the flag it does or does not add. **None of it was observed.**

`reap::run(-y)` is now a probe body under the recording shims (`src/probe.rs`), so the whole chain from the bytes `gh` would print to the argv `dl` receives is watched. Two mutations that all 387 preceding tests missed are each caught by it alone:

| mutation | before | after |
|---|---|---|
| reap always passes `dl --force` | green | 1 fail |
| the loop walks every verdict, not just `doomed` | green | 1 fail |

`Recording::touched_no_files` splits out the in-process half of `destroyed_nothing`, because reaping is the one path whose argv is *supposed* to carry an `<rm>`. What must still hold there is the separation `dl`'s own guard depends on: `wf` names a workspace, `dl` decides what happens to its clone.

### Verification

Every claim above was checked by applying the mutation and confirming the intended test goes red under the **full** suite selection, not an isolated `-k` run. 16 mutations, 16 caught.

`cargo test` green (388 lib + all integration targets), `cargo clippy --all-targets` clean, `cargo fmt` applied.

## Summary by Sourcery

Strengthen reap’s safety around workspace deletion by making issue state handling explicit, tying GraphQL selections and batch parsing together, and adding an end‑to‑end probe of the deleting run, while correcting README documentation to match the implemented keep rules.

Bug Fixes:
- Ensure only a tracker state of `CLOSED` can trigger workspace deletion, treating unknown or new issue states as live and decided by PRs and claims rather than as closed.
- Fix precedence between merged and rejected PRs on the same ticket so a merge correctly outweighs a neighboring rejection when deriving node facts.
- Prevent drift and missing fields between GraphQL queries and the batch parser by enforcing that reap’s linked‑PR selection matches the map query and that parsing only depends on fields actually requested.

Enhancements:
- Introduce a `TicketState` enum to replace the previous boolean issue state, making the deleting condition explicit and future‑proof against new tracker states.
- Extend node‑fact and batch parsing tests to cover mixed PR outcomes, unknown issue states, and full derivation from wire data through to the deletion plan.
- Add parsing and pruning helpers for GraphQL selection text to validate that fixtures reflect exactly what the batch query asks for.
- Expose the map query text for internal testing to keep fetch and reap GraphQL selections aligned.
- Add probe‑based recording tests that run `wf reap -y` end‑to‑end to verify that only doomed workspaces are handed to `dl`, that `--force` is never passed unasked, and that reap itself does not touch workspace directories.

Documentation:
- Update the README to accurately describe the keep rule by qualifying claimed tickets as being kept only when no PR has come of them, matching the derivation logic and user‑facing behavior.

Tests:
- Add unit tests for `TicketState` reading semantics, ensuring only the literal `CLOSED` state is treated as closed and unknown states match the open‑ticket behavior.
- Expand batch response fixtures and tests to cover unknown issue states and tickets with both merged and rejected PRs, verifying correct node facts and deletion sets.
- Introduce tests that compare flattened linked‑PR selections between map and batch queries and that prune JSON fixtures according to the GraphQL selection to ensure parser and query stay in sync.
- Add probe recording tests that observe `wf reap`’s actual `dl` invocations and filesystem effects to confirm safe deletion behavior and non‑destructive runs when issue states are unreadable.