### PR TITLE
wf stamps the launch t0 and hands it across the exec seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,18 @@ call for those tests (a machine with devlaunch installed and one without must
 not take different paths through the same test) and it leaves the fixtures
 unchecked against the program they describe. They have been wrong twice.
 
+There is a fifth thing `wf` hands `dl`, and it is not an argument: the launch
+`exec` sets two environment stamps of what `wf` itself did — the keystroke that
+resolved to the exec, and when this node's prewarm fired, if one did (#160,
+names and format minted by devlaunch#194). Two rules go with them. They are set
+only where the exec *is* a `dl`, so a host launch carries neither and clears
+both rather than leaving an inherited one in an agent's environment; and neither
+is ever a claim about how the launch went — a hit, a partial and a miss are
+`dl`'s to observe from the arm it takes, and `wf` is gone by then. The seam is
+observable only through a real exec, so its end-to-end guard is claim 6 of
+`tests/live_launch_exec.rs`, and the variable names the README publishes are
+compared to the ones the binary sets in `tests/skill_docs.rs`.
+
 `pixi.toml` is here for that and nothing else: it installs a chosen `devlaunch`
 and `tests/live_devlaunch.rs` asks it the questions `wf` asks it. **Pixi does
 not build this crate** — the compiler is still rustup's, and adding `rust` to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,8 @@ There is a fifth thing `wf` hands `dl`, and it is not an argument: the launch
 resolved to the exec, and when this node's prewarm fired, if one did (#160,
 names and format minted by devlaunch#194). Two rules go with them. They are set
 only where the exec *is* a `dl`, so a host launch carries neither and clears
-both rather than leaving an inherited one in an agent's environment; and neither
+both rather than leaving an inherited one in an agent's environment — as does
+every other `dl` `wf` starts, which is what `launch::unstamped` is for; and neither
 is ever a claim about how the launch went — a hit, a partial and a miss are
 `dl`'s to observe from the arm it takes, and `wf` is gone by then. The seam is
 observable only through a real exec, so its end-to-end guard is claim 6 of

--- a/README.md
+++ b/README.md
@@ -997,7 +997,10 @@ A **host** launch carries neither, and clears both rather than passing on one it
 inherited. The reader is the `dl` a launch becomes; a host launch becomes the
 agent instead, and a stamp left standing in an agent session's environment would
 be picked up by every unrelated `dl` that session went on to run, each reporting
