### PR TITLE
The ctx handoff's guards guard what they claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -752,8 +752,8 @@ through `codex --dangerously-bypass-approvals-and-sandbox`. Both receive one
 prompt argument, so the route, numbers, and steering text cannot be split apart
 by the shell.
 
-**Every launch of a node also hands the agent what `wf` already knew**, as a
-`ctx: <json>` block between the skill's arguments and any steering suffix:
+**Every skill launch of a node also hands the agent what `wf` already knew**,
+as a `ctx: <json>` block between the skill's arguments and any steering suffix:
 
 ```
 /wf-review 124 ctx: {"v":1,"repo":"blooop/wayfinder","map":{…},"aim":{"ticket":{…,"prs":[…]}}} steer: <text>
@@ -766,7 +766,9 @@ never went through the picker, finds no block, and discovers exactly as before.
 The one thing it deliberately cannot say is whether the ticket is still yours to
 take — there is no assignee and no ticket status in the schema, so claiming stays
 a live call and a stale block cannot make an agent act on someone else's work.
-The creation rows carry no block at all: they name nothing that exists yet.
+The creation rows carry no block at all: they name nothing that exists yet, and
+the plain rows carry none either — a block is addressed to a skill, and plain
+runs none.
 
 The auto mode collapses the ticket rows on purpose: the launched session is a
 *manager*, and what it manages is the node's whole remaining lifecycle —

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -601,6 +601,13 @@ pub enum Launchable {
 }
 
 impl Launchable {
+    /// Every launchable stage, compiler-complete
+    /// ([`crate::model::every_variant`]): the iteration the launch matrix and
+    /// the doc vocabulary run over, so a stage cannot exist unlaunched (#133).
+    pub fn every() -> Vec<Launchable> {
+        crate::model::every_variant!(Launchable: Ready, Building, InReview, NeedsAttention)
+    }
+
     /// Narrow a derived stage to one an agent can be launched on. Exhaustive
     /// on [`Stage`]: a new stage must decide whether it is launchable, or this
     /// stops compiling.
@@ -651,6 +658,25 @@ pub enum Aim {
         stage: Launchable,
         prs: Vec<PrLink>,
     },
+}
+
+impl Aim {
+    /// One value of every arm, compiler-complete
+    /// ([`crate::model::every_variant`]) — the wire only ever sees the tag,
+    /// so the ticket representative's payload is the doc guards' business to
+    /// vary, not this list's.
+    pub fn every_arm() -> Vec<Aim> {
+        crate::model::every_variant!(Aim:
+            Map,
+            Ticket => Aim::Ticket {
+                number: 1,
+                title: String::new(),
+                ticket_type: TicketType::Build,
+                stage: Launchable::Ready,
+                prs: vec![],
+            },
+        )
+    }
 }
 
 /// The map a launch was picked in: its identity *and* its title (#124).
@@ -3157,9 +3183,13 @@ mod tests {
     /// These four are the whole vocabulary the tracker doc publishes, written
     /// as literals traceable to it rather than derived from the types — a
     /// derivation would only prove serde agrees with itself. Being `match`es
-    /// with no wildcard is the other half: adding a type, a stage, a check
-    /// rollup or a review decision stops this module compiling until the new
-    /// word has been decided and pinned here.
+    /// with no wildcard is half of the guarantee: adding a type, a stage, a
+    /// check rollup or a review decision stops this module compiling until
+    /// the new word has been decided and pinned here. The other half is the
+    /// matrix below iterating [`TicketType::every`] and friends rather than
+    /// hand-written arrays, so the new variant is also *launched* — a probe
+    /// variant once compiled and greened with its word pinned while the
+    /// arrays never exercised it (#133).
     fn type_word(ticket_type: TicketType) -> &'static str {
         match ticket_type {
             TicketType::Build => "build",
@@ -3225,25 +3255,16 @@ mod tests {
     /// uses. Before this, only `ready`, `build` and a single open PR were ever
     /// emitted by any test, so every other word the tracker doc publishes
     /// rested on the doc's say-so.
+    ///
+    /// "Whole" is the type's own claim, not this test's: the iteration comes
+    /// from [`TicketType::every`] and friends, where the compiler holds the
+    /// list complete, so a new variant cannot green without a row here (#133).
     #[test]
     fn every_stage_type_and_pr_state_spells_itself_on_the_wire() {
-        let types = [
-            TicketType::Build,
-            TicketType::Research,
-            TicketType::Task,
-            TicketType::Grilling,
-            TicketType::Prototype,
-            TicketType::Untyped,
-        ];
-        let stages = [
-            (Stage::Ready, Launchable::Ready),
-            (Stage::Building, Launchable::Building),
-            (Stage::InReview, Launchable::InReview),
-            (Stage::NeedsAttention, Launchable::NeedsAttention),
-        ];
-        for ticket_type in types {
-            for (stage, launchable) in stages {
-                let ctx = ctx_of(&ticket_prompt(ticket_type, stage, &interactive("")))
+        for ticket_type in TicketType::every() {
+            for launchable in Launchable::every() {
+                let prompt = ticket_prompt(ticket_type, staged_at(launchable), &interactive(""));
+                let ctx = ctx_of(&prompt)
                     .expect("a ticket launch carries context")
                     .to_string();
                 let expected = format!(
@@ -3254,20 +3275,17 @@ mod tests {
                 assert!(ctx.contains(&expected), "expected {expected} in {ctx}");
             }
         }
-        let mut pr_states = vec![PrStatus::Draft, PrStatus::Merged, PrStatus::Closed];
-        for checks in [
-            Checks::Absent,
-            Checks::Pending,
-            Checks::Passing,
-            Checks::Failing,
-        ] {
-            for review in [
-                Review::NotRequired,
-                Review::Required,
-                Review::Approved,
-                Review::ChangesRequested,
-            ] {
-                pr_states.push(PrStatus::Open { checks, review });
+        let mut pr_states = Vec::new();
+        for arm in PrStatus::every_arm() {
+            match arm {
+                PrStatus::Open { .. } => {
+                    for checks in Checks::every() {
+                        for review in Review::every() {
+                            pr_states.push(PrStatus::Open { checks, review });
+                        }
+                    }
+                }
+                settled => pr_states.push(settled),
             }
         }
         for status in pr_states {
@@ -3285,6 +3303,21 @@ mod tests {
         assert!(map.ends_with(r#""aim":"map"}"#), "{map}");
         for absent in ["ticket_type", "stage", "prs"] {
             assert!(!map.contains(absent), "a map aim names no {absent}: {map}");
+        }
+    }
+
+    /// The model stage a launch at this launchable stage is staged from — the
+    /// inverse of [`Launchable::parse`], its own wildcard-free `match` so the
+    /// matrix can iterate [`Launchable::every`] and still hand
+    /// [`Staged::ticket`] the [`Stage`] it wants. A launchable stage no
+    /// [`Stage`] maps to cannot be launched at all, and this is where that
+    /// refuses to compile.
+    fn staged_at(launchable: Launchable) -> Stage {
+        match launchable {
+            Launchable::Ready => Stage::Ready,
+            Launchable::Building => Stage::Building,
+            Launchable::InReview => Stage::InReview,
+            Launchable::NeedsAttention => Stage::NeedsAttention,
         }
     }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -602,7 +602,7 @@ pub enum Launchable {
 
 impl Launchable {
     /// Every launchable stage, compiler-complete
-    /// ([`crate::model::every_variant`]): the iteration the launch matrix and
+    /// (`every_variant` (src/model.rs)): the iteration the launch matrix and
     /// the doc vocabulary run over, so a stage cannot exist unlaunched (#133).
     pub fn every() -> Vec<Launchable> {
         crate::model::every_variant!(Launchable: Ready, Building, InReview, NeedsAttention)
@@ -662,7 +662,7 @@ pub enum Aim {
 
 impl Aim {
     /// One value of every arm, compiler-complete
-    /// ([`crate::model::every_variant`]) — the wire only ever sees the tag,
+    /// (`every_variant` (src/model.rs)) — the wire only ever sees the tag,
     /// so the ticket representative's payload is the doc guards' business to
     /// vary, not this list's.
     pub fn every_arm() -> Vec<Aim> {

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -3999,27 +3999,31 @@ mod tests {
             std::process::id(),
             NEXT_SCRATCH.fetch_add(1, Ordering::Relaxed)
         ));
-        std::fs::create_dir_all(&scratch).expect("a scratch directory for the shell");
-        let script = format!(
-            "set -- {}\nfor arg; do printf '%s\\0' \"$arg\"; done",
-            argv[3]
-        );
+        recovered_in(&scratch, &argv[3])
+    }
+
+    /// The recovery itself, in a scratch directory named by the caller —
+    /// created here, and removed here on **every** exit, the refusal panic
+    /// included: a long-lived host must not accumulate `wf-seam-*` litter
+    /// because one command was refused (#133).
+    fn recovered_in(scratch: &Path, command: &str) -> Vec<String> {
+        std::fs::create_dir_all(scratch).expect("a scratch directory for the shell");
+        let script = format!("set -- {command}\nfor arg; do printf '%s\\0' \"$arg\"; done");
         let out = Command::new("sh")
             .arg("-c")
             .arg(&script)
-            .current_dir(&scratch)
+            .current_dir(scratch)
             .output()
             .expect("a POSIX shell");
-        assert!(
-            out.status.success(),
-            "the container's shell refused the command {:?}",
-            argv[3]
-        );
-        let spilled: Vec<_> = std::fs::read_dir(&scratch)
+        let spilled: Vec<_> = std::fs::read_dir(scratch)
             .expect("the scratch directory outlives the shell")
             .map(|entry| entry.expect("a readable entry").file_name())
             .collect();
-        std::fs::remove_dir_all(&scratch).expect("the scratch directory is ours to remove");
+        std::fs::remove_dir_all(scratch).expect("the scratch directory is ours to remove");
+        assert!(
+            out.status.success(),
+            "the container's shell refused the command {command:?}"
+        );
         assert!(
             spilled.is_empty(),
             "the shell executed something the quoting should have made inert, \
@@ -4033,6 +4037,21 @@ mod tests {
             "every argument is NUL-terminated"
         );
         words
+    }
+
+    #[test]
+    fn a_refused_command_leaves_no_scratch_behind() {
+        // The normal path already asserts its scratch is empty and removes
+        // it; this is the other path. A refused command panics — that is the
+        // canary doing its job — but the panic must not be the reason a
+        // long-lived host collects `wf-seam-*` directories in $TMPDIR.
+        let scratch = std::env::temp_dir().join(format!("wf-seam-{}-refused", std::process::id()));
+        let refused = std::panic::catch_unwind(|| recovered_in(&scratch, "'unterminated"));
+        assert!(refused.is_err(), "an unterminated quote is refused by sh");
+        assert!(
+            !scratch.exists(),
+            "the refusal path must clean its scratch too: {scratch:?}"
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,48 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Every variant of a sum type, one value per variant, with the compiler
+/// holding the list complete.
+///
+/// The single variant list feeds both a wildcard-free `match` and the
+/// returned `Vec`, so the proof and the iteration cannot disagree: a variant
+/// missing from the list is a non-exhaustive match naming it, a variant
+/// listed twice is an unreachable pattern (a warning CI denies), and there is
+/// no way to satisfy the compiler without also entering the iteration. That
+/// is what lets the launch matrix and the doc-vocabulary guards iterate *the
+/// type* rather than a restatement of it (#133) — a hand-written array beside
+/// a wildcard-free `match` reintroduces exactly the drift the `match`
+/// removed: a probe variant compiled and greened while never being launched
+/// and never being required of the docs.
+///
+/// A variant that carries data names one representative value after `=>` —
+/// the `match` still covers its arm by pattern, the representative is checked
+/// at run time to be the arm it stands for, and a caller that needs the full
+/// payload grid expands it itself.
+macro_rules! every_variant {
+    ($ty:ident: $($variant:ident $(=> $value:expr)?),+ $(,)?) => {{
+        let _list_is_complete = |value: &$ty| match value {
+            $($ty::$variant { .. } => ()),+
+        };
+        vec![$(crate::model::every_variant!(@one $ty, $variant $(, $value)?)),+]
+    }};
+    (@one $ty:ident, $variant:ident) => { $ty::$variant };
+    (@one $ty:ident, $variant:ident, $value:expr) => {{
+        let representative = $value;
+        assert!(
+            matches!(representative, $ty::$variant { .. }),
+            concat!(
+                "the representative must be ",
+                stringify!($ty),
+                "::",
+                stringify!($variant)
+            )
+        );
+        representative
+    }};
+}
+pub(crate) use every_variant;
+
 /// The identity of one map: the repo it lives in and its map issue number.
 ///
 /// A repo can hold several open maps at once (#50), so the slug alone stopped
@@ -243,6 +285,13 @@ pub enum TicketType {
 }
 
 impl TicketType {
+    /// Every type, in declaration order, with the compiler holding the list
+    /// complete — see [`every_variant`]. What the launch matrix and the doc
+    /// vocabulary iterate, so a new type cannot exist unlaunched (#133).
+    pub fn every() -> Vec<TicketType> {
+        every_variant!(TicketType: Build, Research, Task, Grilling, Prototype, Untyped)
+    }
+
     /// Parse one label name. `None` for anything that is not a type label —
     /// the *only* wildcard match in the type's whole surface, and it belongs
     /// here because a label string genuinely is an open domain: any repo can
@@ -352,6 +401,23 @@ pub enum PrStatus {
     Closed,
 }
 
+impl PrStatus {
+    /// One value of every arm, compiler-complete ([`every_variant`]). `Open`
+    /// carries data, so a representative stands for it; a caller after the
+    /// full signal grid expands it over [`Checks::every`] × [`Review::every`].
+    pub fn every_arm() -> Vec<PrStatus> {
+        every_variant!(PrStatus:
+            Draft,
+            Open => PrStatus::Open {
+                checks: Checks::Absent,
+                review: Review::NotRequired,
+            },
+            Merged,
+            Closed,
+        )
+    }
+}
+
 /// The check rollup on an open PR. `Absent` is its own meaning — no checks
 /// configured — parsed from the *nullable* `statusCheckRollup` (#49), not a
 /// stand-in for "unknown".
@@ -364,6 +430,13 @@ pub enum Checks {
     Failing,
 }
 
+impl Checks {
+    /// Every rollup, compiler-complete ([`every_variant`]).
+    pub fn every() -> Vec<Checks> {
+        every_variant!(Checks: Absent, Pending, Passing, Failing)
+    }
+}
+
 /// The review decision on an open PR. A null `reviewDecision` means no review
 /// is required (#49) — `NotRequired`, a settled state — where `Required` is a
 /// review asked for and not yet given.
@@ -374,6 +447,13 @@ pub enum Review {
     Required,
     Approved,
     ChangesRequested,
+}
+
+impl Review {
+    /// Every decision, compiler-complete ([`every_variant`]).
+    pub fn every() -> Vec<Review> {
+        every_variant!(Review: NotRequired, Required, Approved, ChangesRequested)
+    }
 }
 
 /// One ticket (sub-issue) on a map.

--- a/src/model.rs
+++ b/src/model.rs
@@ -286,7 +286,7 @@ pub enum TicketType {
 
 impl TicketType {
     /// Every type, in declaration order, with the compiler holding the list
-    /// complete — see [`every_variant`]. What the launch matrix and the doc
+    /// complete — see `every_variant`. What the launch matrix and the doc
     /// vocabulary iterate, so a new type cannot exist unlaunched (#133).
     pub fn every() -> Vec<TicketType> {
         every_variant!(TicketType: Build, Research, Task, Grilling, Prototype, Untyped)
@@ -402,7 +402,7 @@ pub enum PrStatus {
 }
 
 impl PrStatus {
-    /// One value of every arm, compiler-complete ([`every_variant`]). `Open`
+    /// One value of every arm, compiler-complete (`every_variant`). `Open`
     /// carries data, so a representative stands for it; a caller after the
     /// full signal grid expands it over [`Checks::every`] × [`Review::every`].
     pub fn every_arm() -> Vec<PrStatus> {
@@ -431,7 +431,7 @@ pub enum Checks {
 }
 
 impl Checks {
-    /// Every rollup, compiler-complete ([`every_variant`]).
+    /// Every rollup, compiler-complete (`every_variant`).
     pub fn every() -> Vec<Checks> {
         every_variant!(Checks: Absent, Pending, Passing, Failing)
     }
@@ -450,7 +450,7 @@ pub enum Review {
 }
 
 impl Review {
-    /// Every decision, compiler-complete ([`every_variant`]).
+    /// Every decision, compiler-complete (`every_variant`).
     pub fn every() -> Vec<Review> {
         every_variant!(Review: NotRequired, Required, Approved, ChangesRequested)
     }

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -219,6 +219,29 @@ fn field<'a>(record: &'a str, key: &str) -> &'a str {
         .unwrap_or_else(|| panic!("the shim records {key:?}\n{record}"))
 }
 
+/// Every field name a serialized context block contains, at any depth —
+/// including the tag keys the enums write (`ticket`, `open`). The same shape
+/// the unit tests assert the claim-free invariant with — a copy of their
+/// helper, since `src`'s test module is not reachable from here, so an edit
+/// to one side is owed to the other by hand.
+fn keys_of(value: &serde_json::Value) -> std::collections::BTreeSet<String> {
+    let mut keys = std::collections::BTreeSet::new();
+    let mut stack = vec![value];
+    while let Some(node) = stack.pop() {
+        match node {
+            serde_json::Value::Object(fields) => {
+                for (key, child) in fields {
+                    keys.insert(key.clone());
+                    stack.push(child);
+                }
+            }
+            serde_json::Value::Array(items) => stack.extend(items),
+            _ => {}
+        }
+    }
+    keys
+}
+
 /// Every invocation a shim recorded, oldest first.
 fn invocations(report: &str) -> Vec<&str> {
     report.split(INVOCATION).skip(1).collect()
@@ -608,10 +631,54 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     );
     // The claim is unrepresentable in the schema, which is what makes the
     // block safe to orient from: whatever the live tracker said about this
-    // node, no assignee can have reached the agent.
-    let flat = ctx.to_string();
-    for forbidden in ["assignee", "claim"] {
-        assert!(!flat.contains(forbidden), "{forbidden:?} in {flat}");
+    // node, no assignee can have reached the agent. Asserted on the block's
+    // *field names*, the shape the unit tests use (#133) — the substring scan
+    // this replaces could not tell a key from a value, so a ticket whose live
+    // title happened to contain "claim" failed it spuriously while a field a
+    // blacklist never thought of sailed through. The live node varies, so
+    // instead of the unit tests' pinned set, every key must be one the v1
+    // schema writes and the aim-independent core must be present. One caveat
+    // said plainly rather than implied away: this file is excluded from the
+    // CI chain by design (AGENTS.md) and guards only when run by name.
+    let keys = keys_of(&ctx);
+    let schema: std::collections::BTreeSet<&str> = [
+        "v",
+        "repo",
+        "map",
+        "number",
+        "title",
+        "aim",
+        "ticket",
+        "ticket_type",
+        "stage",
+        "prs",
+        "status",
+        "open",
+        "checks",
+        "review",
+    ]
+    .into();
+    for key in &keys {
+        assert!(
+            schema.contains(key.as_str()),
+            "{key:?} is not a field the v1 schema writes: {ctx}"
+        );
+    }
+    for always in ["v", "repo", "map", "number", "title", "aim"] {
+        assert!(keys.contains(always), "{always:?} missing from {ctx}");
+    }
+    for forbidden in [
+        "assignee",
+        "assignees",
+        "claim",
+        "frontier",
+        "blocked_by",
+        "needs",
+    ] {
+        assert!(
+            !schema.contains(forbidden),
+            "{forbidden:?} must be unrepresentable in the handed context"
+        );
     }
     let (skill, numbers) = invocation.split_once(' ').expect("a skill and arguments");
     let halves: Vec<&str> = match skill {

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -246,82 +246,23 @@ fn vocabulary<T: Serialize>(values: &[T]) -> BTreeSet<String> {
     values.iter().map(wire_word).collect()
 }
 
-/// One value of every arm of the aim sum — the wire only ever sees the tag.
-fn every_aim() -> Vec<Aim> {
-    vec![
-        Aim::Map,
-        Aim::Ticket {
-            number: 1,
-            title: String::new(),
-            ticket_type: TicketType::Build,
-            stage: Launchable::Ready,
-            prs: vec![],
-        },
-    ]
-}
-
-/// One value of every arm of the PR-status sum, likewise.
-fn every_pr_status() -> Vec<PrStatus> {
-    vec![
-        PrStatus::Draft,
-        PrStatus::Open {
-            checks: Checks::Absent,
-            review: Review::NotRequired,
-        },
-        PrStatus::Merged,
-        PrStatus::Closed,
-    ]
-}
-
 /// Every value each enumerated field of the block can hold, as serde spells
 /// it — the answer coming from the same serializer the launch itself runs, so
 /// a `rename_all` change moves this side without anyone editing it.
 ///
-/// Adding a variant to any of these types is already a compile error in
-/// `src/launch.rs`, where each word is pinned to a golden literal by an
-/// exhaustive `match`; this side is what then forces the docs to learn it.
+/// The value lists are the types' own (`every`/`every_arm`, #133), where the
+/// compiler holds each list complete — not restatements of them, which a new
+/// variant would silently sit out of. Adding a variant therefore cannot green
+/// until the doc publishes its word, on top of the compile error in
+/// `src/launch.rs` where the word itself gets pinned.
 fn emitted_vocabularies() -> Vec<(&'static str, BTreeSet<String>)> {
     vec![
-        ("aim", vocabulary(&every_aim())),
-        (
-            "ticket_type",
-            vocabulary(&[
-                TicketType::Build,
-                TicketType::Research,
-                TicketType::Task,
-                TicketType::Grilling,
-                TicketType::Prototype,
-                TicketType::Untyped,
-            ]),
-        ),
-        (
-            "stage",
-            vocabulary(&[
-                Launchable::Ready,
-                Launchable::Building,
-                Launchable::InReview,
-                Launchable::NeedsAttention,
-            ]),
-        ),
-        ("status", vocabulary(&every_pr_status())),
-        (
-            "checks",
-            vocabulary(&[
-                Checks::Absent,
-                Checks::Pending,
-                Checks::Passing,
-                Checks::Failing,
-            ]),
-        ),
-        (
-            "review",
-            vocabulary(&[
-                Review::NotRequired,
-                Review::Required,
-                Review::Approved,
-                Review::ChangesRequested,
-            ]),
-        ),
+        ("aim", vocabulary(&Aim::every_arm())),
+        ("ticket_type", vocabulary(&TicketType::every())),
+        ("stage", vocabulary(&Launchable::every())),
+        ("status", vocabulary(&PrStatus::every_arm())),
+        ("checks", vocabulary(&Checks::every())),
+        ("review", vocabulary(&Review::every())),
     ]
 }
 

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -304,6 +304,45 @@ fn the_documented_vocabularies_are_the_words_the_types_serialize() {
     }
 }
 
+/// The contract prose itself, pinned whole rather than phrase-sampled.
+///
+/// The other tests bind the schema — field names, vocabularies, the worked
+/// example. This binds the *rule* those fields exist to serve: orient from
+/// the block, verify live before any write, and your arguments win. Mutation
+/// showed that rule could be inverted wholesale ("the block beats your
+/// arguments") with every schema test green (#133), because the phrase
+/// checks below sample words an inverted sentence still contains. Equality
+/// on the two normative sentences leaves an editor free to move them, not to
+/// reverse them: changing the contract now means changing this literal in
+/// the same diff, which is the two-sided edit a contract change owes.
+#[test]
+fn the_contract_sentences_read_exactly_as_the_contract_rules() {
+    let section = context_section();
+    let sentence = |lead: &str| {
+        section
+            .lines()
+            .find(|line| line.starts_with(lead))
+            .unwrap_or_else(|| panic!("the context section must keep the sentence opening {lead:?}"))
+            .to_string()
+    };
+    assert_eq!(
+        sentence("A launch line may carry"),
+        "A launch line may carry `ctx: <json>` — a snapshot of what `wf` knew at exec time. \
+         It is an accelerator, never a precondition: use it to skip discovery reads (which \
+         map, which PR, what type and stage); never let it substitute for a live read before \
+         any write — claiming, commenting, closing, gating. If it is absent, does not parse, \
+         has a `v` you don't recognise, or names a repo or ticket other than the one your \
+         arguments and pinned `$REPO` name, ignore it entirely and discover via the commands \
+         below, as a hand-invoked session always does."
+    );
+    assert_eq!(
+        sentence("**Precedence:"),
+        "**Precedence: your arguments beat the block, and the tracker beats both.** The \
+         ticket number in your invocation is the assignment; a block naming a different \
+         number or repo is discarded whole, never merged field by field."
+    );
+}
+
 /// The contract is *accelerator, never precondition*, and every failure mode
 /// resolves to the same move — discard the block whole and discover as a
 /// hand-invoked session always has.

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -322,7 +322,9 @@ fn the_contract_sentences_read_exactly_as_the_contract_rules() {
         section
             .lines()
             .find(|line| line.starts_with(lead))
-            .unwrap_or_else(|| panic!("the context section must keep the sentence opening {lead:?}"))
+            .unwrap_or_else(|| {
+                panic!("the context section must keep the sentence opening {lead:?}")
+            })
             .to_string()
     };
     assert_eq!(

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -343,6 +343,55 @@ fn the_contract_sentences_read_exactly_as_the_contract_rules() {
     );
 }
 
+/// One README paragraph, unwrapped: the lines from the one opening with
+/// `lead` to the next blank line, joined the way a reader reads them.
+fn readme_paragraph(lead: &str) -> String {
+    let readme = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))
+        .expect("the README ships in this repo");
+    let from = readme
+        .lines()
+        .skip_while(|line| !line.starts_with(lead))
+        .take_while(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    assert!(
+        !from.is_empty(),
+        "the README must keep the paragraph opening {lead:?}"
+    );
+    from.join(" ")
+}
+
+/// The README promises the block only where a skill receives it.
+///
+/// It said "Every launch of a node", which reads as including the plain
+/// mode — a mode whose whole point is that no skill runs, so there is nobody
+/// to address a block to and none is emitted (the binary's own test,
+/// `nothing_that_has_no_skill_to_address_is_handed_context`). A reader
+/// following the README would expect a block where none arrives. Pinned by
+/// equality like the contract sentences above, so contradicting the
+/// plain-mode statement — or quietly widening the promise again — turns this
+/// red rather than surviving on sampled phrases (#133).
+#[test]
+fn the_readme_promises_the_block_only_where_a_skill_receives_it() {
+    assert_eq!(
+        readme_paragraph("**Every skill launch of a node"),
+        "**Every skill launch of a node also hands the agent what `wf` already knew**, as a \
+         `ctx: <json>` block between the skill's arguments and any steering suffix:"
+    );
+    assert_eq!(
+        readme_paragraph("That is the parent map"),
+        "That is the parent map, the ticket's type and stage, and its linked PRs — the \
+         three serial `gh` calls a launched skill used to open with, answered before it \
+         starts. It is an accelerator and never a precondition: a skill invoked by hand \
+         never went through the picker, finds no block, and discovers exactly as before. \
+         The one thing it deliberately cannot say is whether the ticket is still yours to \
+         take — there is no assignee and no ticket status in the schema, so claiming stays \
+         a live call and a stale block cannot make an agent act on someone else's work. \
+         The creation rows carry no block at all: they name nothing that exists yet, and \
+         the plain rows carry none either — a block is addressed to a skill, and plain \
+         runs none."
+    );
+}
+
 /// The contract is *accelerator, never precondition*, and every failure mode
 /// resolves to the same move — discard the block whole and discover as a
 /// hand-invoked session always has.


### PR DESCRIPTION
Closes #133.

The six findings #131's re-verdict deliberately did not hold against the merge, worked as one PR. Every changed guard is proven by mutation, with the selection stated; the manager's re-verification against post-#135 main was re-confirmed here before each fix.

### What changed

**Item 1 — the matrix iterates the type, not a restatement of it.** Reproduced the axis's probe first: on current main, `Launchable::Spiking` compiled and greened with its word pinned, never launched, never required of the docs. Now a single `every_variant!` list feeds both a wildcard-free `match` and the returned iteration, so the completeness proof and the loop cannot disagree; the launch matrix and the doc vocabularies iterate `TicketType::every()`, `Launchable::every()`, `Checks::every()`, `Review::every()`, `PrStatus::every_arm()`, `Aim::every_arm()`. Mutation (selections `--lib launch`, `--test skill_docs`): re-adding `Spiking` fails to compile in `every()` and in the matrix's stage inverse; force-listing it and mapping it onto an existing stage fails the matrix at runtime (`expected "stage":"spiking"`, wire says `"ready"`); the doc-vocabulary test then demands the word the doc never published.

**Item 2 — the contract prose is bound, not just the vocabulary.** Re-ran the mutation experiment on the post-#135 file first, as instructed: inverting the precedence sentence to "the block beats your arguments" left the full `--test skill_docs` selection green (7/7), so the finding still stood. The two normative sentences (accelerator/verify-live/discard-whole, and the precedence line) are now pinned whole by equality; the inverted doc fails the new test under the full selection, the true doc passes all 9.

**Item 3 — the live test asserts field names, not substrings.** The `"assignee"`/`"claim"` text scan is replaced with the unit tests' shape: every key of the parsed block must be one the v1 schema writes, the aim-independent core must be present, and the forbidden names are checked against the allowed universe. The file stays excluded from the CI chain by design and now says so at the assertion. Beyond the ticket's expectation that it never runs: it was executed here by name (`--test live_launch_exec -- enter_execs_the_agent`) — green against the real tracker, and red at the new assertion with the binary mutated to smuggle an `assignee` field into `LaunchContext`.

**Item 4 — the README promises the block only where a skill receives it.** "Every launch of a node" is now "Every **skill** launch", and the exclusions paragraph names the plain rows beside the creation rows. Both paragraphs are pinned by equality in `skill_docs`; the old wording fails the new test, and flipping the exclusion to "the plain rows carry one too" fails it again.

**Item 5 — the seam canary cleans up on the refusal path.** The scratch dir is now removed before the shell's exit status is asserted, and a test drives a real refused command (an unterminated quote) and asserts the `wf-seam-*` dir is gone. Red before the reorder, green after.

### Departures

- **Item 6, inherited from #131:** the binding clause of #122 §5 ("no test anywhere may require ctx for a skill to proceed") was satisfied and stated in #131's body, but its `live_launch_exec.rs` change was missing from that PR's departures list. Recorded here instead: that change was a departure from #122 §5's letter, and the Spec axis graded the omission blocking where the compiling reviewer graded it non-blocking.
- **The live assertion is bounded, not pinned.** The ticket asked for "the exact-field-name-set assertion the unit test already uses"; the live node varies (stage, PRs), so an equality pin would fail on tracker state. The assertion is subset-of-schema plus mandatory core instead — every key must be one the schema writes, which still fails on any new field.
- **`tests/skill_docs.rs` now also reads `README.md`.** The ticket routed items 2 and 4 at that seam; the file's charter is skill docs, and the README paragraphs it binds are the same ctx contract the skills consume.
- `Aim::every_arm()`/`PrStatus::every_arm()` carry one representative payload per data-carrying arm (checked at run time to be the arm it stands for); callers expand the payload grid themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten ctx contract guarantees by driving both launch behavior and documentation from compiler-complete enumerations and literal contract text, and by strengthening live execution and seam cleanup tests.

New Features:
- Add compiler-checked enumeration helpers and per-type iteration APIs so launch matrices and doc vocabulary tests iterate the actual variants for ticket types, stages, PR status, checks, and review decisions.
- Introduce tests that pin key ctx contract sentences and README paragraphs by exact equality to ensure documented behavior matches the schema and runtime guarantees.

Bug Fixes:
- Ensure seam scratch directories are cleaned up on both successful and refused shell command paths to avoid leaking wf-seam-* directories on long-lived hosts.

Enhancements:
- Refactor launch matrix and ctx emission tests to use type-provided variant iterators and a stage inverse helper, ensuring every variant is both launched and validated on the wire.
- Strengthen live launch execution guards to assert context block field names against the v1 schema and enforce mandatory core fields, replacing brittle substring scans and expanding the forbidden-field checks.
- Document and enforce that ctx blocks are only emitted for skill launches and not for plain or creation rows, aligning runtime behavior with README promises.

Tests:
- Extend skill_docs tests to cover emitted vocabularies via type-driven iterators, literal contract prose, and README context guarantees.
- Add live execution tests that mirror unit-test schema shape assertions for ctx blocks and verify behavior when mutated binaries attempt to introduce forbidden fields.
- Add a seam test for refused commands to confirm scratch directory cleanup on panic paths.