### PR TITLE
Boot the devcontainer from a published image, not a build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,9 +55,20 @@ RUN set -eux; \
 # user that will run it. `~/.claude` is a bind mount from the host (see
 # devcontainer.json) and is deliberately *not* what this writes to — the binary
 # lives in the image, the credentials and settings come from the host at runtime.
+#
+# The pin is an argument to a third-party installer, so it is compared, not
+# trusted: `gh` and `zellij` above carry their versions in the download URL and
+# a wrong version cannot resolve, but an installer that silently ignored its
+# argument would leave this pin buying nothing with the build still green. The
+# comparison also backstops the unpiped `curl | bash` — a truncated script that
+# installed something else fails here.
 USER vscode
 RUN set -eux; \
     curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_VERSION"; \
-    /home/vscode/.local/bin/claude --version
+    installed="$(/home/vscode/.local/bin/claude --version)"; \
+    case "$installed" in \
+      *"$CLAUDE_VERSION"*) ;; \
+      *) echo "pinned CLAUDE_VERSION=$CLAUDE_VERSION but installed: $installed" >&2; exit 1 ;; \
+    esac
 ENV PATH=/home/vscode/.local/bin:$PATH
 USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,9 +16,18 @@
 FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
 
 # Pinned rather than "latest" so an image rebuild is a deliberate version bump
-# and not a silent one. Both are plain static binaries with no build step.
+# and not a silent one. `gh` and `zellij` are plain static binaries with no build
+# step; the agent CLI arrives through its own installer, which turns out to
+# accept a version (`install.sh [stable|latest|VERSION]`) — so it is pinned here
+# too rather than left to drift, which matters more now that this image is
+# published and shared than it did when every workspace built its own.
+#
+# It is a floor and not a ceiling: the agent CLI updates itself in place, so a
+# long-lived container will run something newer than this. What the pin buys is
+# that two workspaces created from the same image *start* from the same version.
 ARG GH_VERSION=2.97.0
 ARG ZELLIJ_VERSION=0.44.3
+ARG CLAUDE_VERSION=2.1.223
 
 # One layer, and the tarballs are deleted in it: an unpacked tarball left behind
 # in an earlier layer stays in the image however thoroughly a later layer removes
@@ -48,7 +57,7 @@ RUN set -eux; \
 # lives in the image, the credentials and settings come from the host at runtime.
 USER vscode
 RUN set -eux; \
-    curl -fsSL https://claude.ai/install.sh | bash; \
+    curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_VERSION"; \
     /home/vscode/.local/bin/claude --version
 ENV PATH=/home/vscode/.local/bin:$PATH
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,9 +19,12 @@
   // spellings the spec allows (string and array) were ignored. So `cacheFrom`
   // here would look like a cache and never be one.
   //
-  // To build from source instead — a `Dockerfile` change, or a host whose
-  // architecture the published tag does not cover — use the variant beside this
-  // file: `dl blooop/wayfinder@<branch> --devcontainer local`. It carries the
+  // To build from source instead — a `Dockerfile` change, a host whose
+  // architecture the published tag does not cover, or the pull was denied
+  // (GHCR packages are private by default until made public, and the tag does
+  // not exist at all before `devcontainer.yml`'s first run on `main`) — use
+  // the variant beside this file:
+  // `dl blooop/wayfinder@<branch> --devcontainer local`. It carries the
   // `build:` block, and a test holds the two configs to the same settings so
   // this one cannot drift away from it.
   "image": "ghcr.io/blooop/wayfinder-devcontainer:latest",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,30 @@
 {
   "name": "wayfinder",
 
-  // Built from this repo's own Dockerfile rather than a prebuilt image. A cold
-  // `cargo build` here is 9 seconds (see blooop/wayfinder#39), so the thing a
-  // prebuilt image would save is the *image* build, not the crate build —
-  // whether that is worth a registry and a publishing workflow is
-  // blooop/wayfinder#43, still open. Until then, local build.
-  // `context` is this directory, NOT the repo root. The Dockerfile copies nothing
-  // out of the context — it only downloads pinned binaries — so a repo-root
-  // context would buy nothing and costs a great deal: devpod hashes the build
-  // context and gives up past 5000 files, and `target/` alone is far beyond that
-  // ("failed to compute context hash: exceeded limit of 5000 files"). If a future
-  // change needs Cargo.toml/Cargo.lock in the image (e.g. baking compiled deps),
-  // widen this to ".." and add a .dockerignore excluding target/ in the same
-  // commit.
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": "."
-  },
+  // A prebuilt image, not a build from `Dockerfile` — blooop/wayfinder#43 is
+  // settled and this is its answer (blooop/wayfinder#150). What a prebuild saves
+  // was never the crate build: a cold `cargo build` here is 9 seconds
+  // (blooop/wayfinder#39). It is the *image* build — the pinned `gh`, `zellij`
+  // and agent-CLI downloads in `Dockerfile`, which every branch's first `dl`
+  // paid for again. `devcontainer.yml` publishes this tag on any push to `main`
+  // that touches this directory.
+  //
+  // `image:` rather than the `build:` block plus `cacheFrom`, which is what #43
+  // expected, and the difference is a probed fact rather than a preference:
+  // **devpod does not honor `build.cacheFrom`**. Measured on 2026-08-14 against
+  // devpod v0.26.1 with a marker layer costing a fixed 25 s, pushed to a
+  // registry with inline cache metadata and absent from the builder's local
+  // cache — the layer rebuilt in full, and devpod's own log of the
+  // `docker buildx build` it shells out to carries no cache flag at all. Both
+  // spellings the spec allows (string and array) were ignored. So `cacheFrom`
+  // here would look like a cache and never be one.
+  //
+  // To build from source instead — a `Dockerfile` change, or a host whose
+  // architecture the published tag does not cover — use the variant beside this
+  // file: `dl blooop/wayfinder@<branch> --devcontainer local`. It carries the
+  // `build:` block, and a test holds the two configs to the same settings so
+  // this one cannot drift away from it.
+  "image": "ghcr.io/blooop/wayfinder-devcontainer:latest",
 
   // Note what is NOT here: `"runArgs": ["--network=host"]`. python_template sets
   // it, and copying it would defeat one of the three reasons this container

