### PR TITLE
Drop the allow for a lint that does not exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,6 @@ cast_possible_truncation = "allow"
 cast_possible_wrap = "allow"
 cast_sign_loss = "allow"
 
-# Wants `Duration::from_mins(1)` where a test writes `from_secs(60)`. The
-# timeouts in tests/live_launch_exec.rs are meant to be compared with each other
-# at a glance — `from_secs(60)` beside `from_secs(30)` says more than one of each
-# unit does — and the suggested constructor is newer than the toolchain the
-# recipe asks for anyway.
-duration_suboptimal_units = "allow"
-
 # `dbg!` survives a review far too easily.
 dbg_macro = "warn"
 


### PR DESCRIPTION
`clippy::duration_suboptimal_units` is not a clippy lint. On the toolchain this crate pins, every `cargo clippy` run printed:

```
warning[E0602]: unknown lint: `clippy::duration_suboptimal_units`
  = note: requested on the command line with `-A clippy::duration_suboptimal_units`
```

once per target — eleven lines of noise on a clean tree.

`cargo clippy -- -W help` on clippy 0.1.93 lists no such lint. The nearest names are `duration_subsec` and `unchecked_time_subtraction`, and neither does what the comment described.

So the `allow` silenced nothing, and the comment justified something that never happens — the `from_secs(60)` timeouts in `tests/live_launch_exec.rs` it claimed to protect were never at risk. AGENTS.md requires every `allow` to carry a comment saying why; this one had a comment, about a lint nobody has ever run.

**Deleted rather than renamed**, because there is no name to rename it to. If a future clippy adds the lint it will warn on its own, and can be silenced then under a name that exists.

### Why it survived

`-D warnings` never promoted it to an error: an unknown lint named on the command line is reported before lint levels apply. CI stayed green while printing it on every run, which is precisely the shape of thing that stops getting read.

### Verification

`cargo clippy --all-targets --all-features --locked` under `-D warnings` is now completely silent. Full gate green: fmt, clippy, 390 lib + 18 bin tests, 7 skill-doc tests, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)