### PR TITLE
Run wf against a real dl, at a version pixi chooses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
-# Formatting, lints, tests and docs — everything that can be judged without
-# building a package. `package.yml` is the other half: it proves the recipe
-# still installs and runs. Kept apart on purpose. A rattler build takes minutes
-# and downloads a toolchain of its own, so folding `cargo fmt` into it would
-# make the cheapest possible failure the slowest one to hear about.
+# Formatting, lints, tests and docs — everything that can be judged with
+# nothing but a compiler and this checkout. Two other workflows cover what
+# cannot: `package.yml` proves the recipe still installs and runs, and
+# `devlaunch-contract.yml` runs `wf` against a real `dl` at three chosen
+# versions. All three are kept apart on purpose, and for one reason — a rattler
+# build and a conda solve each take minutes and download a toolchain of their
+# own, so folding `cargo fmt` into either would make the cheapest possible
+# failure the slowest one to hear about.
 on:
   pull_request:
   push:
@@ -74,10 +77,13 @@ jobs:
         run: cargo clippy --all-targets --all-features --locked
 
       # The unit tests, the ones that need nothing but a compiler. The `live_*`
-      # integration tests under `tests/` — a real `gh`, real network, and
-      # assertions against this project's own tracker as it stands today — are
-      # excluded, because running them here would make CI fail whenever the map
-      # moves on. They are compiled below instead of run.
+      # integration tests under `tests/` are excluded: most of them want a real
+      # `gh`, real network, and assertions against this project's own tracker as
+      # it stands today, so running them here would make CI fail whenever the
+      # map moves on. `live_devlaunch.rs` is excluded for a different reason —
+      # it wants a real `dl` at a chosen version, which is a pixi environment
+      # and therefore `devlaunch-contract.yml`'s job, not this one's. All of
+      # them are compiled below instead of run.
       - name: Unit tests
         run: cargo test --locked --lib --bins --examples
 

--- a/.github/workflows/devlaunch-contract.yml
+++ b/.github/workflows/devlaunch-contract.yml
@@ -91,6 +91,12 @@ jobs:
       - name: The suite is hermetic with no dl installed
         run: pixi run suite
 
+      # The fallbacks, which are the half of this a user actually meets: a host
+      # launch instead of an isolated one, and a `wf reap` that refuses rather
+      # than reading "cannot see the workspaces" as "there are none".
+      - name: No devlaunch at all — the fallbacks
+        run: pixi run -e default contract
+
       - name: The floor — devlaunch == launch::DEVLAUNCH_FLOOR
         run: pixi run -e floor contract
 

--- a/.github/workflows/devlaunch-contract.yml
+++ b/.github/workflows/devlaunch-contract.yml
@@ -31,8 +31,16 @@ permissions:
   contents: read
 
 concurrency:
-  group: devlaunch-contract-${{ github.ref }}
-  cancel-in-progress: true
+  # Keyed on the event as well as the ref, which matters for exactly one pair:
+  # on a scheduled run `github.ref` is `refs/heads/main`, identical to a push to
+  # main. Keyed on the ref alone they share a group, so a PR merged during the
+  # weekly run cancels it — and a cancelled workflow is neither red nor a failed
+  # check, so the one trigger that can discover a new devlaunch release would
+  # disappear without a word.
+  group: devlaunch-contract-${{ github.event_name }}-${{ github.ref }}
+  # Never for the scheduled run, for the same reason: there is nothing newer
+  # coming along to supersede it.
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 env:
   RUSTFLAGS: -D warnings

--- a/.github/workflows/devlaunch-contract.yml
+++ b/.github/workflows/devlaunch-contract.yml
@@ -1,0 +1,104 @@
+name: devlaunch contract
+
+# The half of the test suite that needs a real `devlaunch` — see `pixi.toml`
+# for why it exists at all, and `tests/live_devlaunch.rs` for what it asks.
+#
+# A workflow of its own rather than a job in `ci.yml`, for two reasons that
+# both come down to "a failure here means something different". It needs a
+# toolchain `ci.yml` does not (a conda solve and three Python prefixes), and
+# when it goes red the thing that moved is usually in *another repository* —
+# so a contributor reading a failed run should not have to work out which of
+# nine steps was about their patch. `ci.yml` stays the fast, self-contained
+# answer to "is this commit sound".
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # Weekly, and this is the trigger that earns the `latest` environment.
+  #
+  # `pixi.lock` pins what `latest` installs, so on a pull request that
+  # environment is only ever "a second fixed version" — useful, but it cannot
+  # discover anything. The scheduled run below re-solves devlaunch first, so a
+  # release published in between is tested here before anybody upgrades into
+  # it. A red scheduled run therefore means devlaunch changed under `wf`, not
+  # that anything in this repository is wrong: fix it by taking the change and
+  # committing the lock, or by raising the floor.
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: devlaunch-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: -D warnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  contract:
+    name: wf against a real dl
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # The compiler comes from rustup, exactly as in `ci.yml`. pixi supplies
+      # `dl` and nothing else — see the header of `pixi.toml`.
+      - name: Install the Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo's registry and the target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: devlaunch-contract
+
+      - uses: prefix-dev/setup-pixi@v0
+        with:
+          # Named rather than `all`, so an environment added to `pixi.toml`
+          # without a step below is a missing install rather than a silently
+          # unrun check.
+          environments: >-
+            default floor latest stale
+          # Only on the scheduled run: everywhere else the committed lock is
+          # the point, and a workflow that quietly re-solved it would mean a
+          # pull request never tested the versions it shipped with.
+          locked: ${{ github.event_name != 'schedule' }}
+
+      - name: Take any devlaunch published since the lock
+        if: github.event_name == 'schedule'
+        run: pixi update devlaunch
+
+      # Before anything is run, because the script below is what decides
+      # whether the next step tested anything at all.
+      - name: Lint the PATH scrubber
+        run: pixi run lint
+
+      # First of the test steps, because it is the only one that can fail for a
+      # reason inside this repository. A test that reaches the ambient `dl`
+      # passes on every developer's machine and means nothing; this is where it
+      # is caught.
+      - name: The suite is hermetic with no dl installed
+        run: pixi run suite
+
+      - name: The floor — devlaunch == launch::DEVLAUNCH_FLOOR
+        run: pixi run -e floor contract
+
+      - name: Whatever devlaunch a user gets today
+        run: pixi run -e latest contract
+
+      # Below the floor, and still `wf`'s problem: `reap` reads a listing from
+      # whichever `dl` is on PATH, floor or no floor, so the degradation is a
+      # supported path rather than an unsupported one.
+      - name: Below the floor — the degradation, not the happy path
+        run: pixi run -e stale contract
+
+      - name: What was actually installed
+        if: always()
+        run: |
+          for env in floor latest stale; do
+            printf '%-8s ' "$env"
+            pixi run -e "$env" dl --version
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 # a shell that inherits the crate root) still drops one here, and this file was
 # once committed to a public repo that way.
 /pwned
+
+# The pixi environments (`pixi.toml`). Three prefixes with a Python and a
+# devpod in each; `pixi.lock` is what is committed, not what it unpacks to.
+/.pixi/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,20 +147,31 @@ pixi run -e latest contract  # whatever pixi.lock resolved
 pixi run -e stale  contract  # 0.0.23 — below the floor, where wf must degrade
 ```
 
-Two things follow for anyone editing here:
+Three things follow for anyone editing here:
 
 - **Raising `DEVLAUNCH_FLOOR` means editing `pixi.toml` in the same commit.**
-  The `floor` environment pins the exact version that constant names, and the
-  test asserts the two agree — a floor nothing is ever run at is a floor nobody
-  has checked.
+  The `floor` environment pins the exact version that constant names, and
+  `the_floor_environment_is_pinned_to_the_floor` compares them unconditionally —
+  a floor nothing is ever run at is a floor nobody has checked. Note what it
+  deliberately does *not* assert: that `DEVLAUNCH_FLOOR` equals
+  `UNSAVED_IS_AN_OBJECT`. Those are two facts about two different questions and a
+  floor bump has to be able to part them; a draft of this test tied them
+  together, and the only way to satisfy that after a bump would have been to
+  raise `UNSAVED_IS_AN_OBJECT` too, which walks `wf reap` straight back into
+  devlaunch#171.
 - **`pixi run suite` failing is not the contract breaking.** It is a test in
   `src/` that reached the ambient `dl`, which means it passes on your machine
   for a reason that has nothing to do with what it claims to check.
+- **Two of the four calls are only checked by name.** `dl <id> rm` and
+  `dl <ws> up` change the machine and need a devpod daemon, so the contract test
+  runs neither — it asserts only that `dl --help` still names them, which
+  catches a removal or a rename (the failure that actually happened) and nothing
+  about what they do. `--version` and `--ls --json` are exercised for real.
 
-`.github/workflows/devlaunch-contract.yml` runs all four on every pull request,
-and once a week re-solves devlaunch first — that scheduled run is the only thing
-that can discover a release published since the lock, and a red one means the
-other repo moved rather than that this one is broken.
+`.github/workflows/devlaunch-contract.yml` runs all four environments on every
+pull request, and once a week re-solves devlaunch first — that scheduled run is
+the only thing that can discover a release published since the lock, and a red
+one means the other repo moved rather than that this one is broken.
 
 ## House style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,11 +141,21 @@ those environments would give the repo two toolchains to keep in step for no
 gain.
 
 ```