--- a/.devcontainer/local/devcontainer.json
+++ b/.devcontainer/local/devcontainer.json
@@ -1,0 +1,59 @@
+{
+  "name": "wayfinder (local build)",
+
+  // The build-from-source variant, selected by name:
+  //
+  //     dl blooop/wayfinder@<branch> --devcontainer local
+  //
+  // Reach for it when the published image is not what you want to run: you are
+  // changing `Dockerfile` itself and want the change before it is merged and
+  // published, or you are on an architecture the published tag does not carry.
+  // Everything else should use the default config beside this one, which pulls
+  // the prebuilt image instead (blooop/wayfinder#150).
+  //
+  // A separate file rather than `cacheFrom` on the default, because devpod does
+  // not honor `build.cacheFrom` — probed, not assumed; the default config's
+  // header records the measurement.
+  //
+  // Paths are relative to *this* file, so both point one level up: one
+  // `Dockerfile`, shared with the image the workflow publishes, so a local build
+  // and a published image can never be built from different instructions. Why
+  // the context is the parent and not the repo root is not stylistic — devpod
+  // hashes the build context and gives up past 5000 files, which `target/` alone
+  // exceeds. If a future change needs Cargo.toml/Cargo.lock in the image (e.g.
+  // baking compiled deps), widen it and add a .dockerignore excluding `target/`
+  // in the same commit.
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+
+  // Everything below is deliberately identical to the default config, and a test
+  // holds it that way (tests/devcontainer_prebuild.rs): these two files may
+  // differ in *how the image is obtained* and in nothing else, because a variant
+  // that quietly stopped mounting the agent's credentials would be a confusing
+  // way to find out. The reasoning for each setting lives in the default config
+  // and is not duplicated here — read it there.
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"
+  },
+
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind"
+  ],
+
+  "initializeCommand": "mkdir -p \"$HOME/.claude\"",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "mhutchie.git-graph",
+        "anthropic.claude-code"
+      ]
+    }
+  },
+
+  "remoteUser": "vscode"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,14 @@ jobs:
       - name: Skill doc shape checks
         run: cargo test --locked --test skill_docs
 