-a hand-over measured from a keystroke hours old.
+a hand-over measured from a keystroke hours old. The same clearing covers every
+`dl` `wf` starts and does not become — the version probe, the prewarm's `dl <ws>
+up`, and `wf reap`'s listing and removals — because `wf` run inside a workspace
+starts with the stamps of the launch that built it already in its environment.
 
 ### `wf reap` — clearing away finished tickets
 

--- a/README.md
+++ b/README.md
@@ -967,6 +967,38 @@ Container lifecycle is `dl`'s: `wf` never stops or rebuilds one, and could not
 during a session — it `exec`s and is gone, so there is no `wf` left to observe
 an agent exiting. `dl <ws> stop`, `dl <ws> rm` and `dl --ls` are yours to run.
 
+### What a launch tells `dl` about itself
+
+**An isolated launch hands `dl` two stamps of what `wf` itself did**, in the
+environment of the process it becomes:
+
+| variable | what it stamps |
+| --- | --- |
+| `DEVLAUNCH_HANDOFF_T0` | the keystroke that resolved to this exec — the moment nothing is waiting on a human any more |
+| `DEVLAUNCH_PREWARM_FIRED_AT` | when staging fired this node's `dl <ws> up`, if it fired one |
+
+Both are Unix epoch seconds, spelt the way `date +%s.%N` prints them, and the
+names and the format are `dl`'s to mint rather than `wf`'s — `wf` is the writer,
+and a writer that invented its own names would be handing the reader nothing.
+The gap from `DEVLAUNCH_HANDOFF_T0` to `dl`'s own start is the only measurement
+of the exec there is, since everything either side of it is inside one program
+or the other.
+
+**Neither stamp is a claim about how the launch went.** `wf` fires a prewarm and
+forgets it — the process that fired it is gone long before the container is
+ready — so whether the warm-up helped, was still running, or saved this launch
+nothing is visible only to the `dl` that then had to run the launch, and that is
+`dl`'s to report from the arm it took. What `wf` sends is when it acted, twice,
+and nothing else. An absent stamp is an absent measurement and never a zero: a
+launch nobody prewarmed sets no `DEVLAUNCH_PREWARM_FIRED_AT`, rather than
+setting it to something that would read as an instant warm-up.
+
+A **host** launch carries neither, and clears both rather than passing on one it
+inherited. The reader is the `dl` a launch becomes; a host launch becomes the
+agent instead, and a stamp left standing in an agent session's environment would
+be picked up by every unrelated `dl` that session went on to run, each reporting
+a hand-over measured from a keystroke hours old.
+
 ### `wf reap` — clearing away finished tickets
 
 A workspace per ticket means workspaces accumulate as fast as tickets are

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::SystemTime;
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -294,12 +295,34 @@ pub struct App {
     /// toggle — it is a choice about a *map*, not about a frame.
     expanded: Expanded,
     cursor: Cursor,
-    /// Workspaces already prewarmed this session ([`launch::prewarm`]): the
-    /// first enter fires `dl <ws> up` in the background so the container is
-    /// building while the human types steer text, and this is what keeps
-    /// re-staging the same node from firing a second one. Session-scoped on
-    /// purpose — after `wf` execs away, the workspace's own state answers.
-    prewarmed: BTreeSet<String>,
+    /// What staging already did about each workspace this session
+    /// ([`launch::prewarm`]): the first enter fires `dl <ws> up` in the
+    /// background so the container is building while the human types steer
+    /// text, and this is what keeps re-staging the same node from firing a
+    /// second one. Session-scoped on purpose — after `wf` execs away, the
+    /// workspace's own state answers.
+    ///
+    /// A map rather than a set because the launch that follows hands `dl` the
+    /// instant the warm-up fired (#160), and "it fired" without "when" is not
+    /// something a timing reader can weigh a launch against.
+    prewarmed: BTreeMap<String, Prewarmed>,
+}
+
+/// What staging did about one workspace's container — the record a launch of
+/// that workspace then reads.
+///
+/// A sum rather than an `Option<SystemTime>` beside a claim flag, because the
+/// two states answer different questions and both are ordinary: a node was
+/// warmed at an instant, or it was looked at and found to have no container to
+/// warm. Absence from the map is the third state — never staged this session —
+/// and needs no variant of its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Prewarmed {
+    /// `dl <workspace> up` went out at this instant.
+    At(SystemTime),
+    /// Nothing was fired and nothing would be: this node's launch plans no
+    /// container, so there is no warm-up to stamp.
+    Nothing,
 }
 
 impl App {
@@ -321,7 +344,7 @@ impl App {
             lens: Lens::Leverage,
             expanded: Expanded::new(),
             cursor: Cursor::Untouched,
-            prewarmed: BTreeSet::new(),
+            prewarmed: BTreeMap::new(),
         }
     }
 
@@ -947,32 +970,61 @@ impl App {
     /// fire-and-forget — the launch itself neither depends on it nor waits for
     /// it, beyond `dl`'s own per-workspace serialization.
     fn prewarm(&mut self, staged: &Staged) {
-        if !self.claim_prewarm(staged, launch::prewarm_enabled()) {
-            return;
-        }
-        if let Some(argv) = launch::prewarm(&self.checkouts, staged) {
-            launch::spawn_detached(&argv);
-        }
+        self.warm(staged, launch::prewarm_enabled());
     }
 
-    /// Whether this staging is the one that gets to warm `staged`, recording
-    /// it if so. Split from the spawn deliberately: the gate and the
-    /// once-per-node rule are the parts with logic in them, and this way they
-    /// are testable without a container, a `dl` on `PATH`, or reaching into
-    /// the process environment.
+    /// The whole of it, with the gate passed in rather than read from the
+    /// environment, so the rules below are testable without a container, a
+    /// `dl` on `PATH`, or a mutated process environment. Answers what was
+    /// recorded, and `None` when this staging is not the one that warms
+    /// `staged` at all.
     ///
-    /// Nothing is recorded while the prewarm is off — `&&` short-circuits —
-    /// so a session that exports `WF_PREWARM` and re-stages a node still
-    /// warms it. A stop with no workspace to warm (a project row) is not
-    /// recorded either, because there is nothing to record it under. A node
-    /// whose launch turns out to be host-only *is* recorded: it plans nothing
-    /// now and would plan nothing later, and remembering that saves
-    /// re-walking the checkouts on every re-stage.
-    fn claim_prewarm(&mut self, staged: &Staged, enabled: bool) -> bool {
-        enabled
-            && staged
-                .node_workspace()
-                .is_some_and(|workspace| self.prewarmed.insert(workspace))
+    /// **The instant is taken from the spawn, not from the claim**, because
+    /// only a prewarm that actually went out has one: a node whose launch is
+    /// host-only is claimed all the same — it plans nothing now and would plan
+    /// nothing later, and remembering that saves re-walking the checkouts on
+    /// every re-stage — but recording an instant for it would name a
+    /// `dl <ws> up` that never happened, and the launch would hand `dl` a
+    /// prewarm to weigh itself against that nobody fired (#160).
+    fn warm(&mut self, staged: &Staged, enabled: bool) -> Option<Prewarmed> {
+        let workspace = self.claim_prewarm(staged, enabled)?;
+        let recorded = match launch::prewarm(&self.checkouts, staged) {
+            Some(argv) => {
+                launch::spawn_detached(&argv);
+                Prewarmed::At(SystemTime::now())
+            }
+            None => Prewarmed::Nothing,
+        };
+        self.prewarmed.insert(workspace, recorded);
+        Some(recorded)
+    }
+
+    /// The workspace this staging gets to warm, or `None` if it does not get
+    /// to. Split from the spawn deliberately: the gate and the once-per-node
+    /// rule are the parts with logic in them.
+    ///
+    /// Nothing is claimed while the prewarm is off — `?` short-circuits — so a
+    /// session that exports `WF_PREWARM` and re-stages a node still warms it.
+    /// A stop with no workspace to warm (a project row) claims nothing either,
+    /// because there is nothing to record it under.
+    fn claim_prewarm(&self, staged: &Staged, enabled: bool) -> Option<String> {
+        let workspace = staged.node_workspace()?;
+        (enabled && !self.prewarmed.contains_key(&workspace)).then_some(workspace)
+    }
+
+    /// When this session fired a prewarm for what `launch` is about to attach
+    /// to, if it fired one — the second half of what a launch hands across the
+    /// exec seam ([`launch::Handoff`], #160).
+    ///
+    /// Keyed on the launch's own workspace rather than on whatever was last
+    /// staged: the two are the same node in the ordinary case, and where they
+    /// are not — a creation, whose workspace is the repo's default — the
+    /// answer must be nothing rather than another node's instant.
+    pub fn prewarm_fired(&self, launch: &Launch) -> Option<SystemTime> {
+        match self.prewarmed.get(&launch.workspace()) {
+            Some(Prewarmed::At(fired)) => Some(*fired),
+            Some(Prewarmed::Nothing) | None => None,
+        }
     }
 
     /// The second enter: resolve the staged launch against the projects cache
@@ -2269,10 +2321,10 @@ mod tests {
         // had already looked at.
         let mut app = fixture_app();
         let staged = staged_six(&app);
-        assert!(!app.claim_prewarm(&staged, false));
+        assert_eq!(app.warm(&staged, false), None);
         assert!(app.prewarmed.is_empty());
         // ...and enabling afterwards still gets its turn.
-        assert!(app.claim_prewarm(&staged, true));
+        assert!(app.warm(&staged, true).is_some());
     }
 
     #[test]
@@ -2281,10 +2333,11 @@ mod tests {
         // each visit must not add another `dl up` to the pile.
         let mut app = fixture_app();
         let staged = staged_six(&app);
-        assert!(app.claim_prewarm(&staged, true), "the first staging warms");
+        assert!(app.warm(&staged, true).is_some(), "the first staging warms");
         for _ in 0..3 {
-            assert!(
-                !app.claim_prewarm(&staged, true),
+            assert_eq!(
+                app.warm(&staged, true),
+                None,
                 "a re-stage must not warm again"
             );
         }
@@ -2299,21 +2352,70 @@ mod tests {
         let six = staged_six(&app);
         let map = Staged::map(&MapRef::new(&MapId::new("blooop/wayfinder", 1), "a map"));
         assert_ne!(six.node_workspace(), map.node_workspace());
-        assert!(app.claim_prewarm(&six, true));
-        assert!(app.claim_prewarm(&map, true));
+        assert!(app.warm(&six, true).is_some());
+        assert!(app.warm(&map, true).is_some());
         assert_eq!(app.prewarmed.len(), 2);
     }
 
     #[test]
-    fn staging_a_host_launch_spawns_nothing() {
+    fn staging_a_host_launch_spawns_nothing_and_stamps_nothing() {
         // Even claimed, a launch with no container to start plans no command:
         // the fixture's checkout paths do not exist, so no candidate can
         // declare a devcontainer, which is exactly the host case.
-        let app = fixture_app().with_checkouts(vec![Checkout::new(
+        let mut app = fixture_app().with_checkouts(vec![Checkout::new(
             std::path::PathBuf::from("/data/proj/wayfinder"),
             "blooop/wayfinder".to_string(),
         )]);
-        assert_eq!(launch::prewarm(&app.checkouts, &staged_six(&app)), None);
+        let staged = staged_six(&app);
+        assert_eq!(launch::prewarm(&app.checkouts, &staged), None);
+        // And what staging records says so: claimed, so a re-stage does not
+        // re-walk the checkouts, but with no instant to hand anyone — a stamp
+        // here would name a `dl up` that was never fired (#160).
+        assert_eq!(app.warm(&staged, true), Some(Prewarmed::Nothing));
+    }
+
+    #[test]
+    fn a_launch_carries_the_instant_its_own_workspace_was_warmed() {
+        // The stamp is a fact about this node's container, so it is looked up
+        // by the workspace the launch is about to attach to — the same name
+        // the prewarm used, which is what makes the two halves meet (#160).
+        let mut app = launchable_app();
+        let fired = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_755_194_030);
+        let workspace = staged_six(&app)
+            .node_workspace()
+            .expect("a ticket names a workspace");
+        app.prewarmed.insert(workspace, Prewarmed::At(fired));
+        go_to(&mut app, "#6");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(app.prewarm_fired(&launch), Some(fired));
+    }
+
+    #[test]
+    fn a_launch_of_a_node_nobody_warmed_carries_no_instant() {
+        // Two ways to have nothing to hand on, and both must answer the same:
+        // a session that warmed a *different* node, and one that warmed this
+        // node's workspace but fired nothing into it.
+        let mut app = launchable_app();
+        let workspace = staged_six(&app)
+            .node_workspace()
+            .expect("a ticket names a workspace");
+        app.prewarmed.insert(
+            "blooop/wayfinder@wayfinder/wayfinder-999".to_string(),
+            Prewarmed::At(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_755_194_030)),
+        );
+        go_to(&mut app, "#6");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        let launch = match app.handle_key(key(KeyCode::Enter)) {
+            Outcome::Launch(launch) => launch,
+            other => panic!("expected a launch, got {other:?}"),
+        };
+        assert_eq!(app.prewarm_fired(&launch), None);
+        app.prewarmed.insert(workspace, Prewarmed::Nothing);
+        assert_eq!(app.prewarm_fired(&launch), None);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -987,7 +987,7 @@ impl App {
     /// `dl <ws> up` that never happened, and the launch would hand `dl` a
     /// prewarm to weigh itself against that nobody fired (#160).
     fn warm(&mut self, staged: &Staged, enabled: bool) -> Option<Prewarmed> {
-        let workspace = self.claim_prewarm(staged, enabled)?;
+        let workspace = self.workspace_to_warm(staged, enabled)?;
         let recorded = match launch::prewarm(&self.checkouts, staged) {
             Some(argv) => {
                 launch::spawn_detached(&argv);
@@ -1003,11 +1003,16 @@ impl App {
     /// to. Split from the spawn deliberately: the gate and the once-per-node
     /// rule are the parts with logic in them.
     ///
-    /// Nothing is claimed while the prewarm is off — `?` short-circuits — so a
+    /// A **question, not a claim** — `&self`, and asking twice answers twice.
+    /// The once-per-node rule is enforced by the insert in [`warm`](Self::warm),
+    /// which is the only writer of `prewarmed`; this names the key that insert
+    /// will land under, and answers `None` where there will be no insert.
+    ///
+    /// Nothing is offered while the prewarm is off — `?` short-circuits — so a
     /// session that exports `WF_PREWARM` and re-stages a node still warms it.
-    /// A stop with no workspace to warm (a project row) claims nothing either,
-    /// because there is nothing to record it under.
-    fn claim_prewarm(&self, staged: &Staged, enabled: bool) -> Option<String> {
+    /// A stop with no workspace to warm (a project row) is offered nothing
+    /// either, because there is nothing to record it under.
+    fn workspace_to_warm(&self, staged: &Staged, enabled: bool) -> Option<String> {
         let workspace = staged.node_workspace()?;
         (enabled && !self.prewarmed.contains_key(&workspace)).then_some(workspace)
     }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1351,7 +1351,7 @@ fn devlaunch_on_path() -> Devlaunch {
         let Ok(program) = resolve_on_path(DEVLAUNCH) else {
             return Devlaunch::Absent;
         };
-        match Command::new(program).arg("--version").output() {
+        match unstamped(program).arg("--version").output() {
             Ok(answer) => Devlaunch::from_version_output(&String::from_utf8_lossy(&answer.stdout)),
             // On PATH but it would not run — a file that is not executable, or
             // not a program. There is no version to report, so this is the same
@@ -1461,6 +1461,33 @@ const HANDOFF_T0_VAR: &str = "DEVLAUNCH_HANDOFF_T0";
 
 /// The prewarm stamp's variable: see [`Handoff`].
 const PREWARM_FIRED_VAR: &str = "DEVLAUNCH_PREWARM_FIRED_AT";
+
+/// A child `wf` starts and does **not** become, with the seam's stamps
+/// (#160) stripped out of its environment.
+///
+/// Every `dl` `wf` runs except the launch itself is one of these — the
+/// `--version` probe, the prewarm's `dl <ws> up`, and `wf reap`'s listing and
+/// removals — and none of them is a hand-over, so none may arrive carrying a
+/// keystroke stamp. Declining to *set* one is not enough, because a child
+/// inherits `wf`'s own environment and `wf` is routinely run from inside a
+/// workspace whose environment `dl` stamped for the launch that created it: an
+/// agent doing that would have every `dl` it ran report a hand-over from a
+/// keystroke hours old, indistinguishable on the far side from a real one.
+/// This is the same reason [`Launch::stamps`] hands `exec` a *removal* rather
+/// than a skip.
+///
+/// One constructor rather than a removal remembered at each site, so a `dl`
+/// child added later cannot quietly reopen it — and it takes the program name
+/// rather than a whole argv because one caller runs `dl` and another runs the
+/// `sh` that backgrounds it ([`spawn_detached`]), which is the same seam and a
+/// different program.
+pub fn unstamped(program: impl AsRef<std::ffi::OsStr>) -> Command {
+    let mut command = Command::new(program);
+    for var in Handoff::variables() {
+        command.env_remove(var);
+    }
+    command
+}
 
 /// One stamp as the seam spells it: seconds since the Unix epoch, to nine
 /// decimal places — the string `date +%s.%N` prints, which is the format the
@@ -2068,7 +2095,7 @@ pub fn spawn_detached(argv: &[String]) {
         .join(" ");
     command.push_str(" >/dev/null 2>&1 &");
 
-    let spawned = Command::new("sh")
+    let spawned = unstamped("sh")
         .arg("-c")
         .arg(&command)
         .stdin(std::process::Stdio::null())
@@ -4124,6 +4151,43 @@ mod tests {
                 ("DEVLAUNCH_HANDOFF_T0", None),
                 ("DEVLAUNCH_PREWARM_FIRED_AT", None),
             ]
+        );
+    }
+
+    #[test]
+    fn a_dl_wf_starts_and_does_not_become_clears_the_stamps_it_inherited() {
+        // The other half of the rule above, and the one a clean environment
+        // hides: the probe, the prewarm's `dl <ws> up` and `wf reap`'s listing
+        // and removals are children, not execs, so they inherit `wf`'s
+        // environment — and `wf` run inside a workspace has both stamps in it
+        // already, set by the `dl` that launched the agent running it. Every
+        // one of those children would then report a hand-over from a keystroke
+        // in another session, which the reader cannot tell from a real one.
+        //
+        // Asserted on the command as built rather than on a child's
+        // environment, because the machine running this need not have a `dl`
+        // at all; the end-to-end version is claim 6 of
+        // `tests/live_launch_exec.rs`, which starts `wf` with both already set.
+        let command = unstamped(DEVLAUNCH);
+        let changed: BTreeSet<(&str, Option<&str>)> = command
+            .get_envs()
+            .map(|(var, value)| {
+                (
+                    var.to_str().expect("ascii"),
+                    value.map(|v| v.to_str().expect("ascii")),
+                )
+            })
+            .collect();
+        // The whole environment delta, not merely "the two are in it": a `None`
+        // is a removal and a `Some` is a stamp, so this is also the assertion
+        // that no child of `wf`'s is quietly *given* one.
+        let expected: BTreeSet<(&str, Option<&str>)> = Handoff::variables()
+            .into_iter()
+            .map(|var| (var, None))
+            .collect();
+        assert_eq!(
+            changed, expected,
+            "a `dl` that is not the launch clears both stamps and sets neither"
         );
     }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -36,6 +36,7 @@ use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
+use std::time::SystemTime;
 
 use serde::{Deserialize, Serialize};
 
@@ -1402,6 +1403,77 @@ fn shell_quote(arg: &str) -> String {
     format!("'{}'", arg.replace('\'', r"'\''"))
 }
 
+/// The instant the keystroke that resolved to an exec landed, and the instant
+/// `wf` fired a prewarm for that node, if it fired one (#160).
+///
+/// Two stamps of things **`wf` itself did**, and nothing else. Neither is a
+/// claim about how the launch went: whether the prewarm was still running, was
+/// already finished, or saved this launch nothing at all is visible only to the
+/// process that then had to run the launch, and `dl` decides it from the arm it
+/// takes. A `wf` that reported a "prewarm hit" would be reporting on a
+/// container it fired and forgot and never saw again.
+///
+/// They travel in the **environment of the exec'd process**, not in the `ctx:`
+/// block: `ctx:` is addressed to the agent, and these are addressed to the
+/// timing reader inside `dl`, which reads them at the top of its own `main`.
+/// The variable names and the spelling of the values are `dl`'s to mint
+/// (blooop/devlaunch#194); `wf` is the writer, and a writer that invented its
+/// own names would be handing the reader nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Handoff {
+    /// The last keystroke before the exec — the one whose meaning was "run it",
+    /// after which nothing waits on a human. `dl` reports the gap from here to
+    /// its own start as the one stage that measures the exec itself.
+    t0: SystemTime,
+    /// When staging fired `dl <workspace> up` for the node being launched, if
+    /// staging fired one. Absent is the ordinary case and says exactly that:
+    /// nothing was warmed, so there is nothing for `dl` to weigh its launch
+    /// against.
+    prewarm_fired: Option<SystemTime>,
+}
+
+impl Handoff {
+    /// Stamp the keystroke that has just resolved to an exec.
+    ///
+    /// The only public constructor, so a handoff always carries the clock at
+    /// the moment it was taken — never one assembled after the fact, which
+    /// would silently fold whatever came between into the gap `dl` measures.
+    /// The prewarm's instant is passed in because it happened earlier, and
+    /// only the session that fired it knows when.
+    pub fn now(prewarm_fired: Option<SystemTime>) -> Handoff {
+        Handoff {
+            t0: SystemTime::now(),
+            prewarm_fired,
+        }
+    }
+
+    /// The variables this seam owns, in the order the docs publish them.
+    ///
+    /// One list, read by both the exec path and the docs guard, so the names a
+    /// launch sets and the names the README teaches cannot drift apart.
+    pub fn variables() -> [&'static str; 2] {
+        [HANDOFF_T0_VAR, PREWARM_FIRED_VAR]
+    }
+}
+
+/// The keystroke stamp's variable: see [`Handoff`].
+const HANDOFF_T0_VAR: &str = "DEVLAUNCH_HANDOFF_T0";
+
+/// The prewarm stamp's variable: see [`Handoff`].
+const PREWARM_FIRED_VAR: &str = "DEVLAUNCH_PREWARM_FIRED_AT";
+
+/// One stamp as the seam spells it: seconds since the Unix epoch, to nine
+/// decimal places — the string `date +%s.%N` prints, which is the format the
+/// reader on the other side parses.
+///
+/// `None` for an instant before the epoch, which is a clock this side has no
+/// business describing: the far side would read it as a handoff that began
+/// decades ago, and a fiction in a trend is worse than a stage nobody reported.
+fn epoch_seconds(at: SystemTime) -> Option<String> {
+    let since = at.duration_since(SystemTime::UNIX_EPOCH).ok()?;
+    Some(format!("{}.{:09}", since.as_secs(), since.subsec_nanos()))
+}
+
 /// A fully-resolved launch: which checkout the agent runs in, which ticket of
 /// which map it is handed, and — since the two-step (#62) — which skill it
 /// runs ([`Route`]) and in what mode ([`LaunchMode`]).
@@ -1528,7 +1600,12 @@ impl Launch {
     /// A creation has no number, so no per-ticket branch exists to name: it
     /// gets the bare `owner/repo` — the default workspace — and the launched
     /// skill files its own issues and makes its own branches (#114).
-    fn workspace(&self) -> String {
+    ///
+    /// Public because it is also the key a session's prewarm record is kept
+    /// under ([`crate::app::App::prewarm_fired`]): asking "was *this* launch's
+    /// container warmed" is asking about this name, and computing it a second
+    /// way at the asking site is how the two would come to disagree.
+    pub fn workspace(&self) -> String {
         match self.job.number() {
             Some(number) => node_workspace_name(&self.repo, number),
             None => self.repo.clone(),
@@ -1698,6 +1775,31 @@ impl Launch {
         }
     }
 
+    /// What this launch tells the process it is about to become about the
+    /// keystroke it came from ([`Handoff`]) — one entry per seam variable, in
+    /// the published order, and `None` for one this launch has nothing to say
+    /// with.
+    ///
+    /// **A stamp is set only where the exec *is* the `dl` that reads it.** A
+    /// host launch execs the agent itself: nothing there parses these, and one
+    /// left sitting in an agent session's environment would be picked up by
+    /// every unrelated `dl` that session goes on to run — each reporting a
+    /// handoff measured from a keystroke hours old. So the host arm says
+    /// nothing, and `None` is applied as a *removal* rather than a skip
+    /// ([`Launch::exec`]), which is what keeps a stamp `wf` inherited from
+    /// travelling on under `wf`'s name.
+    pub fn stamps(&self, handoff: &Handoff) -> [(&'static str, Option<String>); 2] {
+        let carried = |at: Option<SystemTime>| match self.isolation {
+            Isolation::Devlaunch => at.and_then(epoch_seconds),
+            Isolation::Host => None,
+        };
+        let [t0, prewarm_fired] = Handoff::variables();
+        [
+            (t0, carried(Some(handoff.t0))),
+            (prewarm_fired, carried(handoff.prewarm_fired)),
+        ]
+    }
+
     /// Become the selected agent: replace `wf`'s process image with it — or,
     /// for an isolated Claude launch, with the `dl` that carries it into the
     /// container — in the checkout.
@@ -1714,12 +1816,17 @@ impl Launch {
     /// chance after the image is replaced, so that ordering lives in `main`,
     /// where it is one statement above the call, rather than in here.
     ///
+    /// The [`Handoff`] is an argument for the same reason: its `t0` is the
+    /// keystroke, not this moment, and everything between the two — the
+    /// shutdowns, the cache write, the skill refresh — is part of what the far
+    /// side measures. A stamp taken here would quietly leave all of it out.
+    ///
     /// # Panics
     ///
     /// Never in practice: [`agent_argv`](Self::agent_argv) builds the vector
     /// literally and always starts it with the program name, so the split below
     /// cannot come up empty. The `expect` is there to say so.
-    pub fn exec(&self) -> anyhow::Error {
+    pub fn exec(&self, handoff: &Handoff) -> anyhow::Error {
         let argv = self.agent_argv();
         let (program, rest) = argv.split_first().expect("agent argv is never empty");
 
@@ -1746,11 +1853,20 @@ impl Launch {
             );
         }
 
+        let mut command = Command::new(&program);
+        command.args(rest).current_dir(&self.cwd);
+        // The seam (#160). Written onto the child rather than into `wf`'s own
+        // environment, so nothing here can be read back by anything but the
+        // process this is about to become — and removed, not skipped, where
+        // this launch has no stamp of its own to hand over.
+        for (var, stamp) in self.stamps(handoff) {
+            match stamp {
+                Some(value) => command.env(var, value),
+                None => command.env_remove(var),
+            };
+        }
         // `CommandExt::exec` only ever returns on failure.
-        let err = Command::new(&program)
-            .args(rest)
-            .current_dir(&self.cwd)
-            .exec();
+        let err = command.exec();
         // Quoted, so the prompt reads as the single argument it is — the whole
         // invariant `agent_argv` exists to hold.
         let quoted: Vec<String> = std::iter::once(program.display().to_string())
@@ -3916,6 +4032,127 @@ mod tests {
         let staged = Staged::ticket(&node, &map_ref(67), Stage::Ready).expect("launchable");
         assert_eq!(prewarm(&cache(), &staged), None);
         assert_eq!(prewarm(&[], &staged), None);
+    }
+
+    /// A handoff with both stamps chosen, rather than read off this machine's
+    /// clock: the values below are literals, so what the seam *spells* is
+    /// checkable and not merely self-consistent.
+    fn handoff(t0: SystemTime, prewarm_fired: Option<SystemTime>) -> Handoff {
+        Handoff { t0, prewarm_fired }
+    }
+
+    /// A wall-clock instant, epoch seconds and nanoseconds.
+    fn instant(secs: u64, nanos: u32) -> SystemTime {
+        SystemTime::UNIX_EPOCH + std::time::Duration::new(secs, nanos)
+    }
+
+    /// The same launch on the host — the arm that execs the agent directly,
+    /// with no `dl` between `wf` and it.
+    fn on_the_host(route: Route, mode: LaunchMode) -> Launch {
+        Launch {
+            isolation: Isolation::Host,
+            ..isolated(route, mode)
+        }
+    }
+
+    #[test]
+    fn the_launch_hands_dl_the_keystroke_it_resolved_from() {
+        // The variable names and the spelling of the value are `dl`'s to mint
+        // (blooop/devlaunch#194) and are quoted here as the literals they are:
+        // Unix epoch seconds, exactly what `date +%s.%N` prints, so a reader
+        // that parses one parses the other.
+        assert_eq!(
+            isolated(Route::Tdd, interactive(""))
+                .stamps(&handoff(instant(1_755_194_037, 123_456_789), None)),
+            [
+                (
+                    "DEVLAUNCH_HANDOFF_T0",
+                    Some("1755194037.123456789".to_string())
+                ),
+                ("DEVLAUNCH_PREWARM_FIRED_AT", None),
+            ],
+            "the keystroke travels; a prewarm nobody fired does not"
+        );
+    }
+
+    #[test]
+    fn a_prewarm_that_fired_travels_beside_it_as_the_instant_it_fired() {
+        // The second variable carries *when `wf` fired*, never how the launch
+        // turned out: hit, partial and miss are `dl`'s to observe from the arm
+        // it takes, and a stamp that claimed one would be `wf` reporting on a
+        // container it never saw.
+        let stamps = isolated(Route::Tdd, interactive("")).stamps(&handoff(
+            instant(1_755_194_037, 500_000_000),
+            Some(instant(1_755_194_030, 0)),
+        ));
+        assert_eq!(
+            stamps,
+            [
+                (
+                    "DEVLAUNCH_HANDOFF_T0",
+                    Some("1755194037.500000000".to_string())
+                ),
+                (
+                    "DEVLAUNCH_PREWARM_FIRED_AT",
+                    Some("1755194030.000000000".to_string())
+                ),
+            ]
+        );
+        for (var, value) in stamps {
+            let value = value.expect("both stamps are set here");
+            assert!(
+                value.parse::<f64>().is_ok(),
+                "{var} carries an instant and nothing else, not {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_launch_that_is_not_a_handover_to_dl_carries_no_stamp() {
+        // The seam is `wf` → `dl`, and a host launch execs the agent itself:
+        // there is no reader for a stamp there, and one left in an agent's
+        // environment would be read by every unrelated `dl` that session goes
+        // on to run — a handoff measured from a keystroke hours old. `None` is
+        // *removed*, not merely unset, so an inherited stamp cannot ride out
+        // on a launch that never minted one.
+        assert_eq!(
+            on_the_host(Route::Tdd, interactive("")).stamps(&handoff(
+                instant(1_755_194_037, 0),
+                Some(instant(1_755_194_030, 0))
+            )),
+            [
+                ("DEVLAUNCH_HANDOFF_T0", None),
+                ("DEVLAUNCH_PREWARM_FIRED_AT", None),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_seam_owns_exactly_two_variables() {
+        // The published list, which the docs guard reads: two, in the order
+        // they are documented, and every stamp a launch sets is one of them.
+        assert_eq!(
+            Handoff::variables(),
+            ["DEVLAUNCH_HANDOFF_T0", "DEVLAUNCH_PREWARM_FIRED_AT"]
+        );
+        let set: Vec<&str> = isolated(Route::Tdd, interactive(""))
+            .stamps(&handoff(instant(1_755_194_037, 0), None))
+            .into_iter()
+            .map(|(var, _)| var)
+            .collect();
+        assert_eq!(set, Handoff::variables());
+    }
+
+    #[test]
+    fn the_keystroke_is_stamped_when_the_handoff_is_taken() {
+        // `now` is the whole production constructor: there is no way to build a
+        // handoff carrying an instant that is not this machine's clock at the
+        // moment it was taken.
+        let before = SystemTime::now();
+        let taken = Handoff::now(None);
+        let after = SystemTime::now();
+        assert!(taken.t0 >= before && taken.t0 <= after);
+        assert_eq!(taken.prewarm_fired, None);
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -101,7 +101,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 
 use wf::app::{App, Outcome};
-use wf::launch::{Agent, Launch};
+use wf::launch::{Agent, Handoff, Launch};
 use wf::model::{Map, MapId};
 use wf::projects::{self, ProjectsCache};
 use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup, Survey};
@@ -165,8 +165,9 @@ impl Keys for Typed {
 enum Ending {
     /// The user quit.
     Quit,
-    /// A ticket was picked. `wf`'s last act is to become its agent.
-    Handover(Box<Launch>),
+    /// A ticket was picked. `wf`'s last act is to become its agent, carrying
+    /// the stamps of what `wf` itself did on the way here (#160).
+    Handover(Box<Launch>, Handoff),
 }
 
 /// Everything the screen is drawn from, and the arrivals that change it.
@@ -393,9 +394,19 @@ async fn run<B: Backend, K: Keys>(
             // outlives the `exec` otherwise, and the agent inherits it
             // as a zombie holding the terminal it just took over.
             Outcome::Launch(launch) => {
+                // **The keystroke is stamped here, first, before anything is
+                // waited on** (#160). This is the instant a human's part in
+                // the launch ends: `handle_key` has just turned a keypress
+                // into a launch, and everything from this line to the agent's
+                // first frame is machine time — the shutdowns below, the cache
+                // write, the exec, and `dl`'s own start. Taking it any later
+                // would quietly drop `wf`'s own hand-over cost out of the one
+                // measurement that spans the exec; taking it any earlier would
+                // fold in the human, who was still choosing a mode.
+                let handoff = Handoff::now(picker.app.prewarm_fired(&launch));
                 picker.loaders.shutdown().await;
                 stop_background(discovery, survey).await;
-                return Ok(Ending::Handover(launch));
+                return Ok(Ending::Handover(launch, handoff));
             }
             Outcome::Continue => {}
         }
@@ -501,7 +512,7 @@ pub async fn run_picker() -> Result<()> {
     ratatui::restore();
     match ending? {
         Ending::Quit => Ok(()),
-        Ending::Handover(launch) => {
+        Ending::Handover(launch, handoff) => {
             // The launch is a use of this project, and the last chance to say
             // so: after the exec there is no `wf` left to write anything. This
             // is what keeps the project list ordered for someone who reaches
@@ -548,7 +559,7 @@ pub async fn run_picker() -> Result<()> {
             // ahead by even one release.
             refresh_skills(launch.agent());
             // Only ever returns an error: on success this process *is* the agent.
-            Err(launch.exec())
+            Err(launch.exec(&handoff))
         }
     }
 }
@@ -801,7 +812,7 @@ mod tests {
         }
         let (checkout, ending) = drive_a_launch_from_a_devcontainer_checkout();
         match ending {
-            Ending::Handover(launch) => {
+            Ending::Handover(launch, handoff) => {
                 assert_eq!(
                     launch.cwd(),
                     checkout,
@@ -812,6 +823,28 @@ mod tests {
                     wf::launch::Isolation::Devlaunch,
                     "a devcontainer and a `dl` above the floor is an isolated launch"
                 );
+                // And it carries the keystroke it came from (#160). Taken from
+                // the run rather than from a fixture: the claim is that the
+                // loop stamps the launch arm at all, which is a fact about
+                // this assembly and about no value a test could hand it.
+                let [(_, t0), (_, prewarm_fired)] = launch.stamps(&handoff);
+                let stamped: f64 = t0
+                    .expect("a handover to `dl` stamps its keystroke")
+                    .parse()
+                    .expect("the stamp is epoch seconds");
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .expect("this machine's clock is past 1970")
+                    .as_secs_f64();
+                assert!(
+                    (0.0..60.0).contains(&(now - stamped)),
+                    "the stamp is this keystroke's instant, not some other run's: \
+                     {stamped} against {now}"
+                );
+                // Nothing was warmed — the prewarm is opt-in and this run did
+                // not ask — so the second variable says nothing rather than
+                // saying zero.
+                assert_eq!(prewarm_fired, None);
                 // The enum and not also the argv. An earlier draft asserted
                 // `agent_argv()[0] == "dl"` beside this, on the theory that a
                 // decision and what reaches `execvp` are different things —
@@ -844,11 +877,23 @@ mod tests {
         }
         let (_, ending) = drive_a_launch_from_a_devcontainer_checkout();
         match ending {
-            Ending::Handover(launch) => {
+            Ending::Handover(launch, handoff) => {
                 assert_eq!(
                     launch.isolation(),
                     wf::launch::Isolation::Host,
                     "a `dl` below the floor is a `dl` `wf` will not launch into"
+                );
+                // And the seam is empty with it (#160): the stamps are for the
+                // `dl` this launch is no longer going to become, and one left
+                // in the agent's environment would be read by whatever `dl`
+                // that session ran next.
+                assert!(
+                    launch
+                        .stamps(&handoff)
+                        .iter()
+                        .all(|(_, stamp)| stamp.is_none()),
+                    "a host launch hands the seam nothing: {:?}",
+                    launch.stamps(&handoff)
                 );
             }
             Ending::Quit => {

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -46,7 +46,7 @@ use tokio::process::Command;
 /// [`fetch`](crate::fetch), where the screen reads it too.
 pub use crate::fetch::TicketState;
 use crate::fetch::{parse_pr, Assignee, GraphQlResponse, Nodes, PrNode};
-use crate::launch::devlaunch_answers_unsaved;
+use crate::launch::{self, devlaunch_answers_unsaved};
 use crate::model::PrStatus;
 
 /// The branch prefix `wf` mints its workspaces under (#106): the full branch is
@@ -680,7 +680,7 @@ fn short_repo(slug: &str) -> &str {
 /// not parse. All three mean the same thing to the caller — `wf` cannot see the
 /// workspaces, so it must not delete any.
 pub async fn workspaces() -> Result<Vec<Workspace>> {
-    let output = Command::new("dl")
+    let output = Command::from(launch::unstamped("dl"))
         .args(["--ls", "--json"])
         .stdin(Stdio::null())
         .kill_on_drop(true)
@@ -953,7 +953,7 @@ fn parse_node_facts(body: &[u8], repo: &str, numbers: &[u64]) -> Result<BTreeMap
 /// above, which is a failure `wf` reports rather than quietly overrides.
 async fn remove(id: &str, insist: bool) -> Result<()> {
     let args = removal_argv(id, insist);
-    let output = Command::new("dl")
+    let output = Command::from(launch::unstamped("dl"))
         .args(&args)
         .stdin(Stdio::null())
         .kill_on_drop(true)

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -8,7 +8,7 @@
 //! actually be wrong is what happens between the keypress and the agent's first
 //! frame, and that only happens once, in `main`.
 //!
-//! It pins down six claims, in the order they can fail:
+//! It pins down seven claims, in the order they can fail:
 //!
 //! 0. **The container carries the agent, in a workspace of the ticket's
 //!    own.** This repo has a `.devcontainer/devcontainer.json`, so its
@@ -51,6 +51,12 @@
 //!    `enter enter` returns to that conversation instead of starting another.
 //!    This is the one seam no unit test can reach: `resume_launch` is checked
 //!    exhaustively in the library, but only against a record a test handed it.
+//! 6. **The launch tells `dl` what `wf` did on the way to it** (#160): the
+//!    keystroke that resolved to this exec, and the prewarm this run fired for
+//!    the node, both as environment stamps on the `dl` invocation — and on
+//!    nothing else `wf` ran. The environment is the one thing an argv
+//!    assertion cannot see, and the exec is where it is written, so this is the
+//!    only place the seam is observable end to end.
 //!
 //! Needs network, an authenticated `gh`, and a `blooop/wayfinder` checkout with
 //! at least one ticket on its map — i.e. this repo.
@@ -159,10 +165,17 @@ impl Scratch {
         // an intermittent red pointing at `wf` having lost the launch. A
         // single small `O_APPEND` write is atomic; six are not. src/probe.rs
         // reached the same conclusion for the same reason.
+        //
+        // The two seam stamps are recorded beside the argv because the
+        // environment is where they travel (#160) — a launch that set them on
+        // the wrong child, or left an inherited one on a probe, is invisible in
+        // an argv. Always written, empty when unset, so "the variable is not
+        // here" is a value this file can read rather than a missing line.
         let record = |report: &Path| {
             format!(
                 "line=$({{ echo \"{INVOCATION}\"; echo \"pid=$$\"; echo \"cwd=$PWD\"; \
-                 echo \"argv=$*\"; stty -a; }} 2>&1)\n\
+                 echo \"argv=$*\"; echo \"handoff=$DEVLAUNCH_HANDOFF_T0\"; \
+                 echo \"prewarm=$DEVLAUNCH_PREWARM_FIRED_AT\"; stty -a; }} 2>&1)\n\
                  printf '%s\\n' \"$line\" >> {}\n",
                 report.display()
             )
@@ -292,6 +305,32 @@ fn dl_launch(report: &str) -> &str {
         launches.len()
     );
     launches[0]
+}
+
+/// Every invocation that is *not* a handover — the `--version` probe and the
+/// prewarm's `dl <ws> up`. Neither is a launch, so neither may carry a stamp
+/// (#160): a `wf` that stamped its probes would have `dl` reporting a hand-over
+/// for a question `wf` asked itself.
+fn dl_asides(report: &str) -> Vec<&str> {
+    invocations(report)
+        .into_iter()
+        .filter(|record| !field(record, "argv=").contains(" -- "))
+        .collect()
+}
+
+/// This machine's clock as the seam spells it, for comparing against a stamp.
+fn epoch_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .expect("this machine's clock is past 1970")
+        .as_secs_f64()
+}
+
+/// One stamp out of a record, as the number it claims to be.
+fn stamp(record: &str, key: &str) -> f64 {
+    let raw = field(record, key);
+    raw.parse()
+        .unwrap_or_else(|e| panic!("{key} carries Unix epoch seconds, got {raw:?} ({e})\n{record}"))
 }
 
 /// The workspace spec `dl` was pointed at — everything before the first space
@@ -490,6 +529,9 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
         std::env::var("PATH").unwrap_or_default()
     );
 
+    // Claim 6's floor: every stamp this run reads has to be an instant inside
+    // it, and this is where it starts.
+    let started = epoch_now();
     let mut child = unsafe {
         Command::new(env!("CARGO_BIN_EXE_wf"))
             .current_dir(repo)
@@ -498,6 +540,12 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
             // registers a checkout and writes a map seed.
             .env("XDG_CACHE_HOME", scratch.cache())
             .env("CLAUDE_CONFIG_DIR", scratch.claude())
+            // Opt into the prewarm, so claim 6's *second* stamp has something
+            // to describe: the first enter fires `dl <ws> up` at the shim, and
+            // the launch that follows is the only thing that can tell `dl`
+            // when that happened. No container is built — the `up` reaches the
+            // same recording shim as everything else here.
+            .env("WF_PREWARM", "1")
             .env("TERM", "xterm-256color")
             .stdin(Stdio::from(slave.try_clone().expect("dup slave")))
             .stdout(Stdio::from(slave.try_clone().expect("dup slave")))
@@ -787,6 +835,47 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
         std::fs::read_to_string(repo.join("skills/wf-tdd/SKILL.md")).ok(),
         "the launch must refresh the prompt it is about to exec"
     );
+
+    // Claim 6: the launch told `dl` when the keystroke that resolved to it
+    // landed, and when this node's prewarm went out (#160). Read off the
+    // *environment* the shim was handed, which is the only place this can be
+    // observed at all: the stamps are not in the argv, and the exec is where
+    // they are applied.
+    let launch = dl_launch(&dl_report);
+    let t0 = stamp(launch, "handoff=");
+    let fired = stamp(launch, "prewarm=");
+    let now = epoch_now();
+    assert!(
+        (started..=now).contains(&t0),
+        "the keystroke stamp must be an instant inside this run: \
+         {t0} against {started}..={now}"
+    );
+    // The prewarm went out at the *first* enter and the keystroke stamp is the
+    // second, so this ordering is the two halves of the two-step launch,
+    // observed from the far side of the exec. It is also what makes the pair
+    // worth sending: `dl` subtracts them to see how much head start it had.
+    assert!(
+        (started..=t0).contains(&fired),
+        "the prewarm fired before the keystroke that resolved to the launch: \
+         {fired} against {started}..={t0}"
+    );
+    // And nothing that is not a launch carries either stamp. `wf` asks `dl` its
+    // version and fires the prewarm's `dl <ws> up` from the same process with
+    // the same environment; a stamp on those would have `dl` report a hand-over
+    // for a question `wf` asked itself, or for the warm-up the stamp is *about*.
+    let asides = dl_asides(&dl_report);
+    assert!(
+        asides.len() >= 2,
+        "this run probes `dl --version` and fires a prewarm, so there are \
+         asides to check\n{dl_report}"
+    );
+    for aside in asides {
+        assert_eq!(
+            (field(aside, "handoff="), field(aside, "prewarm=")),
+            ("", ""),
+            "only a launch is stamped, and this is not one:\n{aside}"
+        );
+    }
 }
 
 /// Spawn `wf` under a fresh pty in `scratch`, returning the child, a handle to

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -94,6 +94,17 @@ const INVOCATION: &str = "--- shim invocation ---";
 /// What the `dl` shim answers `--version` with. See `write_shims`.
 const DL_SHIM_VERSION: &str = "9999.0.0";
 
+/// A seam stamp from **somebody else's launch**, exported into `wf`'s own
+/// environment before it starts (#160).
+///
+/// This is not a hypothetical: `dl` sets these for the session it launches, so
+/// an agent that runs `wf` inside its own workspace runs it with both already
+/// set. Every `dl` child `wf` starts inherits that environment, so the claim
+/// "only a launch is stamped" is a claim about a *dirty* environment or it is
+/// only a claim about the test rig. The instant is a real one from long before
+/// any run of this test, so a leak reads as a handoff that began last year.
+const INHERITED_STAMP: &str = "1755194037.000000000";
+
 /// A scratch tree of this test's own: `claude` and `dl` shims on PATH and a
 /// cache directory, so neither the user's PATH nor their real projects cache is
 /// touched. Removed on drop, panic or not.
@@ -532,6 +543,10 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     // Claim 6's floor: every stamp this run reads has to be an instant inside
     // it, and this is where it starts.
     let started = epoch_now();
+    // Read off the binary rather than spelled again, so a renamed variable
+    // cannot leave this test polluting the environment with a name nothing
+    // reads — which would pass while proving nothing.
+    let [t0_var, prewarm_var] = wf::launch::Handoff::variables();
     let mut child = unsafe {
         Command::new(env!("CARGO_BIN_EXE_wf"))
             .current_dir(repo)
@@ -546,6 +561,11 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
             // when that happened. No container is built — the `up` reaches the
             // same recording shim as everything else here.
             .env("WF_PREWARM", "1")
+            // Start `wf` inside a launch that is not this one — see
+            // `INHERITED_STAMP`. Every `dl` this run starts that is not the
+            // exec has to clear these rather than pass them on.
+            .env(t0_var, INHERITED_STAMP)
+            .env(prewarm_var, INHERITED_STAMP)
             .env("TERM", "xterm-256color")
             .stdin(Stdio::from(slave.try_clone().expect("dup slave")))
             .stdout(Stdio::from(slave.try_clone().expect("dup slave")))
@@ -863,6 +883,13 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     // version and fires the prewarm's `dl <ws> up` from the same process with
     // the same environment; a stamp on those would have `dl` report a hand-over
     // for a question `wf` asked itself, or for the warm-up the stamp is *about*.
+    //
+    // This `wf` was started with both stamps already set (`INHERITED_STAMP`),
+    // which is what makes the assertion a claim about `wf` rather than about
+    // the test rig: inheriting is the default, so a `wf` that merely declines
+    // to *set* a stamp on its asides passes this only in a clean environment,
+    // and an agent's shell inside a workspace is not one. Empty here means
+    // every such child was scrubbed on the way out.
     let asides = dl_asides(&dl_report);
     assert!(
         asides.len() >= 2,

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -575,7 +575,10 @@ fn the_seam_paragraph_reads_exactly_as_the_claim_free_rule() {
          inherited. The reader is the `dl` a launch becomes; a host launch becomes the \
          agent instead, and a stamp left standing in an agent session's environment would \
          be picked up by every unrelated `dl` that session went on to run, each reporting \
-         a hand-over measured from a keystroke hours old."
+         a hand-over measured from a keystroke hours old. The same clearing covers every \
+         `dl` `wf` starts and does not become — the version probe, the prewarm's `dl <ws> \
+         up`, and `wf reap`'s listing and removals — because `wf` run inside a workspace \
+         starts with the stamps of the launch that built it already in its environment."
     );
 }
 

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -500,6 +500,85 @@ fn readme_paragraph(lead: &str) -> String {
     from.join(" ")
 }
 
+/// The README section documenting the exec seam's stamps (#160) — the shared
+/// contract between `wf`, which writes them, and `dl`, which reads them.
+fn seam_section() -> String {
+    let readme = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))
+        .expect("the README ships in this repo");
+    readme
+        .split("### What a launch tells `dl` about itself")
+        .nth(1)
+        .expect("the README documents what a launch hands across the exec seam")
+        .split("\n### ")
+        .next()
+        .expect("split always yields a first piece")
+        .to_string()
+}
+
+/// Every `DEVLAUNCH_`-prefixed name the seam section publishes in backticks.
+fn documented_seam_variables() -> BTreeSet<String> {
+    seam_section()
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .filter(|word| word.starts_with("DEVLAUNCH_"))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The variables the docs publish are the variables a launch sets — both
+/// directions, read off the binary rather than restated (#133's pattern, as
+/// #160's seam asked for).
+///
+/// A one-directional check would let either side drift on its own: a third
+/// variable added to the seam and documented nowhere is as bad for a reader as
+/// a documented one nothing ever sets, and the second failure is worse, since
+/// it is the kind a reader only discovers by finding their field missing.
+#[test]
+fn the_documented_seam_variables_are_the_ones_a_launch_sets() {
+    let published: BTreeSet<String> = wf::launch::Handoff::variables()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(
+        documented_seam_variables(),
+        published,
+        "the seam section and the launch's own variable list have drifted"
+    );
+}
+
+/// The rule the stamps exist to serve, pinned whole rather than phrase-sampled
+/// — the same treatment `ctx:`'s contract sentences get above, and for the same
+/// reason: a sampled phrase survives a sentence that says the opposite.
+///
+/// What may not be reversed here is the claim-free rule. The whole design point
+/// this seam settled is that `wf` sends *when it acted* and never *how the
+/// launch went* — a README that started promising a prewarm hit would be
+/// describing a different product, one where the party that fired and forgot a
+/// container reports on how it turned out.
+#[test]
+fn the_seam_paragraph_reads_exactly_as_the_claim_free_rule() {
+    assert_eq!(
+        readme_paragraph("**Neither stamp is a claim"),
+        "**Neither stamp is a claim about how the launch went.** `wf` fires a prewarm and \
+         forgets it — the process that fired it is gone long before the container is \
+         ready — so whether the warm-up helped, was still running, or saved this launch \
+         nothing is visible only to the `dl` that then had to run the launch, and that is \
+         `dl`'s to report from the arm it took. What `wf` sends is when it acted, twice, \
+         and nothing else. An absent stamp is an absent measurement and never a zero: a \
+         launch nobody prewarmed sets no `DEVLAUNCH_PREWARM_FIRED_AT`, rather than \
+         setting it to something that would read as an instant warm-up."
+    );
+    assert_eq!(
+        readme_paragraph("A **host** launch carries neither"),
+        "A **host** launch carries neither, and clears both rather than passing on one it \
+         inherited. The reader is the `dl` a launch becomes; a host launch becomes the \
+         agent instead, and a stamp left standing in an agent session's environment would \
+         be picked up by every unrelated `dl` that session went on to run, each reporting \
+         a hand-over measured from a keystroke hours old."
+    );
+}
+
 /// The README promises the block only where a skill receives it.
 ///
 /// It said "Every launch of a node", which reads as including the plain


### PR DESCRIPTION
Closes #160

`wf` now stamps what it did on the way to a launch and hands it to the `dl` it becomes: `DEVLAUNCH_HANDOFF_T0` (the keystroke that resolved to this exec) and `DEVLAUNCH_PREWARM_FIRED_AT` (when staging fired this node's `dl <ws> up`, if it fired one), both Unix epoch seconds in `date +%s.%N`'s spelling, in the environment of the exec'd process. The names and the format are devlaunch#194's to mint; this side is the writer.

Per #161's resolution and the ticket's spec amendment: **the prewarm travels as its firing time in a second variable, never as a hit claim and never in the `ctx:` block.** `wf` fires a prewarm and forgets it, so whether the warm-up helped is visible only to the `dl` that then had to run the launch — hit, partial and miss are its to derive from the arm it took. An absent stamp is an absent measurement, never a zero.

### Where each stamp is minted

- **The keystroke** in the picker's launch arm — the one place a keypress has already resolved to an exec and nothing is left waiting on a human. Taken *before* the loader shutdowns, so `wf`'s own hand-over cost (the shutdowns, the cache write, the skill refresh, the exec) falls inside the gap the far side measures rather than being lost between the two programs.
- **The prewarm's firing time** at the spawn, not at the claim. A node whose launch is host-only is still claimed — it plans nothing now and would plan nothing later — but recording an instant for it would name a `dl <ws> up` that never went out. The session's record therefore grew from "which workspaces were prewarmed" to "what happened to each, and when".

### Only where the exec *is* a `dl`

A host launch execs the agent itself. Nothing there reads these, and one left standing in an agent session's environment would be picked up by every unrelated `dl` that session went on to run, each reporting a hand-over measured from a keystroke hours old. That arm carries neither variable and *clears* both, so a stamp `wf` inherited cannot travel on under `wf`'s name.

### Tests, at the seams the ticket named

- **The launch path's stamping decision** — asserted as name→value pairs rather than through a spawn, so absence is as checkable as presence: the keystroke travels, a prewarm nobody fired does not, a host launch carries nothing, and the values are instants and nothing else.
- **The picker's launch arm** — its two existing launch probes (a `dl` above the floor, one below) now also assert that the isolated run stamps an instant inside the run, and that the host run stamps nothing.
- **End to end**, `tests/live_launch_exec.rs` claim 6: the run opts into the prewarm, and the `dl` shim records the *environment* it was handed — the only place this is observable at all, since a stamp is not in an argv and the exec is where it is applied. Both stamps are instants inside the run, the prewarm's precedes the keystroke's (the two-step launch, seen from the far side of the exec), and the run's non-launch `dl` invocations — the `--version` probe and the prewarm's own `up` — carry neither.
- **The docs guard**, #133's pattern: the seam's variable names are read off the binary and compared to the README's in both directions, and the claim-free rule is pinned by equality on its own sentences. Mutating either side turns them red.

### Checked

`cargo fmt --check`, `clippy --all-targets --all-features`, `--lib --bins --examples`, `skill_docs`, `devcontainer_prebuild`, `cargo doc`, all under `-D warnings`; `pixi run suite` (hermetic, no `dl` on PATH); and the live binaries that cover what changed — `live_launch_exec`, `live_fetch`, `live_discovery`, `live_streaming_startup`. `live_devlaunch` needs the pixi devlaunch environments and is left to the contract workflow, which this diff does not touch the argv side of.

## Summary by Sourcery

Stamp keystroke and prewarm timing information into the environment of devlaunch execs so dl can measure handoff timing, while ensuring host launches carry no stamps and documenting the seam contract.

New Features:
- Track per-workspace prewarm outcomes and firing instants within the session and expose them to launches for inclusion in exec environment stamps.
- Introduce explicit handoff metadata for launches, including keystroke and prewarm timestamps, and propagate these as DEVLAUNCH_* environment variables only to devlaunch-based execs.

Enhancements:
- Refine prewarm bookkeeping from a simple set to a richer map that distinguishes warmed workspaces from those with no container to warm.
- Expose Launch.workspace and add helper APIs to compute and serialize handoff stamps consistently for both runtime and documentation checks.
- Strengthen picker and launch integration so the keystroke instant is captured before shutdowns and exec, ensuring `wf`'s own handover cost is measured.

Documentation:
- Add README and AGENTS documentation describing the exec seam environment stamps, their meaning, and the claim-free and host-launch-clearing rules.

Tests:
- Extend unit and live exec tests to cover handoff stamping behavior, prewarm recording semantics, absence-on-host and non-launch invocations, and to guard README seam documentation against drift.