-pixi run    suite            # the ordinary suite with no `dl` anywhere on PATH
-pixi run -e floor  contract  # devlaunch pinned to exactly launch::DEVLAUNCH_FLOOR
-pixi run -e latest contract  # whatever pixi.lock resolved
-pixi run -e stale  contract  # 0.0.23 — below the floor, where wf must degrade
+pixi run    suite             # the ordinary suite with no `dl` anywhere on PATH
+pixi run -e default contract  # no devlaunch: the fallbacks
+pixi run -e floor   contract  # devlaunch pinned to exactly launch::DEVLAUNCH_FLOOR
+pixi run -e latest  contract  # whatever pixi.lock resolved
+pixi run -e stale   contract  # 0.0.23 — below the floor, where wf must degrade
 ```
+
+The contract test makes two kinds of claim. Most of it is about what `wf`
+**reads** from a `dl` — the version, the listing, the `unsaved` field. Three
+tests are about what it then **does**, and those are the ones that answer "is
+the fallback real": `Isolation::detect` must return `Host` in a checkout that
+really carries a devcontainer whenever `dl` is absent or below the floor, the
+launch notice must say why, and `wf reap` with no `dl` must fail rather than
+mistake "cannot see the workspaces" for "there are none". All three are checked
+against a real absent-or-old devlaunch rather than a shim.
 
 Three things follow for anyone editing here:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,43 @@ changed is what they cover. `tests/skill_docs.rs` is the exception under
 `tests/` — offline shape checks on the skill docs' snippets, so it runs in the
 chain (and in CI) like any unit test.
 
+## The devlaunch contract
+
+`wf` shells out to `dl` four ways — `--version`, `--ls --json`, `<id> rm`, and
+`<ws> up` / `<ws> -- <cmd>` — and every one of them is exercised in `src/` and
+in `tests/live_launch_exec.rs` against a *recording shim*. That is the right
+call for those tests (a machine with devlaunch installed and one without must
+not take different paths through the same test) and it leaves the fixtures
+unchecked against the program they describe. They have been wrong twice.
+
+`pixi.toml` is here for that and nothing else: it installs a chosen `devlaunch`
+and `tests/live_devlaunch.rs` asks it the questions `wf` asks it. **Pixi does
+not build this crate** — the compiler is still rustup's, and adding `rust` to
+those environments would give the repo two toolchains to keep in step for no
+gain.
+
+```
+pixi run    suite            # the ordinary suite with no `dl` anywhere on PATH
+pixi run -e floor  contract  # devlaunch pinned to exactly launch::DEVLAUNCH_FLOOR
+pixi run -e latest contract  # whatever pixi.lock resolved
+pixi run -e stale  contract  # 0.0.23 — below the floor, where wf must degrade
+```
+
+Two things follow for anyone editing here:
+
+- **Raising `DEVLAUNCH_FLOOR` means editing `pixi.toml` in the same commit.**
+  The `floor` environment pins the exact version that constant names, and the
+  test asserts the two agree — a floor nothing is ever run at is a floor nobody
+  has checked.
+- **`pixi run suite` failing is not the contract breaking.** It is a test in
+  `src/` that reached the ambient `dl`, which means it passes on your machine
+  for a reason that has nothing to do with what it claims to check.
+
+`.github/workflows/devlaunch-contract.yml` runs all four on every pull request,
+and once a week re-solves devlaunch first — that scheduled run is the only thing
+that can discover a release published since the lock, and a red one means the
+other repo moved rather than that this one is broken.
+
 ## House style
 
 The code explains *why*, not *what*, and the doc comments carry the design

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,20 +177,35 @@ Three things follow for anyone editing here:
   `dl <ws> up` would build or destroy a container, so they run against a
   recording `devpod` on PATH — devlaunch's only devpod spawn is a bare name, so
   the real `dl` does its real argument parsing and workspace resolution and
-  stops where the daemon would start. The argvs come from `reap::removal_argv`,
-  `launch::prewarm_argv` and `launch::isolated_argv`, so the test sends what the
-  binary sends. No daemon is needed and nothing creates a container.
+  stops where the daemon would start. The verbs and flags come from
+  `reap::removal_argv`, `launch::prewarm_argv` and `launch::isolated_argv`, so
+  the test sends what the binary sends — with one limit worth knowing: the
+  *workspace argument* is a devpod id, not the `owner/repo@wayfinder/<repo>-<n>`
+  spec a real launch passes, because the spec form makes `dl` clone. A devlaunch
+  change to how that spec is parsed or cloned is therefore not caught here. No
+  daemon is needed and nothing creates a container.
 
-- **Nothing there inherits your environment.** The contract test records every
-  argument `dl` hands devpod and prints that recording when an assertion fails,
-  so a credential reaching argv would reach a CI log. `hermetic` is the only
-  function in the file allowed to start a process; it clears the environment and
-  gives back three variables, one of which is devlaunch's own
-  `DEVLAUNCH_NO_GH_TOKEN`. Two guards keep that true rather than merely written
-  down: one reads a real child's environment and compares it to the whole
-  allowlist, and one refuses any capture holding a token-shaped string or a
-  `NAME=value` whose name looks like a secret — matched on shape, so a variable
-  neither repo has invented yet is still caught, and reported by name only.
+- **Nothing whose output is captured inherits your environment.** The contract
+  test records every argument `dl` hands devpod and prints that recording when
+  an assertion fails, so a credential reaching argv would reach a CI log.
+  `hermetic` is the only function in the file that starts a subprocess; it
+  clears the environment and gives back three variables, one of which is
+  devlaunch's own `DEVLAUNCH_NO_GH_TOKEN`.
+
+  The qualifier is exact and was once missing. Two tests reach a real `dl`
+  *without* going through `hermetic` — `Isolation::detect` and the launch-notice
+  check both spawn `dl --version` from inside `src/launch.rs`, with the whole
+  ambient environment — and they are meant to, because driving the production
+  path is what they are for. `--version` consults no credential, prints none,
+  and nothing captured from it is printed. Anything that *is* captured and
+  printed goes through `hermetic`.
+
+  Three guards keep that true rather than merely written down: one reads a real
+  child's environment and compares it to the whole allowlist, one reads this
+  file's own source and requires the single spawn to sit inside `hermetic`, and
+  one refuses any capture holding a token-shaped string or a `NAME=value` whose
+  name looks like a secret — matched on shape, so a variable neither repo has
+  invented yet is still caught, and reported by name only.
 
 `.github/workflows/devlaunch-contract.yml` runs all four environments on every
 pull request, and once a week re-solves devlaunch first — that scheduled run is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,11 +172,14 @@ Three things follow for anyone editing here:
 - **`pixi run suite` failing is not the contract breaking.** It is a test in
   `src/` that reached the ambient `dl`, which means it passes on your machine
   for a reason that has nothing to do with what it claims to check.
-- **Two of the four calls are only checked by name.** `dl <id> rm` and
-  `dl <ws> up` change the machine and need a devpod daemon, so the contract test
-  runs neither — it asserts only that `dl --help` still names them, which
-  catches a removal or a rename (the failure that actually happened) and nothing
-  about what they do. `--version` and `--ls --json` are exercised for real.
+- **All four calls are run, two of them over a shimmed `devpod`.** `--version`
+  and `--ls --json` go straight to the installed `dl`. `dl <id> rm` and
+  `dl <ws> up` would build or destroy a container, so they run against a
+  recording `devpod` on PATH — devlaunch's only devpod spawn is a bare name, so
+  the real `dl` does its real argument parsing and workspace resolution and
+  stops where the daemon would start. The argvs come from `reap::removal_argv`,
+  `launch::prewarm_argv` and `launch::isolated_argv`, so the test sends what the
+  binary sends. No daemon is needed and nothing creates a container.
 
 `.github/workflows/devlaunch-contract.yml` runs all four environments on every
 pull request, and once a week re-solves devlaunch first — that scheduled run is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,17 @@ Three things follow for anyone editing here:
   `launch::prewarm_argv` and `launch::isolated_argv`, so the test sends what the
   binary sends. No daemon is needed and nothing creates a container.
 
+- **Nothing there inherits your environment.** The contract test records every
+  argument `dl` hands devpod and prints that recording when an assertion fails,
+  so a credential reaching argv would reach a CI log. `hermetic` is the only
+  function in the file allowed to start a process; it clears the environment and
+  gives back three variables, one of which is devlaunch's own
+  `DEVLAUNCH_NO_GH_TOKEN`. Two guards keep that true rather than merely written
+  down: one reads a real child's environment and compares it to the whole
+  allowlist, and one refuses any capture holding a token-shaped string or a
+  `NAME=value` whose name looks like a secret — matched on shape, so a variable
+  neither repo has invented yet is still caught, and reported by name only.
+
 `.github/workflows/devlaunch-contract.yml` runs all four environments on every
 pull request, and once a week re-solves devlaunch first — that scheduled run is
 the only thing that can discover a release published since the lock, and a red

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,510 @@
+version: 7
+platforms:
+- name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
+environments:
+  default:
+    channels:
+    - url: https://prefix.dev/blooop/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.10.0-ha770c72_0.conda
+  floor:
+    channels:
+    - url: https://prefix.dev/blooop/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.10.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/blooop/linux-64/devpod-0.26.1-hb0f4dca_0.conda
+      - conda: https://prefix.dev/blooop/linux-64/iterfzf-1.9.0.67.0-hb0f4dca_0.conda
+      - conda: https://prefix.dev/blooop/noarch/devlaunch-0.0.24-pyh4616a5c_0.conda
+  latest:
+    channels:
+    - url: https://prefix.dev/blooop/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.10.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/blooop/linux-64/devpod-0.26.1-hb0f4dca_0.conda
+      - conda: https://prefix.dev/blooop/linux-64/iterfzf-1.9.0.67.0-hb0f4dca_0.conda
+      - conda: https://prefix.dev/blooop/noarch/devlaunch-0.0.25-pyh4616a5c_0.conda
+  stale:
+    channels:
+    - url: https://prefix.dev/blooop/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.10.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://prefix.dev/blooop/linux-64/devpod-0.26.1-hb0f4dca_0.conda
+      - conda: https://prefix.dev/blooop/linux-64/iterfzf-1.9.0.67.0-hb0f4dca_0.conda
+      - conda: https://prefix.dev/blooop/noarch/devlaunch-0.0.23-pyh4616a5c_0.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 257808
+  timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+  sha256: d7c260b7e1cf22ce04d6ba8a86eabf4e6c50bc96a5c27fe2ecb32298af3e88eb
+  md5: 4ef4b977bb216a3001a3334696a80850
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14455340
+  timestamp: 1784916378180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+  sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+  md5: 0abe40a9880086ca4d2e5daf09dceff9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 67576
+  timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1057877
+  timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 640415
+  timestamp: 1785375373755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 112995
+  timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+  md5: 2c21e66f50753a083cbe6b80f38268fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 92400
+  timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+  sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
+  md5: df088a279cd5e6fd2790b4c196434da1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 964200
+  timestamp: 1785016112246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 6631744
+  timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63713
+  timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 911196
+  timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3182423
+  timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+  build_number: 102
+  sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
+  md5: 9b6c336ef7195fbee1c10c09bfcf901b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 36866750
+  timestamp: 1786444737142
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.10.0-ha770c72_0.conda
+  sha256: 6809031184c07280dcbaed58e15020317226a3ed234b99cb1bd98384ea5be813
+  md5: 61b19e9e334ddcdf8bb2422ee576549e
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 2606806
+  timestamp: 1713719553683
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3550916
+  timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 601375
+  timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
+  depends:
+  - __unix
+  license: ISC
+  run_exports: {}
+  size: 131780
+  timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  run_exports: {}
+  size: 118849
+  timestamp: 1784250406640
+- conda: https://prefix.dev/blooop/linux-64/devpod-0.26.1-hb0f4dca_0.conda
+  sha256: 4f62639766455cd6ae32c4a17d724973e23149e91601fc89960ffc9fb104c843
+  md5: f444973099e1b46e6cf08177b1735390
+  license: MPL-2.0
+  license_family: MOZILLA
+  run_exports: {}
+  size: 28907591
+  timestamp: 1783320168481
+- conda: https://prefix.dev/blooop/linux-64/iterfzf-1.9.0.67.0-hb0f4dca_0.conda
+  sha256: f826b37f54c9983e4a579c266c94fc2a5d948546587c311a7e6ea1dd95bba133
+  depends:
+  - python >=3.8
+  - python_abi 3.14.* *_cp314
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1688230
+  timestamp: 1769400119633
+- conda: https://prefix.dev/blooop/noarch/devlaunch-0.0.23-pyh4616a5c_0.conda
+  sha256: ef6aaea94afec616b290d3f9c0732118585d3cbbd47f20dd2ddd41480d653bcf
+  md5: 57008122c9f7d76098c2c836d707f7fa
+  depends:
+  - python >=3.10
+  - iterfzf >=1.0.0
+  - tomli >=2.0.0
+  - devpod >=0.26.1
+  - python
+  license: MIT
+  run_exports: {}
+  size: 86311
+  timestamp: 1786221056249
+- conda: https://prefix.dev/blooop/noarch/devlaunch-0.0.24-pyh4616a5c_0.conda
+  sha256: bac6aec8e5fd5c8d104295c0e38eee44864d7b4090dcd441a126cf89ff24f793
+  md5: 98ccc49469d5919a1472e70c4684aebb
+  depends:
+  - python >=3.10
+  - iterfzf >=1.0.0
+  - tomli >=2.0.0
+  - devpod >=0.26.1
+  - python
+  license: MIT
+  run_exports: {}
+  size: 110800
+  timestamp: 1786383282114
+- conda: https://prefix.dev/blooop/noarch/devlaunch-0.0.25-pyh4616a5c_0.conda
+  sha256: 26afb185168252a39eadc907ac9898663e0a50d0e87689693e54327687d95a55
+  md5: be74180f5daca049e69c8186b1afe3e8
+  depends:
+  - python >=3.10
+  - iterfzf >=1.0.0
+  - tomli >=2.0.0
+  - devpod >=0.26.1
+  - python
+  license: MIT
+  run_exports: {}
+  size: 110809
+  timestamp: 1786390783884

--- a/pixi.toml
+++ b/pixi.toml
@@ -71,14 +71,19 @@ wf = "scripts/without-dl.sh cargo run --locked --bin wf --"
 [feature.contract.tasks]
 # One `--test-threads=1`: the tests here each spawn `dl`, and a real devlaunch
 # start is ~90 ms of Python. Serial keeps the failure output in an order a human
-# can read, and there are six of them.
+# can read.
 contract = "cargo test --locked --test live_devlaunch -- --test-threads=1"
 
 [feature.floor.dependencies]
 devlaunch = "==0.0.24"
 [feature.floor.activation.env]
-# Asserted against `launch::DEVLAUNCH_FLOOR`, so this pin and that constant
-# cannot drift apart unnoticed.
+# `role` decides which assertions apply and carries no facts of its own; the
+# other three are facts about the release, stated here so the test never has to
+# derive one from an environment name. All four are required and all four are
+# checked against a closed set — an unrecognised value is a panic, not a skip.
+WF_CONTRACT_ROLE = "floor"
+# Asserted equal to `launch::DEVLAUNCH_FLOOR`, unconditionally: whichever of the
+# two moves, the other has to move with it.
 WF_CONTRACT_DL = "0.0.24"
 WF_CONTRACT_EXPECT = "usable"
 WF_CONTRACT_UNSAVED = "object"
@@ -86,15 +91,17 @@ WF_CONTRACT_UNSAVED = "object"
 [feature.latest.dependencies]
 devlaunch = "*"
 [feature.latest.activation.env]
-# No `WF_CONTRACT_DL`: whatever `pixi.lock` resolved is the subject, and writing
-# the number here as well would mean updating the lock could leave a stale
-# assertion passing against the version it no longer installs.
+# No `WF_CONTRACT_DL`, and the test rejects one here: whatever `pixi.lock`
+# resolved is the subject, and a number written beside it is one nobody updates
+# when the lock moves.
+WF_CONTRACT_ROLE = "latest"
 WF_CONTRACT_EXPECT = "usable"
 WF_CONTRACT_UNSAVED = "object"
 
 [feature.stale.dependencies]
 devlaunch = "==0.0.23"
 [feature.stale.activation.env]
+WF_CONTRACT_ROLE = "stale"
 WF_CONTRACT_DL = "0.0.23"
 WF_CONTRACT_EXPECT = "too-old"
 # The release before `unsaved` became an object. `wf` still has to read this

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,7 +30,7 @@
 #
 # | environment | `dl`     | what it is for                                        |
 # |-------------|----------|-------------------------------------------------------|
-# | `default`   | none     | the ordinary suite, with no `dl` anywhere on PATH      |
+# | `default`   | none     | the suite *and* the contract, no `dl` anywhere on PATH |
 # | `floor`     | 0.0.24   | exactly `launch::DEVLAUNCH_FLOOR` — the required one   |
 # | `latest`    | newest   | the release a user gets today                          |
 # | `stale`     | 0.0.23   | below the floor: the degradation, not the happy path   |
@@ -67,6 +67,20 @@ suite = "scripts/without-dl.sh cargo test --locked --lib --bins --examples"
 # `wf` itself, with no devlaunch installed, for driving the degradation by hand:
 # an isolated launch has to fall back to the host and say nothing about it (#80).
 wf = "scripts/without-dl.sh cargo run --locked --bin wf --"
+
+# The environment with no `dl` at all is a role like any other, and its
+# contract run goes through the scrubber — otherwise `pixi run` hands it the
+# developer's own devlaunch and the "absent" case is a fiction. Its own task
+# rather than the shared one below, for exactly that reason.
+[feature.none.tasks]
+contract = "scripts/without-dl.sh cargo test --locked --test live_devlaunch -- --test-threads=1"
+
+[feature.none.activation.env]
+# Only the role. The absent case is declared by the *silence* of the other
+# three, and `Contract::read` asserts that silence — an environment that
+# inherited another's activation block would be making claims about a `dl` it
+# does not have.
+WF_CONTRACT_ROLE = "none"
 
 [feature.contract.tasks]
 # One `--test-threads=1`: the tests here each spawn `dl`, and a real devlaunch
@@ -109,6 +123,7 @@ WF_CONTRACT_EXPECT = "too-old"
 WF_CONTRACT_UNSAVED = "sentence"
 
 [environments]
+default = ["none"]
 floor = ["contract", "floor"]
 latest = ["contract", "latest"]
 stale = ["contract", "stale"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,6 +26,12 @@
 # installed devlaunch the questions `wf` asks it, and holds the answers against
 # what `wf` believes.
 #
+# `devpod` arrives with devlaunch rather than being listed here — it is
+# devlaunch's own dependency and pinning it separately would only give the two
+# constraints a chance to disagree. `dl --ls --json` really does run it; the two
+# calls that would build a container run against a recording shim instead, so no
+# daemon is needed and nothing here creates one.
+#
 # ## The environments
 #
 # | environment | `dl`     | what it is for                                        |

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,107 @@
+# Pixi is here for one job: to put a *real* `dl` of a *chosen* version in front
+# of the tests, and to take it away again.
+#
+# `wf` does not build with pixi and this file deliberately does not try to make
+# it. The compiler comes from the same rustup toolchain `cargo` and CI already
+# use; the only thing these environments contribute is which `devlaunch` — if
+# any — is on PATH. Adding `rust` here would give the repo two ways to build
+# itself and two toolchains to keep in step, for no gain: the Rust side of the
+# contract is already covered by `cargo test`, and it is the *other* side that
+# has never been run.
+#
+# ## Why it was needed
+#
+# Every one of `wf`'s four calls into `dl` — `--version`, `--ls --json`,
+# `<id> rm`, `<ws> up` / `<ws> -- <cmd>` — is exercised in this repo against a
+# recording shim (`src/probe.rs`), including in `tests/live_launch_exec.rs`,
+# which shims `dl` on purpose so that a machine with devlaunch installed and a
+# machine without one take the same path. Devlaunch, for its part, has no test
+# that names `wf`. The agreement between the two repositories is therefore two
+# independent transcriptions of the same prose, and it has already been wrong
+# once: `dl <workspace> up` shipped in `wf` 0.14.0 before devlaunch 0.0.24
+# carried it, and neither repository's CI noticed. `unsaved` changing from a
+# string to a one-key object was the same class of event.
+#
+# `tests/live_devlaunch.rs` is what these environments exist to run. It asks the
+# installed devlaunch the questions `wf` asks it, and holds the answers against
+# what `wf` believes.
+#
+# ## The environments
+#
+# | environment | `dl`     | what it is for                                        |
+# |-------------|----------|-------------------------------------------------------|
+# | `default`   | none     | the ordinary suite, with no `dl` anywhere on PATH      |
+# | `floor`     | 0.0.24   | exactly `launch::DEVLAUNCH_FLOOR` — the required one   |
+# | `latest`    | newest   | the release a user gets today                          |
+# | `stale`     | 0.0.23   | below the floor: the degradation, not the happy path   |
+#
+# `floor` and `stale` are pinned to an exact version because a constant in
+# `src/launch.rs` names that release and the test asserts the two agree.
+# `latest` is deliberately unpinned in *this* file — `pixi.lock` is what fixes
+# it, so taking a newer devlaunch is a reviewable lockfile change rather than
+# something that happens silently on a Tuesday.
+
+[workspace]
+name = "wayfinder"
+channels = ["https://prefix.dev/blooop", "conda-forge"]
+# Only where devlaunch is published, and only where CI runs. The contract test
+# is not portable in principle, it is unbuilt elsewhere in practice.
+platforms = ["linux-64"]
+
+# No devlaunch, on purpose: the default environment is the "no `dl` installed"
+# case, and the only way to be sure of that is for it to contain nothing that
+# could pull one in. `shellcheck` is here because `scripts/without-dl.sh` is the
+# thing that makes this environment mean anything, and this repo denies warnings
+# in every other language it is written in.
+[dependencies]
+shellcheck = ">=0.10,<0.11"
+
+[tasks]
+lint = "shellcheck --shell=sh --severity=style scripts/without-dl.sh"
+# The ordinary offline suite, run with every directory holding a `dl` stripped
+# out of PATH. Not a contract check — a *hermeticity* check. A test that reaches
+# the ambient `dl` passes on a developer's machine and means nothing, and the
+# only way to see that is to take the `dl` away.
+suite = "scripts/without-dl.sh cargo test --locked --lib --bins --examples"
+
+# `wf` itself, with no devlaunch installed, for driving the degradation by hand:
+# an isolated launch has to fall back to the host and say nothing about it (#80).
+wf = "scripts/without-dl.sh cargo run --locked --bin wf --"
+
+[feature.contract.tasks]
+# One `--test-threads=1`: the tests here each spawn `dl`, and a real devlaunch
+# start is ~90 ms of Python. Serial keeps the failure output in an order a human
+# can read, and there are six of them.
+contract = "cargo test --locked --test live_devlaunch -- --test-threads=1"
+
+[feature.floor.dependencies]
+devlaunch = "==0.0.24"
+[feature.floor.activation.env]
+# Asserted against `launch::DEVLAUNCH_FLOOR`, so this pin and that constant
+# cannot drift apart unnoticed.
+WF_CONTRACT_DL = "0.0.24"
+WF_CONTRACT_EXPECT = "usable"
+WF_CONTRACT_UNSAVED = "object"
+
+[feature.latest.dependencies]
+devlaunch = "*"
+[feature.latest.activation.env]
+# No `WF_CONTRACT_DL`: whatever `pixi.lock` resolved is the subject, and writing
+# the number here as well would mean updating the lock could leave a stale
+# assertion passing against the version it no longer installs.
+WF_CONTRACT_EXPECT = "usable"
+WF_CONTRACT_UNSAVED = "object"
+
+[feature.stale.dependencies]
+devlaunch = "==0.0.23"
+[feature.stale.activation.env]
+WF_CONTRACT_DL = "0.0.23"
+WF_CONTRACT_EXPECT = "too-old"
+# The release before `unsaved` became an object. `wf` still has to read this
+# one's listings — `reap` reads whatever `dl` is on PATH, floor or no floor.
+WF_CONTRACT_UNSAVED = "sentence"
+
+[environments]
+floor = ["contract", "floor"]
+latest = ["contract", "latest"]
+stale = ["contract", "stale"]

--- a/scripts/without-dl.sh
+++ b/scripts/without-dl.sh
@@ -1,22 +1,39 @@
 #!/bin/sh
-# Run a command with every directory that holds a `dl` removed from PATH.
+# Run a command with no `dl` reachable on PATH, and nothing else taken away.
 #
-# The point of the `default` pixi environment is that devlaunch is not
-# installed in it — but `pixi run` *prepends* its prefix to the inherited PATH
-# rather than replacing it, so a developer's `~/.pixi/bin/dl` is still there and
-# the environment proves nothing. This is what actually takes it away.
+# The point of the `default` pixi environment is that devlaunch is not installed
+# in it — but `pixi run` *prepends* its prefix to the inherited PATH rather than
+# replacing it, so a developer's own `dl` is still there and the environment
+# proves nothing. This is what actually takes it away.
 #
-# Removing directories rather than unsetting PATH: the build needs `cargo`,
-# `rustc`, `cc` and `git`, none of which live beside a `dl`. Anything that does
-# ship a `dl` in the same directory as the compiler was already unable to
-# express this test.
+# ## Why a shadow directory rather than dropping the entry
 #
-# Not `set -e`: the loop below is a sequence of tests that are *expected* to
-# fail (most directories have no `dl` in them), and `set -e` plus a bare
-# `[ ... ] && continue` exits the script on the first such directory — which
-# leaves PATH holding only its leading entries and the failure looks like a
-# missing compiler. `set -u` is kept, because an unset variable here would
-# silently produce an empty PATH.
+# The obvious implementation deletes any PATH entry that holds a `dl`. That is
+# wrong here, and specifically wrong: the ordinary way to get devlaunch is
+# `pixi global install devlaunch`, which puts `dl` in `~/.pixi/bin` — the same
+# directory as `gh`, as `wf` itself, and as anything else the developer
+# installed that way, up to and including the Rust toolchain. Dropping the
+# directory takes all of it. The `wf` task below would then run with no `gh`,
+# draw an empty picker, and look like the isolation fallback was broken; a
+# `cargo` installed the same way would make this script fail with
+# `cargo: not found`, having "proved" nothing about hermeticity.
+#
+# So each offending directory is replaced by a shadow of itself: a scratch
+# directory of symlinks to everything in it *except* `dl`. Nothing but the one
+# program disappears.
+#
+# ## Two shell details that are load-bearing
+#
+# `set -f` around the split, because `IFS=:; for dir in $PATH` does pathname
+# expansion as well as word splitting — a PATH entry containing `[`, `*` or `?`
+# that matches a real sibling would be silently rewritten to it, and a `dl`
+# inside the real directory would then survive untested.
+#
+# Not `set -e`: the loop is a sequence of tests that are *expected* to fail for
+# most directories, and `set -e` plus a bare `[ ... ] && continue` exits on the
+# first one — leaving PATH holding only its leading entries, which surfaces as a
+# missing compiler rather than as a bug here. `set -u` is kept, because an unset
+# variable would silently produce an empty PATH.
 set -u
 
 if [ "$#" -eq 0 ]; then
@@ -24,30 +41,64 @@ if [ "$#" -eq 0 ]; then
     exit 2
 fi
 
+shadow_root=$(mktemp -d "${TMPDIR:-/tmp}/without-dl.XXXXXX") || exit 1
+# Cleaned up rather than left behind, which is why the command below is run as a
+# child instead of `exec`ed: an `exec` replaces this shell and the trap never
+# fires, and a symlink farm per invocation is not something to leave in /tmp.
+trap 'rm -rf "$shadow_root"' EXIT INT TERM
+
 kept=
-found=
+shadowed=
+n=0
+
+set -f
 # An empty PATH entry means the working directory, which is not somewhere a
 # toolchain lives and is somewhere a checkout might have a file called `dl`.
 # Dropped rather than tested.
 IFS=:
 for dir in $PATH; do
     [ -n "$dir" ] || continue
+
     # `-f` as well as `-x`: a *directory* named `dl` is executable by this test
-    # and is not a program, so checking only `-x` would throw away a directory
-    # of the toolchain for no reason.
-    if [ -f "$dir/dl" ] && [ -x "$dir/dl" ]; then
-        found="${found:+$found }$dir/dl"
+    # and is not a program, so checking only `-x` would shadow a directory of
+    # the toolchain for no reason.
+    if [ ! -f "$dir/dl" ] || [ ! -x "$dir/dl" ]; then
+        kept="${kept:+$kept:}$dir"
         continue
     fi
-    kept="${kept:+$kept:}$dir"
+
+    n=$((n + 1))
+    shadow="$shadow_root/$n"
+    mkdir -p "$shadow" || exit 1
+    # Globbing back on for exactly this loop, and off again before the outer
+    # split resumes. The `set -f` above is there to stop `$PATH` being expanded
+    # as a pattern; leaving it on here would stop the three patterns below being
+    # expanded *as* patterns, so every shadow came out empty and the directory
+    # was effectively deleted after all — which is the bug this rewrite exists
+    # to fix, reintroduced one line further down. (The outer `for dir in $PATH`
+    # list is already expanded, so toggling inside the body is safe.)
+    #
+    # The three patterns are the standard idiom for "everything including
+    # dotfiles but not `.` or `..`": a hidden executable is unusual in a bin
+    # directory, and losing one silently is the same class of bug again.
+    set +f
+    for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
+        [ -e "$entry" ] || continue
+        [ "${entry##*/}" = "dl" ] && continue
+        ln -s "$entry" "$shadow/" 2>/dev/null
+    done
+    set -f
+    kept="${kept:+$kept:}$shadow"
+    shadowed="${shadowed:+$shadowed }$dir/dl"
 done
 unset IFS
+set +f
 
-if [ -n "$found" ]; then
-    # Said out loud, because a run that silently found nothing to remove and a
-    # run that removed the only `dl` are the same command with very different
-    # meanings, and only one of them tested anything.
-    echo "without-dl.sh: removed from PATH: $found" >&2
+if [ -n "$shadowed" ]; then
+    # Said out loud, because a run that found nothing to remove and a run that
+    # removed the only `dl` are the same command with very different meanings,
+    # and only one of them tested anything.
+    echo "without-dl.sh: hidden from PATH: $shadowed" >&2
 fi
 
 PATH=$kept
@@ -64,4 +115,9 @@ if command -v dl >/dev/null 2>&1; then
     exit 1
 fi
 
-exec "$@"
+# Captured and re-raised explicitly rather than left to fall off the end: the
+# EXIT trap above runs between the command finishing and this script exiting,
+# and "the status survives that" is a thing to state rather than to rely on.
+"$@"
+status=$?
+exit "$status"

--- a/scripts/without-dl.sh
+++ b/scripts/without-dl.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Run a command with every directory that holds a `dl` removed from PATH.
+#
+# The point of the `default` pixi environment is that devlaunch is not
+# installed in it — but `pixi run` *prepends* its prefix to the inherited PATH
+# rather than replacing it, so a developer's `~/.pixi/bin/dl` is still there and
+# the environment proves nothing. This is what actually takes it away.
+#
+# Removing directories rather than unsetting PATH: the build needs `cargo`,
+# `rustc`, `cc` and `git`, none of which live beside a `dl`. Anything that does
+# ship a `dl` in the same directory as the compiler was already unable to
+# express this test.
+#
+# Not `set -e`: the loop below is a sequence of tests that are *expected* to
+# fail (most directories have no `dl` in them), and `set -e` plus a bare
+# `[ ... ] && continue` exits the script on the first such directory — which
+# leaves PATH holding only its leading entries and the failure looks like a
+# missing compiler. `set -u` is kept, because an unset variable here would
+# silently produce an empty PATH.
+set -u
+
+if [ "$#" -eq 0 ]; then
+    echo "without-dl.sh: nothing to run" >&2
+    exit 2
+fi
+
+kept=
+found=
+# An empty PATH entry means the working directory, which is not somewhere a
+# toolchain lives and is somewhere a checkout might have a file called `dl`.
+# Dropped rather than tested.
+IFS=:
+for dir in $PATH; do
+    [ -n "$dir" ] || continue
+    # `-f` as well as `-x`: a *directory* named `dl` is executable by this test
+    # and is not a program, so checking only `-x` would throw away a directory
+    # of the toolchain for no reason.
+    if [ -f "$dir/dl" ] && [ -x "$dir/dl" ]; then
+        found="${found:+$found }$dir/dl"
+        continue
+    fi
+    kept="${kept:+$kept:}$dir"
+done
+unset IFS
+
+if [ -n "$found" ]; then
+    # Said out loud, because a run that silently found nothing to remove and a
+    # run that removed the only `dl` are the same command with very different
+    # meanings, and only one of them tested anything.
+    echo "without-dl.sh: removed from PATH: $found" >&2
+fi
+
+PATH=$kept
+export PATH
+
+# A post-condition on the loop above, not a guard against the outside world:
+# with the same PATH the loop just walked, `command -v` should agree there is
+# nothing left. It is here because the *failure* mode of a wrong filter is
+# silent — the suite goes back to testing whatever the developer has installed
+# and still passes — so the loop is the one piece of this script that must not
+# be allowed to be subtly wrong after somebody edits it.
+if command -v dl >/dev/null 2>&1; then
+    echo "without-dl.sh: a \`dl\` is still reachable at $(command -v dl)" >&2
+    exit 1
+fi
+
+exec "$@"

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1226,7 +1226,7 @@ impl Devlaunch {
     ///
     /// [`Usable`]: Devlaunch::Usable
     /// [`Absent`]: Devlaunch::Absent
-    fn shortfall(self) -> Option<String> {
+    pub fn shortfall(self) -> Option<String> {
         match self {
             Devlaunch::Absent | Devlaunch::Usable => None,
             Devlaunch::TooOld(found) => Some(format!(

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1136,6 +1136,10 @@ pub const DEVLAUNCH_FLOOR: DlVersion = DlVersion(0, 0, 24);
 /// Named rather than built inline so `tests/live_devlaunch.rs` can hand *this*
 /// to a real `dl`. An argv a contract test spells out for itself only proves
 /// the test agrees with the test.
+///
+/// The `workspace` that test passes is its own — a devpod id rather than the
+/// `owner/repo@branch` spec every real caller here builds, because the spec
+/// form makes `dl` clone. What comes from here is the shape after it.
 pub fn isolated_argv(workspace: &str, agent: &[String]) -> Vec<String> {
     vec![
         DEVLAUNCH.to_string(),

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1126,6 +1126,44 @@ fn has_devcontainer(checkout: &Path) -> bool {
 /// nothing is ever run at is a floor nobody has checked.
 pub const DEVLAUNCH_FLOOR: DlVersion = DlVersion(0, 0, 24);
 
+/// What `wf` execs to carry an agent into a container: `dl <ws> -- <command>`.
+///
+/// The workspace spec is a plain argv entry and needs no quoting; the agent
+/// command after `--` does, because `dl` runs it through a shell, and it is one
+/// entry rather than several because "a shell command" is exactly what `dl`
+/// documents it to be.
+///
+/// Named rather than built inline so `tests/live_devlaunch.rs` can hand *this*
+/// to a real `dl`. An argv a contract test spells out for itself only proves
+/// the test agrees with the test.
+pub fn isolated_argv(workspace: &str, agent: &[String]) -> Vec<String> {
+    vec![
+        DEVLAUNCH.to_string(),
+        workspace.to_string(),
+        "--".to_string(),
+        agent
+            .iter()
+            .map(|arg| shell_quote(arg))
+            .collect::<Vec<_>>()
+            .join(" "),
+    ]
+}
+
+/// What [`prewarm`] spawns to build the container ahead of the launch.
+///
+/// `up` is the verb that made [`DEVLAUNCH_FLOOR`] necessary: it arrived in
+/// devlaunch 0.0.24, and a `wf` that sent it to 0.0.23 got
+/// `Unknown command 'up'` from inside a detached process nobody was watching.
+/// Named here for the same reason as [`isolated_argv`], and the contract test
+/// sends it to a real 0.0.23 to watch exactly that happen.
+pub fn prewarm_argv(workspace: &str) -> Vec<String> {
+    vec![
+        DEVLAUNCH.to_string(),
+        workspace.to_string(),
+        "up".to_string(),
+    ]
+}
+
 /// A `dl` version, ordered by the three numbers `dl --version` prints.
 ///
 /// A tuple struct rather than three fields because the derived [`Ord`] is
@@ -1626,16 +1664,7 @@ impl Launch {
         let agent = self.agent_argv_inner();
         match self.isolation {
             Isolation::Host => agent,
-            Isolation::Devlaunch => vec![
-                DEVLAUNCH.to_string(),
-                self.workspace(),
-                "--".to_string(),
-                agent
-                    .iter()
-                    .map(|arg| shell_quote(arg))
-                    .collect::<Vec<_>>()
-                    .join(" "),
-            ],
+            Isolation::Devlaunch => isolated_argv(&self.workspace(), &agent),
         }
     }
 
@@ -1846,7 +1875,7 @@ pub fn prewarm(checkouts: &[Checkout], staged: &Staged) -> Option<Vec<String>> {
     let isolated = candidate_checkouts(checkouts, &staged.repo)
         .into_iter()
         .any(|c| Isolation::detect(&c.path, Agent::default()) == Isolation::Devlaunch);
-    isolated.then(|| vec![DEVLAUNCH.to_string(), workspace, "up".to_string()])
+    isolated.then(|| prewarm_argv(&workspace))
 }
 
 /// Run `argv` in the background, detached from this process and its terminal.

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1119,7 +1119,12 @@ fn has_devcontainer(checkout: &Path) -> bool {
 /// A floor is the honest expression of a subprocess dependency: `wf` cannot
 /// pin `dl`'s version the way a linked crate would (devlaunch#53), so it
 /// checks what it found and degrades when the answer is too old.
-const DEVLAUNCH_FLOOR: DlVersion = DlVersion(0, 0, 24);
+/// Public because it is half of a contract with another repository, and
+/// `tests/live_devlaunch.rs` holds the two halves against each other: the pixi
+/// `floor` environment pins `devlaunch` to exactly this number, and the test
+/// fails if the pin and this constant ever name different releases. A floor
+/// nothing is ever run at is a floor nobody has checked.
+pub const DEVLAUNCH_FLOOR: DlVersion = DlVersion(0, 0, 24);
 
 /// A `dl` version, ordered by the three numbers `dl --version` prints.
 ///
@@ -1127,7 +1132,7 @@ const DEVLAUNCH_FLOOR: DlVersion = DlVersion(0, 0, 24);
 /// exactly the comparison wanted — major, then minor, then patch — and there
 /// is nothing else to say about it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-struct DlVersion(u32, u32, u32);
+pub struct DlVersion(u32, u32, u32);
 
 impl std::fmt::Display for DlVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1176,8 +1181,12 @@ impl DlVersion {
 /// worth explaining to anybody. [`Isolation`] stays two-state about the
 /// *outcome* — what will actually happen — and this is the type that carries
 /// why, so neither has to pretend the other's job is simple.
+///
+/// Public for `tests/live_devlaunch.rs`, which is the only place this
+/// classification is ever applied to a `dl` that actually exists. Every other
+/// test of it — and every shimmed probe — hands it a string this repo wrote.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Devlaunch {
+pub enum Devlaunch {
     /// Not on PATH, or on PATH and not runnable. The ordinary state of a
     /// machine that never installed it, and there is no version to report.
     Absent,
@@ -1195,9 +1204,9 @@ impl Devlaunch {
     /// Read `dl --version`'s answer.
     ///
     /// Split from the probe so the rule is testable without a `dl` on the
-    /// machine running the tests — the same split [`enabled_from`] makes for
+    /// machine running the tests — the same split `enabled_from` below makes for
     /// `WF_PREWARM`.
-    fn from_version_output(stdout: &str) -> Devlaunch {
+    pub fn from_version_output(stdout: &str) -> Devlaunch {
         match DlVersion::parse(stdout) {
             None => Devlaunch::Unreadable,
             Some(found) if found < DEVLAUNCH_FLOOR => Devlaunch::TooOld(found),
@@ -1244,7 +1253,7 @@ impl Devlaunch {
     /// this binary cannot place reads the old, permissive way. The failure mode
     /// is then "behaves as it did before the floor existed" rather than
     /// "refuses every workspace on a machine `wf` could not probe".
-    fn answers_unsaved(self) -> bool {
+    pub fn answers_unsaved(self) -> bool {
         match self {
             Devlaunch::Usable => true,
             // Too old for the *floor* is not too old for this question: a `dl`
@@ -1297,7 +1306,7 @@ fn devlaunch_on_path() -> Devlaunch {
 /// from whatever `dl` is on PATH rather than only from one a launch would
 /// accept. Collapsing them would make a future floor bump silently restate a
 /// fact about a past release.
-const UNSAVED_IS_AN_OBJECT: DlVersion = DlVersion(0, 0, 24);
+pub const UNSAVED_IS_AN_OBJECT: DlVersion = DlVersion(0, 0, 24);
 
 /// Does the `dl` on this machine say what every clone it made would lose?
 ///

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -704,8 +704,11 @@ pub async fn workspaces() -> Result<Vec<Workspace>> {
 /// Named rather than built inline at the call site so that
 /// `tests/live_devlaunch.rs` can hand *this* to a real `dl` instead of
 /// re-typing it. An argv a contract test spells out for itself is an argv the
-/// test agrees with the test about; the point is to run the one the binary
-/// actually sends.
+/// test agrees with the test about.
+///
+/// The `id` that test passes is its own — a devpod workspace id its shimmed
+/// devpod reports as existing. What comes from here is the verb and the flag,
+/// which is what a devlaunch release can take away.
 pub fn removal_argv(id: &str, insist: bool) -> Vec<String> {
     let mut args = vec![id.to_string(), "rm".to_string()];
     if insist {

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -699,6 +699,21 @@ pub async fn workspaces() -> Result<Vec<Workspace>> {
     Ok(workspaces)
 }
 
+/// What `wf` hands `dl` to destroy one workspace, as a value.
+///
+/// Named rather than built inline at the call site so that
+/// `tests/live_devlaunch.rs` can hand *this* to a real `dl` instead of
+/// re-typing it. An argv a contract test spells out for itself is an argv the
+/// test agrees with the test about; the point is to run the one the binary
+/// actually sends.
+pub fn removal_argv(id: &str, insist: bool) -> Vec<String> {
+    let mut args = vec![id.to_string(), "rm".to_string()];
+    if insist {
+        args.push("--force".to_string());
+    }
+    args
+}
+
 /// The parse boundary for `dl`'s listing, kept apart from the process call so
 /// it is testable without devlaunch installed.
 ///
@@ -934,10 +949,7 @@ fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap
 /// No `dl` on PATH, or a `dl <ws> rm` that failed — including the refusal
 /// above, which is a failure `wf` reports rather than quietly overrides.
 async fn remove(id: &str, insist: bool) -> Result<()> {
-    let mut args = vec![id, "rm"];
-    if insist {
-        args.push("--force");
-    }
+    let args = removal_argv(id, insist);
     let output = Command::new("dl")
         .args(&args)
         .stdin(Stdio::null())

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -701,7 +701,17 @@ pub async fn workspaces() -> Result<Vec<Workspace>> {
 
 /// The parse boundary for `dl`'s listing, kept apart from the process call so
 /// it is testable without devlaunch installed.
-fn parse_workspaces(body: &[u8]) -> Result<Vec<Workspace>> {
+///
+/// Public so `tests/live_devlaunch.rs` can feed it the bytes a *real* `dl`
+/// wrote. Every other caller of this function in the repo hands it a fixture
+/// transcribed from devlaunch's documentation by hand, which is a check that
+/// this repo agrees with itself.
+///
+/// # Errors
+///
+/// The body is not JSON, or not an array of objects this binary can read as
+/// workspaces. All-or-nothing on purpose — see [`Unsaved::Unrecognized`].
+pub fn parse_workspaces(body: &[u8]) -> Result<Vec<Workspace>> {
     serde_json::from_slice(body).context("unparseable workspace listing from `dl --ls --json`")
 }
 

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -282,9 +282,8 @@ fn scratch(what: &str) -> PathBuf {
 /// Run the `dl` under test and return its stdout, or panic with its stderr.
 fn ask_dl(args: &[&str], what: &str) -> String {
     let program = dl();
-    let out = Command::new(&program)
+    let out = hermetic(&program, &scratch(what))
         .args(args)
-        .env("HOME", scratch(what))
         .output()
         .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
     assert!(
@@ -331,7 +330,7 @@ fn python_of(program: &Path) -> PathBuf {
 fn ask_devlaunch(snippet: &str, args: &[&str], why: &str) -> String {
     let program = dl();
     let python = python_of(&program);
-    let out = Command::new(&python)
+    let out = hermetic(&python, &scratch("devlaunch-ask"))
         .arg("-c")
         .arg(snippet)
         .args(args)
@@ -702,7 +701,7 @@ fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
 /// does not), and a `commit` that fails for that reason would look like the
 /// clone being unreadable.
 fn git(dir: &Path, args: &[&str]) {
-    let out = Command::new("git")
+    let out = hermetic(Path::new("git"), dir)
         .arg("-C")
         .arg(dir)
         .args(["-c", "user.email=contract@example.invalid"])
@@ -838,9 +837,8 @@ fn a_reap_with_no_dl_refuses_instead_of_guessing() {
         return;
     }
     let home = scratch("reap-home");
-    let out = Command::new(env!("CARGO_BIN_EXE_wf"))
+    let out = hermetic(Path::new(env!("CARGO_BIN_EXE_wf")), &home)
         .args(["reap", "-y"])
-        .env("HOME", &home)
         .output()
         .expect("the wf binary");
     let said = format!(
@@ -906,6 +904,132 @@ impl Asked {
     }
 }
 
+/// Every subprocess this file starts, with an environment **built rather than
+/// inherited**.
+///
+/// The inheriting version of this was two `env_remove` calls, `GH_TOKEN` and
+/// `GITHUB_TOKEN`, which is a denylist of the two names that happened to be
+/// true when it was written. Three things are wrong with that shape and all of
+/// them are drift:
+///
+/// * devlaunch reads `HOST_TOKEN_VARS` *first* and falls back to running
+///   `gh auth token`, so the credential need never be in the environment at
+///   all — it can come from `gh`'s config or keyring.
+/// * a variable added on either side is admitted by default.
+/// * nothing notices when the list stops being complete.
+///
+/// So the environment is allowlisted: cleared, then given back the four things
+/// a run needs. Anything new is excluded because it was never let in.
+/// `DEVLAUNCH_NO_GH_TOKEN` is devlaunch's own documented opt-out and covers the
+/// sources clearing the environment cannot reach; the scratch `HOME` covers
+/// `gh`'s config directory. Neither is trusted on its own — see
+/// [`refuse_secrets`], which is the part that keeps working when both of these
+/// stop being the right names.
+fn hermetic(program: &Path, home: &Path) -> Command {
+    let mut cmd = Command::new(program);
+    cmd.env_clear()
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".to_string()),
+        )
+        .env("HOME", home)
+        // devlaunch's `DISABLE_VAR`. Set so that no credential is *fetched*,
+        // rather than hoping none is *inherited*.
+        .env("DEVLAUNCH_NO_GH_TOKEN", "1");
+    cmd
+}
+
+/// Names whose value is nobody's business, matched on shape rather than spelled
+/// out — the point is to catch the variable that does not exist yet.
+fn looks_secret(name: &str) -> bool {
+    let name = name.to_ascii_uppercase();
+    [
+        "TOKEN",
+        "SECRET",
+        "PASSWORD",
+        "PASSWD",
+        "CREDENTIAL",
+        "AUTH",
+    ]
+    .iter()
+    .any(|needle| name.contains(needle))
+        || name.ends_with("_KEY")
+}
+
+/// Token shapes, for a credential that arrives without a name attached.
+const TOKEN_PREFIXES: [&str; 6] = ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"];
+
+/// Fail if anything captured here looks like a credential — before it can be
+/// printed.
+///
+/// This is the durable half of the mitigation. devlaunch **deliberately** keeps
+/// the token off the command line today: `gh_auth.up_args` writes it to a
+/// private file and passes `--workspace-env-file`, and its docstring says why —
+/// `devpod up` runs for minutes and its argv is visible to anyone who can run
+/// `ps`. So there is nothing to redact right now. That is a decision in another
+/// repository, and the reason this exists is that a change to it must surface
+/// as a failed test here rather than as a token in a CI log.
+///
+/// Shape, not name: a rename on devlaunch's side leaves this working. The
+/// message names only the key, never the value — a guard that prints what it
+/// caught is the leak it was guarding against.
+fn refuse_secrets(what: &str, lines: &[String]) {
+    for line in lines {
+        for prefix in TOKEN_PREFIXES {
+            assert!(
+                !line.contains(prefix),
+                "{what} contains something shaped like a GitHub token \
+                 (a `{prefix}` string). The value is deliberately not shown. \
+                 devlaunch used to keep credentials off argv; if that changed, \
+                 this test has to stop capturing them before it can run again."
+            );
+        }
+        for field in line.split(['<', '>']) {
+            let Some((name, value)) = field.split_once('=') else {
+                continue;
+            };
+            assert!(
+                !looks_secret(name) || value.is_empty(),
+                "{what} carries `{name}=...` — a name shaped like a secret, \
+                 with a value. The value is deliberately not shown. Either \
+                 devlaunch has started putting credentials on the command line, \
+                 or this needs to learn why that one is harmless."
+            );
+        }
+    }
+}
+
+/// Blank the value of every `NAME=VALUE` argument.
+///
+/// Belt and braces behind [`refuse_secrets`], for the credential whose name and
+/// shape are both ones nobody thought of: the assertions in this file never
+/// need the *value* of an environment assignment, only that it was passed and
+/// under what name, so nothing is lost by never holding one.
+fn redact(line: &str) -> String {
+    // Only a field whose left side is a plausible *variable name* is treated as
+    // an assignment. `bash -lc 'FOO=1 ...'` is a command, not an environment
+    // entry, and blanking the right of its first `=` would quietly rewrite the
+    // thing `an_isolated_launch_arrives_as_one_shell_command` is asserting.
+    let is_name = |name: &str| {
+        !name.is_empty()
+            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+            && !name.starts_with(|c: char| c.is_ascii_digit())
+    };
+    line.split_inclusive('>')
+        .map(|field| {
+            let bare = field.trim_start_matches([' ', '<']);
+            match bare.split_once('=') {
+                Some((name, _)) if is_name(name) => {
+                    format!(" <{name}=…>")
+                }
+                _ => field.to_string(),
+            }
+        })
+        .collect::<String>()
+        .trim_start()
+        .to_string()
+}
+
 /// Run the real `dl` with a recording `devpod` in front of it.
 ///
 /// `argv` is what `wf` itself builds — `reap::removal_argv`,
@@ -956,33 +1080,34 @@ exit 0
         dir.display(),
         std::env::var("PATH").unwrap_or_default()
     );
-    let out = Command::new(&program)
+    let out = hermetic(&program, &home)
         .args(&after_program)
         .env("PATH", path)
-        .env("HOME", &home)
         .env("DP_LOG", &log)
-        // Cleared, not inherited. With a token in the environment `dl` forwards
-        // it to devpod as `--init-env GH_TOKEN=...`, which would put a real
-        // credential into the recording below — and this test prints that
-        // recording when it fails.
-        .env_remove("GH_TOKEN")
-        .env_remove("GITHUB_TOKEN")
         .output()
         .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
 
+    let raw: Vec<String> = std::fs::read_to_string(&log)
+        .expect("the log")
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Checked on the raw capture and stored redacted, in that order. Redacting
+    // first would leave the guard nothing to find; storing raw would leave a
+    // credential in something every assertion below prints on failure.
+    refuse_secrets("the devpod recording", &raw);
+    refuse_secrets("what dl said", std::slice::from_ref(&said));
+
     Asked {
-        devpod: std::fs::read_to_string(&log)
-            .expect("the log")
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(str::to_string)
-            .collect(),
+        devpod: raw.iter().map(|line| redact(line)).collect(),
         status: out.status,
-        said: format!(
-            "{}{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
-        ),
+        said,
     }
 }
 
@@ -1146,7 +1271,7 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
     std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
     std::fs::set_permissions(&claude, perms).expect("an executable recorder");
 
-    let out = Command::new("sh")
+    let out = hermetic(Path::new("sh"), &bin)
         .arg("-c")
         .arg(command)
         .env(
@@ -1157,7 +1282,6 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
                 std::env::var("PATH").unwrap_or_default()
             ),
         )
-        .env("HOME", &bin)
         .output()
         .expect("a shell");
     assert!(
@@ -1172,5 +1296,94 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
         got, "<--dangerously-skip-permissions></wf-one blooop/wayfinder 137>",
         "the agent was called with the wrong argv. The prompt has to arrive as \
          one argument; three is what an unquoted join produces.\nfrom: {command}"
+    );
+}
+
+#[test]
+fn every_subprocess_here_is_started_by_the_one_function_that_sanitises() {
+    // A guard on this file's own source, because the mitigation it protects is
+    // the kind that decays by addition rather than by edit: nothing about
+    // writing a new test here reminds anybody that the environment has to be
+    // built rather than inherited, and a run that inherits one is
+    // indistinguishable from a run that does not until the day it prints a
+    // token. `hermetic` is the only place allowed to start a process, so
+    // "did you sanitise?" becomes "does this compile", and the answer is
+    // checked rather than remembered.
+    //
+    // The needle is assembled rather than written, so that this test does not
+    // count itself.
+    let needle = concat!("Command", "::new");
+    let source = include_str!("live_devlaunch.rs");
+
+    assert_eq!(
+        source.matches(needle).count(),
+        1,
+        "something in this file starts a subprocess without going through \
+         `hermetic`, so it inherits the developer's whole environment — \
+         including whatever credential is in it. Route it through `hermetic`, \
+         or, if it genuinely must inherit, say why here and change this count."
+    );
+
+    let at = source.find(needle).expect("the one spawn");
+    let opens = source
+        .find("fn hermetic(")
+        .expect("the sanitising spawn is called `hermetic`");
+    let closes = source[opens..]
+        .find("\nfn ")
+        .map_or(source.len(), |rel| opens + rel);
+    assert!(
+        (opens..closes).contains(&at),
+        "the one subprocess spawn has moved out of `hermetic`. Counting it is \
+         not the point; being inside the function that clears the environment is."
+    );
+}
+
+#[test]
+fn the_sanitised_spawn_hands_on_nothing_it_was_not_given() {
+    // The allowlist, read off a real child rather than off the source.
+    //
+    // `hermetic` is only worth anything if it actually clears, and nothing else
+    // here would notice if it stopped: every test would go on passing, quietly
+    // inheriting the developer's environment again. So a child is asked what it
+    // received and the answer is compared to the whole intended list — an
+    // equality, not a "contains", because the failure being guarded against is
+    // a variable arriving that nobody meant to send.
+    //
+    // `CARGO_MANIFEST_DIR` is in this process's environment (cargo puts it
+    // there) and must not be in the child's. It is the canary: no variable has
+    // to be planted, because the point is precisely that ambient ones do not
+    // travel.
+    assert!(
+        std::env::var_os("CARGO_MANIFEST_DIR").is_some(),
+        "this test's canary is gone — it assumed cargo sets CARGO_MANIFEST_DIR \
+         in the test process, and something else is needed if it no longer does"
+    );
+    let home = scratch("hermetic-env");
+    let out = hermetic(Path::new("sh"), &home)
+        .args(["-c", "env"])
+        .output()
+        .expect("a shell");
+    assert!(
+        out.status.success(),
+        "could not read the child's environment"
+    );
+
+    let printed = String::from_utf8_lossy(&out.stdout);
+    let mut got: Vec<&str> = printed
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(name, _)| name)
+        // Set by the shell itself, not passed in: `sh` defines these on start
+        // whatever it was handed, so they are not evidence of inheritance.
+        .filter(|name| !matches!(*name, "PWD" | "SHLVL" | "_"))
+        .collect();
+    got.sort_unstable();
+    got.dedup();
+    assert_eq!(
+        got,
+        ["DEVLAUNCH_NO_GH_TOKEN", "HOME", "PATH"],
+        "the sanitised spawn passed on a variable it was not given. Anything \
+         beyond the allowlist reached the child by inheritance, which is the \
+         one thing `hermetic` exists to prevent."
     );
 }

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -24,17 +24,29 @@
 //! pixi run -e stale  contract   # 0.0.23, below the floor
 //! ```
 //!
+//! # Everything here fails closed
+//!
 //! It is not runnable outside those environments and does not try to be: with
-//! no `WF_CONTRACT_EXPECT` in the environment every test here panics saying so,
+//! no `WF_CONTRACT_*` in the environment **every** test here panics saying so,
 //! rather than quietly testing whichever `dl` the developer happens to have.
 //! That distinction is the whole point — a contract test that silently accepts
 //! the ambient install is the shim again, wearing a different hat.
 //!
-//! **Read-only.** The only two subcommands used are `--version` and
-//! `--ls --json`, and both run under a scratch `HOME`, so this cannot see or
-//! touch a real workspace. The scratch home matters for a second reason: a
-//! listing read from the developer's own machine would assert against whatever
-//! they happen to have cloned.
+//! The same rule governs the variables' *values*, and it is not decoration. An
+//! earlier draft compared `WF_CONTRACT_UNSAVED` for equality and returned early
+//! otherwise; typing `objekt` into `pixi.toml` then disabled both of the tests
+//! that read it and the file still reported seven passes. Anything unrecognised
+//! is a panic now, and [`Contract::read`] is the one place that decides.
+//!
+//! # What it cannot reach
+//!
+//! `dl <id> rm` and `dl <ws> up` change the machine and need a devpod daemon, so
+//! neither is run — only that this `dl` still names them is checked, in
+//! [`the_verbs_wf_hands_dl_are_ones_it_still_knows`]. Everything else here is
+//! read-only, under a scratch `HOME`, so it cannot see or touch a real
+//! workspace. The scratch home matters for a second reason: a listing read from
+//! the developer's own machine would assert against whatever they happen to
+//! have cloned.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -44,12 +56,102 @@ use wf::reap::{parse_workspaces, Unsaved};
 
 /// How `pixi.toml` tells this file what environment it is in.
 ///
-/// Three variables rather than one, because they are three independent facts
-/// and a single "environment name" would make this file re-derive them from it
-/// — which is the transcription problem again, one repository further in.
+/// Four variables rather than one name, because three of them are *facts about
+/// the release* and a single environment name would make this file re-derive
+/// them — which is the transcription problem again, one repository further in.
+/// [`Role`] is the exception and carries no facts: it decides which assertions
+/// apply, not what any of them expect.
+const ROLE: &str = "WF_CONTRACT_ROLE";
 const EXPECT: &str = "WF_CONTRACT_EXPECT";
 const VERSION: &str = "WF_CONTRACT_DL";
 const UNSAVED: &str = "WF_CONTRACT_UNSAVED";
+
+/// Which of the three environments this is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Role {
+    /// Pinned to exactly [`DEVLAUNCH_FLOOR`].
+    Floor,
+    /// Whatever `pixi.lock` resolved — no version is written down for it.
+    Latest,
+    /// Pinned below the floor.
+    Stale,
+}
+
+/// What `wf` must make of this release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Expect {
+    Usable,
+    TooOld,
+}
+
+/// How this release writes `unsaved` in `dl --ls --json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Shape {
+    /// devlaunch ≥ 0.0.24: a one-key object.
+    Object,
+    /// devlaunch ≤ 0.0.23: a bare sentence, or `null`.
+    Sentence,
+}
+
+/// The environment's claims about the `dl` it installed, all of them present
+/// and all of them recognised.
+#[derive(Debug)]
+struct Contract {
+    role: Role,
+    expect: Expect,
+    unsaved: Shape,
+    /// The exact version `pixi.toml` pinned. `None` only for [`Role::Latest`],
+    /// which deliberately has no number written down.
+    pinned: Option<String>,
+}
+
+impl Contract {
+    /// Read all four variables, or panic saying which one is wrong.
+    ///
+    /// Absent and unrecognised are both fatal, and the pin's presence is tied
+    /// to the role rather than left optional: a pinned environment that lost
+    /// its `WF_CONTRACT_DL` would otherwise skip the only check that the
+    /// version installed is the version named, and `latest` carrying one would
+    /// be a number nobody updates when the lock moves.
+    fn read() -> Contract {
+        let role = match promised(ROLE).as_str() {
+            "floor" => Role::Floor,
+            "latest" => Role::Latest,
+            "stale" => Role::Stale,
+            other => panic!("{ROLE} says {other:?}, which is not an environment in pixi.toml"),
+        };
+        let expect = match promised(EXPECT).as_str() {
+            "usable" => Expect::Usable,
+            "too-old" => Expect::TooOld,
+            other => panic!("{EXPECT} says {other:?}; it is `usable` or `too-old`"),
+        };
+        let unsaved = match promised(UNSAVED).as_str() {
+            "object" => Shape::Object,
+            "sentence" => Shape::Sentence,
+            other => panic!("{UNSAVED} says {other:?}; it is `object` or `sentence`"),
+        };
+        let pinned = std::env::var(VERSION).ok();
+        match (role, &pinned) {
+            (Role::Latest, Some(v)) => panic!(
+                "the `latest` environment pinned {v} in {VERSION}. It installs \
+                 whatever pixi.lock resolved, and a number written beside that \
+                 is one nobody updates when the lock moves."
+            ),
+            (Role::Floor | Role::Stale, None) => panic!(
+                "the `{role:?}` environment pins an exact devlaunch but set no \
+                 {VERSION}, so nothing checks that the version installed is the \
+                 version named."
+            ),
+            _ => {}
+        }
+        Contract {
+            role,
+            expect,
+            unsaved,
+            pinned,
+        }
+    }
+}
 
 /// The panic for a run outside the pixi environments.
 ///