+      # The other config-as-behavior binary, same reasoning: what a workspace
+      # boots from and what `devcontainer.yml` publishes are promises split
+      # across two devcontainer configs and a workflow, and nothing but this
+      # notices when one of them moves. Named here for the same reason as the
+      # step above — the unit-test step stops at `--lib --bins --examples`.
+      - name: Devcontainer prebuild contract
+        run: cargo test --locked --test devcontainer_prebuild
+
       # The one part of `tests/` that needs neither network nor `gh`: the
       # fixture's own diagnostic, which decides what a failing live test tells
       # you about a missing GH_TOKEN. It is split from the environment it reads

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,82 @@
+name: Devcontainer image
+
+# Publishes the image every `dl blooop/wayfinder@<branch>` boots from, so that
+# the pinned `gh`, `zellij` and agent-CLI downloads in `.devcontainer/Dockerfile`
+# are paid for once here instead of once per branch on every developer's machine.
+# The crate build was never the cost — a cold `cargo build` is 9 seconds
+# (blooop/wayfinder#39) — which is why this publishes a thin image and warms no
+# cargo cache at all (blooop/wayfinder#38, reaffirmed on #43).
+#
+# The fourth workflow, and separate for the same reason the other three are:
+# `ci.yml` answers "is this commit sound" with nothing but a compiler,
+# `package.yml` proves the recipe installs, `devlaunch-contract.yml` runs against
+# a real `dl`. This one talks to a registry and is the only one that writes a
+# package, so a failure here means "the image did not publish" and nothing else.
+#
+# Plain `docker build`, deliberately not `devpod build`: nothing in this
+# devcontainer uses devcontainer *features*, so there is no metadata for a
+# devcontainer-aware builder to bake in, and a plain build is one less tool that
+# has to be installed and understood to read this file.
+on:
+  # A push to main that actually touched the devcontainer. The image's inputs are
+  # all in that directory, so any other push would republish identical content.
+  push:
+    branches: [main]
+    paths:
+      - ".devcontainer/**"
+
+  # By hand, which is not a nicety: the Actions outage of 2026-08-06
+  # (blooop/wayfinder#79) dropped webhook deliveries and three merges to main ran
+  # nothing at all. A missed run here leaves every workspace booting a stale tag,
+  # and nothing announces that — this is how you re-fire it without an empty
+  # commit. It is also the way to rebuild after a base-image security update,
+  # which changes the image without changing this repository.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: devcontainer-${{ github.ref }}
+  # There is one mutable tag, so two runs racing to write it is the one thing
+  # worth preventing: the winner would be whichever finished last, not whichever
+  # commit is newer.
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: build + push (latest)
+    runs-on: ubuntu-latest
+    # On the job, not on the workflow, following `package.yml`: the only thing in
+    # this repository that can write to the package registry is the job below,
+    # and any job added to this file later starts read-only unless it says
+    # otherwise in its own block.
+    permissions:
+      contents: read
+      packages: write # push the image to ghcr.io
+    steps:
+      - uses: actions/checkout@v7
+
+      # Before the build, so a credential problem fails in two seconds rather
+      # than after the whole image has been built.
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # The context is `.devcontainer`, not the repo root — the Dockerfile copies
+      # nothing out of the context, so the root would only send `target/` to the
+      # daemon for no reason. The devcontainer configs make the same choice for a
+      # harder reason (devpod's 5000-file context hash limit); this keeps all
+      # three building the same thing from the same directory.
+      #
+      # One tag, `latest`, and it is mutable on purpose: the devcontainer configs
+      # name a tag rather than a digest, so a workspace gets whatever is newest
+      # without anything in the repository having to be edited on every publish.
+      # A test holds this tag and the one the configs boot from to be the same
+      # string (tests/devcontainer_prebuild.rs).
+      - name: Build the image
+        run: docker build -t ghcr.io/blooop/wayfinder-devcontainer:latest .devcontainer
+
+      - name: Push it
+        run: docker push ghcr.io/blooop/wayfinder-devcontainer:latest

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -60,9 +60,15 @@ jobs:
       # Before the build, so a credential problem fails in two seconds rather
       # than after the whole image has been built.
       - name: Log in to ghcr.io
+        # Through step `env:` rather than `${{ }}` rendered into the script,
+        # following `package.yml`: the token never appears in a command line or
+        # a process listing (`echo` is a builtin, the login reads stdin).
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "$GHCR_TOKEN" \
+            | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
       # The context is `.devcontainer`, not the repo root — the Dockerfile copies
       # nothing out of the context, so the root would only send `target/` to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ RUSTFLAGS=-D\ warnings RUSTDOCFLAGS=-D\ warnings sh -c '
   cargo clippy --all-targets --all-features --locked &&
   cargo test --locked --lib --bins --examples &&
   cargo test --locked --test skill_docs &&
