### PR TITLE
Release 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.17.1"
+  version: "0.17.2"
 
 package:
   name: wf


### PR DESCRIPTION
Version bump only — `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` in step, which CI checks for drift ("Recipe version tracks Cargo.toml").

Releases the three commits sitting on `main` past `v0.17.1`:

- **#146 / [#132](https://github.com/blooop/wayfinder/issues/132)** — `fetch::is_open` was a positive test for `OPEN`, so reap read every *other* issue state, including any GitHub adds after this binary ships, as closed — and `NodeFact::Closed` deletes a workspace. A `TicketState` replaces the bool, so the deleting condition is positive at its definition and the inversion that caused it is a compile error rather than a `!`. Also: `DoneByMerge`/`Superseded` precedence is now pinned by a fixture carrying both, the `NODE_FACT_SELECTION` test derives its input *from* the selection (10/10 field mutations caught), and the GraphQL selection reap had copied out of `fetch` is held to **equality** with it rather than containment.
- **#145** — the PTY tests cover the isolated launch.
- **#147** — `wf` is exercised against a real `dl`, at the version pixi resolves.

Patch rather than minor: no new surface, three fixes and their tests. That matches how 0.15.1 and 0.17.1 were cut.

Tagging `v0.17.2` after this merges is what actually publishes — only a `v*` tag reaches the `release` job in `package.yml`, which creates the GitHub release and uploads to prefix.dev/blooop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bump the project to version 0.17.2 and keep packaging metadata in sync with the crate version.

Build:
- Update Cargo.toml and Cargo.lock versions to 0.17.2.

Deployment:
- Update recipe.yaml context version to 0.17.2 to align with Cargo.toml for release workflows.

Chores:
- Prepare release metadata for the 0.17.2 patch release.