@@ -87,21 +189,20 @@ fn dl() -> PathBuf {
         .find(|candidate| candidate.is_file())
         .unwrap_or_else(|| {
             panic!(
-                "no `dl` on PATH, but {EXPECT} says there should be one \
-                 ({}). Is this the `default` environment?",
-                promised(EXPECT)
+                "no `dl` on PATH, but {ROLE} says this is the `{}` environment. \
+                 Is this the `default` one?",
+                promised(ROLE)
             )
         })
 }
 
-/// A `HOME` with nothing in it, for the duration of one call.
+/// A scratch directory under the temp dir, keyed by pid.
 ///
 /// Not cleaned up on a panic, deliberately: a failing contract test is a thing
-/// somebody is about to go and look at, and the listing `dl` wrote is evidence.
-/// It is under the temp dir, keyed by pid, so it costs nothing to leave.
-fn scratch_home(what: &str) -> PathBuf {
+/// somebody is about to go and look at, and what `dl` wrote is the evidence.
+fn scratch(what: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("wf-contract-{}-{what}", std::process::id()));
-    std::fs::create_dir_all(&dir).expect("a scratch home");
+    std::fs::create_dir_all(&dir).expect("a scratch directory");
     dir
 }
 
@@ -110,7 +211,7 @@ fn ask_dl(args: &[&str], what: &str) -> String {
     let program = dl();
     let out = Command::new(&program)
         .args(args)
-        .env("HOME", scratch_home(what))
+        .env("HOME", scratch(what))
         .output()
         .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
     assert!(
@@ -146,6 +247,47 @@ fn python_of(program: &Path) -> PathBuf {
     python
 }
 
+/// Run a snippet against the devlaunch under test and return its stdout.
+///
+/// Reaching past the CLI into the package is deliberate rather than an
+/// oversight, and it is the only way to reach two of the things worth pinning:
+/// the CLI cannot be made to emit a `wouldLose` row without a real workspace
+/// and a devpod daemon. The coupling is honest — a failure here says devlaunch
+/// moved something that defines this contract, which is a thing `wf` needs to
+/// be told rather than to find out from a user.
+fn ask_devlaunch(snippet: &str, args: &[&str], why: &str) -> String {
+    let program = dl();
+    let python = python_of(&program);
+    let out = Command::new(&python)
+        .arg("-c")
+        .arg(snippet)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("could not run {}: {e}", python.display()));
+    assert!(
+        out.status.success(),
+        "{why}:\n{}",
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// One row of a listing, carrying `unsaved` exactly as devlaunch wrote it.
+///
+/// Read back through the real parser rather than through a `serde_json` call on
+/// the field alone: `unsaved` is read as part of a `Workspace`, and a row is
+/// what `dl` actually emits.
+fn read_back(unsaved: &str) -> Option<Unsaved> {
+    let row = format!(
+        r#"[{{"id":"ws","devlaunch":true,"repo":"blooop/wayfinder",
+              "branch":"wayfinder/wayfinder-1","state":"Stopped",
+              "unsaved":{unsaved}}}]"#
+    );
+    let parsed = parse_workspaces(row.as_bytes())
+        .unwrap_or_else(|e| panic!("`wf` could not read {unsaved}: {e:#}"));
+    parsed.into_iter().next().expect("one row").unsaved
+}
+
 #[test]
 fn the_dl_under_test_is_the_one_the_environment_installed() {
     // `pixi run` prepends its prefix to the *inherited* PATH, so a developer's
@@ -155,6 +297,7 @@ fn the_dl_under_test_is_the_one_the_environment_installed() {
     // would carry on happily against the host's install and report a verdict
     // about a version nobody selected. This is the assertion that makes the
     // pin mean something.
+    let _ = Contract::read();
     let program = dl();
     let prefix = std::env::var("CONDA_PREFIX")
         .unwrap_or_else(|_| panic!("{}", only_under_pixi("CONDA_PREFIX")));
@@ -172,6 +315,7 @@ fn wf_can_read_the_version_this_dl_prints() {
     // parse, and it sends every isolated launch to the host. It has never been
     // reached by anything but a string written in this repository. A devlaunch
     // that reformatted its version banner would land here and nowhere else.
+    let contract = Contract::read();
     let printed = ask_dl(&["--version"], "version");
     assert_ne!(
         Devlaunch::from_version_output(&printed),
@@ -179,32 +323,44 @@ fn wf_can_read_the_version_this_dl_prints() {
         "`wf` could not read a version out of what this `dl` prints: {printed:?}"
     );
 
-    let expected = promised(EXPECT);
     let got = verdict();
-    match expected.as_str() {
-        "usable" => assert_eq!(
+    match contract.expect {
+        Expect::Usable => assert_eq!(
             got,
             Devlaunch::Usable,
             "this dl ({}) should clear the {DEVLAUNCH_FLOOR} floor",
             printed.trim()
         ),
-        "too-old" => assert!(
+        Expect::TooOld => assert!(
             matches!(got, Devlaunch::TooOld(_)),
             "this dl ({}) is below the {DEVLAUNCH_FLOOR} floor and should read \
              as TooOld, not {got:?}",
             printed.trim()
         ),
-        other => panic!("{EXPECT} says {other:?}, which this file does not know"),
     }
 }
 
 #[test]
-fn the_pinned_version_and_the_installed_one_are_the_same_release() {
-    // Only the exactly-pinned environments set this. `latest` deliberately does
-    // not: what it installs is whatever `pixi.lock` resolved, and a number
-    // written in `pixi.toml` beside it would be a second place to update and a
-    // stale assertion the day somebody forgot.
-    let Ok(pinned) = std::env::var(VERSION) else {
+fn the_floor_environment_is_pinned_to_the_floor() {
+    // The claim AGENTS.md makes, stated as an assertion rather than as a guard.
+    //
+    // An earlier draft wrote this as `if pinned == DEVLAUNCH_FLOOR { ... }`,
+    // which can only fire when the two already agree — so lowering the constant
+    // to 0.0.23 while pixi still pinned 0.0.24 left all seven tests green, and
+    // the `floor` environment was no longer running at the floor. That is the
+    // exact condition this file exists to prevent, so the role is asked
+    // explicitly and the comparison is unconditional.
+    //
+    // Note what is *not* asserted: that `DEVLAUNCH_FLOOR` equals
+    // `UNSAVED_IS_AN_OBJECT`. The draft did, and it was actively dangerous —
+    // `src/launch.rs` documents those two as separate facts that a floor bump
+    // must be able to part, and the only way to satisfy such an assertion after
+    // a legitimate bump is to raise `UNSAVED_IS_AN_OBJECT` too, which makes
+    // `answers_unsaved` false for a real 0.0.24 and walks `wf reap` straight
+    // back into devlaunch#171.
+    let contract = Contract::read();
+    let Some(pinned) = contract.pinned else {
+        assert_eq!(contract.role, Role::Latest, "only `latest` may omit a pin");
         return;
     };
     let printed = ask_dl(&["--version"], "version");
@@ -213,15 +369,14 @@ fn the_pinned_version_and_the_installed_one_are_the_same_release() {
         printed.split_whitespace().any(|word| word == pinned),
         "pixi pinned devlaunch {pinned} but the `dl` on PATH says {printed:?}"
     );
-
-    // And the floor environment's pin *is* the constant. Two files, one
-    // release: `pixi.toml` naming 0.0.24 and `launch.rs` naming something else
-    // would mean the floor is never actually run at.
-    if promised(EXPECT) == "usable" && pinned == DEVLAUNCH_FLOOR.to_string() {
+    if contract.role == Role::Floor {
         assert_eq!(
-            DEVLAUNCH_FLOOR, UNSAVED_IS_AN_OBJECT,
-            "these two constants have parted company; the environments below \
-             assume `WF_CONTRACT_UNSAVED=object` follows from clearing the floor"
+            pinned,
+            DEVLAUNCH_FLOOR.to_string(),
+            "the `floor` environment installs devlaunch {pinned}, but the floor \
+             is {DEVLAUNCH_FLOOR}. Whichever of the two moved, the other has to \
+             move with it — a floor nothing is ever run at is a floor nobody \
+             has checked."
         );
     }
 }
@@ -234,12 +389,9 @@ fn a_listing_from_a_real_dl_is_one_wf_can_read() {
     // The listing here is empty — a scratch `HOME` has no workspaces — so what
     // this pins is the envelope: that `--ls --json` still exists, still exits
     // zero without a daemon, and still answers with a JSON array rather than a
-    // banner, a wrapper object, or a line of prose.
-    //
-    // The rows themselves cannot be reached this way. Making one means a real
-    // devpod workspace and a Docker daemon, which is devlaunch's own e2e
-    // suite's job, not this file's; the row *shape* is checked below, from the
-    // emitter rather than from an instance.
+    // banner, a wrapper object, or a line of prose. The rows themselves are
+    // reached below, from the emitter rather than from an instance.
+    let _ = Contract::read();
     let body = ask_dl(&["--ls", "--json"], "listing");
     let parsed = parse_workspaces(body.as_bytes())
         .unwrap_or_else(|e| panic!("`wf` could not read this dl's listing ({e:#}): {body:?}"));
@@ -259,18 +411,12 @@ fn every_unsaved_answer_this_dl_can_give_is_one_wf_reads() {
     // `unsaved_as_json` to produce them instead, so a rename on that side is a
     // failure here rather than a `wf reap` that silently refuses every
     // workspace on every machine.
-    //
-    // Reaching into `devlaunch.workspace_state` is reaching past the CLI, and
-    // that is the point rather than an oversight: the CLI cannot be made to
-    // emit a `wouldLose` row without a real clone holding real uncommitted
-    // work, and the three arms are exactly what is worth pinning. The coupling
-    // is honest — an ImportError here says devlaunch moved the function that
-    // defines this contract, which is a thing `wf` needs to be told.
-    if promised(UNSAVED) != "object" {
+    let contract = Contract::read();
+    if contract.unsaved != Shape::Object {
         return;
     }
-    let program = dl();
-    let emit = r#"
+    let emitted = ask_devlaunch(
+        r#"
 import json
 from devlaunch.workspace_state import (
     unsaved_as_json, NothingToLose, WouldLose, CouldNotTell,
@@ -281,20 +427,12 @@ for answer in (
     CouldNotTell("fatal: not a git repository"),
 ):
     print(json.dumps(unsaved_as_json(answer)))
-"#;
-    let python = python_of(&program);
-    let out = Command::new(&python)
-        .args(["-c", emit])
-        .output()
-        .unwrap_or_else(|e| panic!("could not run {}: {e}", python.display()));
-    assert!(
-        out.status.success(),
+"#,
+        &[],
         "devlaunch could not be asked what it writes for `unsaved` — it has \
          probably moved or renamed `workspace_state.unsaved_as_json`, which is \
-         the function that defines this contract:\n{}",
-        String::from_utf8_lossy(&out.stderr).trim()
+         the function that defines this contract",
     );
-    let emitted = String::from_utf8_lossy(&out.stdout);
     let answers: Vec<&str> = emitted.lines().filter(|l| !l.trim().is_empty()).collect();
     assert_eq!(
         answers.len(),
@@ -308,50 +446,139 @@ for answer in (
         Unsaved::CouldNotTell("fatal: not a git repository".to_string()),
     ];
     for (answer, want) in answers.iter().zip(expected) {
-        // Through the real parser, in a real row, rather than through a
-        // `serde_json::from_str` on the field alone: `unsaved` is read as part
-        // of a `Workspace`, and a row is what `dl` actually emits.
-        let row = format!(
-            r#"[{{"id":"ws","devlaunch":true,"repo":"blooop/wayfinder",
-                  "branch":"wayfinder/wayfinder-1","state":"Stopped",
-                  "unsaved":{answer}}}]"#
-        );
-        let parsed = parse_workspaces(row.as_bytes())
-            .unwrap_or_else(|e| panic!("`wf` could not read {answer}: {e:#}"));
         assert_eq!(
-            parsed[0].unsaved.as_ref(),
+            read_back(answer).as_ref(),
             Some(&want),
-            "devlaunch writes {answer} and `wf` read it as {:?}",
-            parsed[0].unsaved
+            "devlaunch writes {answer} and `wf` read it as something else"
         );
     }
 }
 
 #[test]
-fn a_dl_older_than_the_object_release_has_no_object_to_write() {
-    // The version boundary from the other side. `UNSAVED_IS_AN_OBJECT` claims
-    // 0.0.24 is where the one-key object arrived; the way to be sure is that
-    // the release below it cannot produce one. Without this, the constant is a
-    // date somebody remembered.
-    if promised(UNSAVED) != "sentence" {
-        return;
-    }
-    let program = dl();
-    let python = python_of(&program);
-    let out = Command::new(&python)
-        .args([
-            "-c",
-            "from devlaunch.workspace_state import unsaved_as_json",
-        ])
-        .output()
-        .unwrap_or_else(|e| panic!("could not run {}: {e}", python.display()));
-    assert!(
-        !out.status.success(),
-        "this devlaunch has `unsaved_as_json`, so it writes the object form — \
-         but {UNSAVED_IS_AN_OBJECT} is where `wf` believes that started, and \
-         `dl --version` says {}",
-        ask_dl(&["--version"], "version").trim()
+fn what_this_dl_says_about_a_clone_holding_work_is_what_wf_reads() {
+    // The whole path, on both sides of the version boundary: a real checkout
+    // with a real uncommitted file, inspected by *this* devlaunch's own
+    // `read_clone`, serialised the way *this* release serialises it, and read
+    // back by `wf`. Whatever comes out, `wf` has to arrive at "there is work
+    // here" — that is the answer standing between `wf reap` and somebody's
+    // afternoon.
+    //
+    // This is also what pins `WF_CONTRACT_UNSAVED` to the release rather than
+    // to a comment. An earlier draft checked the 0.0.23 side by asserting that
+    // `from devlaunch.workspace_state import unsaved_as_json` *failed*, which
+    // is true whenever anything at all is wrong with the interpreter, the
+    // prefix or the package — a test that passes for reasons unrelated to its
+    // subject. The shape is now read off a value the release actually produced.
+    let contract = Contract::read();
+    let clone = scratch("dirty-clone");
+    let _ = std::fs::remove_dir_all(&clone);
+    std::fs::create_dir_all(&clone).expect("a clone directory");
+    git(&clone, &["init", "-q"]);
+    git(&clone, &["commit", "-q", "--allow-empty", "-m", "first"]);
+    std::fs::write(clone.join("scratch.txt"), "half-finished\n").expect("uncommitted work");
+
+    let reported = ask_devlaunch(
+        r#"
+import json, sys
+from pathlib import Path
+from devlaunch.workspace_state import read_clone
+state = read_clone(Path(sys.argv[1]))
+try:
+    from devlaunch.workspace_state import unsaved_as_json
+    wire = unsaved_as_json(state.unsaved)
+except ImportError:
+    # devlaunch <= 0.0.23: the field was the bare sentence, with no
+    # serialiser between the value and the listing.
+    wire = state.unsaved
+print(json.dumps({
+    "wire": wire,
+    "shape": "object" if isinstance(wire, dict) else "sentence",
+}))
+"#,
+        &[&clone.to_string_lossy()],
+        "devlaunch could not be asked what a clone holds — `read_clone` is the \
+         function whose answer becomes the `unsaved` field",
     );
+    let reported: serde_json::Value =
+        serde_json::from_str(reported.trim()).expect("devlaunch's answer as JSON");
+
+    let shape = match reported["shape"].as_str() {
+        Some("object") => Shape::Object,
+        Some("sentence") => Shape::Sentence,
+        other => panic!("devlaunch reported an unknown shape: {other:?}"),
+    };
+    assert_eq!(
+        shape, contract.unsaved,
+        "this devlaunch writes `unsaved` as a {shape:?}, but {UNSAVED} in \
+         pixi.toml says {:?}. {} is where `wf` believes the object form began.",
+        contract.unsaved, UNSAVED_IS_AN_OBJECT
+    );
+
+    let wire = reported["wire"].to_string();
+    let read = read_back(&wire);
+    let Some(Unsaved::WouldLose(said)) = read else {
+        panic!(
+            "devlaunch says this clone holds work ({wire}), and `wf` read that \
+             as {read:?} — anything but WouldLose here is a workspace `wf reap` \
+             would be willing to delete"
+        );
+    };
+    assert!(
+        said.contains("uncommitted"),
+        "the sentence survived the round trip but says nothing about what is \
+         at risk: {said:?}"
+    );
+}
+
+#[test]
+fn the_verbs_wf_hands_dl_are_ones_it_still_knows() {
+    // `wf` builds two argvs it never gets to try here: `dl <ws> up` (prewarm)
+    // and `dl <id> rm [--force]` (reap). Both change the machine and both need
+    // a devpod daemon, so running them is devlaunch's own e2e suite's job — but
+    // *not checking them at all* is how the 0.14.0 incident happened, where
+    // `wf` shipped a call to an `up` the installed release had never heard of.
+    //
+    // `dl <bogus> up` cannot stand in for it: `dl` resolves the workspace
+    // before it looks at the verb, so an unknown workspace and an unknown verb
+    // produce the same error. What is left is the vocabulary — `dl --help` is
+    // where devlaunch documents its own subcommands, and a verb that is removed
+    // stops being named there. It catches a deletion or a rename, which is the
+    // failure that has actually happened, and it does not pretend to catch a
+    // change in what the verb does.
+    // The two verbs are not asked for on the same terms, and the difference is
+    // the floor's whole justification. `rm` is wanted from every release: reap
+    // reads and deletes through whichever `dl` is on PATH, floor or no floor.
+    // `up` is wanted only at or above the floor — it *arrived* in 0.0.24, which
+    // is why `DEVLAUNCH_FLOOR` is that number. Below the floor its absence is
+    // therefore asserted rather than tolerated, and that assertion is the only
+    // place in this repo where the reason the floor exists is evidence instead
+    // of a sentence in a doc comment. (It also caught a first draft of this very
+    // test, which demanded `up` of 0.0.23 and was wrong to.)
+    let contract = Contract::read();
+    let help = ask_dl(&["--help"], "help");
+    let names = |verb: &str| {
+        help.split_whitespace()
+            .any(|word| word.trim_matches(',') == verb)
+    };
+    assert!(
+        names("rm"),
+        "`dl --help` no longer names `rm`, which `src/reap.rs` hands it on \
+         every release:\n{help}"
+    );
+    match contract.expect {
+        Expect::Usable => assert!(
+            names("up"),
+            "`dl --help` no longer names `up`, which `src/launch.rs` hands it \
+             for every prewarm. That verb is the {DEVLAUNCH_FLOOR} floor's \
+             subject: a `dl` clearing the floor must carry it.\n{help}"
+        ),
+        Expect::TooOld => assert!(
+            !names("up"),
+            "this `dl` is below the {DEVLAUNCH_FLOOR} floor and yet names \
+             `up`, so the floor is not where `up` arrived and the number is \
+             wrong:\n{help}"
+        ),
+    }
 }
 
 #[test]
@@ -363,7 +590,8 @@ fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
     // is the ordinary clean case and refusing it would break `wf reap`
     // entirely. Nothing but the version can tell them apart, so the two facts
     // are asserted against each other here rather than each against a fixture.
-    let object = promised(UNSAVED) == "object";
+    let contract = Contract::read();
+    let object = contract.unsaved == Shape::Object;
     assert_eq!(
         verdict().answers_unsaved(),
         object,
@@ -371,5 +599,27 @@ fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
          every clone it made",
         if object { "writes" } else { "predates" },
         if object { "does not expect" } else { "expects" }
+    );
+}
+
+/// A git command in the scratch clone, with an identity of its own.
+///
+/// `-c user.*`: the machine running this may have no global git identity (CI
+/// does not), and a `commit` that fails for that reason would look like the
+/// clone being unreadable.
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["-c", "user.email=contract@example.invalid"])
+        .args(["-c", "user.name=contract"])
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("could not run git: {e}"));
+    assert!(
+        out.status.success(),
+        "git {}: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stderr).trim()
     );
 }

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -52,15 +52,32 @@
 //! that read it and the file still reported seven passes. Anything unrecognised
 //! is a panic now, and [`Contract::read`] is the one place that decides.
 //!
-//! # What it cannot reach
+//! # The calls that change the machine
 //!
-//! `dl <id> rm` and `dl <ws> up` change the machine and need a devpod daemon, so
-//! neither is run — only that this `dl` still names them is checked, in
-//! [`the_verbs_wf_hands_dl_are_ones_it_still_knows`]. Everything else here is
-//! read-only, under a scratch `HOME`, so it cannot see or touch a real
-//! workspace. The scratch home matters for a second reason: a listing read from
-//! the developer's own machine would assert against whatever they happen to
-//! have cloned.
+//! `dl <id> rm` and `dl <ws> up` build and destroy containers, so they cannot
+//! simply be run. They are not left unchecked either: `dl`'s only devpod spawn
+//! is `subprocess.run(["devpod", ...])` — a bare name on PATH — so a recording
+//! `devpod` in front of the **real** `dl` runs devlaunch's own argument
+//! parsing, its own workspace resolution and its own decision about what to ask
+//! devpod, and stops where the container would begin.
+//!
+//! That is the inverse of the shim this file exists to escape. `src/probe.rs`
+//! shims `dl` itself, which is how its fixtures were able to drift; here the
+//! real `dl` is the subject and the shim stands one layer below it, in for the
+//! daemon rather than for the program under test. The argvs come from
+//! [`wf::reap::removal_argv`], [`wf::launch::prewarm_argv`] and
+//! [`wf::launch::isolated_argv`] rather than being typed out here — an argv a
+//! contract test spells out for itself only proves the test agrees with the
+//! test.
+//!
+//! It is worth what it costs: [`the_prewarm_wf_sends_is_the_verb_the_floor_exists_for`]
+//! sends `wf`'s own prewarm argv to a real devlaunch 0.0.23 and watches it come
+//! back `Unknown command 'up'`, which is the 0.14.0 regression itself, running.
+//!
+//! Everything else here is read-only, and all of it runs under a scratch `HOME`
+//! so it cannot see or touch a real workspace. The scratch home matters for a
+//! second reason: a listing read from the developer's own machine would assert
+//! against whatever they happen to have cloned.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -845,5 +862,315 @@ fn a_reap_with_no_dl_refuses_instead_of_guessing() {
     assert!(
         !said.contains("nothing to reap"),
         "`wf` reported an empty plan when it simply could not see: {said}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The two calls that change the machine, run for real with `devpod` shimmed.
+//
+// `dl <ws> rm` and `dl <ws> up` need a devpod daemon and a container, so this
+// file used to check only that `dl --help` still named them. It does not have
+// to stop there. `dl`'s single devpod spawn is `subprocess.run(["devpod", ...])`
+// — a bare name, resolved on PATH — so putting a recording `devpod` in front of
+// the *real* `dl` runs devlaunch's own argument parsing, its own workspace
+// resolution and its own decision about what to ask devpod, and stops at the
+// point where a container would be built.
+//
+// That is the opposite of the shim this whole file exists to get away from.
+// `src/probe.rs` shims `dl` itself, which is why its fixtures could drift; here
+// the real `dl` is the subject and the shim is one layer *below* it, standing in
+// for the daemon rather than for the program under test.
+// ---------------------------------------------------------------------------
+
+/// The workspace the shimmed devpod claims to have.
+///
+/// Shaped like one `wf` makes, because `dl` derives things from the name.
+const SHIMMED_WORKSPACE: &str = "devlaunch-wayfinder-wayfinder-137-abcdefgh";
+
+/// What the real `dl` asked devpod to do, and what it said while doing it.
+#[derive(Debug)]
+struct Asked {
+    /// One line per devpod invocation: the program and each argument in angle
+    /// brackets, so an argument containing a space cannot read as two.
+    devpod: Vec<String>,
+    status: std::process::ExitStatus,
+    said: String,
+}
+
+impl Asked {
+    /// The one devpod call whose first argument is `verb`, or `None`.
+    fn call(&self, verb: &str) -> Option<&String> {
+        self.devpod
+            .iter()
+            .find(|line| line.starts_with(&format!("devpod <{verb}>")))
+    }
+}
+
+/// Run the real `dl` with a recording `devpod` in front of it.
+///
+/// `argv` is what `wf` itself builds — `reap::removal_argv`,
+/// `launch::prewarm_argv`, `launch::isolated_argv` — with a leading `dl`
+/// stripped if it carries one. Nothing here spells an argument out.
+fn dl_over_a_shimmed_devpod(argv: &[String], what: &str) -> Asked {
+    let program = dl();
+    let dir = scratch(&format!("devpod-{what}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    let home = dir.join("home");
+    std::fs::create_dir_all(&home).expect("a scratch home");
+    let log = dir.join("devpod.log");
+    std::fs::write(&log, "").expect("the log");
+
+    // Records and answers; runs nothing. `dl <ws> up` hands devpod a
+    // `--command` carrying a shell script that would install tooling — this
+    // shim must never be the thing that executes it, which is why every arm
+    // below either echoes a fixture or does nothing at all.
+    let shim = dir.join("devpod");
+    std::fs::write(
+        &shim,
+        format!(
+            r#"#!/bin/sh
+printf 'devpod' >> "$DP_LOG"
+for a in "$@"; do printf ' <%s>' "$a" >> "$DP_LOG"; done
+echo >> "$DP_LOG"
+case "$1" in
+  version) echo "v0.26.1" ;;
+  list) echo '[{{"id":"{SHIMMED_WORKSPACE}","source":{{"localFolder":"/nonexistent"}},"provider":{{"name":"docker"}},"ide":{{"name":"none"}},"lastUsed":"2026-08-08T11:43:27Z"}}]' ;;
+  status) echo '{{"state":"Stopped"}}' ;;
+  context) echo '{{}}' ;;
+esac
+exit 0
+"#
+        ),
+    )
+    .expect("the devpod shim");
+    let mut perms = std::fs::metadata(&shim).expect("the shim").permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&shim, perms).expect("an executable shim");
+
+    let after_program: Vec<&String> = argv
+        .iter()
+        .skip(usize::from(argv.first().is_some_and(|a| a == "dl")))
+        .collect();
+    let path = format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let out = Command::new(&program)
+        .args(&after_program)
+        .env("PATH", path)
+        .env("HOME", &home)
+        .env("DP_LOG", &log)
+        // Cleared, not inherited. With a token in the environment `dl` forwards
+        // it to devpod as `--init-env GH_TOKEN=...`, which would put a real
+        // credential into the recording below — and this test prints that
+        // recording when it fails.
+        .env_remove("GH_TOKEN")
+        .env_remove("GITHUB_TOKEN")
+        .output()
+        .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
+
+    Asked {
+        devpod: std::fs::read_to_string(&log)
+            .expect("the log")
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect(),
+        status: out.status,
+        said: format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    }
+}
+
+#[test]
+fn the_removal_wf_sends_reaches_devpod_as_a_delete() {
+    // `wf reap`'s argv, run by the real `dl`, on every release: reap deletes
+    // through whichever `dl` is on PATH, so this has to hold below the floor
+    // too.
+    let contract = Contract::read();
+    if contract.installed().is_none() {
+        return;
+    }
+    let argv = wf::reap::removal_argv(SHIMMED_WORKSPACE, true);
+    let asked = dl_over_a_shimmed_devpod(&argv, "rm");
+    assert!(
+        asked.status.success(),
+        "`dl {}` failed ({}):\n{}",
+        argv.join(" "),
+        asked.status,
+        asked.said
+    );
+    let deleted = asked.call("delete").unwrap_or_else(|| {
+        panic!(
+            "`dl {}` never asked devpod to delete anything. It asked:\n{:#?}\n{}",
+            argv.join(" "),
+            asked.devpod,
+            asked.said
+        )
+    });
+    assert!(
+        deleted.contains(&format!("<{SHIMMED_WORKSPACE}>")),
+        "the delete names a different workspace: {deleted}"
+    );
+}
+
+#[test]
+fn the_prewarm_wf_sends_is_the_verb_the_floor_exists_for() {
+    // The 0.14.0 regression, as a test.
+    //
+    // `wf` 0.14.0 shipped `dl <workspace> up` while the released devlaunch was
+    // 0.0.23, which had no `up`. It failed inside a detached prewarm nobody was
+    // watching, and neither repository's CI noticed. `DEVLAUNCH_FLOOR` exists
+    // because of it. Here the same argv goes to a real 0.0.23 and a real
+    // 0.0.24, and the two answers are asserted apart: one reaches `devpod up`,
+    // the other is refused by `dl`'s own argument parsing before devpod is
+    // asked anything at all.
+    let contract = Contract::read();
+    let Some(installed) = contract.installed() else {
+        return;
+    };
+    let argv = wf::launch::prewarm_argv(SHIMMED_WORKSPACE);
+    let asked = dl_over_a_shimmed_devpod(&argv, "up");
+    match installed.expect {
+        Expect::Usable => {
+            assert!(
+                asked.status.success(),
+                "`{}` failed on a dl at or above the floor ({}):\n{}",
+                argv.join(" "),
+                asked.status,
+                asked.said
+            );
+            let up = asked.call("up").unwrap_or_else(|| {
+                panic!(
+                    "`{}` never reached `devpod up`. It asked:\n{:#?}\n{}",
+                    argv.join(" "),
+                    asked.devpod,
+                    asked.said
+                )
+            });
+            assert!(
+                up.contains(&format!("<{SHIMMED_WORKSPACE}>")),
+                "the prewarm brought up a different workspace: {up}"
+            );
+        }
+        Expect::TooOld => {
+            assert!(
+                !asked.status.success(),
+                "`{}` succeeded on a dl below the {DEVLAUNCH_FLOOR} floor, so \
+                 either `up` predates it and the floor is wrong, or this dl \
+                 accepted a verb it does not have:\n{}",
+                argv.join(" "),
+                asked.said
+            );
+            assert!(
+                asked.call("up").is_none(),
+                "a dl below the floor still reached `devpod up`: {:#?}",
+                asked.devpod
+            );
+        }
+    }
+}
+
+#[test]
+fn an_isolated_launch_arrives_as_one_shell_command() {
+    // `wf`'s quoting against `dl`'s shell, with nothing between them.
+    //
+    // `dl <ws> -- <cmd>` joins everything after `--` and runs it through a
+    // shell inside the container, so `wf` single-quotes each argument and sends
+    // one entry. An unquoted prompt arrives as several arguments and the agent
+    // is launched with the wrong argv — and a prompt is the one thing here that
+    // always contains spaces. This is checked against the real `dl` because the
+    // splitting happens on its side of the boundary.
+    let contract = Contract::read();
+    if contract.installed().map(|i| i.expect) != Some(Expect::Usable) {
+        return;
+    }
+    let agent = [
+        "claude".to_string(),
+        "--dangerously-skip-permissions".to_string(),
+        "/wf-one blooop/wayfinder 137".to_string(),
+    ];
+    let argv = wf::launch::isolated_argv(SHIMMED_WORKSPACE, &agent);
+    let asked = dl_over_a_shimmed_devpod(&argv, "exec");
+    assert!(
+        asked.status.success(),
+        "`{}` failed ({}):\n{}",
+        argv.join(" "),
+        asked.status,
+        asked.said
+    );
+    // The last `devpod ssh --command` is the agent; the earlier ones are
+    // devlaunch's own tool probes.
+    let ran = asked
+        .devpod
+        .iter()
+        .rfind(|line| line.starts_with("devpod <ssh>"))
+        .unwrap_or_else(|| {
+            panic!(
+                "the launch never reached the container. It asked:\n{:#?}\n{}",
+                asked.devpod, asked.said
+            )
+        });
+    let command = ran
+        .rsplit_once("<--command> <")
+        .and_then(|(_, rest)| rest.strip_suffix('>'))
+        .unwrap_or_else(|| panic!("no `--command` in the ssh call: {ran}"));
+
+    // Not asserted as a string. How `dl` escapes this for its own shell is
+    // `dl`'s business and it re-quotes what `wf` already quoted; pinning the
+    // spelling would fail on a change that is none of `wf`'s concern. What `wf`
+    // depends on is what the *agent* ends up being called with, so the command
+    // is run — in a real shell, with `claude` replaced by something that writes
+    // its argv down. This is the only place the quoting can actually be
+    // checked, and it is checked on the far side of `dl`.
+    let bin = scratch("agent-argv");
+    let _ = std::fs::remove_dir_all(&bin);
+    std::fs::create_dir_all(&bin).expect("a scratch bin");
+    let seen = bin.join("argv");
+    let claude = bin.join("claude");
+    std::fs::write(
+        &claude,
+        format!(
+            "#!/bin/sh\nfor a in \"$@\"; do printf '<%s>' \"$a\" >> '{}'; done\n",
+            seen.display()
+        ),
+    )
+    .expect("the claude recorder");
+    let mut perms = std::fs::metadata(&claude)
+        .expect("the recorder")
+        .permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&claude, perms).expect("an executable recorder");
+
+    let out = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                bin.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .env("HOME", &bin)
+        .output()
+        .expect("a shell");
+    assert!(
+        out.status.success(),
+        "the command `dl` would run in the container is not one a shell \
+         accepts ({}): {command}\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let got = std::fs::read_to_string(&seen).unwrap_or_default();
+    assert_eq!(
+        got, "<--dangerously-skip-permissions></wf-one blooop/wayfinder 137>",
+        "the agent was called with the wrong argv. The prompt has to arrive as \
+         one argument; three is what an unquoted join produces.\nfrom: {command}"
     );
 }

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -1,0 +1,375 @@
+//! What the installed `devlaunch` actually says, held against what `wf`
+//! believes it says.
+//!
+//! Every other test in this repository that touches `dl` hands the code a
+//! string this repository wrote. `src/probe.rs` shims it; so, deliberately,
+//! does `tests/live_launch_exec.rs`, because a machine with devlaunch installed
+//! and a machine without one must not take different paths through the same
+//! test. That is the right call for those tests and it leaves exactly one thing
+//! unchecked: whether the fixtures are still a description of the program.
+//!
+//! They were not, twice. `dl <workspace> up` shipped in `wf` 0.14.0 before
+//! devlaunch 0.0.24 carried it. `unsaved` changed from a string to a one-key
+//! object in the same release, and this repo learned about it afterwards. Both
+//! are the same failure: two repositories agreeing in prose, with nothing
+//! executed that could disagree.
+//!
+//! This file is the executed part. It runs a **real** `dl` — the one `pixi.toml`
+//! installed, at a version that file chose — and asks it the questions `wf`
+//! asks it.
+//!
+//! ```text
+//! pixi run -e floor  contract   # devlaunch == launch::DEVLAUNCH_FLOOR
+//! pixi run -e latest contract   # whatever pixi.lock resolved
+//! pixi run -e stale  contract   # 0.0.23, below the floor
+//! ```
+//!
+//! It is not runnable outside those environments and does not try to be: with
+//! no `WF_CONTRACT_EXPECT` in the environment every test here panics saying so,
+//! rather than quietly testing whichever `dl` the developer happens to have.
+//! That distinction is the whole point — a contract test that silently accepts
+//! the ambient install is the shim again, wearing a different hat.
+//!
+//! **Read-only.** The only two subcommands used are `--version` and
+//! `--ls --json`, and both run under a scratch `HOME`, so this cannot see or
+//! touch a real workspace. The scratch home matters for a second reason: a
+//! listing read from the developer's own machine would assert against whatever
+//! they happen to have cloned.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use wf::launch::{Devlaunch, DEVLAUNCH_FLOOR, UNSAVED_IS_AN_OBJECT};
+use wf::reap::{parse_workspaces, Unsaved};
+
+/// How `pixi.toml` tells this file what environment it is in.
+///
+/// Three variables rather than one, because they are three independent facts
+/// and a single "environment name" would make this file re-derive them from it
+/// — which is the transcription problem again, one repository further in.
+const EXPECT: &str = "WF_CONTRACT_EXPECT";
+const VERSION: &str = "WF_CONTRACT_DL";
+const UNSAVED: &str = "WF_CONTRACT_UNSAVED";
+
+/// The panic for a run outside the pixi environments.
+///
+/// Spelled out rather than left as a missing-variable unwrap, because the
+/// obvious thing to type is `cargo test --test live_devlaunch` and the obvious
+/// reading of a failure there is "the contract is broken", which it is not.
+fn only_under_pixi(var: &str) -> String {
+    format!(
+        "{var} is not set, so there is nothing to hold this `dl` to.\n\
+         This file runs a real devlaunch at a version pixi chose:\n\
+         \n\
+         \x20   pixi run -e floor  contract\n\
+         \x20   pixi run -e latest contract\n\
+         \x20   pixi run -e stale  contract\n\
+         \n\
+         Running it under a bare `cargo test` would test whichever `dl` happens \
+         to be installed, which is what this file exists not to do."
+    )
+}
+
+fn promised(var: &str) -> String {
+    std::env::var(var).unwrap_or_else(|_| panic!("{}", only_under_pixi(var)))
+}
+
+/// The `dl` this run is about: the first one on PATH, which under `pixi run` is
+/// the environment's.
+///
+/// Resolved here rather than by handing `Command` a bare name, because *which
+/// file* answered is itself one of the assertions — see
+/// [`the_dl_under_test_is_the_one_the_environment_installed`].
+fn dl() -> PathBuf {
+    let path = std::env::var_os("PATH").expect("a PATH");
+    std::env::split_paths(&path)
+        .map(|dir| dir.join("dl"))
+        .find(|candidate| candidate.is_file())
+        .unwrap_or_else(|| {
+            panic!(
+                "no `dl` on PATH, but {EXPECT} says there should be one \
+                 ({}). Is this the `default` environment?",
+                promised(EXPECT)
+            )
+        })
+}
+
+/// A `HOME` with nothing in it, for the duration of one call.
+///
+/// Not cleaned up on a panic, deliberately: a failing contract test is a thing
+/// somebody is about to go and look at, and the listing `dl` wrote is evidence.
+/// It is under the temp dir, keyed by pid, so it costs nothing to leave.
+fn scratch_home(what: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("wf-contract-{}-{what}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("a scratch home");
+    dir
+}
+
+/// Run the `dl` under test and return its stdout, or panic with its stderr.
+fn ask_dl(args: &[&str], what: &str) -> String {
+    let program = dl();
+    let out = Command::new(&program)
+        .args(args)
+        .env("HOME", scratch_home(what))
+        .output()
+        .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
+    assert!(
+        out.status.success(),
+        "`dl {}` failed ({}): {}",
+        args.join(" "),
+        out.status,
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// What `wf` makes of the installed `dl`.
+fn verdict() -> Devlaunch {
+    Devlaunch::from_version_output(&ask_dl(&["--version"], "version"))
+}
+
+/// The Python interpreter beside the `dl` under test.
+///
+/// Beside it, not the first on PATH: devlaunch is a Python package, and the
+/// only interpreter that can import *this* devlaunch is the one in the same
+/// prefix. A host `python` would either fail to import it or — worse — import a
+/// different copy and answer for a release nobody asked about.
+fn python_of(program: &Path) -> PathBuf {
+    let bin = program.parent().expect("dl lives in a directory");
+    let python = bin.join("python");
+    assert!(
+        python.is_file(),
+        "no interpreter beside {} — this test needs the devlaunch package, \
+         not only the `dl` entry point",
+        program.display()
+    );
+    python
+}
+
+#[test]
+fn the_dl_under_test_is_the_one_the_environment_installed() {
+    // `pixi run` prepends its prefix to the *inherited* PATH, so a developer's
+    // own `~/.pixi/bin/dl` is still on it, several entries later. If the
+    // environment's own devlaunch were ever missing — a feature not listed on
+    // the environment, a solve that dropped it — every other test in this file
+    // would carry on happily against the host's install and report a verdict
+    // about a version nobody selected. This is the assertion that makes the
+    // pin mean something.
+    let program = dl();
+    let prefix = std::env::var("CONDA_PREFIX")
+        .unwrap_or_else(|_| panic!("{}", only_under_pixi("CONDA_PREFIX")));
+    assert!(
+        program.starts_with(&prefix),
+        "the first `dl` on PATH is {}, which is outside this pixi environment \
+         ({prefix}) — the version under test is not the one pixi installed",
+        program.display()
+    );
+}
+
+#[test]
+fn wf_can_read_the_version_this_dl_prints() {
+    // `Devlaunch::Unreadable` is the arm for a `--version` this binary cannot
+    // parse, and it sends every isolated launch to the host. It has never been
+    // reached by anything but a string written in this repository. A devlaunch
+    // that reformatted its version banner would land here and nowhere else.
+    let printed = ask_dl(&["--version"], "version");
+    assert_ne!(
+        Devlaunch::from_version_output(&printed),
+        Devlaunch::Unreadable,
+        "`wf` could not read a version out of what this `dl` prints: {printed:?}"
+    );
+
+    let expected = promised(EXPECT);
+    let got = verdict();
+    match expected.as_str() {
+        "usable" => assert_eq!(
+            got,
+            Devlaunch::Usable,
+            "this dl ({}) should clear the {DEVLAUNCH_FLOOR} floor",
+            printed.trim()
+        ),
+        "too-old" => assert!(
+            matches!(got, Devlaunch::TooOld(_)),
+            "this dl ({}) is below the {DEVLAUNCH_FLOOR} floor and should read \
+             as TooOld, not {got:?}",
+            printed.trim()
+        ),
+        other => panic!("{EXPECT} says {other:?}, which this file does not know"),
+    }
+}
+
+#[test]
+fn the_pinned_version_and_the_installed_one_are_the_same_release() {
+    // Only the exactly-pinned environments set this. `latest` deliberately does
+    // not: what it installs is whatever `pixi.lock` resolved, and a number
+    // written in `pixi.toml` beside it would be a second place to update and a
+    // stale assertion the day somebody forgot.
+    let Ok(pinned) = std::env::var(VERSION) else {
+        return;
+    };
+    let printed = ask_dl(&["--version"], "version");
+    let printed = printed.trim();
+    assert!(
+        printed.split_whitespace().any(|word| word == pinned),
+        "pixi pinned devlaunch {pinned} but the `dl` on PATH says {printed:?}"
+    );
+
+    // And the floor environment's pin *is* the constant. Two files, one
+    // release: `pixi.toml` naming 0.0.24 and `launch.rs` naming something else
+    // would mean the floor is never actually run at.
+    if promised(EXPECT) == "usable" && pinned == DEVLAUNCH_FLOOR.to_string() {
+        assert_eq!(
+            DEVLAUNCH_FLOOR, UNSAVED_IS_AN_OBJECT,
+            "these two constants have parted company; the environments below \
+             assume `WF_CONTRACT_UNSAVED=object` follows from clearing the floor"
+        );
+    }
+}
+
+#[test]
+fn a_listing_from_a_real_dl_is_one_wf_can_read() {
+    // `parse_workspaces` is all-or-nothing: a listing with one field `wf`
+    // cannot read is a listing it reads *none* of, and `wf reap` then collects
+    // nothing and says so in a way that looks like "there is nothing to do".
+    // The listing here is empty — a scratch `HOME` has no workspaces — so what
+    // this pins is the envelope: that `--ls --json` still exists, still exits
+    // zero without a daemon, and still answers with a JSON array rather than a
+    // banner, a wrapper object, or a line of prose.
+    //
+    // The rows themselves cannot be reached this way. Making one means a real
+    // devpod workspace and a Docker daemon, which is devlaunch's own e2e
+    // suite's job, not this file's; the row *shape* is checked below, from the
+    // emitter rather than from an instance.
+    let body = ask_dl(&["--ls", "--json"], "listing");
+    let parsed = parse_workspaces(body.as_bytes())
+        .unwrap_or_else(|e| panic!("`wf` could not read this dl's listing ({e:#}): {body:?}"));
+    assert!(
+        parsed.is_empty(),
+        "a scratch HOME reported workspaces, so this ran against a real \
+         machine's devpod: {parsed:?}"
+    );
+}
+
+#[test]
+fn every_unsaved_answer_this_dl_can_give_is_one_wf_reads() {
+    // The field that has already broken once, asked of the code that writes it.
+    //
+    // `wf`'s fixtures spell these three keys because somebody read devlaunch's
+    // documentation and typed them out. This asks devlaunch's own
+    // `unsaved_as_json` to produce them instead, so a rename on that side is a
+    // failure here rather than a `wf reap` that silently refuses every
+    // workspace on every machine.
+    //
+    // Reaching into `devlaunch.workspace_state` is reaching past the CLI, and
+    // that is the point rather than an oversight: the CLI cannot be made to
+    // emit a `wouldLose` row without a real clone holding real uncommitted
+    // work, and the three arms are exactly what is worth pinning. The coupling
+    // is honest — an ImportError here says devlaunch moved the function that
+    // defines this contract, which is a thing `wf` needs to be told.
+    if promised(UNSAVED) != "object" {
+        return;
+    }
+    let program = dl();
+    let emit = r#"
+import json
+from devlaunch.workspace_state import (
+    unsaved_as_json, NothingToLose, WouldLose, CouldNotTell,
+)
+for answer in (
+    NothingToLose(),
+    WouldLose("2 uncommitted change(s) (pixi.lock, notes.md)"),
+    CouldNotTell("fatal: not a git repository"),
+):
+    print(json.dumps(unsaved_as_json(answer)))
+"#;
+    let python = python_of(&program);
+    let out = Command::new(&python)
+        .args(["-c", emit])
+        .output()
+        .unwrap_or_else(|e| panic!("could not run {}: {e}", python.display()));
+    assert!(
+        out.status.success(),
+        "devlaunch could not be asked what it writes for `unsaved` — it has \
+         probably moved or renamed `workspace_state.unsaved_as_json`, which is \
+         the function that defines this contract:\n{}",
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    let emitted = String::from_utf8_lossy(&out.stdout);
+    let answers: Vec<&str> = emitted.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        answers.len(),
+        3,
+        "expected one line per arm, got {emitted:?}"
+    );
+
+    let expected = [
+        Unsaved::NothingToLose,
+        Unsaved::WouldLose("2 uncommitted change(s) (pixi.lock, notes.md)".to_string()),
+        Unsaved::CouldNotTell("fatal: not a git repository".to_string()),
+    ];
+    for (answer, want) in answers.iter().zip(expected) {
+        // Through the real parser, in a real row, rather than through a
+        // `serde_json::from_str` on the field alone: `unsaved` is read as part
+        // of a `Workspace`, and a row is what `dl` actually emits.
+        let row = format!(
+            r#"[{{"id":"ws","devlaunch":true,"repo":"blooop/wayfinder",
+                  "branch":"wayfinder/wayfinder-1","state":"Stopped",
+                  "unsaved":{answer}}}]"#
+        );
+        let parsed = parse_workspaces(row.as_bytes())
+            .unwrap_or_else(|e| panic!("`wf` could not read {answer}: {e:#}"));
+        assert_eq!(
+            parsed[0].unsaved.as_ref(),
+            Some(&want),
+            "devlaunch writes {answer} and `wf` read it as {:?}",
+            parsed[0].unsaved
+        );
+    }
+}
+
+#[test]
+fn a_dl_older_than_the_object_release_has_no_object_to_write() {
+    // The version boundary from the other side. `UNSAVED_IS_AN_OBJECT` claims
+    // 0.0.24 is where the one-key object arrived; the way to be sure is that
+    // the release below it cannot produce one. Without this, the constant is a
+    // date somebody remembered.
+    if promised(UNSAVED) != "sentence" {
+        return;
+    }
+    let program = dl();
+    let python = python_of(&program);
+    let out = Command::new(&python)
+        .args([
+            "-c",
+            "from devlaunch.workspace_state import unsaved_as_json",
+        ])
+        .output()
+        .unwrap_or_else(|e| panic!("could not run {}: {e}", python.display()));
+    assert!(
+        !out.status.success(),
+        "this devlaunch has `unsaved_as_json`, so it writes the object form — \
+         but {UNSAVED_IS_AN_OBJECT} is where `wf` believes that started, and \
+         `dl --version` says {}",
+        ask_dl(&["--version"], "version").trim()
+    );
+}
+
+#[test]
+fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
+    // The decision `answers_unsaved` exists for, and the most dangerous one in
+    // the pair: on a release that answers for every clone of its own, a `null`
+    // beside `devlaunch: true` means devlaunch's inspection fell over, and
+    // reaping on it destroys work. On a release that does not, the same `null`
+    // is the ordinary clean case and refusing it would break `wf reap`
+    // entirely. Nothing but the version can tell them apart, so the two facts
+    // are asserted against each other here rather than each against a fixture.
+    let object = promised(UNSAVED) == "object";
+    assert_eq!(
+        verdict().answers_unsaved(),
+        object,
+        "this dl {} the object form, but `wf` {} it to answer `unsaved` for \
+         every clone it made",
+        if object { "writes" } else { "predates" },
+        if object { "does not expect" } else { "expects" }
+    );
+}

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -19,10 +19,24 @@
 //! asks it.
 //!
 //! ```text
-//! pixi run -e floor  contract   # devlaunch == launch::DEVLAUNCH_FLOOR
-//! pixi run -e latest contract   # whatever pixi.lock resolved
-//! pixi run -e stale  contract   # 0.0.23, below the floor
+//! pixi run -e default contract  # no devlaunch at all
+//! pixi run -e floor   contract  # devlaunch == launch::DEVLAUNCH_FLOOR
+//! pixi run -e latest  contract  # whatever pixi.lock resolved
+//! pixi run -e stale   contract  # 0.0.23, below the floor
 //! ```
+//!
+//! # Reading a weaker `dl`, and then behaving
+//!
+//! Two different claims, and both are made here. Most of the tests are about
+//! what `wf` *reads* — the version, the listing, the `unsaved` field. Three are
+//! about what it then *does*, which is the half that reaches a user:
+//! [`a_devcontainer_repo_is_isolated_only_when_a_real_dl_can_carry_it`] asks
+//! `Isolation::detect` in a checkout that really carries a devcontainer (this
+//! one) and requires a host launch when `dl` is absent or below the floor,
+//! [`a_launch_that_fell_back_says_why_and_names_the_version`] requires the
+//! notice that says so, and [`a_reap_with_no_dl_refuses_instead_of_guessing`]
+//! runs the real binary and requires it to fail rather than mistake "cannot
+//! see the workspaces" for "there are none".
 //!
 //! # Everything here fails closed
 //!
@@ -51,7 +65,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use wf::launch::{Devlaunch, DEVLAUNCH_FLOOR, UNSAVED_IS_AN_OBJECT};
+use wf::launch::{Agent, Devlaunch, Isolation, DEVLAUNCH_FLOOR, UNSAVED_IS_AN_OBJECT};
 use wf::reap::{parse_workspaces, Unsaved};
 
 /// How `pixi.toml` tells this file what environment it is in.
@@ -66,9 +80,12 @@ const EXPECT: &str = "WF_CONTRACT_EXPECT";
 const VERSION: &str = "WF_CONTRACT_DL";
 const UNSAVED: &str = "WF_CONTRACT_UNSAVED";
 
-/// Which of the three environments this is.
+/// Which of the four environments this is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Role {
+    /// No devlaunch at all, and `scripts/without-dl.sh` has taken away any the
+    /// developer had. The environment `wf` has to keep working in.
+    None,
     /// Pinned to exactly [`DEVLAUNCH_FLOOR`].
     Floor,
     /// Whatever `pixi.lock` resolved — no version is written down for it.
@@ -98,6 +115,13 @@ enum Shape {
 #[derive(Debug)]
 struct Contract {
     role: Role,
+    /// `None` for [`Role::None`], which has no `dl` to make claims about.
+    installed: Option<Installed>,
+}
+
+/// What the environment says about the devlaunch it put on PATH.
+#[derive(Debug)]
+struct Installed {
     expect: Expect,
     unsaved: Shape,
     /// The exact version `pixi.toml` pinned. `None` only for [`Role::Latest`],
@@ -115,11 +139,29 @@ impl Contract {
     /// be a number nobody updates when the lock moves.
     fn read() -> Contract {
         let role = match promised(ROLE).as_str() {
+            "none" => Role::None,
             "floor" => Role::Floor,
             "latest" => Role::Latest,
             "stale" => Role::Stale,
             other => panic!("{ROLE} says {other:?}, which is not an environment in pixi.toml"),
         };
+        if role == Role::None {
+            // The absent case is declared by *silence*, and the silence is
+            // checked: an environment that inherited another's activation block
+            // would set these, and every assertion below would then be about a
+            // machine that does not exist.
+            for var in [EXPECT, VERSION, UNSAVED] {
+                assert!(
+                    std::env::var_os(var).is_none(),
+                    "the `none` environment set {var}, but it installs no `dl` \
+                     for that to be true of"
+                );
+            }
+            return Contract {
+                role,
+                installed: None,
+            };
+        }
         let expect = match promised(EXPECT).as_str() {
             "usable" => Expect::Usable,
             "too-old" => Expect::TooOld,
@@ -146,10 +188,24 @@ impl Contract {
         }
         Contract {
             role,
-            expect,
-            unsaved,
-            pinned,
+            installed: Some(Installed {
+                expect,
+                unsaved,
+                pinned,
+            }),
         }
+    }
+
+    /// The installed devlaunch, or `None` in the environment that has none.
+    ///
+    /// Tests that need a `dl` bail on `None`. That is a skip, and skips are
+    /// what this file spent a review round removing — the difference is that
+    /// the value skipped on is a validated enum rather than a string nobody
+    /// checked, `Role::None` is itself asserted (no `dl` is reachable, see
+    /// [`the_environment_without_devlaunch_really_has_none`]), and every test
+    /// below does real work in at least one of the other three.
+    fn installed(&self) -> Option<&Installed> {
+        self.installed.as_ref()
     }
 }
 
@@ -297,7 +353,10 @@ fn the_dl_under_test_is_the_one_the_environment_installed() {
     // would carry on happily against the host's install and report a verdict
     // about a version nobody selected. This is the assertion that makes the
     // pin mean something.
-    let _ = Contract::read();
+    let contract = Contract::read();
+    if contract.installed().is_none() {
+        return;
+    }
     let program = dl();
     let prefix = std::env::var("CONDA_PREFIX")
         .unwrap_or_else(|_| panic!("{}", only_under_pixi("CONDA_PREFIX")));
@@ -316,6 +375,9 @@ fn wf_can_read_the_version_this_dl_prints() {
     // reached by anything but a string written in this repository. A devlaunch
     // that reformatted its version banner would land here and nowhere else.
     let contract = Contract::read();
+    let Some(installed) = contract.installed() else {
+        return;
+    };
     let printed = ask_dl(&["--version"], "version");
     assert_ne!(
         Devlaunch::from_version_output(&printed),
@@ -324,7 +386,7 @@ fn wf_can_read_the_version_this_dl_prints() {
     );
 
     let got = verdict();
-    match contract.expect {
+    match installed.expect {
         Expect::Usable => assert_eq!(
             got,
             Devlaunch::Usable,
@@ -359,7 +421,10 @@ fn the_floor_environment_is_pinned_to_the_floor() {
     // `answers_unsaved` false for a real 0.0.24 and walks `wf reap` straight
     // back into devlaunch#171.
     let contract = Contract::read();
-    let Some(pinned) = contract.pinned else {
+    let Some(installed) = contract.installed() else {
+        return;
+    };
+    let Some(pinned) = installed.pinned.as_deref() else {
         assert_eq!(contract.role, Role::Latest, "only `latest` may omit a pin");
         return;
     };
@@ -391,7 +456,10 @@ fn a_listing_from_a_real_dl_is_one_wf_can_read() {
     // zero without a daemon, and still answers with a JSON array rather than a
     // banner, a wrapper object, or a line of prose. The rows themselves are
     // reached below, from the emitter rather than from an instance.
-    let _ = Contract::read();
+    let contract = Contract::read();
+    if contract.installed().is_none() {
+        return;
+    }
     let body = ask_dl(&["--ls", "--json"], "listing");
     let parsed = parse_workspaces(body.as_bytes())
         .unwrap_or_else(|e| panic!("`wf` could not read this dl's listing ({e:#}): {body:?}"));
@@ -412,7 +480,7 @@ fn every_unsaved_answer_this_dl_can_give_is_one_wf_reads() {
     // failure here rather than a `wf reap` that silently refuses every
     // workspace on every machine.
     let contract = Contract::read();
-    if contract.unsaved != Shape::Object {
+    if contract.installed().map(|i| i.unsaved) != Some(Shape::Object) {
         return;
     }
     let emitted = ask_devlaunch(
@@ -470,6 +538,9 @@ fn what_this_dl_says_about_a_clone_holding_work_is_what_wf_reads() {
     // prefix or the package — a test that passes for reasons unrelated to its
     // subject. The shape is now read off a value the release actually produced.
     let contract = Contract::read();
+    let Some(installed) = contract.installed() else {
+        return;
+    };
     let clone = scratch("dirty-clone");
     let _ = std::fs::remove_dir_all(&clone);
     std::fs::create_dir_all(&clone).expect("a clone directory");
@@ -508,10 +579,10 @@ print(json.dumps({
         other => panic!("devlaunch reported an unknown shape: {other:?}"),
     };
     assert_eq!(
-        shape, contract.unsaved,
+        shape, installed.unsaved,
         "this devlaunch writes `unsaved` as a {shape:?}, but {UNSAVED} in \
          pixi.toml says {:?}. {} is where `wf` believes the object form began.",
-        contract.unsaved, UNSAVED_IS_AN_OBJECT
+        installed.unsaved, UNSAVED_IS_AN_OBJECT
     );
 
     let wire = reported["wire"].to_string();
@@ -555,6 +626,9 @@ fn the_verbs_wf_hands_dl_are_ones_it_still_knows() {
     // of a sentence in a doc comment. (It also caught a first draft of this very
     // test, which demanded `up` of 0.0.23 and was wrong to.)
     let contract = Contract::read();
+    let Some(installed) = contract.installed() else {
+        return;
+    };
     let help = ask_dl(&["--help"], "help");
     let names = |verb: &str| {
         help.split_whitespace()
@@ -565,7 +639,7 @@ fn the_verbs_wf_hands_dl_are_ones_it_still_knows() {
         "`dl --help` no longer names `rm`, which `src/reap.rs` hands it on \
          every release:\n{help}"
     );
-    match contract.expect {
+    match installed.expect {
         Expect::Usable => assert!(
             names("up"),
             "`dl --help` no longer names `up`, which `src/launch.rs` hands it \
@@ -591,7 +665,10 @@ fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
     // entirely. Nothing but the version can tell them apart, so the two facts
     // are asserted against each other here rather than each against a fixture.
     let contract = Contract::read();
-    let object = contract.unsaved == Shape::Object;
+    let Some(installed) = contract.installed() else {
+        return;
+    };
+    let object = installed.unsaved == Shape::Object;
     assert_eq!(
         verdict().answers_unsaved(),
         object,
@@ -621,5 +698,152 @@ fn git(dir: &Path, args: &[&str]) {
         "git {}: {}",
         args.join(" "),
         String::from_utf8_lossy(&out.stderr).trim()
+    );
+}
+
+#[test]
+fn the_environment_without_devlaunch_really_has_none() {
+    // The premise every assertion in the `none` environment rests on, and the
+    // one that is easiest to lose: `pixi run` prepends its prefix to the
+    // *inherited* PATH, so an environment that installs no devlaunch still sees
+    // the developer's own. `scripts/without-dl.sh` is what takes it away, and
+    // this is where its failure would surface as a failed test rather than as
+    // every check below quietly passing against a `dl` nobody chose.
+    if Contract::read().role != Role::None {
+        return;
+    }
+    let path = std::env::var_os("PATH").expect("a PATH");
+    let found: Vec<PathBuf> = std::env::split_paths(&path)
+        .map(|dir| dir.join("dl"))
+        .filter(|candidate| candidate.is_file())
+        .collect();
+    assert!(
+        found.is_empty(),
+        "the `none` environment still has a `dl` on PATH: {found:?}. Either the \
+         task is not going through scripts/without-dl.sh, or the scrubber has \
+         stopped working."
+    );
+}
+
+#[test]
+fn a_devcontainer_repo_is_isolated_only_when_a_real_dl_can_carry_it() {
+    // The fallback itself, rather than the reading that decides it.
+    //
+    // `Isolation::detect` is the function that answers "does this launch go
+    // into a container or stay on the host", and until now it had only ever
+    // been asked on a machine whose `dl` was a shell script this repo wrote.
+    // This asks it in a checkout that really does carry a
+    // `.devcontainer/devcontainer.json` — this one — against a `dl` that really
+    // is absent, really is 0.0.23, or really is the floor.
+    //
+    // The two `Host` answers are the point. A `dl` that is missing, and a `dl`
+    // that is too old, both have to end in an ordinary host launch: #80's rule
+    // is that a repo may carry a devcontainer for its editor users without that
+    // conscripting `wf` into a container it cannot actually produce.
+    let contract = Contract::read();
+    let here = Path::new(env!("CARGO_MANIFEST_DIR"));
+    assert!(
+        here.join(".devcontainer/devcontainer.json").is_file(),
+        "this test is only meaningful in a checkout that declares a \
+         devcontainer, and {} no longer does",
+        here.display()
+    );
+    let got = Isolation::detect(here, Agent::Claude);
+    let want = match contract.installed().map(|i| i.expect) {
+        Some(Expect::Usable) => Isolation::Devlaunch,
+        // Absent, or on PATH and below the floor.
+        None | Some(Expect::TooOld) => Isolation::Host,
+    };
+    assert_eq!(
+        got,
+        want,
+        "a devcontainer checkout with {} resolved to {got:?}",
+        match contract.role {
+            Role::None => "no dl at all".to_string(),
+            _ => format!("dl {}", ask_dl(&["--version"], "version").trim()),
+        }
+    );
+}
+
+#[test]
+fn a_launch_that_fell_back_says_why_and_names_the_version() {
+    // The half of a degradation a missing `(devlaunch)` suffix cannot carry.
+    //
+    // A `wf` that silently runs on the host looks exactly like a `wf` that
+    // ignored the devcontainer, and the difference is a fixable install. The
+    // sentence is built from the version `dl` actually printed, so this is
+    // where it is checked against one.
+    let contract = Contract::read();
+    let Some(installed) = contract.installed() else {
+        // Absent is deliberately silent — #80 again: a line on every launch
+        // would be noise about a tool the user never asked for. That arm is
+        // asserted in `src/launch.rs`, where no `dl` is needed to state it.
+        return;
+    };
+    let said = verdict().shortfall();
+    match installed.expect {
+        Expect::Usable => assert_eq!(
+            said, None,
+            "a usable dl has nothing to explain, but the notice would say: {said:?}"
+        ),
+        Expect::TooOld => {
+            let said = said.expect(
+                "a dl below the floor sends the launch to the host, and the \
+                 notice is the only thing that says so",
+            );
+            let printed = ask_dl(&["--version"], "version");
+            let version = printed.split_whitespace().nth(1).unwrap_or_default();
+            assert!(
+                said.contains(version) && said.contains(&DEVLAUNCH_FLOOR.to_string()),
+                "the notice should name both the version found and the floor \
+                 it missed, and says: {said:?}"
+            );
+            assert!(
+                said.contains("ran on the host"),
+                "the notice should say what happened instead: {said:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_reap_with_no_dl_refuses_instead_of_guessing() {
+    // `wf reap` is the one path in this crate that deletes, and it decides what
+    // to delete from what `dl --ls --json` told it. With no `dl` there is no
+    // listing, and the only safe reading of "no listing" is *stop* — an empty
+    // one would mean "no workspaces exist", which is the same bytes and the
+    // opposite fact.
+    //
+    // The real binary, because that is the only way to see the exit status and
+    // the message a user gets; `reap::workspaces` returning an `Err` in-process
+    // says nothing about whether `main` treats it as fatal.
+    if Contract::read().role != Role::None {
+        return;
+    }
+    let home = scratch("reap-home");
+    let out = Command::new(env!("CARGO_BIN_EXE_wf"))
+        .args(["reap", "-y"])
+        .env("HOME", &home)
+        .output()
+        .expect("the wf binary");
+    let said = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !out.status.success(),
+        "`wf reap -y` with no devlaunch exited {} — a reap that cannot see the \
+         workspaces must fail rather than report success over an empty plan:\n{said}",
+        out.status
+    );
+    assert!(
+        said.contains("devlaunch") && said.contains("PATH"),
+        "the failure should say what is missing and where it was looked for, \
+         and says:\n{said}"
+    );
+    assert!(
+        !said.contains("nothing to reap"),
+        "`wf` reported an empty plan when it simply could not see: {said}"
     );
 }

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -41,8 +41,11 @@
 //! # Everything here fails closed
 //!
 //! It is not runnable outside those environments and does not try to be: with
-//! no `WF_CONTRACT_*` in the environment **every** test here panics saying so,
-//! rather than quietly testing whichever `dl` the developer happens to have.
+//! no `WF_CONTRACT_*` in the environment every test that goes near a `dl`
+//! panics saying so, rather than quietly testing whichever one the developer
+//! happens to have. (The two guards at the bottom of the file are the
+//! exception, and are meant to be: one reads this file's source and one reads a
+//! child's environment, and neither needs a devlaunch to be right about.)
 //! That distinction is the whole point — a contract test that silently accepts
 //! the ambient install is the shim again, wearing a different hat.
 //!
@@ -73,6 +76,14 @@
 //! It is worth what it costs: [`the_prewarm_wf_sends_is_the_verb_the_floor_exists_for`]
 //! sends `wf`'s own prewarm argv to a real devlaunch 0.0.23 and watches it come
 //! back `Unknown command 'up'`, which is the 0.14.0 regression itself, running.
+//!
+//! One limit, because the argv is only half `wf`'s: the *verbs* and flags come
+//! from `wf`'s own builders, but the workspace argument is a devpod id rather
+//! than the `owner/repo@wayfinder/<repo>-<n>` spec a real launch passes. The id
+//! sends `dl` down its resolve-an-existing-workspace branch; the spec form
+//! would have it clone, which needs a network and a credential and is
+//! devlaunch's own e2e suite's business. So a devlaunch release that changed
+//! how it *parses or clones* a `repo@branch` spec is not caught here.
 //!
 //! Everything else here is read-only, and all of it runs under a scratch `HOME`
 //! so it cannot see or touch a real workspace. The scratch home matters for a
@@ -286,14 +297,21 @@ fn ask_dl(args: &[&str], what: &str) -> String {
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
+    // Everything captured from a real `dl` is checked before it can be
+    // printed, not only the shimmed recording: these panics quote stderr
+    // verbatim and they run in a public CI log.
+    let printed = String::from_utf8_lossy(&out.stdout).into_owned();
+    let complained = String::from_utf8_lossy(&out.stderr).into_owned();
+    refuse_tokens("what dl printed", &printed);
+    refuse_tokens("what dl said", &complained);
     assert!(
         out.status.success(),
         "`dl {}` failed ({}): {}",
         args.join(" "),
         out.status,
-        String::from_utf8_lossy(&out.stderr).trim()
+        complained.trim()
     );
-    String::from_utf8_lossy(&out.stdout).into_owned()
+    printed
 }
 
 /// What `wf` makes of the installed `dl`.
@@ -336,12 +354,12 @@ fn ask_devlaunch(snippet: &str, args: &[&str], why: &str) -> String {
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("could not run {}: {e}", python.display()));
-    assert!(
-        out.status.success(),
-        "{why}:\n{}",
-        String::from_utf8_lossy(&out.stderr).trim()
-    );
-    String::from_utf8_lossy(&out.stdout).into_owned()
+    let printed = String::from_utf8_lossy(&out.stdout).into_owned();
+    let complained = String::from_utf8_lossy(&out.stderr).into_owned();
+    refuse_tokens("what devlaunch printed", &printed);
+    refuse_tokens("what devlaunch said", &complained);
+    assert!(out.status.success(), "{why}:\n{}", complained.trim());
+    printed
 }
 
 /// One row of a listing, carrying `unsaved` exactly as devlaunch wrote it.
@@ -618,60 +636,6 @@ print(json.dumps({
 }
 
 #[test]
-fn the_verbs_wf_hands_dl_are_ones_it_still_knows() {
-    // `wf` builds two argvs it never gets to try here: `dl <ws> up` (prewarm)
-    // and `dl <id> rm [--force]` (reap). Both change the machine and both need
-    // a devpod daemon, so running them is devlaunch's own e2e suite's job — but
-    // *not checking them at all* is how the 0.14.0 incident happened, where
-    // `wf` shipped a call to an `up` the installed release had never heard of.
-    //
-    // `dl <bogus> up` cannot stand in for it: `dl` resolves the workspace
-    // before it looks at the verb, so an unknown workspace and an unknown verb
-    // produce the same error. What is left is the vocabulary — `dl --help` is
-    // where devlaunch documents its own subcommands, and a verb that is removed
-    // stops being named there. It catches a deletion or a rename, which is the
-    // failure that has actually happened, and it does not pretend to catch a
-    // change in what the verb does.
-    // The two verbs are not asked for on the same terms, and the difference is
-    // the floor's whole justification. `rm` is wanted from every release: reap
-    // reads and deletes through whichever `dl` is on PATH, floor or no floor.
-    // `up` is wanted only at or above the floor — it *arrived* in 0.0.24, which
-    // is why `DEVLAUNCH_FLOOR` is that number. Below the floor its absence is
-    // therefore asserted rather than tolerated, and that assertion is the only
-    // place in this repo where the reason the floor exists is evidence instead
-    // of a sentence in a doc comment. (It also caught a first draft of this very
-    // test, which demanded `up` of 0.0.23 and was wrong to.)
-    let contract = Contract::read();
-    let Some(installed) = contract.installed() else {
-        return;
-    };
-    let help = ask_dl(&["--help"], "help");
-    let names = |verb: &str| {
-        help.split_whitespace()
-            .any(|word| word.trim_matches(',') == verb)
-    };
-    assert!(
-        names("rm"),
-        "`dl --help` no longer names `rm`, which `src/reap.rs` hands it on \
-         every release:\n{help}"
-    );
-    match installed.expect {
-        Expect::Usable => assert!(
-            names("up"),
-            "`dl --help` no longer names `up`, which `src/launch.rs` hands it \
-             for every prewarm. That verb is the {DEVLAUNCH_FLOOR} floor's \
-             subject: a `dl` clearing the floor must carry it.\n{help}"
-        ),
-        Expect::TooOld => assert!(
-            !names("up"),
-            "this `dl` is below the {DEVLAUNCH_FLOOR} floor and yet names \
-             `up`, so the floor is not where `up` arrived and the number is \
-             wrong:\n{help}"
-        ),
-    }
-}
-
-#[test]
 fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
     // The decision `answers_unsaved` exists for, and the most dangerous one in
     // the pair: on a release that answers for every clone of its own, a `null`
@@ -885,27 +849,105 @@ fn a_reap_with_no_dl_refuses_instead_of_guessing() {
 /// Shaped like one `wf` makes, because `dl` derives things from the name.
 const SHIMMED_WORKSPACE: &str = "devlaunch-wayfinder-wayfinder-137-abcdefgh";
 
+/// One recorded devpod invocation, parsed into arguments.
+///
+/// Parsed rather than kept as a line, because everything that reads a recording
+/// wants a *field*: the guard below asks whether any argument is an assignment,
+/// the isolated-launch test asks for the value of `--command`. Both used to do
+/// it by string surgery on the whole line, and both were wrong in the same way
+/// — one treated `dl`'s entire output as a single `NAME=value`, the other
+/// assumed `--command` was the last argument. A parse costs four lines and
+/// removes the class.
+#[derive(Debug, Clone)]
+struct Call {
+    args: Vec<String>,
+}
+
+impl Call {
+    /// `devpod <a> <b>` → `["a", "b"]`.
+    fn parse(line: &str) -> Option<Call> {
+        let rest = line.strip_prefix("devpod")?;
+        Some(Call {
+            args: rest
+                .split('<')
+                .skip(1)
+                .filter_map(|field| field.rsplit_once('>').map(|(arg, _)| arg.to_string()))
+                .collect(),
+        })
+    }
+
+    fn verb(&self) -> Option<&str> {
+        self.args.first().map(String::as_str)
+    }
+
+    /// The argument after `flag`, or `None` if it was not passed.
+    fn value_of(&self, flag: &str) -> Option<&str> {
+        let at = self.args.iter().position(|arg| arg == flag)?;
+        self.args.get(at + 1).map(String::as_str)
+    }
+
+    fn mentions(&self, needle: &str) -> bool {
+        self.args.iter().any(|arg| arg.contains(needle))
+    }
+
+    /// How this call reads in a failure message: every `NAME=VALUE` argument
+    /// with its value elided.
+    ///
+    /// Display only. The assertions read [`Call::args`], which is untouched —
+    /// an earlier version rewrote the recording itself and could therefore
+    /// change what a test was asserting on, which is a strange way to keep a
+    /// secret.
+    fn shown(&self) -> String {
+        let shown: Vec<String> = self
+            .args
+            .iter()
+            .map(|arg| match arg.split_once('=') {
+                Some((name, _)) if is_variable_name(name) => format!("{name}=…"),
+                _ => arg.clone(),
+            })
+            .collect();
+        format!("devpod {}", shown.join(" "))
+    }
+}
+
+/// A plausible environment-variable name, and nothing else.
+///
+/// The distinction matters twice: `NAME=VALUE` is an assignment worth hiding,
+/// while `bash -lc 'FOO=1 …'` is a command and rewriting it would corrupt the
+/// thing under assertion.
+fn is_variable_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !name.starts_with(|c: char| c.is_ascii_digit())
+}
+
 /// What the real `dl` asked devpod to do, and what it said while doing it.
 #[derive(Debug)]
 struct Asked {
-    /// One line per devpod invocation: the program and each argument in angle
-    /// brackets, so an argument containing a space cannot read as two.
-    devpod: Vec<String>,
+    calls: Vec<Call>,
     status: std::process::ExitStatus,
     said: String,
 }
 
 impl Asked {
-    /// The one devpod call whose first argument is `verb`, or `None`.
-    fn call(&self, verb: &str) -> Option<&String> {
-        self.devpod
-            .iter()
-            .find(|line| line.starts_with(&format!("devpod <{verb}>")))
+    /// The one devpod call whose verb is `verb`, or `None`.
+    fn call(&self, verb: &str) -> Option<&Call> {
+        self.calls.iter().find(|call| call.verb() == Some(verb))
+    }
+
+    /// Every call, rendered for a failure message with assignment values gone.
+    fn shown(&self) -> String {
+        self.calls.iter().fold(String::new(), |mut out, call| {
+            out.push_str("  ");
+            out.push_str(&call.shown());
+            out.push('\n');
+            out
+        })
     }
 }
 
-/// Every subprocess this file starts, with an environment **built rather than
-/// inherited**.
+/// Every subprocess this file starts **directly**, with an environment built
+/// rather than inherited.
 ///
 /// The inheriting version of this was two `env_remove` calls, `GH_TOKEN` and
 /// `GITHUB_TOKEN`, which is a denylist of the two names that happened to be
@@ -918,13 +960,23 @@ impl Asked {
 /// * a variable added on either side is admitted by default.
 /// * nothing notices when the list stops being complete.
 ///
-/// So the environment is allowlisted: cleared, then given back the four things
-/// a run needs. Anything new is excluded because it was never let in.
-/// `DEVLAUNCH_NO_GH_TOKEN` is devlaunch's own documented opt-out and covers the
-/// sources clearing the environment cannot reach; the scratch `HOME` covers
-/// `gh`'s config directory. Neither is trusted on its own — see
-/// [`refuse_secrets`], which is the part that keeps working when both of these
-/// stop being the right names.
+/// So the environment is allowlisted: cleared, then given back the three things
+/// a run needs — `PATH`, `HOME`, and devlaunch's own `DEVLAUNCH_NO_GH_TOKEN`.
+/// Anything new is excluded because it was never let in. The opt-out covers the
+/// sources clearing cannot reach; the scratch `HOME` covers `gh`'s config
+/// directory. Neither is trusted on its own — see [`refuse_secrets`].
+///
+/// **Directly** is load-bearing and was once wrong here. Two tests reach `dl`
+/// without going through this function, and both are meant to:
+/// [`a_devcontainer_repo_is_isolated_only_when_a_real_dl_can_carry_it`] calls
+/// `Isolation::detect`, and [`a_launch_that_fell_back_says_why_and_names_the_version`]
+/// reads the version through the same path — each of which spawns
+/// `dl --version` from inside `src/launch.rs`, with this process's whole
+/// environment, because *that is what `wf` does in production* and the point of
+/// those tests is the production path. `--version` is also the one `dl` call
+/// that consults no credential and prints none. What must not happen is a
+/// *capture* being taken from an inherited environment, and that is what this
+/// function and the guard below are for.
 fn hermetic(program: &Path, home: &Path) -> Command {
     let mut cmd = Command::new(program);
     cmd.env_clear()
@@ -959,75 +1011,61 @@ fn looks_secret(name: &str) -> bool {
 /// Token shapes, for a credential that arrives without a name attached.
 const TOKEN_PREFIXES: [&str; 6] = ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"];
 
-/// Fail if anything captured here looks like a credential — before it can be
+/// Fail if any *recorded argument* looks like a credential — before it can be
 /// printed.
 ///
 /// This is the durable half of the mitigation. devlaunch **deliberately** keeps
 /// the token off the command line today: `gh_auth.up_args` writes it to a
 /// private file and passes `--workspace-env-file`, and its docstring says why —
 /// `devpod up` runs for minutes and its argv is visible to anyone who can run
-/// `ps`. So there is nothing to redact right now. That is a decision in another
+/// `ps`. So there is nothing to catch right now. That is a decision in another
 /// repository, and the reason this exists is that a change to it must surface
 /// as a failed test here rather than as a token in a CI log.
 ///
 /// Shape, not name: a rename on devlaunch's side leaves this working. The
-/// message names only the key, never the value — a guard that prints what it
-/// caught is the leak it was guarding against.
-fn refuse_secrets(what: &str, lines: &[String]) {
-    for line in lines {
-        for prefix in TOKEN_PREFIXES {
-            assert!(
-                !line.contains(prefix),
-                "{what} contains something shaped like a GitHub token \
-                 (a `{prefix}` string). The value is deliberately not shown. \
-                 devlaunch used to keep credentials off argv; if that changed, \
-                 this test has to stop capturing them before it can run again."
-            );
-        }
-        for field in line.split(['<', '>']) {
-            let Some((name, value)) = field.split_once('=') else {
+/// message names only the key, never the value.
+///
+/// It takes parsed arguments rather than a line. The version that took the line
+/// was also handed `dl`'s combined stdout and stderr, which contains no angle
+/// brackets — so the whole blob became one field, "the name" became every byte
+/// before the first `=`, and the guard would both accuse innocent output and
+/// print the entire capture it exists to withhold. Free text is [`refuse_tokens`]'s
+/// job and is checked for shapes only, because free text has no fields.
+fn refuse_secrets(what: &str, calls: &[Call]) {
+    for call in calls {
+        for arg in &call.args {
+            refuse_tokens(what, arg);
+            let Some((name, value)) = arg.split_once('=') else {
                 continue;
             };
             assert!(
-                !looks_secret(name) || value.is_empty(),
-                "{what} carries `{name}=...` — a name shaped like a secret, \
-                 with a value. The value is deliberately not shown. Either \
-                 devlaunch has started putting credentials on the command line, \
-                 or this needs to learn why that one is harmless."
+                !is_variable_name(name) || !looks_secret(name) || value.is_empty(),
+                "{what} carries `{name}=…` — a name shaped like a secret, with a \
+                 value. The value is deliberately not shown. Either devlaunch \
+                 has started putting credentials on the command line, or this \
+                 needs to learn why that one is harmless."
             );
         }
     }
 }
 
-/// Blank the value of every `NAME=VALUE` argument.
+/// Fail if free text holds something shaped like a token.
 ///
-/// Belt and braces behind [`refuse_secrets`], for the credential whose name and
-/// shape are both ones nobody thought of: the assertions in this file never
-/// need the *value* of an environment assignment, only that it was passed and
-/// under what name, so nothing is lost by never holding one.
-fn redact(line: &str) -> String {
-    // Only a field whose left side is a plausible *variable name* is treated as
-    // an assignment. `bash -lc 'FOO=1 ...'` is a command, not an environment
-    // entry, and blanking the right of its first `=` would quietly rewrite the
-    // thing `an_isolated_launch_arrives_as_one_shell_command` is asserting.
-    let is_name = |name: &str| {
-        !name.is_empty()
-            && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-            && !name.starts_with(|c: char| c.is_ascii_digit())
-    };
-    line.split_inclusive('>')
-        .map(|field| {
-            let bare = field.trim_start_matches([' ', '<']);
-            match bare.split_once('=') {
-                Some((name, _)) if is_name(name) => {
-                    format!(" <{name}=…>")
-                }
-                _ => field.to_string(),
-            }
-        })
-        .collect::<String>()
-        .trim_start()
-        .to_string()
+/// The half that applies to anything captured from a real `dl` — its stderr on
+/// a failed call, a listing body, a Python traceback — all of which end up in
+/// a panic message and therefore in a CI log. No field parsing is possible
+/// here, so this is prefixes only, and the message names the prefix rather than
+/// quoting what it found.
+fn refuse_tokens(what: &str, text: &str) {
+    for prefix in TOKEN_PREFIXES {
+        assert!(
+            !text.contains(prefix),
+            "{what} contains something shaped like a GitHub token (a `{prefix}` \
+             string). It is deliberately not shown. This test prints what it \
+             captures when it fails, so it must stop capturing this before it \
+             can run again."
+        );
+    }
 }
 
 /// Run the real `dl` with a recording `devpod` in front of it.
@@ -1087,25 +1125,20 @@ exit 0
         .output()
         .unwrap_or_else(|e| panic!("could not run {}: {e}", program.display()));
 
-    let raw: Vec<String> = std::fs::read_to_string(&log)
-        .expect("the log")
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(str::to_string)
-        .collect();
+    let raw = std::fs::read_to_string(&log).expect("the log");
+    let calls: Vec<Call> = raw.lines().filter_map(Call::parse).collect();
     let said = format!(
         "{}{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
-    // Checked on the raw capture and stored redacted, in that order. Redacting
-    // first would leave the guard nothing to find; storing raw would leave a
-    // credential in something every assertion below prints on failure.
-    refuse_secrets("the devpod recording", &raw);
-    refuse_secrets("what dl said", std::slice::from_ref(&said));
+    // Both channels, each by the rule that suits it: the recording has fields,
+    // so it gets the full check; `dl`'s own output does not, so it gets shapes.
+    refuse_secrets("the devpod recording", &calls);
+    refuse_tokens("what dl said", &said);
 
     Asked {
-        devpod: raw.iter().map(|line| redact(line)).collect(),
+        calls,
         status: out.status,
         said,
     }
@@ -1131,15 +1164,16 @@ fn the_removal_wf_sends_reaches_devpod_as_a_delete() {
     );
     let deleted = asked.call("delete").unwrap_or_else(|| {
         panic!(
-            "`dl {}` never asked devpod to delete anything. It asked:\n{:#?}\n{}",
+            "`dl {}` never asked devpod to delete anything. It asked:\n{}{}",
             argv.join(" "),
-            asked.devpod,
+            asked.shown(),
             asked.said
         )
     });
     assert!(
-        deleted.contains(&format!("<{SHIMMED_WORKSPACE}>")),
-        "the delete names a different workspace: {deleted}"
+        deleted.mentions(SHIMMED_WORKSPACE),
+        "the delete names a different workspace: {}",
+        deleted.shown()
     );
 }
 
@@ -1171,15 +1205,16 @@ fn the_prewarm_wf_sends_is_the_verb_the_floor_exists_for() {
             );
             let up = asked.call("up").unwrap_or_else(|| {
                 panic!(
-                    "`{}` never reached `devpod up`. It asked:\n{:#?}\n{}",
+                    "`{}` never reached `devpod up`. It asked:\n{}{}",
                     argv.join(" "),
-                    asked.devpod,
+                    asked.shown(),
                     asked.said
                 )
             });
             assert!(
-                up.contains(&format!("<{SHIMMED_WORKSPACE}>")),
-                "the prewarm brought up a different workspace: {up}"
+                up.mentions(SHIMMED_WORKSPACE),
+                "the prewarm brought up a different workspace: {}",
+                up.shown()
             );
         }
         Expect::TooOld => {
@@ -1193,8 +1228,19 @@ fn the_prewarm_wf_sends_is_the_verb_the_floor_exists_for() {
             );
             assert!(
                 asked.call("up").is_none(),
-                "a dl below the floor still reached `devpod up`: {:#?}",
-                asked.devpod
+                "a dl below the floor still reached `devpod up`:\n{}",
+                asked.shown()
+            );
+            // *Why* it failed, not merely that it did. Without this the test
+            // passes on any failure at all — a shim fixture that stopped
+            // parsing, a resolution error under the scratch HOME — while the
+            // regression it exists to reproduce quietly stops being reproduced.
+            assert!(
+                asked.said.contains("Unknown command"),
+                "a dl below the floor refused the prewarm, but not by saying it \
+                 does not have the verb — so this is no longer the 0.14.0 \
+                 failure being reproduced:\n{}",
+                asked.said
             );
         }
     }
@@ -1228,22 +1274,34 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
         asked.status,
         asked.said
     );
-    // The last `devpod ssh --command` is the agent; the earlier ones are
-    // devlaunch's own tool probes.
-    let ran = asked
-        .devpod
+    // Selected by what it carries, not by where it sits.
+    //
+    // The first version took the *last* `devpod ssh` call, on a comment-level
+    // assumption that devlaunch puts its tool probes before the agent. That
+    // payload is then executed, so a reordering or an extra post-launch step on
+    // devlaunch's side would have run its container bootstrap — which pipes
+    // `curl` into `bash` — on this machine. It is named instead, and required
+    // to be the only match.
+    let agent_program = &agent[0];
+    let carried: Vec<&Call> = asked
+        .calls
         .iter()
-        .rfind(|line| line.starts_with("devpod <ssh>"))
-        .unwrap_or_else(|| {
-            panic!(
-                "the launch never reached the container. It asked:\n{:#?}\n{}",
-                asked.devpod, asked.said
-            )
-        });
-    let command = ran
-        .rsplit_once("<--command> <")
-        .and_then(|(_, rest)| rest.strip_suffix('>'))
-        .unwrap_or_else(|| panic!("no `--command` in the ssh call: {ran}"));
+        .filter(|call| {
+            call.verb() == Some("ssh")
+                && call
+                    .value_of("--command")
+                    .is_some_and(|command| command.contains(agent_program.as_str()))
+        })
+        .collect();
+    assert_eq!(
+        carried.len(),
+        1,
+        "expected exactly one devpod call carrying `{agent_program}`, and this \
+         test runs the one it finds — so anything but one call means it does \
+         not know what it would be running:\n{}",
+        asked.shown()
+    );
+    let command = carried[0].value_of("--command").expect("matched above");
 
     // Not asserted as a string. How `dl` escapes this for its own shell is
     // `dl`'s business and it re-quotes what `wf` already quoted; pinning the
@@ -1256,7 +1314,7 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
     let _ = std::fs::remove_dir_all(&bin);
     std::fs::create_dir_all(&bin).expect("a scratch bin");
     let seen = bin.join("argv");
-    let claude = bin.join("claude");
+    let claude = bin.join(agent_program);
     std::fs::write(
         &claude,
         format!(
@@ -1264,24 +1322,29 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
             seen.display()
         ),
     )
-    .expect("the claude recorder");
+    .expect("the agent recorder");
     let mut perms = std::fs::metadata(&claude)
         .expect("the recorder")
         .permissions();
     std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
     std::fs::set_permissions(&claude, perms).expect("an executable recorder");
 
-    let out = hermetic(Path::new("sh"), &bin)
+    // The command runs with a PATH holding only what it may legitimately need:
+    // the recorder, and the shell `dl` asked for. Belt and braces behind the
+    // selection above — if that ever picks the wrong call anyway, devlaunch's
+    // bootstrap finds no `curl`, no `pixi` and no `gh`, and does nothing to
+    // this machine.
+    for tool in ["bash", "sh"] {
+        let real = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+            .map(|dir| dir.join(tool))
+            .find(|candidate| candidate.is_file())
+            .unwrap_or_else(|| panic!("no `{tool}` on PATH to run the agent command with"));
+        std::os::unix::fs::symlink(real, bin.join(tool)).expect("link the shell");
+    }
+    let out = hermetic(&bin.join("sh"), &bin)
         .arg("-c")
         .arg(command)
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                bin.display(),
-                std::env::var("PATH").unwrap_or_default()
-            ),
-        )
+        .env("PATH", &bin)
         .output()
         .expect("a shell");
     assert!(
@@ -1300,8 +1363,19 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
 }
 
 #[test]
-fn every_subprocess_here_is_started_by_the_one_function_that_sanitises() {
-    // A guard on this file's own source, because the mitigation it protects is
+fn every_subprocess_this_file_starts_itself_goes_through_hermetic() {
+    // A guard on this file's own source — and only on this file's own source,
+    // which is a real limit rather than an oversight. `Isolation::detect` and
+    // `Devlaunch::from_version_output`'s caller both spawn `dl --version` from
+    // inside `src/launch.rs`, with this process's whole environment, and they
+    // are *supposed* to: those two tests exist to drive the production path,
+    // and `--version` is the one `dl` call that consults no credential and
+    // prints none. Nothing captured from them is printed either. What this
+    // guard covers is the thing that would put a credential in a log — a
+    // capture taken from an inherited environment — and that only happens
+    // through a spawn written here.
+    //
+    // It is a guard at all because the mitigation it protects is
     // the kind that decays by addition rather than by edit: nothing about
     // writing a new test here reminds anybody that the environment has to be
     // built rather than inherited, and a run that inherits one is
@@ -1320,8 +1394,9 @@ fn every_subprocess_here_is_started_by_the_one_function_that_sanitises() {
         1,
         "something in this file starts a subprocess without going through \
          `hermetic`, so it inherits the developer's whole environment — \
-         including whatever credential is in it. Route it through `hermetic`, \
-         or, if it genuinely must inherit, say why here and change this count."
+         including whatever credential is in it, in something whose output \
+         this file prints when it fails. Route it through `hermetic`, or, if \
+         it genuinely must inherit, say why here and change this count."
     );
 
     let at = source.find(needle).expect("the one spawn");


### PR DESCRIPTION
`wf` shells out to `dl` four ways — `--version`, `--ls --json`, `<id> rm`, `<ws> up` / `<ws> -- <cmd>` — and **every one of them was exercised against a recording shim**, including in `tests/live_launch_exec.rs`, which shims `dl` on purpose so a machine with devlaunch installed and one without take the same path. Devlaunch has no test that names `wf`.

So the agreement between the two repositories was two independent transcriptions of the same prose. It has already been wrong twice: `dl <workspace> up` shipped in `wf` 0.14.0 before devlaunch 0.0.24 carried it, and `unsaved` changed from a string to a one-key object in that same release.

## What this adds

`pixi.toml` installs a **chosen** devlaunch and nothing else — it deliberately does not build the crate; the compiler stays rustup's.

| environment | `dl` | for |
|---|---|---|
| `default` | none | the suite *and* the contract, no `dl` anywhere on PATH |
| `floor` | 0.0.24 | exactly `launch::DEVLAUNCH_FLOOR` |
| `latest` | newest | what a user gets today |
| `stale` | 0.0.23 | below the floor: the degradation |

```
pixi run    suite              pixi run -e latest contract
pixi run -e default contract   pixi run -e stale  contract
pixi run -e floor   contract
```

`tests/live_devlaunch.rs` — 16 tests × 4 environments. The ones that matter:

- **`what_this_dl_says_about_a_clone_holding_work_is_what_wf_reads`** — a real checkout with a real uncommitted file, inspected by *this* devlaunch's own `read_clone`, serialised as *this* release serialises it, read back through `parse_workspaces`. Runs on both sides of the version boundary, so the `unsaved` shape is **observed**, not declared.
- **`the_prewarm_wf_sends_is_the_verb_the_floor_exists_for`** — the 0.14.0 regression, live. `wf`'s own prewarm argv to a real 0.0.23 comes back `Unknown command 'up'`; the same argv on 0.0.24 reaches `devpod up`. `dl`'s only devpod spawn is a bare name on PATH, so a recording `devpod` in front of the **real** `dl` runs devlaunch's real parsing and resolution and stops where the container would begin. No daemon, nothing created.
- **The fallbacks** — `Isolation::detect` must return `Host` in a checkout that really carries a devcontainer whenever `dl` is absent or below the floor; the launch notice must say why; `wf reap` with no `dl` must fail rather than mistake "cannot see the workspaces" for "there are none".
- **`the_floor_environment_is_pinned_to_the_floor`** — the pixi pin and `DEVLAUNCH_FLOOR`, compared unconditionally.

`scripts/without-dl.sh` shadows each PATH directory holding a `dl` with symlinks to everything but `dl`, because `pixi run` prepends its prefix rather than replacing PATH — and `pixi global install devlaunch` puts `dl` next to `gh` and `wf`.

`.github/workflows/devlaunch-contract.yml` runs all four per PR and weekly re-solves devlaunch first — the only trigger that can discover a release published since the lock.

## Two adversarial review rounds, 20 findings

**Round one (10).** The worst was a test that would have caused the bug it was written to prevent: it asserted `DEVLAUNCH_FLOOR == UNSAVED_IS_AN_OBJECT`, an equality `src/launch.rs` documents as two facts a floor bump must be able to part — satisfying it after a bump means making `answers_unsaved` false for a real 0.0.24 and walking `wf reap` back into devlaunch#171. Also: the floor could drift *down* undetected (the check was guarded by the equality it checked); four checks failed open on a typo'd or absent env var; the scrubber deleted whole PATH directories.

**Round two (10).** The sharpest was that this file's central claim was false — `hermetic` is *not* the only thing that starts a process, because `Isolation::detect` spawns `dl --version` from inside `src/launch.rs` with the ambient environment, and the source-scanning guard cannot see it. That is correct behaviour (those tests exist to drive the production path), so the claim was corrected rather than the code. Also: `refuse_secrets` was handed `dl`'s combined output, which has no field structure, so it would have accused innocent output *and* printed the whole capture in a message advertised as name-only; the isolated-launch test re-executed a recorded container command on the host, picked by position, and devlaunch's bootstrap payload pipes `curl` into `bash`; `redact()` was unverified in both directions and could rewrite the string under assertion, so it is deleted and redaction is display-only now.

One finding is **documented rather than fixed**: the shimmed runs hand `dl` a devpod workspace id, not the `owner/repo@branch` spec every real caller builds, because the spec form makes `dl` clone. The verbs and flags are `wf`'s; the workspace argument is the test's own. Three places said otherwise and now say this.

## Verification

Everything is mutation-verified — applied, confirmed red, reverted. Across both rounds: `DEVLAUNCH_FLOOR` moved up *and* down, both wire-key renames, the legacy sentence arm (**turns `stale` red — that is the mutation that deletes uncommitted work**), `shell_quote` neutered, `up`→`start`, `rm` dropped, `detect` no longer consulting `dl` (**red in `default` and `stale`, green in `floor`**), `shortfall` silenced, `workspaces()` swallowing its error, `env_clear` removed, a fabricated `SOME_FUTURE_AUTH_TOKEN` argument, a fabricated `ghp_` string in free text, an unidentifiable agent call, a stale failure for the wrong reason, and a direct spawn bypassing `hermetic`. Plus 12 environment mutations (unknown/absent/wrong `WF_CONTRACT_*`, host `dl` ahead on PATH, bare `cargo test`).

Local chain green under `-D warnings` and `RUSTDOCFLAGS=-D warnings`. CI green on the merge commit, and the job does real work: 390 lib + 18 bin tests with no `dl` on PATH, then 16 contract tests against real 0.0.24 / 0.0.25 / 0.0.23.

## Public surface

`DEVLAUNCH_FLOOR`, `UNSAVED_IS_AN_OBJECT`, `DlVersion`, `Devlaunch`, `Devlaunch::shortfall`, `reap::parse_workspaces`, and the three argv builders `reap::removal_argv` / `launch::prewarm_argv` / `launch::isolated_argv` become `pub`. That is exactly the contract with the other repository, and it is now the part of this crate's surface actually run against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)