+  cargo test --locked --test devcontainer_prebuild &&
   cargo doc --no-deps --all-features --locked'
 ```
 
@@ -121,9 +122,12 @@ fails the build before any of the interesting checks get a chance to run.
 
 The `tests/live_*.rs` files are excluded from that test command on purpose: they
 talk to real GitHub and drive a real pty. Run them by name when the thing you
-changed is what they cover. `tests/skill_docs.rs` is the exception under
-`tests/` — offline shape checks on the skill docs' snippets, so it runs in the
-chain (and in CI) like any unit test.
+changed is what they cover. Two binaries under `tests/` are exceptions and run
+in the chain (and in CI) like any unit test, because both are offline checks on
+files-as-behavior: `tests/skill_docs.rs` (shape checks on the skill docs'
+snippets) and `tests/devcontainer_prebuild.rs` (the contract between the
+devcontainer configs and the workflow that publishes the prebuilt image to
+GHCR — see the comments in `.devcontainer/devcontainer.json`).
 
 ## The devlaunch contract
 

--- a/README.md
+++ b/README.md
@@ -847,6 +847,15 @@ keeping an editor from opening over the terminal. `wf` builds no flags, reads no
 `devcontainer.json` and writes none: **the repo's own config is the entire
 opt-in**, and there is nothing to configure on the `wf` side.
 
+This repo's own devcontainer is that opt-in put to work, and it boots from a
+**prebuilt image** rather than building: the default config names
+`ghcr.io/blooop/wayfinder-devcontainer:latest`, published by
+`.github/workflows/devcontainer.yml` on any push to `main` that touches
+`.devcontainer/`. If the pull is denied — GHCR packages are private by default
+until made public, and the tag does not exist before that workflow's first run
+on `main` — build from source instead with
+`dl blooop/wayfinder@<branch> --devcontainer local`.
+
 Each launched node gets a **workspace of its own**:
 `owner/repo@wayfinder/<repo>-<n>`, where `n` is the ticket's number (the map's,
 for a whole-map session). `dl` creates that branch off the default branch if it

--- a/tests/devcontainer_prebuild.rs
+++ b/tests/devcontainer_prebuild.rs
@@ -1,0 +1,352 @@
+//! The devcontainer prebuild contract (#150).
+//!
+//! Offline by design, like `skill_docs.rs` and for the same reason: the seam is
+//! the config text itself. What a workspace boots from, and what the publishing
+//! workflow is allowed to write to, are promises made in two files that no
+//! compiler reads — so they are asserted here rather than discovered by a cold
+//! `devpod up` on somebody's laptop.
+
+use serde_json::Value;
+
+/// The published image every workspace boots from. A literal, on purpose: it is
+/// the decision (#150), and the tests below check that both the config and the
+/// workflow agree with *it* rather than merely with each other.
+const PUBLISHED_IMAGE: &str = "ghcr.io/blooop/wayfinder-devcontainer:latest";
+
+fn repo_file(relative: &str) -> String {
+    let path = format!("{}/{relative}", env!("CARGO_MANIFEST_DIR"));
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{relative} ships in this repo: {e}"))
+}
+
+/// `devcontainer.json` is JSONC — the spec allows comments, and this repo's
+/// configs are mostly comment. `serde_json` is not, so the comments come out
+/// first, string literals respected (a `//` inside a value is data, not a
+/// comment).
+fn strip_jsonc_comments(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_string = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            match c {
+                '\\' => {
+                    if let Some(escaped) = chars.next() {
+                        out.push(escaped);
+                    }
+                }
+                '"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                for skipped in chars.by_ref() {
+                    if skipped == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                let mut previous = '\0';
+                for skipped in chars.by_ref() {
+                    if previous == '*' && skipped == '/' {
+                        break;
+                    }
+                    previous = skipped;
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// One of this repo's devcontainer configs, parsed.
+fn devcontainer(relative: &str) -> Value {
+    let text = strip_jsonc_comments(&repo_file(relative));
+    serde_json::from_str(&text).unwrap_or_else(|e| {
+        panic!("{relative} is valid JSONC once its comments are removed (a trailing comma is the usual culprit): {e}")
+    })
+}
+
+/// The two configs this repo ships: the default, and the variant `dl` selects
+/// by bare name (`--devcontainer local` means
+/// `.devcontainer/local/devcontainer.json`).
+const DEFAULT_CONFIG: &str = ".devcontainer/devcontainer.json";
+const LOCAL_CONFIG: &str = ".devcontainer/local/devcontainer.json";
+
+/// Where a path inside a devcontainer config points, relative to the config's
+/// own directory — which is how the spec resolves `dockerfile` and `context`,
+/// and the only reason the variant can reach a `Dockerfile` it does not sit
+/// beside.
+fn resolved_from(config: &str, path: &str) -> std::path::PathBuf {
+    let config_dir = std::path::Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/"))
+        .join(config)
+        .parent()
+        .expect("a config path always has a parent directory")
+        .to_path_buf();
+    config_dir
+        .join(path)
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("{config}'s `{path}` names something that exists: {e}"))
+}
+
+fn repo_path(relative: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join(relative)
+        .canonicalize()
+        .unwrap_or_else(|e| panic!("{relative} exists in this repo: {e}"))
+}
+
+/// The default path — `dl blooop/wayfinder@<branch>` with no variant named —
+/// pulls the published image instead of building one. That is the whole point of
+/// the prebuild: a cold host boots without compiling a Dockerfile.
+#[test]
+fn the_default_config_boots_from_the_published_image() {
+    let config = devcontainer(DEFAULT_CONFIG);
+    assert_eq!(
+        config["image"].as_str(),
+        Some(PUBLISHED_IMAGE),
+        "the default config boots from the published image"
+    );
+    assert!(
+        config.get("build").is_none(),
+        "a config with both `image` and `build` is ambiguous: `build` wins in \
+         the devcontainer spec, so leaving it here would silently rebuild and \
+         the prebuild would buy nothing"
+    );
+}
+
+/// Building from source is still available, and it builds *this* repo's one
+/// Dockerfile — not a copy that can drift from the one the workflow publishes.
+/// Asserted by where the paths resolve rather than how they are spelled, so
+/// rewriting them is free and pointing them somewhere else is not.
+#[test]
+fn the_local_variant_builds_this_repos_dockerfile() {
+    let config = devcontainer(LOCAL_CONFIG);
+    assert!(
+        config.get("image").is_none(),
+        "the variant exists to build; an `image` here would override the point of it"
+    );
+    let build = config
+        .get("build")
+        .expect("the local variant carries the `build:` block the default gave up");
+    assert_eq!(
+        resolved_from(
+            LOCAL_CONFIG,
+            build["dockerfile"]
+                .as_str()
+                .expect("`dockerfile` names a path")
+        ),
+        repo_path(".devcontainer/Dockerfile"),
+        "one Dockerfile, shared with the published image"
+    );
+    // The narrow context, and it is load-bearing rather than tidy: devpod hashes
+    // the build context and gives up past 5000 files ("failed to compute context
+    // hash: exceeded limit of 5000 files"), which `target/` alone blows through.
+    // The Dockerfile copies nothing out of the context — it only downloads
+    // pinned binaries — so the repo root would buy nothing and cost that.
+    assert_eq!(
+        resolved_from(
+            LOCAL_CONFIG,
+            build["context"].as_str().expect("`context` names a path")
+        ),
+        repo_path(".devcontainer"),
+        "the context stays this directory: a repo-root context exceeds devpod's \
+         5000-file context hash limit on `target/` alone, and buys nothing"
+    );
+}
+
+/// Two config files is a standing invitation to drift, and the cost of drift
+/// here is not cosmetic: a variant that quietly stopped mounting the agent's
+/// credentials, or dropped `CLAUDE_CONFIG_DIR`, would look like a working
+/// container and behave like a broken one. So the variant may differ from the
+/// default in *how the image is obtained* and in nothing else.
+#[test]
+fn the_variant_differs_from_the_default_only_in_how_the_image_is_obtained() {
+    // `name` earns its place in this list — the two containers should be
+    // distinguishable in `docker ps`. `image` and `build` are the difference the
+    // variant exists for.
+    const MAY_DIFFER: [&str; 3] = ["name", "image", "build"];
+
+    let settings = |config: &str| -> std::collections::BTreeMap<String, Value> {
+        devcontainer(config)
+            .as_object()
+            .expect("a devcontainer config is a JSON object")
+            .iter()
+            .filter(|(key, _)| !MAY_DIFFER.contains(&key.as_str()))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect()
+    };
+
+    assert_eq!(
+        settings(LOCAL_CONFIG),
+        settings(DEFAULT_CONFIG),
+        "the local variant has drifted from the default. Every setting except \
+         {MAY_DIFFER:?} must be identical in both — copy the change across, or \
+         if the difference is deliberate, say so here and in both files"
+    );
+}
+
+/// The publishing workflow, with its full-line comments removed. The prose in
+/// this repo's workflows is dense and discusses the very triggers asserted
+/// below, so a plain substring check against the raw text would be reading the
+/// commentary rather than the configuration.
+fn publishing_workflow() -> String {
+    repo_file(".github/workflows/devcontainer.yml")
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A top-level block of a workflow file — `on:`, `permissions:`, `jobs:` — from
+/// its key to the next line that starts in column zero.
+fn top_level_block(workflow: &str, key: &str) -> String {
+    let start = workflow.find(&format!("\n{key}:")).map_or_else(
+        || {
+            assert!(
+                workflow.starts_with(&format!("{key}:")),
+                "the workflow declares `{key}:`"
+            );
+            0
+        },
+        |index| index + 1,
+    );
+    let rest = &workflow[start..];
+    let mut block = String::new();
+    for (number, line) in rest.lines().enumerate() {
+        let starts_new_block =
+            number > 0 && !line.starts_with([' ', '\t']) && !line.trim().is_empty();
+        if starts_new_block {
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    block
+}
+
+/// The decided trigger set: a push to the default branch that actually touched
+/// the devcontainer, plus a handle to pull by hand. Deliberately no
+/// pull-request leg and no schedule — this image is rebuilt when its inputs
+/// change, and a nightly rebuild of an unchanged Dockerfile would only churn the
+/// tag every workspace boots from.
+#[test]
+fn the_workflow_publishes_on_a_devcontainer_change_to_main_or_by_hand() {
+    let triggers = top_level_block(&publishing_workflow(), "on");
+
+    assert!(
+        triggers.contains("push:") && triggers.contains("branches: [main]"),
+        "publishes on a push to main:\n{triggers}"
+    );
+    assert!(
+        triggers.contains(".devcontainer/**"),
+        "filtered on the devcontainer directory, so an unrelated push to main \
+         does not rebuild and republish the image:\n{triggers}"
+    );
+    assert!(
+        triggers.contains("workflow_dispatch:"),
+        "can be fired by hand — a dropped webhook leaves the tag stale with \
+         nothing to say so (see #79):\n{triggers}"
+    );
+    assert!(
+        !triggers.contains("pull_request"),
+        "no pull-request leg: it could not push anyway (a fork's token cannot \
+         write packages), so it would be a build whose only output is a green \
+         check:\n{triggers}"
+    );
+    assert!(
+        !triggers.contains("schedule") && !triggers.contains("cron"),
+        "no schedule: the image's inputs are the pinned versions in the \
+         Dockerfile, so a timed rebuild republishes identical content:\n{triggers}"
+    );
+}
+
+/// The narrow-job pattern `package.yml` already uses: the workflow as a whole
+/// can only read, and the ability to write a package is granted to the one job
+/// that publishes. The distinction is what a compromised step in some later,
+/// unrelated job would be able to do — overwrite the image every workspace
+/// boots from, or not.
+#[test]
+fn only_the_publishing_job_can_write_a_package() {
+    let workflow = publishing_workflow();
+    let workflow_level = top_level_block(&workflow, "permissions");
+
+    assert!(
+        workflow_level.contains("contents: read"),
+        "the default for the whole workflow is read-only:\n{workflow_level}"
+    );
+    assert!(
+        !workflow_level.contains("packages:"),
+        "package write is never a workflow-wide grant — every job added later \
+         would inherit it silently:\n{workflow_level}"
+    );
+    assert_eq!(
+        top_level_block(&workflow, "jobs")
+            .matches("packages: write")
+            .count(),
+        1,
+        "exactly one job may write the package: the one that pushes it"
+    );
+}
+
+/// Every reference to the devcontainer package anywhere in the workflow, as
+/// `repository:tag` pairs.
+fn published_references(workflow: &str) -> std::collections::BTreeSet<String> {
+    let (repository, _) = PUBLISHED_IMAGE
+        .rsplit_once(':')
+        .expect("the published image names a tag");
+    workflow
+        .split_whitespace()
+        .flat_map(|token| token.split(['"', '\'', '=', ',', '(', ')']))
+        .filter(|token| token.starts_with(repository))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The one contract that spans both files, and the failure it exists to catch:
+/// renaming the registry, the repository or the tag in one place and not the
+/// other. That mistake publishes an image nothing boots and leaves every
+/// workspace pulling a tag nothing publishes — and both halves look correct on
+/// their own.
+#[test]
+fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() {
+    let workflow = publishing_workflow();
+    let booted = devcontainer(DEFAULT_CONFIG)["image"]
+        .as_str()
+        .expect("the default config boots from an image")
+        .to_string();
+
+    assert_eq!(
+        published_references(&workflow),
+        std::collections::BTreeSet::from([booted.clone()]),
+        "the workflow must name exactly the reference the default config boots \
+         from ({booted}) and no other — one mutable tag, `latest`, per the \
+         decision on #150"
+    );
+    assert!(
+        workflow.contains("packages: write"),
+        "naming the reference is not publishing it"
+    );
+}
+
+/// The built-in token, not a long-lived secret. It is scoped to this repository,
+/// it expires with the run, and it means publishing keeps working without a
+/// credential anybody has to rotate.
+#[test]
+fn the_push_authenticates_with_the_runs_own_token() {
+    let workflow = publishing_workflow();
+    assert!(
+        workflow.contains("secrets.GITHUB_TOKEN") || workflow.contains("github.token"),
+        "the registry login uses the run's own token:\n{workflow}"
+    );
+}

--- a/tests/devcontainer_prebuild.rs
+++ b/tests/devcontainer_prebuild.rs
@@ -299,25 +299,50 @@ fn only_the_publishing_job_can_write_a_package() {
     );
 }
 
-/// Every reference to the devcontainer package anywhere in the workflow, as
-/// `repository:tag` pairs.
-fn published_references(workflow: &str) -> std::collections::BTreeSet<String> {
-    let (repository, _) = PUBLISHED_IMAGE
-        .rsplit_once(':')
-        .expect("the published image names a tag");
+/// Every argument to `docker push` in the workflow, in order. Collected by
+/// what the command *does*, not by what the reference is expected to look
+/// like: a push target renamed to anything at all — another repository,
+/// another registry, a bare local tag — still lands here, where a filter on
+/// the expected name would let it vanish from the comparison entirely.
+fn pushed_references(workflow: &str) -> Vec<String> {
     workflow
         .split_whitespace()
-        .flat_map(|token| token.split(['"', '\'', '=', ',', '(', ')']))
-        .filter(|token| token.starts_with(repository))
-        .map(str::to_string)
+        .collect::<Vec<_>>()
+        .windows(3)
+        .filter(|window| window[0] == "docker" && window[1] == "push")
+        .map(|window| window[2].trim_matches(['"', '\'']).to_string())
         .collect()
+}
+
+/// Every reference to a container image anywhere in the workflow: each
+/// `docker push` argument, each tag handed to `docker build -t`, and any
+/// `ghcr.io/`-prefixed token besides (a login line, a second tag, a stray
+/// env value). Unfiltered on purpose — see `pushed_references`.
+fn published_references(workflow: &str) -> std::collections::BTreeSet<String> {
+    let mut references: std::collections::BTreeSet<String> =
+        pushed_references(workflow).into_iter().collect();
+    let tokens: Vec<&str> = workflow.split_whitespace().collect();
+    for (index, token) in tokens.iter().enumerate() {
+        if index > 0 && (tokens[index - 1] == "-t" || tokens[index - 1] == "--tag") {
+            references.insert(token.trim_matches(['"', '\'']).to_string());
+        }
+        for subtoken in token.split(['"', '\'', '=', ',', '(', ')']) {
+            if subtoken.starts_with("ghcr.io/") {
+                references.insert(subtoken.to_string());
+            }
+        }
+    }
+    references
 }
 
 /// The one contract that spans both files, and the failure it exists to catch:
 /// renaming the registry, the repository or the tag in one place and not the
 /// other. That mistake publishes an image nothing boots and leaves every
 /// workspace pulling a tag nothing publishes — and both halves look correct on
-/// their own.
+/// their own. Both directions are held: the config renamed away from the
+/// workflow, and the workflow's own push renamed (or deleted) away from the
+/// config — the second is what the first review of #152 mutation-checked
+/// straight through a prefix-filtered version of this test.
 #[test]
 fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() {
     let workflow = publishing_workflow();
@@ -327,15 +352,18 @@ fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() 
         .to_string();
 
     assert_eq!(
+        pushed_references(&workflow),
+        vec![booted.clone()],
+        "naming the reference is not publishing it: the workflow must `docker \
+         push` exactly the reference the default config boots from ({booted}), \
+         exactly once"
+    );
+    assert_eq!(
         published_references(&workflow),
         std::collections::BTreeSet::from([booted.clone()]),
         "the workflow must name exactly the reference the default config boots \
          from ({booted}) and no other — one mutable tag, `latest`, per the \
          decision on #150"
-    );
-    assert!(
-        workflow.contains("packages: write"),
-        "naming the reference is not publishing it"
     );
 }
 


### PR DESCRIPTION
Closes #150.

## Which path, and why

**The fallback path — `image:` plus a `local` variant. devpod does not honor `build.cacheFrom`.**

That was the load-bearing unknown, so it was probed against a real devpod on a host with docker before anything was wired to it. Method: a throwaway registry, and a *separate* builder instance so the layer under test was genuinely absent from the builder devpod uses. A marker layer costing a fixed 25 s was pre-built in the isolated builder and pushed with inline cache metadata; then a workspace was brought up from a config declaring `cacheFrom` pointing at it.

- The layer rebuilt in full — 25.1 s, against 25.2 s for a control run with no `cacheFrom` at all.
- The stronger evidence is upstream of the timing: devpod logs the build command it shells out to, and with `cacheFrom` declared that command is byte-identical to the control. No cache flag is passed at all.
- Tried both spellings the devcontainer spec allows, single string and array. Both ignored, both rebuilt — so this is not a wrong-form mistake.
- The binary does contain the config accessor, so it parses the key and drops it before the build. Reading the schema would have said yes and been wrong, which is the whole reason #150 asked for a probe.

Recorded and deliberately **not** acted on: devpod has a native prebuild mechanism of its own (a repository flag it consults for prebuilt images). Out of scope here — noted so a future effort doesn't re-derive it.

## Measured, not assumed

Per the map's measure-don't-assume rule. Same host, base image present in both columns.

| | build from source (before) | prebuilt image (after) |
|---|---|---|
| image build | **34.9 s** (`--no-cache`) | **none** — zero build lines in the log |
| `devpod up` wall clock, image/layers present | 10.4 s | 10.6 s |
| cold-host download | 963.3 MB base + the tool tarballs fetched inside the build | 1087.3 MB total |

The download rows are the honest comparison, and they come from layer digests rather than a stopwatch on loopback: of the prebuilt image's 17 layers, **15 (963.3 MB) are digest-identical to the base image** the build path pulls anyway. This repo's own contribution is **2 layers, 123.9 MB**. So the prebuild is close to free in bytes — roughly the same base pull either way — and buys back the 35 s build on every cold workspace. A host that already has the image boots in 10.6 s having built nothing.

The `local` variant was booted too, not just asserted: devpod resolves its `../` paths, builds from the same Dockerfile, and the container comes up as `vscode` with `gh` 2.97.0, `zellij` 0.44.3 and the agent CLI at the newly pinned 2.1.223.

## Two operational consequences, flagged rather than assumed away

1. **A new GHCR package is private by default.** Until this one is made public, an anonymous `dl blooop/wayfinder@<branch>` cannot pull it and every default boot fails on authentication. Making the package public after the first publish (or having every user `docker login ghcr.io`) is a step outside this diff.
2. **The tag does not exist until this merges.** The merge commit touches `.devcontainer/`, so the push trigger publishes it automatically — but between merge and that run finishing, a default boot has nothing to pull. `--devcontainer local` is the way through that window, and `workflow_dispatch` re-fires the publish if the webhook is dropped.

## Shape

Simplest version throughout, as scoped: one workflow, one mutable `latest` tag, no pull-request leg and no schedule, plain `docker build` rather than `devpod build` (no features to bake), workflow-level `contents: read` with `packages: write` on the publishing job only, and no cargo warming (#38, reaffirmed on #43).

Seven offline assertions in `tests/devcontainer_prebuild.rs`, wired into `ci.yml` — this repo's rule is that an assertion no workflow runs is not an assertion. The one that earns its place most is the cross-file check that the workflow publishes *exactly* the reference the config boots from: renaming the registry in one place and not the other publishes an image nothing boots and leaves every workspace pulling a tag nothing publishes, and both halves look correct on their own. The drift guard between the two configs was green on arrival, so it was mutation-checked — perturbed until it failed, then restored — because a guard that has never been seen red is worth nothing.

The stale header comment claiming #43 is still open is replaced, and it now records the `cacheFrom` measurement so the next reader doesn't re-run the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Publish a prebuilt devcontainer image and wire configs, CI, and tests to ensure all references and triggers stay in sync.

New Features:
- Introduce a dedicated workflow to build and push the devcontainer image to GHCR on main devcontainer changes or manual dispatch.
- Add a local devcontainer variant that builds the image from the repository Dockerfile instead of pulling the published image.

Enhancements:
- Pin the agent CLI version in the devcontainer Dockerfile alongside existing `gh` and `zellij` pins to stabilize workspace startup state.
- Restrict devcontainer image publishing permissions to a single job and serialize runs with concurrency settings to avoid racing tag updates.

Tests:
- Add devcontainer prebuild contract tests that assert the default and local devcontainer configs, publishing workflow triggers, permissions, and image references remain consistent.
- Wire the devcontainer prebuild contract test binary into the main CI workflow so its assertions run on every commit.