### PR TITLE
reap: end an autonomous run by collecting what it finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ This installs the same bundled workflows under `~/.claude/skills` and
 Codex; each agent therefore finds the route it is given without a separate
 manual install.
 
-`wf --version`, `wf --help`, `wf skills [install]` and
-[`wf reap [-y] [-f]`](#wf-reap--clearing-away-finished-tickets) are the only
-arguments; everything else is keys in the TUI.
+`wf --version`, `wf --help`, `wf skills [install]`,
+[`wf reap [-y] [-f]`](#wf-reap--clearing-away-finished-tickets) and
+[`wf reap --finished <owner/repo#n>...`](#wf-reap---finished--the-cleanup-an-autonomous-run-ends-with)
+are the only arguments; everything else is keys in the TUI.
 
 ## The skills ship with the binary
 
@@ -1079,10 +1080,14 @@ One `gh api graphql` call per repo answers all of this, however many workspaces
 that repo has — which is also what makes the picker's background reading cheap
 enough to take on every start.
 
-**Deleting stays yours.** `wf` notices; it never reaps unattended. The plan is
-printed so a reason you disagree with can be caught while "no" is still an
-answer, and the count-line hint is the same reading with the same posture: it
-names what would go and stops there.
+**Deleting stays a decision.** Nothing sweeps, nothing fires on a timer, and no
+workspace of yours is collected because time passed. `wf reap` is yours: the
+plan is printed so a reason you disagree with can be caught while "no" is still
+an answer, and the count-line hint is the same reading with the same posture —
+it names what would go and stops there. The one path that deletes with nobody
+watching is [an autonomous run collecting the tickets it just
+finished](#wf-reap---finished--the-cleanup-an-autonomous-run-ends-with), which
+is scoped to that run's own nodes and is not a sweep either.
 
 Kept by default but waivable: a workspace whose clone holds uncommitted or
 unpushed work. `-f` reaps those too, and the plan says what it is discarding:
@@ -1097,6 +1102,41 @@ unpushed work. `-f` reaps those too, and the plan says what it is discarding:
 waives the unsaved-work guard only — a running container is still kept, because
 that is a session in progress rather than bytes on disk. `-y` skips the prompt.
 Neither flag can turn a `warn` row into a deletion.
+
+### `wf reap --finished` — the cleanup an autonomous run ends with
+
+`wf-auto` walks a map on its own, and a run that works six tickets leaves six
+workspaces. Its last act is to collect the ones it finished:
+
+```
+$ wf reap --finished blooop/wayfinder#151 blooop/wayfinder#160
+  kept     wayfinder-…-160-a  (holds 1 unpushed commit(s))
+  removed  wayfinder-…-151-b  (wayfinder#151 is closed)
+```
+
+Same reading, same `plan`, same one definition of what is finished. Four things
+are different, and each of them is what removing the reader costs:
+
+- **It is scoped, and the scope is the authority.** Only the nodes that run
+  itself drove to done — named in full, owner included. A finished workspace of
+  a ticket the run never touched is not collected and not mentioned, because
+  that is `wf reap`'s business and a person's.
+- **It does not ask.** The agent that just settled those facts is the reader
+  there is; there is nobody left to answer a prompt.
+- **It deletes only what `dl` has *said* is recoverable.** `wf reap` keeps a
+  workspace whose `unsaved` refuses, so one with no answer at all passes it —
+  right for a release that wrote `null` for a clean clone, with a human reading
+  the row. Here the floor wants a fact `dl` said out loud, so a `dl` too old to
+  answer for every clone it made, or one `wf` could not ask, collects nothing
+  and says so. That single asymmetry is also the version gate.
+- **A surprise stops the whole step.** A node it reads as anything other than
+  finished — a `warn` row, a ticket state this binary cannot place — and nothing
+  is deleted at all, not even the rows it did understand. It exits non-zero
+  saying which workspace and why, and points at `wf reap`.
+
+There is **no `-f`**, in any spelling: the argv that reaches this command has no
+field a waiver could be set in. `-f` waives the guard the recoverability floor
+is built out of, and it stays yours to type, in every mode.
 
 Your host `~/.claude` is bind-mounted in, which is how the Claude agent arrives
 already logged in — and is the reason `wf skills install` keeps the prompts

--- a/README.md
+++ b/README.md
@@ -1130,9 +1130,18 @@ are different, and each of them is what removing the reader costs:
   answer for every clone it made, or one `wf` could not ask, collects nothing
   and says so. That single asymmetry is also the version gate.
 - **A surprise stops the whole step.** A node it reads as anything other than
-  finished — a `warn` row, a ticket state this binary cannot place — and nothing
-  is deleted at all, not even the rows it did understand. It exits non-zero
-  saying which workspace and why, and points at `wf reap`.
+  finished — a ticket the tracker still has open, a `warn` row, a state this
+  binary cannot place — and nothing is deleted at all, not even the rows it did
+  understand. The run's whole authority here is that it drove these nodes to
+  done, so the tracker contradicting it about one of them puts the rest of the
+  same command in doubt. It exits non-zero saying which workspace and why, and
+  points at `wf reap`.
+
+  A workspace *kept* is not a surprise: `dl` saying a clone holds work that
+  exists nowhere else, or devpod saying the container is still up, is the step
+  working. Those rows are printed, the finished workspaces beside them are still
+  collected, and the run ends green — a last push that failed is a thing to
+  report, not a thing to stop for.
 
 There is **no `-f`**, in any spelling: the argv that reaches this command has no
 field a waiver could be set in. `-f` waives the guard the recoverability floor

--- a/skills/wf-auto/SKILL.md
+++ b/skills/wf-auto/SKILL.md
@@ -102,6 +102,20 @@ Then take the next unblocked ticket. The run ends when the frontier is empty, ev
 
 A ticket found **effectively complete** — overtaken by another decision, or done as a side effect — skips to step 4: comment why, close, index.
 
+## Clean up what this run finished
+
+The run's last act, once the summary is settled: collect the workspaces of the tickets **this run itself closed**, and nothing else.
+
+```
+wf reap --finished <owner/repo#n> [<owner/repo#n> ...]
+```
+
+Name every ticket this run closed, in full, owner included. The scope is the whole of the authority here — the agent that just settled those facts is the only reader there is, and it can vouch for exactly the nodes it drove to done. An unscoped `wf reap` is a person's command over their whole machine; this is one run tidying up after itself, which is why nothing fires on a timer or on startup and why a run that closed nothing runs nothing.
+
+Report what it removed and what it kept, both, in the closing summary. The kept lines are the ones worth reading: a workspace stays when its branch never reached a remote, and that line is the only notice anyone gets that the work exists in one place only. A workspace whose container is still up stays too — including, ordinarily, the one this run is sitting in.
+
+It can also stop having deleted nothing, and say why: a node it read as something other than finished, or a `dl` that will not say what a clone holds. That is a report, not an obstacle — put it in the summary and leave the workspaces where they are. **Never** reach past it: not `-f`, which waives the guard the whole step rests on and is never automatic in any mode, and not an unscoped `wf reap -y`, which is the sweep this deliberately is not.
+
 ## Where it stops
 
 Park a ticket — a `### handoff` comment on it, then carry on with other unblocked work — when resolving it would:

--- a/skills/wf-auto/SKILL.md
+++ b/skills/wf-auto/SKILL.md
@@ -114,7 +114,7 @@ Name every ticket this run closed, in full, owner included. The scope is the who
 
 Report what it removed and what it kept, both, in the closing summary. The kept lines are the ones worth reading: a workspace stays when its branch never reached a remote, and that line is the only notice anyone gets that the work exists in one place only. A workspace whose container is still up stays too — including, ordinarily, the one this run is sitting in.
 
-It can also stop having deleted nothing, and say why: a node it read as something other than finished, or a `dl` that will not say what a clone holds. That is a report, not an obstacle — put it in the summary and leave the workspaces where they are. **Never** reach past it: not `-f`, which waives the guard the whole step rests on and is never automatic in any mode, and not an unscoped `wf reap -y`, which is the sweep this deliberately is not.
+It can also stop having deleted nothing, and say why: a node it read as something other than finished — a ticket the tracker still has open is the commonest, and it means this run and the tracker disagree about a node this run vouched for — or a `dl` that will not say what a clone holds. That is a report, not an obstacle — put it in the summary and leave the workspaces where they are. **Never** reach past it: not `-f`, which waives the guard the whole step rests on and is never automatic in any mode, and not an unscoped `wf reap -y`, which is the sweep this deliberately is not.
 
 ## Where it stops
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,12 @@
 //!
 //! This file is argv and nothing else: it decides what was asked for and hands
 //! it to whoever answers. `wf skills` is [`run_skills`] here because linking a
-//! directory is a few lines; `wf reap` is [`wf::reap::run`] in the *library*,
-//! because reaping deletes workspaces and the deletion it calls
-//! ([`wf::reap`]'s private `remove`) is not something this crate may name. The
-//! picker is [`picker`], a module of its own.
+//! directory is a few lines; both reaps — `wf reap` ([`wf::reap::run`]) and the
+//! scoped `wf reap --finished` an autonomous run ends with
+//! ([`wf::reap::cleanup`]) — are in the *library*, because reaping deletes
+//! workspaces and the deletion they call ([`wf::reap`]'s private `remove`) is
+//! not something this crate may name. The picker is [`picker`], a module of its
+//! own.
 //!
 //! Half of that arrangement is a fact about visibility, and needs no checking:
 //! the deletion is private to a module in another crate, so no alias, helper or
@@ -50,6 +52,8 @@
 //! neither is a second name for the module re-exported from the library. See
 //! [`picker`] for the guard that watches a run rather than a file, and #137 for
 //! the crate split that would settle it.
+
+use std::collections::BTreeSet;
 
 use anyhow::Result;
 use tokio::signal::unix::{signal, SignalKind};
@@ -79,18 +83,36 @@ enum Invocation {
     /// Link the bundled skills into Claude Code's and Codex's personal skills
     /// directories.
     SkillsInstall,
-    /// Remove the workspaces whose tickets are closed. `yes` skips the prompt;
-    /// `insist` also reaps workspaces holding work that is not pushed anywhere,
-    /// which is what a devcontainer that dirties its own checkout on every
-    /// build leaves behind.
-    Reap {
-        yes: bool,
-        insist: bool,
-    },
+    /// Remove the workspaces whose tickets are finished, over the scope the
+    /// argv chose.
+    Reap(ReapScope),
     /// Print to stdout, exit 0.
     Print(String),
     /// Print to stderr, exit 2.
     Reject(String),
+}
+
+/// Which workspaces a reap is about — the two commands that share the verb.
+///
+/// A sum rather than a scope field beside the flags, because the flags do not
+/// mean the same things on both sides and one of them must not exist at all on
+/// the second: `-f` waives `dl`'s unsaved-work guard, and the unattended path's
+/// whole safety argument is that the guard holds. There is no field here for it
+/// to be set in, so no argv this parser accepts can force an unattended
+/// deletion — that is the ticket's "never automatic in any mode" as a shape
+/// rather than as a check somebody has to keep passing.
+///
+/// A prompt is the same story: [`ReapScope::Finished`] carries no `yes`,
+/// because the agent that just drove those tickets to done is the reader and
+/// there is nobody left to ask.
+#[derive(Debug, PartialEq, Eq)]
+enum ReapScope {
+    /// `wf reap [-y] [-f]` — every wayfinder workspace on the machine, planned
+    /// for a human to read and confirm.
+    Machine { yes: bool, insist: bool },
+    /// `wf reap --finished <owner/repo#n>…` — the nodes an autonomous run
+    /// itself drove to done, and only those (#151).
+    Finished(BTreeSet<reap::Node>),
 }
 
 const USAGE: &str = "\
@@ -99,6 +121,7 @@ wf — the multi-project wayfinder ticket selector
 usage: wf [--version | --help]
        wf skills [install]
        wf reap [-y] [-f]
+       wf reap --finished <owner/repo#n>...
 
 With no arguments: opens on the project you are standing in, or on the list of
 every registered project — most recently used first — when you are not standing
@@ -116,6 +139,12 @@ wf reap            remove the workspaces whose work is over — a closed ticket,
                    running or holding work that is not pushed anywhere; -f
                    reaps the unpushed ones too, naming what it discards.
                    Needs dl 0.0.21 or newer.
+wf reap --finished the cleanup an autonomous run ends with: the same reading,
+                   scoped to the tickets that run itself drove to done and to
+                   nothing else on the machine. Never prompts, deletes only a
+                   workspace dl has said is fully pushed, and stops without
+                   deleting anything if it meets a row it did not expect. There
+                   is no -f here, in any spelling.
 
 The skills wf execs ship in this package, so they update with it. `install`
 links both agents' skills directories at copies kept beside them; every launch
@@ -144,10 +173,10 @@ fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Invocation {
             "--version" | "-V" => Invocation::Print(format!("wf {}", env!("CARGO_PKG_VERSION"))),
             "--help" | "-h" => Invocation::Print(USAGE.to_string()),
             "skills" => Invocation::SkillsReport,
-            "reap" => Invocation::Reap {
+            "reap" => Invocation::Reap(ReapScope::Machine {
                 yes: false,
                 insist: false,
-            },
+            }),
             other => Invocation::Reject(format!("wf: unknown argument {other:?}\n{USAGE}")),
         },
         [first, second] if first == "skills" => match second.as_str() {
@@ -163,29 +192,65 @@ fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Invocation {
     }
 }
 
-/// Parse `wf reap`'s flags, which unlike every other `wf` argument may be
+/// Parse `wf reap`'s arguments, which unlike every other `wf` argument may be
 /// combined and given in any order.
 ///
 /// Rejecting an unknown flag rather than ignoring it matters more here than
-/// anywhere else in this parser: the two flags waive a confirmation and a
-/// safety guard, so a typo that were quietly dropped would leave someone
-/// believing they had asked for something they had not — and a mistyped `-y`
-/// that silently opened a prompt is a much better outcome than a mistyped `-f`
-/// that silently did nothing.
-fn parse_reap(flags: &[String]) -> Invocation {
-    let (mut yes, mut insist) = (false, false);
-    for flag in flags {
-        match flag.as_str() {
+/// anywhere else in this parser: the flags waive a confirmation and a safety
+/// guard, so a typo that were quietly dropped would leave someone believing
+/// they had asked for something they had not — and a mistyped `-y` that
+/// silently opened a prompt is a much better outcome than a mistyped `-f` that
+/// silently did nothing.
+///
+/// The same posture decides the three combinations refused below rather than
+/// resolved. `--finished` with `-f` is the one this ticket exists for: those
+/// two together spell an unattended deletion with `dl`'s unsaved-work guard
+/// waived, which is the one thing no mode of `wf` may do, so it is rejected at
+/// the argv rather than ignored inside the command. `--finished` with `-y` is
+/// refused because that path has no prompt to skip, and a flag accepted where
+/// it means nothing teaches a caller it did something. And a node reference
+/// with no `--finished` is a scope with no command to apply it to.
+fn parse_reap(args: &[String]) -> Invocation {
+    let (mut yes, mut insist, mut scoped) = (false, false, false);
+    let mut nodes = BTreeSet::new();
+    for arg in args {
+        match arg.as_str() {
             "-y" | "--yes" => yes = true,
             "-f" | "--force" => insist = true,
-            other => {
-                return Invocation::Reject(format!(
-                    "wf: unknown reap argument {other:?} (expected `-y` or `-f`)\n{USAGE}"
-                ))
-            }
+            "--finished" => scoped = true,
+            other => match reap::Node::parse(other) {
+                Some(node) => {
+                    nodes.insert(node);
+                }
+                None => {
+                    return Invocation::Reject(format!(
+                        "wf: unknown reap argument {other:?} (expected `-y`, `-f`, \
+                         `--finished`, or a node like `owner/repo#151`)\n{USAGE}"
+                    ))
+                }
+            },
         }
     }
-    Invocation::Reap { yes, insist }
+    match (scoped, insist, yes, nodes.is_empty()) {
+        (true, true, _, _) => Invocation::Reject(format!(
+            "wf: -f is never automatic — `--finished` waives no guard of dl's, \
+             in any mode\n{USAGE}"
+        )),
+        (true, _, true, _) => Invocation::Reject(format!(
+            "wf: -y says nothing beside `--finished` — that cleanup never \
+             prompts\n{USAGE}"
+        )),
+        (true, _, _, true) => Invocation::Reject(format!(
+            "wf: `--finished` needs the nodes the run drove to done, like \
+             `owner/repo#151`\n{USAGE}"
+        )),
+        (false, _, _, false) => Invocation::Reject(format!(
+            "wf: a node belongs to `--finished` — an unscoped reap is about \
+             every workspace on the machine\n{USAGE}"
+        )),
+        (true, _, _, false) => Invocation::Reap(ReapScope::Finished(nodes)),
+        (false, _, _, true) => Invocation::Reap(ReapScope::Machine { yes, insist }),
+    }
 }
 
 /// `wf skills` and `wf skills install`. Both resolve the bundle and the target
@@ -282,7 +347,11 @@ async fn main() -> Result<()> {
         // merely exists says nothing about the rest of the file, and a prologue
         // before this match is how an earlier round deleted a workspace on
         // `wf --version`.
-        Invocation::Reap { yes, insist } => reap::run(yes, insist).await,
+        Invocation::Reap(ReapScope::Machine { yes, insist }) => reap::run(yes, insist).await,
+        // The unattended sibling, and the argv that reaches it can set neither
+        // flag: `ReapScope::Finished` has no field for a waiver or a prompt, so
+        // this arm cannot spell `reap::run(true, true)` however it is edited.
+        Invocation::Reap(ReapScope::Finished(nodes)) => reap::cleanup(&nodes).await,
         // And the one shape that opens the TUI, which is the whole of what this
         // arm may do — the picker is handed the process, not a deletion, and
         // this line is what keeps the rest of this file out of its path.
@@ -461,12 +530,24 @@ mod tests {
         // workspace and exited 0.
         //
         // So this is the whole list of lines of *code* in this file that write
-        // the word `reap`, compared as a list rather than as a count. All five
-        // are code: the import, the two parse arms — one of which calls
-        // `parse_reap` — the rejection message, and the dispatch arm that calls
-        // `reap::run`. The help text is cut out first (see `without_usage`),
-        // because it is prose and pinning its line wrapping here made the guard
-        // fail on rewraps and say something untrue when it did.
+        // the word `reap`, compared as a list rather than as a count. All nine
+        // are code: the import, the scope type's node field, the two parse arms
+        // — one of which calls `parse_reap` — the node parse the scoped form
+        // needs, two rejection messages, and the two dispatch arms. The help
+        // text is cut out first (see `without_usage`), because it is prose and
+        // pinning its line wrapping here made the guard fail on rewraps and say
+        // something untrue when it did.
+        //
+        // Four of the nine arrived with the unattended cleanup (#151), and what
+        // this guard is worth is different for that arm than for the one above
+        // it. `reap::run(true, true)` is a forced deletion, so the list is what
+        // stands between this file and one; `reap::cleanup` takes a scope and
+        // no flags, and there is no argument to it that waives anything. The
+        // reason it is still listed is the *scope*: a line reaching that
+        // function with a set this file assembled somewhere other than the
+        // parse arm — a default, a widening, every node of a map — would be an
+        // unattended deletion nobody asked for, and it would have to write this
+        // word to get there.
         //
         // Any new line of code *this reads* that writes the word fails here,
         // whatever it writes around it: an alias (`use wf::reap as tidy;`,
@@ -495,10 +576,14 @@ mod tests {
             lines_naming(&without_usage(&code), "reap"),
             [
                 "use wf::reap;",
-                "\"reap\" => Invocation::Reap {", // }
+                "Finished(BTreeSet<reap::Node>),",
+                "\"reap\" => Invocation::Reap(ReapScope::Machine {", // }
                 "[first, rest @ ..] if first == \"reap\" => parse_reap(rest),",
-                "\"wf: unknown reap argument {other:?} (expected `-y` or `-f`)\\n{USAGE}\"",
-                "Invocation::Reap { yes, insist } => reap::run(yes, insist).await,",
+                "other => match reap::Node::parse(other) {", // }
+                "\"wf: unknown reap argument {other:?} (expected `-y`, `-f`, \\",
+                "\"wf: a node belongs to `--finished` — an unscoped reap is about \\",
+                "Invocation::Reap(ReapScope::Machine { yes, insist }) => reap::run(yes, insist).await,",
+                "Invocation::Reap(ReapScope::Finished(nodes)) => reap::cleanup(&nodes).await,",
             ],
             "the lines of code in this file that write `reap` are no longer the five \
              listed here. A line that is not in the list is a way this binary reaches \
@@ -577,24 +662,24 @@ mod tests {
     fn reap_takes_its_two_flags_in_any_order_or_neither() {
         assert_eq!(
             parse_args(argv(&["reap"])),
-            Invocation::Reap {
+            Invocation::Reap(ReapScope::Machine {
                 yes: false,
                 insist: false
-            }
+            })
         );
         assert_eq!(
             parse_args(argv(&["reap", "-y"])),
-            Invocation::Reap {
+            Invocation::Reap(ReapScope::Machine {
                 yes: true,
                 insist: false
-            }
+            })
         );
         assert_eq!(
             parse_args(argv(&["reap", "-f"])),
-            Invocation::Reap {
+            Invocation::Reap(ReapScope::Machine {
                 yes: false,
                 insist: true
-            }
+            })
         );
         // Both, either way round, long or short: these waive a prompt and a
         // safety guard, so the shapes someone will actually type all have to
@@ -606,12 +691,115 @@ mod tests {
         ] {
             assert_eq!(
                 parse_args(argv(&both)),
-                Invocation::Reap {
+                Invocation::Reap(ReapScope::Machine {
                     yes: true,
                     insist: true
-                },
+                }),
                 "{both:?}"
             );
+        }
+    }
+
+    /// The nodes a scoped reap parsed, by name, or `None` if it was not one.
+    fn scoped(invocation: &Invocation) -> Option<Vec<String>> {
+        match invocation {
+            Invocation::Reap(ReapScope::Finished(nodes)) => {
+                Some(nodes.iter().map(reap::Node::name).collect())
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn a_scoped_reap_carries_the_nodes_the_run_finished_and_nothing_else() {
+        // The argv an autonomous run's cleanup step writes. Two repos on one
+        // line, because a run can walk a map whose build tickets landed in more
+        // than one — and the owner is spelt out on each, since that is what
+        // decides whose tracker is asked and therefore what may be deleted.
+        assert_eq!(
+            scoped(&parse_args(argv(&[
+                "reap",
+                "--finished",
+                "blooop/wayfinder#151",
+                "blooop/devlaunch#80",
+            ]))),
+            Some(vec![
+                "devlaunch#80".to_string(),
+                "wayfinder#151".to_string()
+            ])
+        );
+        // The flag may come after the nodes it scopes, like every other reap
+        // argument.
+        assert_eq!(
+            scoped(&parse_args(argv(&[
+                "reap",
+                "blooop/wayfinder#151",
+                "--finished"
+            ]))),
+            Some(vec!["wayfinder#151".to_string()])
+        );
+    }
+
+    #[test]
+    fn the_unattended_cleanup_has_no_argv_that_forces_it() {
+        // The ticket's rule as a rejection: `-f` waives the unsaved-work guard
+        // that the unattended path's whole recoverability floor is built on,
+        // and it stays a human's to type. Both spellings, and the message says
+        // which rule it is rather than only that something was wrong.
+        for forced in [
+            vec!["reap", "--finished", "blooop/wayfinder#151", "-f"],
+            vec!["reap", "-f", "--finished", "blooop/wayfinder#151"],
+            vec!["reap", "--force", "--finished", "blooop/wayfinder#151"],
+        ] {
+            match parse_args(argv(&forced)) {
+                Invocation::Reject(message) => assert!(
+                    message.contains("-f is never automatic"),
+                    "{forced:?}: {message}"
+                ),
+                other => panic!("expected a rejection of {forced:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn the_scoped_forms_that_mean_nothing_are_refused_rather_than_guessed_at() {
+        // Three ways of half-writing the command, each rejected by the thing it
+        // is missing. A scope with nothing in it would otherwise read as "the
+        // run finished nothing", which is indistinguishable from success and is
+        // the reading that lets a broken caller's cleanup pass unnoticed.
+        for (args, expected) in [
+            (vec!["reap", "--finished"], "needs the nodes"),
+            (
+                vec!["reap", "--finished", "blooop/wayfinder#151", "-y"],
+                "never prompts",
+            ),
+            (
+                vec!["reap", "blooop/wayfinder#151"],
+                "belongs to `--finished`",
+            ),
+        ] {
+            match parse_args(argv(&args)) {
+                Invocation::Reject(message) => {
+                    assert!(message.contains(expected), "{args:?}: {message}");
+                }
+                other => panic!("expected a rejection of {args:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_node_this_binary_cannot_place_is_rejected_rather_than_scoped_away() {
+        // A reference without an owner names no repository, so there is no
+        // tracker to ask and no way to know whose workspaces are in question.
+        // Dropping it would silently shrink the scope, which is the failure
+        // direction that leaves workspaces behind rather than deletes extra —
+        // and still a caller believing it asked for something it did not.
+        match parse_args(argv(&["reap", "--finished", "wayfinder#151"])) {
+            Invocation::Reject(message) => {
+                assert!(message.contains("wayfinder#151"), "{message}");
+                assert!(message.contains("owner/repo#151"), "{message}");
+            }
+            other => panic!("expected a rejection, got {other:?}"),
         }
     }
 
@@ -668,6 +856,62 @@ mod tests {
             Invocation::Reject(message) => assert!(message.contains("too many"), "{message}"),
             other => panic!("expected a rejection, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn the_cleanup_the_autonomous_skill_prints_is_one_this_binary_accepts() {
+        // The skills are what `wf` execs, so the command `wf-auto` tells an
+        // unattended run to end with is this binary's behaviour as much as the
+        // parser is — and the two ship in one package and can drift in one
+        // edit. So the documented line is read out of the skill and handed to
+        // the real parser, with its placeholders filled in and nothing else
+        // changed.
+        //
+        // Both directions bite. Renaming the flag here without touching the
+        // skill leaves every autonomous run ending in a rejection; editing the
+        // skill to say `-f` — the one thing that must never be automatic —
+        // fails on the rejection the parser already makes.
+        let skill = include_str!("../skills/wf-auto/SKILL.md");
+        let block = skill
+            .split_once("## Clean up what this run finished")
+            .expect("wf-auto documents the cleanup step")
+            .1
+            .split("```")
+            .nth(1)
+            .expect("and gives it as a command block");
+        let filled = block
+            .replace(
+                "<owner/repo#n> [<owner/repo#n> ...]",
+                "blooop/wayfinder#151",
+            )
+            .trim()
+            .to_string();
+        assert_eq!(filled, "wf reap --finished blooop/wayfinder#151");
+        let typed: Vec<String> = filled
+            .split_whitespace()
+            .skip(1)
+            .map(String::from)
+            .collect();
+        assert!(
+            matches!(
+                parse_args(typed),
+                Invocation::Reap(ReapScope::Finished(ref nodes)) if nodes.len() == 1
+            ),
+            "the command wf-auto prints is not one this binary parses as a \
+             scoped cleanup: {filled}"
+        );
+    }
+
+    #[test]
+    fn the_usage_names_the_scoped_reap_and_says_it_cannot_be_forced() {
+        // The help is where a command is discoverable, and the two facts a
+        // reader has to be able to find without running it are that the scoped
+        // form exists and that no flag of it waives a guard.
+        assert!(USAGE.contains("wf reap --finished"), "{USAGE}");
+        assert!(
+            USAGE.contains("There\n                   is no -f here"),
+            "{USAGE}"
+        );
     }
 
     #[test]

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -545,6 +545,29 @@ pub const DL_LISTING_UNSAVED: &str = r#"[
   {"id":"not-ours","devlaunch":false,"state":"Stopped"}
 ]"#;
 
+/// [`DL_LISTING`] as devlaunch **0.0.23** would have written it.
+///
+/// The same four workspaces, the same repo and branches, and one field
+/// different: `unsaved` is `null` on every clone, because that release wrote a
+/// bare sentence when `git` reported something and nothing at all when it did
+/// not. On that `dl`, `null` on a clone of its own *is* the clean answer, which
+/// is why `wf reap` collects on it — and why the autonomous cleanup does not,
+/// since "the release that wrote this meant clean" is a fact about a version
+/// rather than about a clone.
+///
+/// Paired with `record_as_dl(…, "0.0.23")` and only with it: this listing and
+/// [`SHIMMED_DL`] together would be a machine that does not exist.
+pub const DL_LISTING_LEGACY: &str = r#"[
+  {"id":"wf-129-closed","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-129","state":"Stopped","unsaved":null},
+  {"id":"wf-138-unstarted","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-138","state":"Stopped","unsaved":null},
+  {"id":"wf-137-open","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-137","state":"Running","unsaved":null},
+  {"id":"wf-134-stalled","devlaunch":true,"repo":"blooop/wayfinder",
+   "branch":"wayfinder/wayfinder-134","state":"Stopped","unsaved":null}
+]"#;
+
 /// The tracker's answer to the batched question those four nodes raise:
 /// #129 closed (a reap), #138 open with nobody on it and no PR (a warning),
 /// #137 open and claimed (a keep, and — its container being up — a `▣`),

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -29,6 +29,19 @@
 //! is why [`Verdict::Warn`] exists and why [`doomed`] is the single place that
 //! decides what actually goes.
 //!
+//! Two commands come out of that one decision, and they differ only in who is
+//! reading. [`run`] is `wf reap`: every workspace on the machine, a plan
+//! printed, a prompt. [`cleanup`] is what an autonomous run ends with (#151):
+//! the same [`plan`] and the same [`doomed`], narrowed to the nodes that run
+//! itself drove to done, with no prompt because the agent that just settled
+//! those facts is the reader — and with the guard tightened where losing the
+//! reader costs something. [`decide`] is that narrowing, and everything it does
+//! subtracts: a recoverability floor `dl` has to answer *positively*, and a
+//! full stop on any row the step did not expect. `-f` never reaches the second
+//! one — the binary's scoped argv has no field it could be set in — because it
+//! waives the guard the floor is built on, and that stays a human's to type in
+//! every mode.
+//!
 //! The *deciding* is all here; the *noticing* is [`reclaim`](crate::reclaim),
 //! which calls [`plan`] and [`doomed`] behind the picker so `wf` can say what a
 //! reap would claim without being asked (#137). It adds no deletion path — it
@@ -531,6 +544,28 @@ impl Node {
     pub fn name(&self) -> String {
         format!("{}#{}", short_repo(&self.repo), self.number)
     }
+
+    /// Read a node reference as an autonomous run names one on the command
+    /// line: `owner/repo#number`.
+    ///
+    /// The **owner is required**, unlike [`Node::name`]'s display form, and
+    /// that asymmetry is deliberate: the short name is for a reader who already
+    /// knows which machine they are looking at, while this is what decides
+    /// which repository's tracker is asked and therefore which workspaces are
+    /// eligible to be deleted. A reference the caller has to spell in full
+    /// cannot be resolved against the wrong repo by whatever the cwd happened
+    /// to be.
+    pub fn parse(reference: &str) -> Option<Node> {
+        let (repo, number) = reference.split_once('#')?;
+        let (owner, name) = repo.split_once('/')?;
+        if owner.is_empty() || name.is_empty() || name.contains('/') {
+            return None;
+        }
+        Some(Node {
+            repo: repo.to_string(),
+            number: number.parse().ok()?,
+        })
+    }
 }
 
 /// Which node a workspace is for, or `None` if it is not one of `wf`'s.
@@ -670,6 +705,200 @@ pub fn plan(
 
 fn short_repo(slug: &str) -> &str {
     slug.split('/').next_back().unwrap_or(slug)
+}
+
+/// One workspace the autonomous cleanup has cleared for deletion.
+///
+/// Its fields are private and it has no constructor: the only way to hold one
+/// is to have been handed it by [`decide`], which is the one place the
+/// recoverability floor below is asserted. [`cleanup`] deletes these and
+/// nothing else, so "deleted without the floor being checked" is a value that
+/// cannot be built rather than a rule a reader has to notice was kept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cleared {
+    id: String,
+    reason: String,
+}
+
+impl Cleared {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Why it goes — [`plan`]'s own words, carried through unedited, because a
+    /// run reporting a deletion in words of its own would be a second account
+    /// of a decision this module already made.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+/// What the cleanup step at the end of an autonomous run decided about the
+/// nodes that run drove to done (#151).
+///
+/// Two outcomes and no third, because "some of it" is the shape this must not
+/// have: a step that proceeded with the rows it understood and skipped the one
+/// it did not is a misreading acted on one workspace at a time. Either every
+/// scoped row was one of the two the step expects — a workspace to collect, or
+/// a workspace kept for a reason `dl` or devpod stated — or nothing is deleted
+/// at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Cleanup {
+    /// Collect `going`; report `kept` and leave it.
+    ///
+    /// `kept` is [`plan`]'s own `Keep` rows for the run's nodes, unedited. It
+    /// is reported rather than dropped because a workspace the run expected to
+    /// go and that stayed is the thing whoever reads the run's summary most
+    /// needs told — a branch that never reached the remote reads exactly like
+    /// this, and reads like nothing at all if the row is silent.
+    Proceed {
+        going: Vec<Cleared>,
+        kept: Vec<Verdict>,
+    },
+    /// Delete nothing, and say what stopped it.
+    Abort(Unexpected),
+}
+
+/// What the cleanup step saw that it did not expect.
+///
+/// Both arms are the same shape of surprise — the run believed a node was
+/// finished, and this module's own reading of that node's workspace says
+/// something the step has no authority to interpret unattended. They are
+/// separate arms because they send a reader to different places: the first to
+/// the tracker, the second to `dl`.
+///
+/// The other two ways an autonomous cleanup can be surprised are not here
+/// because they are already errors: a listing that will not parse and a tracker
+/// that will not answer both fail [`workspaces`] and [`node_facts`], before any
+/// decision exists to be made. Failing there and stopping here are the same
+/// outcome — nothing deleted, and a run that says why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Unexpected {
+    /// [`plan`] warned about a node this run believed it had just settled.
+    ///
+    /// `Warn` is display-only everywhere in this module (#128), and a warning
+    /// is precisely `wf` unsure. Unattended, the two readings disagreeing is
+    /// the case with nobody present to adjudicate it, so the step stops rather
+    /// than treating its own belief as the tie-break.
+    Warned { id: String, reason: String },
+    /// [`plan`] would collect a workspace `dl` has not said is recoverable.
+    ///
+    /// `said` is the reason in the words the row would have carried.
+    Unrecoverable { id: String, said: String },
+}
+
+impl Unexpected {
+    /// One line naming what stopped the step, for the run's own report.
+    pub fn report(&self) -> String {
+        match self {
+            Self::Warned { id, reason } => {
+                format!("{id} is not a workspace this run may collect: {reason}")
+            }
+            Self::Unrecoverable { id, said } => {
+                format!("{id} is not established as recoverable: {said}")
+            }
+        }
+    }
+}
+
+/// Why this workspace is not one an autonomous cleanup may delete, or `None`
+/// when `dl` positively said every byte of its clone exists somewhere else.
+///
+/// **The recoverability floor, and the whole of it.** It is a different
+/// question from the one [`plan`] asks, and deliberately stricter in one place:
+/// `plan` keeps a workspace whose `unsaved` *refuses*, and a workspace with no
+/// answer at all therefore passes it. That is right for `wf reap` — a `dl` too
+/// old to answer for every clone it made meant `null` as "clean", and a human
+/// is reading the row either way. It is not right here, where the reader is
+/// gone: the floor wants a fact `dl` **said**, and the absence of a refusal is
+/// not one.
+///
+/// That single asymmetry is also the version gate. A `dl` below
+/// [`UNSAVED_IS_AN_OBJECT`](crate::launch::UNSAVED_IS_AN_OBJECT), or one `wf`
+/// could not probe at all, leaves every clean clone answerless — so a run
+/// against a skewed pair collects nothing and says so, rather than deleting on
+/// a reading whose meaning depends on which release wrote it.
+fn unrecoverable(unsaved: Option<&Unsaved>) -> Option<String> {
+    match unsaved {
+        // The one answer that clears a workspace, and it has to be *that*
+        // answer: this is the floor asserted rather than inferred from nothing
+        // having objected.
+        Some(Unsaved::NothingToLose) => None,
+        // Every other arm already phrases its own refusal for the plan, so the
+        // row reads the same way in both commands. The fallback is unreachable
+        // rather than defensive: it is here so that an arm added to `Unsaved`
+        // which forgot to refuse keeps *this* side closed until somebody means
+        // to open it.
+        Some(other) => Some(
+            other
+                .refusal()
+                .unwrap_or_else(|| format!("dl said something this wf cannot weigh: {other:?}")),
+        ),
+        None => Some("dl did not say what this clone holds".to_string()),
+    }
+}
+
+/// Read a plan the way the cleanup step at the end of an autonomous run reads
+/// it: scoped to the nodes that run drove to done, and refusing anything else.
+///
+/// `verdicts` is [`plan`]'s output and `going` is [`doomed`]'s answer over it —
+/// called, never re-derived (#137). This function adds no definition of what is
+/// finished; what it adds is a *narrower* one of what may be deleted with
+/// nobody watching, and it can only ever subtract.
+///
+/// Three rules, in the order they matter:
+///
+/// - **Scope.** A workspace whose node is not one of `scope` is not looked at.
+///   That is #72's no-sweep posture kept by construction rather than by
+///   promising not to schedule anything: the step cannot reach a workspace the
+///   run did not finish, so there is nothing for a timer to fire.
+/// - **The floor.** A scoped workspace [`doomed`] names is cleared only if
+///   the recoverability floor — `unrecoverable`, below — says nothing about it.
+///   Anything else stops the step.
+/// - **Surprise stops everything.** A scoped `Warn` — `wf` unsure about a node
+///   this run believed settled — is [`Unexpected::Warned`], and the step
+///   deletes nothing at all, not even the rows it did understand.
+///
+/// `insist` has no counterpart here and never will: `-f` waives the guard that
+/// makes the floor meaningful, and it stays a human's to type.
+pub fn decide(workspaces: &[Workspace], verdicts: &[Verdict], scope: &BTreeSet<Node>) -> Cleanup {
+    let mine = |id: &str| -> Option<&Workspace> {
+        workspaces
+            .iter()
+            .find(|w| w.id == id)
+            .filter(|w| node_of(w).is_some_and(|n| scope.contains(&n)))
+    };
+    // Asked for rather than re-derived, and asked for once: `doomed` is the one
+    // definition of what goes, so the loop below decides only whether a
+    // workspace it already named may go *unattended*.
+    let condemned: BTreeSet<&str> = doomed(verdicts).into_iter().map(Verdict::id).collect();
+    let mut going = Vec::new();
+    let mut kept = Vec::new();
+    for verdict in verdicts {
+        let Some(workspace) = mine(verdict.id()) else {
+            continue;
+        };
+        if condemned.contains(verdict.id()) {
+            if let Some(said) = unrecoverable(workspace.unsaved.as_ref()) {
+                return Cleanup::Abort(Unexpected::Unrecoverable {
+                    id: verdict.id().to_string(),
+                    said,
+                });
+            }
+            going.push(Cleared {
+                id: verdict.id().to_string(),
+                reason: verdict.reason().to_string(),
+            });
+        } else if let Verdict::Warn { id, reason } = verdict {
+            return Cleanup::Abort(Unexpected::Warned {
+                id: id.clone(),
+                reason: reason.clone(),
+            });
+        } else {
+            kept.push(verdict.clone());
+        }
+    }
+    Cleanup::Proceed { going, kept }
 }
 
 /// Ask `dl` what workspaces exist and what they hold.
@@ -1064,6 +1293,90 @@ pub async fn run(yes: bool, insist: bool) -> Result<()> {
             Err(e) => {
                 emit(&format!("could not remove {}: {e}\n", verdict.id()));
                 failed.push(verdict.id().to_string());
+            }
+        }
+    }
+    if !failed.is_empty() {
+        bail!("{} workspace(s) could not be removed", failed.len());
+    }
+    Ok(())
+}
+
+/// `wf reap --finished <node>…`: the cleanup step an autonomous run ends with.
+///
+/// The other half of [`run`], and the halves differ in exactly three things.
+/// It is **scoped** — to the nodes the run itself drove to done, so nothing
+/// else on the machine is looked at and #72's no-sweep posture survives
+/// automation. It **does not ask**, because the agent that just settled those
+/// facts is the reader, and there is nobody else to answer a prompt. And it
+/// **refuses more than it is asked to**: [`decide`] holds every scoped
+/// workspace to a recoverability floor `wf reap` does not apply, and stops the
+/// whole step on anything it did not expect.
+///
+/// There is no `insist` parameter and no argv that produces one. `-f` waives
+/// `dl`'s unsaved-work guard — the guard the floor is built out of — and it
+/// stays a human's to type, in every mode.
+///
+/// The tracker is asked only about the scoped nodes that actually have a
+/// workspace, so a run that finished ten tickets and left one workspace behind
+/// asks about one.
+///
+/// # Errors
+///
+/// A listing or a tracker query that failed, a workspace `dl` would not remove,
+/// and — the arm this command adds — a [`Cleanup::Abort`]. All four are the
+/// same outcome from where the run is standing: nothing was deleted, and the
+/// exit code says so rather than leaving a refusal to be skimmed past in a log.
+pub async fn cleanup(scope: &BTreeSet<Node>) -> Result<()> {
+    use std::fmt::Write;
+
+    use crate::emit;
+
+    let workspaces = workspaces().await?;
+    let wanted: BTreeSet<Node> = workspaces
+        .iter()
+        .filter_map(node_of)
+        .filter(|node| scope.contains(node))
+        .collect();
+    if wanted.is_empty() {
+        emit("nothing this run finished has a workspace left on this machine\n");
+        return Ok(());
+    }
+    let known = node_facts(&wanted).await?;
+    let verdicts = plan(&workspaces, &known, false);
+
+    let (going, kept) = match decide(&workspaces, &verdicts, scope) {
+        Cleanup::Abort(unexpected) => bail!(
+            "cleanup stopped and deleted nothing: {}\n\
+             (run `wf reap` to see every workspace on this machine and decide by hand)",
+            unexpected.report()
+        ),
+        Cleanup::Proceed { going, kept } => (going, kept),
+    };
+
+    // What stayed, before what goes, for the reason [`run`] prints its plan in
+    // that order: the workspace somebody expected to be collected and that was
+    // not is the row worth reading, and here it is the only sign that a branch
+    // never reached the remote.
+    let mut out = String::new();
+    for verdict in &kept {
+        let _ = writeln!(out, "  kept     {}  ({})", verdict.id(), verdict.reason());
+    }
+    emit(&out);
+
+    // One at a time and reported as they go, exactly as [`run`] does it: a
+    // failure part-way through leaves a set the next run has to make sense of.
+    let mut failed = Vec::new();
+    for cleared in &going {
+        match remove(cleared.id(), false).await {
+            Ok(()) => emit(&format!(
+                "  removed  {}  ({})\n",
+                cleared.id(),
+                cleared.reason()
+            )),
+            Err(e) => {
+                emit(&format!("  failed   {}  ({e})\n", cleared.id()));
+                failed.push(cleared.id().to_string());
             }
         }
     }
@@ -2544,6 +2857,402 @@ mod tests {
         );
     }
 
+    // ---- the autonomous cleanup a run ends with (#151) ----
+
+    /// A workspace of this repo whose clone `dl` says is fully pushed — the
+    /// ordinary state the lifecycle's continuous commit-and-push leaves behind,
+    /// and the only one the autonomous cleanup may delete.
+    fn pushed(id: &str, number: u64) -> Workspace {
+        Workspace {
+            unsaved: Some(Unsaved::NothingToLose),
+            ..workspace(
+                id,
+                "blooop/wayfinder",
+                &format!("wayfinder/wayfinder-{number}"),
+            )
+        }
+    }
+
+    /// The nodes a run drove to done, as the cleanup step scopes itself to them.
+    fn finished(numbers: &[u64]) -> BTreeSet<Node> {
+        numbers
+            .iter()
+            .map(|n| node("blooop/wayfinder", *n))
+            .collect()
+    }
+
+    /// The whole step as one call: the plan this repo already makes, read by
+    /// the cleanup. Deliberately built from `plan` rather than from hand-made
+    /// verdicts, so every case below is a claim about what a real reading does.
+    fn cleanup_of(
+        workspaces: &[Workspace],
+        known: &BTreeMap<Node, NodeFact>,
+        scope: &[u64],
+    ) -> Cleanup {
+        decide(
+            workspaces,
+            &plan(workspaces, known, false),
+            &finished(scope),
+        )
+    }
+
+    /// The ids the step would hand `dl`, for the cases that only care about
+    /// that. `Abort` is deliberately not "no ids": a step that stopped and a
+    /// step that found nothing are different outcomes and the tests that mean
+    /// the first say so.
+    fn going(cleanup: &Cleanup) -> Vec<&str> {
+        match cleanup {
+            Cleanup::Proceed { going, .. } => going.iter().map(Cleared::id).collect(),
+            Cleanup::Abort(_) => panic!("the step stopped: {cleanup:?}"),
+        }
+    }
+
+    #[test]
+    fn the_run_collects_the_workspace_of_the_ticket_it_finished() {
+        let workspaces = [pushed("wf-151", 151)];
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        assert_eq!(going(&cleanup_of(&workspaces, &known, &[151])), ["wf-151"]);
+    }
+
+    #[test]
+    fn work_that_exists_nowhere_else_keeps_a_workspace_the_run_believed_finished() {
+        // The recoverability floor, at the arm the spec names: a closed ticket,
+        // no prompt to stop at, and the workspace stays because `dl` says its
+        // clone holds the only copy of something. Kept and *named* — a run that
+        // silently left it would leave nobody to notice the branch never
+        // reached the remote.
+        let mut ws = pushed("wf-151", 151);
+        ws.unsaved = Some(Unsaved::WouldLose("1 unpushed commit(s)".to_string()));
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        let Cleanup::Proceed { going, kept } = cleanup_of(&[ws], &known, &[151]) else {
+            panic!("an unpushed workspace is kept, not a reason to stop");
+        };
+        assert!(going.is_empty(), "nothing may be deleted here");
+        assert_eq!(
+            kept,
+            [Verdict::Keep {
+                id: "wf-151".to_string(),
+                reason: "holds 1 unpushed commit(s)".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn a_clone_dl_never_cleared_stops_the_step_even_where_the_plan_would_reap_it() {
+        // The floor asserted rather than assumed, and the version gate with it.
+        // A `dl` too old to answer for every clone it made — or one `wf` could
+        // not ask — leaves no answer at all, and `plan` reaps on that, because
+        // that is what those releases meant by it and a human is reading the
+        // row. Here nobody is: the step wants a fact `dl` *said*, and the
+        // absence of a refusal is not one.
+        //
+        // This is also the guard that survives `plan` changing under it. The
+        // workspace below is one `plan` puts in the doomed set, so the step is
+        // refusing on its own reading rather than inheriting a keep.
+        let mut ws = pushed("wf-151", 151);
+        ws.unsaved = None;
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        let verdicts = plan(std::slice::from_ref(&ws), &known, false);
+        assert_eq!(
+            doomed(&verdicts).len(),
+            1,
+            "the plan this reads really would have reaped it"
+        );
+        assert_eq!(
+            decide(std::slice::from_ref(&ws), &verdicts, &finished(&[151])),
+            Cleanup::Abort(Unexpected::Unrecoverable {
+                id: "wf-151".to_string(),
+                said: "dl did not say what this clone holds".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_plan_made_with_the_waiver_in_it_still_collects_nothing_unattended() {
+        // "`-f` is never automatic in any mode", pinned at the decision and not
+        // only at the argv that cannot spell it. `plan(_, _, true)` is the
+        // forced plan a human gets after reading what it would discard, and it
+        // puts a workspace holding unpushed work straight into the doomed set.
+        // The floor asks `dl` about the *workspace* rather than asking the plan
+        // how it was made, so the answer does not change — which is what keeps
+        // this true for a caller that has not been written yet.
+        let mut ws = pushed("wf-151", 151);
+        ws.unsaved = Some(Unsaved::WouldLose("1 unpushed commit(s)".to_string()));
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        let forced = plan(std::slice::from_ref(&ws), &known, true);
+        assert_eq!(
+            doomed(&forced).len(),
+            1,
+            "the forced plan this reads really would have reaped it"
+        );
+        assert_eq!(
+            decide(std::slice::from_ref(&ws), &forced, &finished(&[151])),
+            Cleanup::Abort(Unexpected::Unrecoverable {
+                id: "wf-151".to_string(),
+                said: "holds 1 unpushed commit(s)".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn a_warning_where_the_run_believed_its_node_finished_stops_the_whole_step() {
+        // A `Warn` is `wf` unsure about a node this run thinks it just settled,
+        // and the two readings disagreeing is the case nobody is present to
+        // adjudicate. Everything stops — including the sibling workspace whose
+        // own row was a clean reap, because "proceed with the ones I did
+        // understand" is how a misreading gets acted on one workspace at a time.
+        let workspaces = [pushed("wf-150", 150), pushed("wf-151", 151)];
+        let known = facts([
+            (
+                node("blooop/wayfinder", 150),
+                NodeFact::Superseded { pr: 97 },
+            ),
+            (node("blooop/wayfinder", 151), NodeFact::Closed),
+        ]);
+        assert_eq!(
+            cleanup_of(&workspaces, &known, &[150, 151]),
+            Cleanup::Abort(Unexpected::Warned {
+                id: "wf-150".to_string(),
+                reason: "wayfinder#150's PR #97 closed unmerged — superseded? reap by hand if so"
+                    .to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn nothing_outside_the_runs_own_nodes_is_collected_or_reported() {
+        // #72's no-sweep posture, kept by construction: the step is scoped to
+        // the nodes the run itself drove to done, so a finished workspace of
+        // somebody else's ticket is not deleted here — and not named either,
+        // because a report about workspaces the run has no business in is the
+        // sweep arriving as advice.
+        let workspaces = [pushed("wf-151", 151), pushed("wf-99", 99)];
+        let known = facts([
+            (node("blooop/wayfinder", 151), NodeFact::Closed),
+            (node("blooop/wayfinder", 99), NodeFact::Closed),
+        ]);
+        let Cleanup::Proceed { going, kept } = cleanup_of(&workspaces, &known, &[151]) else {
+            panic!("a node outside the scope is not a reason to stop");
+        };
+        assert_eq!(
+            going.iter().map(Cleared::id).collect::<Vec<_>>(),
+            ["wf-151"]
+        );
+        assert!(kept.is_empty(), "and it is not reported either: {kept:?}");
+    }
+
+    #[test]
+    fn a_warning_outside_the_runs_own_nodes_does_not_stop_it() {
+        // The same posture pointed the other way. The scope is what makes an
+        // unexpected row unexpected: a superseded ticket nobody in this run
+        // touched is `wf reap`'s business, and stopping on it would make every
+        // run's cleanup hostage to the rest of the machine.
+        let workspaces = [pushed("wf-151", 151), pushed("wf-99", 99)];
+        let known = facts([
+            (node("blooop/wayfinder", 151), NodeFact::Closed),
+            (
+                node("blooop/wayfinder", 99),
+                NodeFact::Superseded { pr: 12 },
+            ),
+        ]);
+        assert_eq!(going(&cleanup_of(&workspaces, &known, &[151])), ["wf-151"]);
+    }
+
+    #[test]
+    fn the_step_deletes_exactly_what_doomed_names_within_the_scope() {
+        // #137's one-vocabulary rule at the deleting end: the set that goes is
+        // `doomed`'s answer narrowed to the run's own nodes, never a second
+        // reading of what "finished" means. Every fact that can reach a
+        // workspace is in the listing, so a partition written twice here would
+        // have to agree with `doomed` on all six to pass.
+        let workspaces: Vec<Workspace> = (1..=6).map(|n| pushed(&format!("wf-{n}"), n)).collect();
+        let known = facts([
+            (node("blooop/wayfinder", 1), NodeFact::Closed),
+            (
+                node("blooop/wayfinder", 2),
+                NodeFact::DoneByMerge { pr: 11 },
+            ),
+            (node("blooop/wayfinder", 3), NodeFact::InFlight { pr: 12 }),
+            (node("blooop/wayfinder", 4), NodeFact::Claimed),
+            (node("blooop/wayfinder", 5), NodeFact::Superseded { pr: 13 }),
+            (node("blooop/wayfinder", 6), NodeFact::Unstarted),
+        ]);
+        // The two warning facts are the step's abort arm, so the scope that
+        // compares the two sets is the one without them.
+        let scope = [1, 2, 3, 4];
+        let verdicts = plan(&workspaces, &known, false);
+        let by_doomed: Vec<&str> = doomed(&verdicts)
+            .iter()
+            .map(|v| v.id())
+            .filter(|id| scope.iter().any(|n| *id == format!("wf-{n}")))
+            .collect();
+        assert_eq!(going(&cleanup_of(&workspaces, &known, &scope)), by_doomed);
+        assert_eq!(by_doomed, ["wf-1", "wf-2"], "the fixture still bites");
+    }
+
+    /// What the autonomous cleanup does with one node — the three outcomes,
+    /// named, so a table can state them as literals.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Fate {
+        Goes,
+        Stays,
+        Stops,
+    }
+
+    /// Which arm of [`NodeFact`] this is, as an index.
+    ///
+    /// An exhaustive match with no wildcard, so a seventh arm fails to compile
+    /// here — and the table below is then what says somebody decided what the
+    /// *deleting* path does with it, rather than letting it inherit an outcome
+    /// from whichever arm it was written next to. #132's second item found this
+    /// module's pinning thin at exactly this end.
+    fn arm(fact: &NodeFact) -> usize {
+        match fact {
+            NodeFact::Closed => 0,
+            NodeFact::DoneByMerge { .. } => 1,
+            NodeFact::Superseded { .. } => 2,
+            NodeFact::InFlight { .. } => 3,
+            NodeFact::Claimed => 4,
+            NodeFact::Unstarted => 5,
+        }
+    }
+
+    #[test]
+    fn every_state_a_node_can_be_in_has_a_decided_fate_and_only_two_delete() {
+        let cases = [
+            (NodeFact::Closed, Fate::Goes),
+            (NodeFact::DoneByMerge { pr: 11 }, Fate::Goes),
+            (NodeFact::Superseded { pr: 12 }, Fate::Stops),
+            (NodeFact::InFlight { pr: 13 }, Fate::Stays),
+            (NodeFact::Claimed, Fate::Stays),
+            (NodeFact::Unstarted, Fate::Stops),
+        ];
+        assert_eq!(
+            cases.iter().map(|(fact, _)| arm(fact)).collect::<Vec<_>>(),
+            (0..6).collect::<Vec<_>>(),
+            "every arm of NodeFact needs a case here, in the order `arm` lists them"
+        );
+        for (fact, expected) in cases {
+            let workspaces = [pushed("wf-151", 151)];
+            let known = facts([(node("blooop/wayfinder", 151), fact.clone())]);
+            let got = match cleanup_of(&workspaces, &known, &[151]) {
+                Cleanup::Abort(_) => Fate::Stops,
+                Cleanup::Proceed { going, .. } if going.is_empty() => Fate::Stays,
+                Cleanup::Proceed { .. } => Fate::Goes,
+            };
+            assert_eq!(got, expected, "{fact:?} reached the wrong arm");
+        }
+    }
+
+    #[test]
+    fn a_ticket_state_this_binary_cannot_read_never_reaches_the_deleting_arm() {
+        // #132's first item, at the autonomous end. The unattended path is the
+        // one #138 held this back for: there is no reader between an unknown
+        // word and a deletion, so the reading has to land on an arm that keeps
+        // whatever the word turns out to mean.
+        let fact = node_fact(TicketState::read("TRANSFERRED"), false, &[]);
+        assert_eq!(fact, NodeFact::Unstarted, "an unreadable state stays live");
+        let workspaces = [pushed("wf-151", 151)];
+        let known = facts([(node("blooop/wayfinder", 151), fact)]);
+        assert!(
+            matches!(cleanup_of(&workspaces, &known, &[151]), Cleanup::Abort(_)),
+            "a state this binary cannot read must cost a workspace nothing"
+        );
+    }
+
+    #[test]
+    fn a_pr_state_this_binary_cannot_read_never_reaches_the_deleting_arm() {
+        // The same claim through the other reading. A PR whose state the badge
+        // parse declines is in flight, which keeps the node — and a keep is not
+        // a stop, because an open PR on a node this run finished is the
+        // ordinary unattended ending (the lifecycle stops at approved).
+        let fact = node_fact(TicketState::Live, false, &[PrOutcome::project(9, None)]);
+        assert_eq!(fact, NodeFact::InFlight { pr: 9 });
+        let workspaces = [pushed("wf-151", 151)];
+        let known = facts([(node("blooop/wayfinder", 151), fact)]);
+        assert_eq!(
+            going(&cleanup_of(&workspaces, &known, &[151])),
+            Vec::<&str>::new()
+        );
+    }
+
+    #[test]
+    fn a_merge_finishes_a_node_and_the_closed_prs_beside_it_do_not() {
+        // #132's second item: the `DoneByMerge`/`Superseded` precedence, pinned
+        // where getting it backwards costs something. Swap the two arms of
+        // `node_fact` and the first case stops the step instead of collecting,
+        // and the second collects a branch a human said no to.
+        let merged_and_closed = [
+            PrOutcome::project(161, Some(&PrStatus::Merged)),
+            PrOutcome::project(162, Some(&PrStatus::Closed)),
+        ];
+        let workspaces = [pushed("wf-151", 151)];
+        let known = facts([(
+            node("blooop/wayfinder", 151),
+            node_fact(TicketState::Live, false, &merged_and_closed),
+        )]);
+        assert_eq!(going(&cleanup_of(&workspaces, &known, &[151])), ["wf-151"]);
+
+        let closed_only = [PrOutcome::project(162, Some(&PrStatus::Closed))];
+        let known = facts([(
+            node("blooop/wayfinder", 151),
+            node_fact(TicketState::Live, false, &closed_only),
+        )]);
+        assert!(
+            matches!(cleanup_of(&workspaces, &known, &[151]), Cleanup::Abort(_)),
+            "a node whose every PR closed unmerged is never this step's to delete"
+        );
+    }
+
+    #[test]
+    fn a_running_workspace_of_a_finished_ticket_is_kept_rather_than_stopped_for() {
+        // A run's own manager reads as this from inside a workspace: the
+        // container is up because the session is in it. `dl`'s fact, kept as a
+        // keep — nothing about it says the reading went wrong.
+        let mut ws = pushed("wf-151", 151);
+        ws.state = Some("Running".to_string());
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        let Cleanup::Proceed { going, kept } = cleanup_of(&[ws], &known, &[151]) else {
+            panic!("a running container is an ordinary keep");
+        };
+        assert!(going.is_empty());
+        assert_eq!(kept[0].reason(), "still running — stop it first");
+    }
+
+    #[test]
+    fn a_node_the_run_names_that_has_no_workspace_is_nothing_to_do() {
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        assert_eq!(
+            cleanup_of(&[], &known, &[151]),
+            Cleanup::Proceed {
+                going: Vec::new(),
+                kept: Vec::new()
+            }
+        );
+    }
+
+    #[test]
+    fn a_node_reference_is_read_back_exactly_as_it_is_written() {
+        assert_eq!(
+            Node::parse("blooop/wayfinder#151"),
+            Some(node("blooop/wayfinder", 151))
+        );
+        // Every rejection is a way of naming something this step must not act
+        // on: without an owner there is no repo to ask the tracker about, and
+        // the rest are not node references at all.
+        for bad in [
+            "wayfinder#151",
+            "blooop/wayfinder",
+            "blooop/wayfinder#",
+            "blooop/wayfinder#-1",
+            "blooop/wayfinder#151#2",
+            "#151",
+            "",
+        ] {
+            assert_eq!(Node::parse(bad), None, "{bad:?} is not a node reference");
+        }
+    }
+
     /// `wf reap -y` taken for real, in a child process whose `dl` and `gh` are
     /// the fixtures the parent hands it and whose every invocation is written
     /// down. The `#[ignore]` is what keeps it out of an ordinary run: without
@@ -2624,6 +3333,157 @@ mod tests {
             run.argv
         );
         run.touched_no_files();
+    }
+
+    /// The autonomous cleanup taken for real, scoped to `wayfinder#129` — the
+    /// one node of [`probe::DL_LISTING`](crate::probe::DL_LISTING) whose ticket
+    /// is closed, standing in for the ticket a run just drove to done.
+    ///
+    /// No flag counterpart to `-y` and none to `-f`: the first is what this
+    /// path *is*, and the second has no spelling anywhere on it.
+    #[tokio::test]
+    #[ignore = "run by `probe::record` from the tests below, under recording shims"]
+    async fn cleanup_probe() {
+        if !crate::probe::is_child() {
+            return;
+        }
+        let said = match cleanup(&finished(&[129])).await {
+            Ok(()) => "the cleanup finished".to_string(),
+            Err(e) => format!("the cleanup stopped: {e}"),
+        };
+        println!("{}{said}", crate::probe::MARK);
+    }
+
+    /// The same run, scoped to one node more: `wayfinder#138`, which the
+    /// tracker fixture says nobody claimed and nothing came of — a `Warn`, and
+    /// therefore a node this run has no business believing it finished.
+    #[tokio::test]
+    #[ignore = "run by `probe::record` from the test below, under recording shims"]
+    async fn cleanup_warned_probe() {
+        if !crate::probe::is_child() {
+            return;
+        }
+        let said = match cleanup(&finished(&[129, 138])).await {
+            Ok(()) => "the cleanup finished".to_string(),
+            Err(e) => format!("the cleanup stopped: {e}"),
+        };
+        println!("{}{said}", crate::probe::MARK);
+    }
+
+    #[test]
+    fn a_cleanup_hands_dl_the_finished_workspace_of_its_own_node_and_no_force() {
+        // The deleting path of the autonomous half as a fact about a run,
+        // beside its interactive sibling above. The listing holds four
+        // workspaces and the tracker answers for all four; what the scope says
+        // is that exactly one of them is this run's to collect.
+        let run = crate::probe::record(
+            "reap::tests::cleanup_probe",
+            crate::probe::DL_LISTING,
+            crate::probe::GH_FACTS,
+        );
+        assert_eq!(
+            run.printed(),
+            ["the cleanup finished"],
+            "the run reached the end: {}",
+            run.stdout
+        );
+        // `--force` is the flag this whole ticket exists to keep out of an
+        // unattended path: it waives `dl`'s own unsaved-work guard, which is
+        // the guard the recoverability floor is built on. One `rm`, by id, and
+        // no second spelling of a deletion.
+        assert_eq!(
+            destructive(&run),
+            ["dl <wf-129-closed> <rm>"],
+            "the run's own finished workspace goes, alone and unforced: {:?}",
+            run.argv
+        );
+        // The three the scope leaves out are not mentioned at all — a report
+        // about workspaces this run has no business in is the sweep #72 refused,
+        // arriving as advice.
+        for other in ["wf-138-unstarted", "wf-137-open", "wf-134-stalled"] {
+            assert!(
+                !run.stdout.contains(other),
+                "{other} is outside the scope and was named anyway: {}",
+                run.stdout
+            );
+        }
+        run.touched_no_files();
+    }
+
+    #[test]
+    fn a_cleanup_that_meets_a_warning_in_its_own_scope_deletes_nothing_at_all() {
+        // Two scoped nodes, one of them warned. The other is the very workspace
+        // the sibling test above removes, so what this pins is that the step
+        // stops *whole*: a surprise on one node is not a reason to go on and
+        // collect the ones it did understand.
+        let run = crate::probe::record(
+            "reap::tests::cleanup_warned_probe",
+            crate::probe::DL_LISTING,
+            crate::probe::GH_FACTS,
+        );
+        run.destroyed_nothing();
+        // One `printed` entry, because only the marked line is the probe's:
+        // the pointer to `wf reap` is the second line of the same message and
+        // is asserted below, out of the same capture.
+        assert_eq!(
+            run.printed(),
+            ["the cleanup stopped: cleanup stopped and deleted nothing: \
+              wf-138-unstarted is not a workspace this run may collect: \
+              wayfinder#138 unclaimed and no PR — an abandoned stage? reap by hand if so"],
+            "the run said what stopped it: {}",
+            run.stdout
+        );
+        assert!(
+            run.stdout
+                .contains("run `wf reap` to see every workspace on this machine"),
+            "and pointed at the command a human reads the rest with: {}",
+            run.stdout
+        );
+    }
+
+    #[test]
+    fn a_cleanup_that_cannot_read_the_listing_deletes_nothing_and_says_so() {
+        // The third way the step is stopped, and the one that never reaches a
+        // decision at all: a listing this `wf` cannot parse. It is the same
+        // outcome as the two arms above — nothing deleted, a non-zero exit, a
+        // sentence naming the cause — which is why it is an error rather than a
+        // fourth arm of `Unexpected`. An empty plan here would read as "this run
+        // finished nothing", which is indistinguishable from success.
+        let run = crate::probe::record(
+            "reap::tests::cleanup_probe",
+            "{not a listing}",
+            crate::probe::GH_FACTS,
+        );
+        run.destroyed_nothing();
+        assert!(
+            run.printed()[0].starts_with("the cleanup stopped: unparseable workspace listing"),
+            "the run named what it could not read: {}",
+            run.stdout
+        );
+    }
+
+    #[test]
+    fn a_cleanup_reading_a_dl_too_old_to_answer_deletes_nothing() {
+        // The version skew, end to end. devlaunch 0.0.23 wrote `null` for a
+        // clean clone of its own, so this listing says nothing about
+        // `wf-129-closed` — and `wf reap` would collect it on exactly that
+        // silence, because on that release silence *was* the clean answer.
+        // Unattended it is not enough: the floor wants a fact `dl` said.
+        let run = crate::probe::record_as_dl(
+            "reap::tests::cleanup_probe",
+            crate::probe::DL_LISTING_LEGACY,
+            crate::probe::GH_FACTS,
+            "0.0.23",
+        );
+        run.destroyed_nothing();
+        assert_eq!(
+            run.printed(),
+            ["the cleanup stopped: cleanup stopped and deleted nothing: \
+              wf-129-closed is not established as recoverable: \
+              dl did not say what this clone holds"],
+            "the run named the workspace and the reason: {}",
+            run.stdout
+        );
     }
 
     #[test]

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -761,11 +761,11 @@ pub enum Cleanup {
 
 /// What the cleanup step saw that it did not expect.
 ///
-/// Both arms are the same shape of surprise — the run believed a node was
-/// finished, and this module's own reading of that node's workspace says
-/// something the step has no authority to interpret unattended. They are
-/// separate arms because they send a reader to different places: the first to
-/// the tracker, the second to `dl`.
+/// Every arm is the same shape of surprise — the run believed a node was
+/// finished, and this module's own reading of that node, or of its workspace,
+/// says something the step has no authority to interpret unattended. They are
+/// separate arms because they send a reader to different places: the first two
+/// to the tracker, the third to `dl`.
 ///
 /// The other two ways an autonomous cleanup can be surprised are not here
 /// because they are already errors: a listing that will not parse and a tracker
@@ -781,6 +781,19 @@ pub enum Unexpected {
     /// the case with nobody present to adjudicate it, so the step stops rather
     /// than treating its own belief as the tie-break.
     Warned { id: String, reason: String },
+    /// The tracker does not read this node as finished, and the run said it
+    /// was.
+    ///
+    /// The commonest disagreement there is, and the one with the most riding on
+    /// it: the run's whole authority here is that it drove these nodes to done,
+    /// so a node the tracker still reads as open is that authority failing on
+    /// the very node it was claimed for — which puts the rest of the same argv
+    /// in doubt, and stops the step whole. `said` names the tracker's reading.
+    ///
+    /// Not folded into [`Self::Warned`]: a `Warn` is [`plan`] unsure and this
+    /// is [`plan`] and the run *sure of different things*, and they point a
+    /// reader at different questions.
+    Unfinished { id: String, said: String },
     /// [`plan`] would collect a workspace `dl` has not said is recoverable.
     ///
     /// `said` is the reason in the words the row would have carried.
@@ -793,6 +806,9 @@ impl Unexpected {
         match self {
             Self::Warned { id, reason } => {
                 format!("{id} is not a workspace this run may collect: {reason}")
+            }
+            Self::Unfinished { id, said } => {
+                format!("{id} is not a workspace of a node this run finished: {said}")
             }
             Self::Unrecoverable { id, said } => {
                 format!("{id} is not established as recoverable: {said}")
@@ -838,6 +854,40 @@ fn unrecoverable(unsaved: Option<&Unsaved>) -> Option<String> {
     }
 }
 
+/// Why the tracker's reading of this node is not one an autonomous cleanup may
+/// have been pointed at, or `None` when the node is finished.
+///
+/// **The scope's own floor**, beside the recoverability one above and asked
+/// first, because it is the earlier question: the run's whole authority here is
+/// that it drove these nodes to done, and a node the tracker still reads as
+/// open is that claim failing on the very node it was made about. `wf reap`
+/// keeps such a workspace and prints a row, which is right with a human reading
+/// the list; unattended there is nobody to weigh "the run says finished, the
+/// tracker says open", so the step stops and hands both readings back.
+///
+/// Finished means the two arms [`plan`] reaps on, and this says so in the same
+/// exhaustive shape: a seventh [`NodeFact`] fails to compile here until
+/// somebody decides what an unattended run does with it. `None` — a scoped node
+/// the tracker was not asked about — is a surprise too, and a louder one than
+/// [`plan`]'s keep for it: the fetch is never partial, so getting here means
+/// this run does not know what it thinks it knows.
+fn unfinished(name: &str, fact: Option<&NodeFact>) -> Option<String> {
+    match fact {
+        Some(NodeFact::Closed | NodeFact::DoneByMerge { .. }) => None,
+        Some(NodeFact::InFlight { pr }) => {
+            Some(format!("{name} is still open, with PR #{pr} in flight"))
+        }
+        Some(NodeFact::Claimed) => Some(format!("{name} is still open, and claimed")),
+        Some(NodeFact::Superseded { pr }) => Some(format!(
+            "{name} is still open, its PR #{pr} closed unmerged"
+        )),
+        Some(NodeFact::Unstarted) => {
+            Some(format!("{name} is still open, unclaimed and with no PR"))
+        }
+        None => Some(format!("the tracker was not asked about {name}")),
+    }
+}
+
 /// Read a plan the way the cleanup step at the end of an autonomous run reads
 /// it: scoped to the nodes that run drove to done, and refusing anything else.
 ///
@@ -852,21 +902,33 @@ fn unrecoverable(unsaved: Option<&Unsaved>) -> Option<String> {
 ///   That is #72's no-sweep posture kept by construction rather than by
 ///   promising not to schedule anything: the step cannot reach a workspace the
 ///   run did not finish, so there is nothing for a timer to fire.
-/// - **The floor.** A scoped workspace [`doomed`] names is cleared only if
-///   the recoverability floor — `unrecoverable`, below — says nothing about it.
-///   Anything else stops the step.
+/// - **The floors.** A scoped workspace [`doomed`] names is cleared only if the
+///   recoverability floor — `unrecoverable`, above — says nothing about it, and
+///   a scoped workspace it does not name is left standing only if the tracker
+///   reads its node as finished — `unfinished`, above. Anything else stops the
+///   step.
 /// - **Surprise stops everything.** A scoped `Warn` — `wf` unsure about a node
-///   this run believed settled — is [`Unexpected::Warned`], and the step
-///   deletes nothing at all, not even the rows it did understand.
+///   this run believed settled — is [`Unexpected::Warned`]; a scoped node the
+///   tracker still reads as open is [`Unexpected::Unfinished`]; and either way
+///   the step deletes nothing at all, not even the rows it did understand.
+///
+/// So the only workspace this reports as kept is one `dl` or devpod spoke about
+/// — work that exists nowhere else, a container still up — on a node the
+/// tracker agrees is done. That is the run's last push having failed, which is
+/// a thing to say in the summary and not a thing to stop for.
 ///
 /// `insist` has no counterpart here and never will: `-f` waives the guard that
 /// makes the floor meaningful, and it stays a human's to type.
-pub fn decide(workspaces: &[Workspace], verdicts: &[Verdict], scope: &BTreeSet<Node>) -> Cleanup {
-    let mine = |id: &str| -> Option<&Workspace> {
-        workspaces
-            .iter()
-            .find(|w| w.id == id)
-            .filter(|w| node_of(w).is_some_and(|n| scope.contains(&n)))
+pub fn decide(
+    workspaces: &[Workspace],
+    verdicts: &[Verdict],
+    known: &BTreeMap<Node, NodeFact>,
+    scope: &BTreeSet<Node>,
+) -> Cleanup {
+    let mine = |id: &str| -> Option<(&Workspace, Node)> {
+        let workspace = workspaces.iter().find(|w| w.id == id)?;
+        let node = node_of(workspace)?;
+        scope.contains(&node).then_some((workspace, node))
     };
     // Asked for rather than re-derived, and asked for once: `doomed` is the one
     // definition of what goes, so the loop below decides only whether a
@@ -875,27 +937,54 @@ pub fn decide(workspaces: &[Workspace], verdicts: &[Verdict], scope: &BTreeSet<N
     let mut going = Vec::new();
     let mut kept = Vec::new();
     for verdict in verdicts {
-        let Some(workspace) = mine(verdict.id()) else {
+        let Some((workspace, node)) = mine(verdict.id()) else {
             continue;
         };
-        if condemned.contains(verdict.id()) {
-            if let Some(said) = unrecoverable(workspace.unsaved.as_ref()) {
-                return Cleanup::Abort(Unexpected::Unrecoverable {
-                    id: verdict.id().to_string(),
-                    said,
+        // A match rather than a chain ending in `else`, because this is the one
+        // function that authorises an unattended deletion and [`Verdict`] is
+        // three arms precisely so that every such site has to say which of them
+        // it means: a fourth arm must fail to compile here rather than inherit
+        // whichever branch it was written next to.
+        match verdict {
+            // The deleting arm, and it is `doomed`'s answer that puts a row in
+            // it — asked rather than re-derived, so a partition written twice
+            // cannot turn a row this module keeps into a row it deletes.
+            Verdict::Reap { id, reason } if condemned.contains(id.as_str()) => {
+                if let Some(said) = unrecoverable(workspace.unsaved.as_ref()) {
+                    return Cleanup::Abort(Unexpected::Unrecoverable {
+                        id: id.clone(),
+                        said,
+                    });
+                }
+                going.push(Cleared {
+                    id: id.clone(),
+                    reason: reason.clone(),
                 });
             }
-            going.push(Cleared {
-                id: verdict.id().to_string(),
-                reason: verdict.reason().to_string(),
-            });
-        } else if let Verdict::Warn { id, reason } = verdict {
-            return Cleanup::Abort(Unexpected::Warned {
-                id: id.clone(),
-                reason: reason.clone(),
-            });
-        } else {
-            kept.push(verdict.clone());
+            // A `Warn` — and a `Reap` `doomed` did not name, which would mean
+            // the one definition of what goes and the row in front of it
+            // disagree about the same listing. Both are `wf` and this run
+            // reading the same workspace differently, with nobody here to say
+            // which is right.
+            Verdict::Warn { id, reason } | Verdict::Reap { id, reason } => {
+                return Cleanup::Abort(Unexpected::Warned {
+                    id: id.clone(),
+                    reason: reason.clone(),
+                })
+            }
+            // Kept — once the node it belongs to is one the tracker agrees
+            // this run finished. A keep is `dl`'s or devpod's fact about the
+            // workspace; the node still being open is the run's own claim
+            // failing, which is not a row to print and go on from.
+            Verdict::Keep { id, .. } => {
+                if let Some(said) = unfinished(&node.name(), known.get(&node)) {
+                    return Cleanup::Abort(Unexpected::Unfinished {
+                        id: id.clone(),
+                        said,
+                    });
+                }
+                kept.push(verdict.clone());
+            }
         }
     }
     Cleanup::Proceed { going, kept }
@@ -1345,7 +1434,7 @@ pub async fn cleanup(scope: &BTreeSet<Node>) -> Result<()> {
     let known = node_facts(&wanted).await?;
     let verdicts = plan(&workspaces, &known, false);
 
-    let (going, kept) = match decide(&workspaces, &verdicts, scope) {
+    let (going, kept) = match decide(&workspaces, &verdicts, &known, scope) {
         Cleanup::Abort(unexpected) => bail!(
             "cleanup stopped and deleted nothing: {}\n\
              (run `wf reap` to see every workspace on this machine and decide by hand)",
@@ -2892,6 +2981,7 @@ mod tests {
         decide(
             workspaces,
             &plan(workspaces, known, false),
+            known,
             &finished(scope),
         )
     }
@@ -2959,7 +3049,12 @@ mod tests {
             "the plan this reads really would have reaped it"
         );
         assert_eq!(
-            decide(std::slice::from_ref(&ws), &verdicts, &finished(&[151])),
+            decide(
+                std::slice::from_ref(&ws),
+                &verdicts,
+                &known,
+                &finished(&[151])
+            ),
             Cleanup::Abort(Unexpected::Unrecoverable {
                 id: "wf-151".to_string(),
                 said: "dl did not say what this clone holds".to_string(),
@@ -2986,7 +3081,12 @@ mod tests {
             "the forced plan this reads really would have reaped it"
         );
         assert_eq!(
-            decide(std::slice::from_ref(&ws), &forced, &finished(&[151])),
+            decide(
+                std::slice::from_ref(&ws),
+                &forced,
+                &known,
+                &finished(&[151])
+            ),
             Cleanup::Abort(Unexpected::Unrecoverable {
                 id: "wf-151".to_string(),
                 said: "holds 1 unpushed commit(s)".to_string(),
@@ -3017,6 +3117,87 @@ mod tests {
                     .to_string(),
             })
         );
+    }
+
+    #[test]
+    fn a_node_the_tracker_still_reads_as_open_stops_the_whole_step() {
+        // The other half of the surprise the `Warn` test above pins, and the
+        // commoner half: the run believed it drove this node to done, and the
+        // tracker says the ticket is open with a PR in flight. Two readings of
+        // the same node disagreeing is the case nobody is present to
+        // adjudicate — and a run whose belief about its own node is contradicted
+        // has every other belief in the same argv put in doubt, so the sibling
+        // whose row was a clean reap is not collected either.
+        let workspaces = [pushed("wf-150", 150), pushed("wf-151", 151)];
+        let known = facts([
+            (node("blooop/wayfinder", 150), NodeFact::InFlight { pr: 97 }),
+            (node("blooop/wayfinder", 151), NodeFact::Closed),
+        ]);
+        assert_eq!(
+            cleanup_of(&workspaces, &known, &[150, 151]),
+            Cleanup::Abort(Unexpected::Unfinished {
+                id: "wf-150".to_string(),
+                said: "wayfinder#150 is still open, with PR #97 in flight".to_string(),
+            })
+        );
+        // A claim is the same disagreement without a PR to name.
+        let known = facts([
+            (node("blooop/wayfinder", 150), NodeFact::Claimed),
+            (node("blooop/wayfinder", 151), NodeFact::Closed),
+        ]);
+        assert_eq!(
+            cleanup_of(&workspaces, &known, &[150, 151]),
+            Cleanup::Abort(Unexpected::Unfinished {
+                id: "wf-150".to_string(),
+                said: "wayfinder#150 is still open, and claimed".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn work_that_exists_nowhere_else_is_kept_rather_than_read_as_a_node_left_open() {
+        // The distinction the arm above must not swallow, stated where a
+        // careless "any keep is a surprise" would break it. The ticket is
+        // closed — this run really did finish it — and the workspace stays only
+        // because `dl` says its clone holds the only copy of something. The
+        // floor keeping a workspace is the step working, so the run reports the
+        // row and ends green; the tracker contradicting the run is not.
+        let mut ws = pushed("wf-151", 151);
+        ws.unsaved = Some(Unsaved::WouldLose("1 unpushed commit(s)".to_string()));
+        let known = facts([(node("blooop/wayfinder", 151), NodeFact::Closed)]);
+        assert!(
+            matches!(cleanup_of(&[ws], &known, &[151]), Cleanup::Proceed { .. }),
+            "a finished node whose clone holds work is a keep, not a stop"
+        );
+    }
+
+    #[test]
+    fn the_step_stops_on_exactly_the_facts_the_plan_would_not_reap() {
+        // What "finished" means here, tied to the one definition rather than
+        // restated beside it (#137). The step reads a fact as finished exactly
+        // when `plan` would have reaped a clean workspace of that node, so a
+        // later arm added to one and not the other is a failure here rather
+        // than an unattended deletion.
+        for fact in [
+            NodeFact::Closed,
+            NodeFact::DoneByMerge { pr: 11 },
+            NodeFact::Superseded { pr: 12 },
+            NodeFact::InFlight { pr: 13 },
+            NodeFact::Claimed,
+            NodeFact::Unstarted,
+        ] {
+            let workspaces = [pushed("wf-151", 151)];
+            let known = facts([(node("blooop/wayfinder", 151), fact.clone())]);
+            let reaped = !doomed(&plan(&workspaces, &known, false)).is_empty();
+            let stopped = matches!(cleanup_of(&workspaces, &known, &[151]), Cleanup::Abort(_));
+            assert_eq!(
+                stopped,
+                !reaped,
+                "{fact:?}: the plan would {} it, and the step {}",
+                if reaped { "reap" } else { "not reap" },
+                if stopped { "stopped" } else { "went on" }
+            );
+        }
     }
 
     #[test]
@@ -3077,9 +3258,12 @@ mod tests {
             (node("blooop/wayfinder", 5), NodeFact::Superseded { pr: 13 }),
             (node("blooop/wayfinder", 6), NodeFact::Unstarted),
         ]);
-        // The two warning facts are the step's abort arm, so the scope that
-        // compares the two sets is the one without them.
-        let scope = [1, 2, 3, 4];
+        // Four of the six facts are the step's abort arm — everything the
+        // tracker does not read as finished — so the scope that compares the
+        // two sets is the one without them. The other four workspaces stay in
+        // the listing, which is what makes this a claim about narrowing rather
+        // than about a fixture with nothing else in it.
+        let scope = [1, 2];
         let verdicts = plan(&workspaces, &known, false);
         let by_doomed: Vec<&str> = doomed(&verdicts)
             .iter()
@@ -3119,12 +3303,18 @@ mod tests {
 
     #[test]
     fn every_state_a_node_can_be_in_has_a_decided_fate_and_only_two_delete() {
+        // Every workspace here is one `dl` says is fully pushed and whose
+        // container is down, so what varies is only the tracker's reading — and
+        // the reading alone never produces a `Stays`. A keep is something `dl`
+        // or devpod said about the *workspace* (unpushed work, a live
+        // container); a node the tracker does not read as finished is the run
+        // being contradicted about its own ticket, and that stops the step.
         let cases = [
             (NodeFact::Closed, Fate::Goes),
             (NodeFact::DoneByMerge { pr: 11 }, Fate::Goes),
             (NodeFact::Superseded { pr: 12 }, Fate::Stops),
-            (NodeFact::InFlight { pr: 13 }, Fate::Stays),
-            (NodeFact::Claimed, Fate::Stays),
+            (NodeFact::InFlight { pr: 13 }, Fate::Stops),
+            (NodeFact::Claimed, Fate::Stops),
             (NodeFact::Unstarted, Fate::Stops),
         ];
         assert_eq!(
@@ -3163,16 +3353,16 @@ mod tests {
     #[test]
     fn a_pr_state_this_binary_cannot_read_never_reaches_the_deleting_arm() {
         // The same claim through the other reading. A PR whose state the badge
-        // parse declines is in flight, which keeps the node — and a keep is not
-        // a stop, because an open PR on a node this run finished is the
-        // ordinary unattended ending (the lifecycle stops at approved).
+        // parse declines is in flight, which is the tracker saying the node is
+        // still open — so the step stops rather than deleting on a word this
+        // binary was never taught, and the workspace costs the run nothing.
         let fact = node_fact(TicketState::Live, false, &[PrOutcome::project(9, None)]);
         assert_eq!(fact, NodeFact::InFlight { pr: 9 });
         let workspaces = [pushed("wf-151", 151)];
         let known = facts([(node("blooop/wayfinder", 151), fact)]);
-        assert_eq!(
-            going(&cleanup_of(&workspaces, &known, &[151])),
-            Vec::<&str>::new()
+        assert!(
+            matches!(cleanup_of(&workspaces, &known, &[151]), Cleanup::Abort(_)),
+            "a PR state this binary cannot read must cost a workspace nothing"
         );
     }
 
@@ -3408,6 +3598,71 @@ mod tests {
             );
         }
         run.touched_no_files();
+    }
+
+    #[test]
+    fn a_cleanup_that_finds_unpushed_work_keeps_that_workspace_names_it_and_ends_green() {
+        // #151's second verification scenario, at the command rather than at
+        // the decision: the run's own finished node, and a `dl` that says its
+        // clone holds a commit which never left this machine. The workspace
+        // stays, the run *says* it stayed and why, and the run ends green —
+        // this is the ordinary ending of a run whose last push failed, not a
+        // surprise, and a cleanup that treated it as one would turn every such
+        // run red.
+        //
+        // The same fixtures as the sibling test above with one field changed,
+        // so the difference between the two recordings is exactly the
+        // difference between a clone that exists somewhere else and one that
+        // does not.
+        let unpushed = crate::probe::DL_LISTING.replacen(
+            r#""unsaved":{"nothingToLose":true}"#,
+            r#""unsaved":{"wouldLose":"1 unpushed commit(s)"}"#,
+            1,
+        );
+        let holds: Vec<String> = parse_workspaces(unpushed.as_bytes())
+            .expect("the edited fixture is still a listing")
+            .iter()
+            .filter(|w| w.unsaved != Some(Unsaved::NothingToLose))
+            .map(|w| w.id.clone())
+            .collect();
+        assert_eq!(
+            holds,
+            ["wf-129-closed"],
+            "the one clone holding work is the scoped run's own: {unpushed}"
+        );
+
+        let run = crate::probe::record(
+            "reap::tests::cleanup_probe",
+            &unpushed,
+            crate::probe::GH_FACTS,
+        );
+        // Green, and by the arm that says so: `cleanup` returning `Ok` is what
+        // the binary exits 0 on. Deliberately not "nothing was deleted" — a
+        // step that stopped deletes nothing too, and the two are opposite
+        // outcomes for a run reading its own summary.
+        assert_eq!(
+            run.printed(),
+            ["the cleanup finished"],
+            "the run ended green: {}",
+            run.stdout
+        );
+        run.destroyed_nothing();
+        // Named, in `plan`'s own words. A run that kept it silently would leave
+        // nobody to notice that the branch exists in one place only. Once, and
+        // as a keep: the child's own test-harness line mentions the probe, so
+        // this counts mentions of the workspace rather than lines.
+        assert!(
+            run.stdout
+                .contains("kept     wf-129-closed  (holds 1 unpushed commit(s))"),
+            "the run named the workspace it kept and why: {}",
+            run.stdout
+        );
+        assert_eq!(
+            run.stdout.matches("wf-129-closed").count(),
+            1,
+            "and said it once, as that row: {}",
+            run.stdout
+        );
     }
 
     #[test]

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -723,7 +723,12 @@ fn cleanup_of(wire: &str) -> Cleanup {
     };
     let known: BTreeMap<Node, NodeFact> = [(node.clone(), NodeFact::Closed)].into_iter().collect();
     let scope: BTreeSet<Node> = [node].into_iter().collect();
-    decide(&workspaces, &plan(&workspaces, &known, false), &scope)
+    decide(
+        &workspaces,
+        &plan(&workspaces, &known, false),
+        &known,
+        &scope,
+    )
 }
 
 /// The ids a cleanup cleared for deletion — and nothing, spelt as nothing,

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -90,11 +90,12 @@
 //! second reason: a listing read from the developer's own machine would assert
 //! against whatever they happen to have cloned.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use wf::launch::{Agent, Devlaunch, Isolation, DEVLAUNCH_FLOOR, UNSAVED_IS_AN_OBJECT};
-use wf::reap::{parse_workspaces, Unsaved};
+use wf::reap::{decide, parse_workspaces, plan, Cleanup, Cleared, Node, NodeFact, Unsaved};
 
 /// How `pixi.toml` tells this file what environment it is in.
 ///
@@ -368,14 +369,64 @@ fn ask_devlaunch(snippet: &str, args: &[&str], why: &str) -> String {
 /// the field alone: `unsaved` is read as part of a `Workspace`, and a row is
 /// what `dl` actually emits.
 fn read_back(unsaved: &str) -> Option<Unsaved> {
-    let row = format!(
+    let parsed = parse_workspaces(row(unsaved).as_bytes())
+        .unwrap_or_else(|e| panic!("`wf` could not read {unsaved}: {e:#}"));
+    parsed.into_iter().next().expect("one row").unsaved
+}
+
+/// A one-workspace listing carrying `unsaved` exactly as devlaunch wrote it.
+///
+/// One spelling, because two tests read a real `dl`'s answer through it — the
+/// parse on its own, and the whole autonomous cleanup — and a row written twice
+/// is a row that can disagree with itself about which node it belongs to.
+/// `wayfinder#1` is the node its branch names, and the fact the cleanup test
+/// hands the planner is about that same number.
+fn row(unsaved: &str) -> String {
+    format!(
         r#"[{{"id":"ws","devlaunch":true,"repo":"blooop/wayfinder",
               "branch":"wayfinder/wayfinder-1","state":"Stopped",
               "unsaved":{unsaved}}}]"#
+    )
+}
+
+/// What *this* devlaunch says a real clone holds: the JSON its listing would
+/// carry, and the shape it wrote it in.
+///
+/// The import is tried and its absence read as the older release rather than as
+/// a broken install, which is the one thing this can be wrong about and the
+/// reason `WF_CONTRACT_UNSAVED` is compared against the shape rather than
+/// trusted on its own.
+fn what_dl_says_about(clone: &Path) -> (String, Shape) {
+    let reported = ask_devlaunch(
+        r#"
+import json, sys
+from pathlib import Path
+from devlaunch.workspace_state import read_clone
+state = read_clone(Path(sys.argv[1]))
+try:
+    from devlaunch.workspace_state import unsaved_as_json
+    wire = unsaved_as_json(state.unsaved)
+except ImportError:
+    # devlaunch <= 0.0.23: the field was the bare sentence, with no
+    # serialiser between the value and the listing.
+    wire = state.unsaved
+print(json.dumps({
+    "wire": wire,
+    "shape": "object" if isinstance(wire, dict) else "sentence",
+}))
+"#,
+        &[&clone.to_string_lossy()],
+        "devlaunch could not be asked what a clone holds — `read_clone` is the \
+         function whose answer becomes the `unsaved` field",
     );
-    let parsed = parse_workspaces(row.as_bytes())
-        .unwrap_or_else(|e| panic!("`wf` could not read {unsaved}: {e:#}"));
-    parsed.into_iter().next().expect("one row").unsaved
+    let reported: serde_json::Value =
+        serde_json::from_str(reported.trim()).expect("devlaunch's answer as JSON");
+    let shape = match reported["shape"].as_str() {
+        Some("object") => Shape::Object,
+        Some("sentence") => Shape::Sentence,
+        other => panic!("devlaunch reported an unknown shape: {other:?}"),
+    };
+    (reported["wire"].to_string(), shape)
 }
 
 #[test]
@@ -582,36 +633,7 @@ fn what_this_dl_says_about_a_clone_holding_work_is_what_wf_reads() {
     git(&clone, &["commit", "-q", "--allow-empty", "-m", "first"]);
     std::fs::write(clone.join("scratch.txt"), "half-finished\n").expect("uncommitted work");
 
-    let reported = ask_devlaunch(
-        r#"
-import json, sys
-from pathlib import Path
-from devlaunch.workspace_state import read_clone
-state = read_clone(Path(sys.argv[1]))
-try:
-    from devlaunch.workspace_state import unsaved_as_json
-    wire = unsaved_as_json(state.unsaved)
-except ImportError:
-    # devlaunch <= 0.0.23: the field was the bare sentence, with no
-    # serialiser between the value and the listing.
-    wire = state.unsaved
-print(json.dumps({
-    "wire": wire,
-    "shape": "object" if isinstance(wire, dict) else "sentence",
-}))
-"#,
-        &[&clone.to_string_lossy()],
-        "devlaunch could not be asked what a clone holds — `read_clone` is the \
-         function whose answer becomes the `unsaved` field",
-    );
-    let reported: serde_json::Value =
-        serde_json::from_str(reported.trim()).expect("devlaunch's answer as JSON");
-
-    let shape = match reported["shape"].as_str() {
-        Some("object") => Shape::Object,
-        Some("sentence") => Shape::Sentence,
-        other => panic!("devlaunch reported an unknown shape: {other:?}"),
-    };
+    let (wire, shape) = what_dl_says_about(&clone);
     assert_eq!(
         shape, installed.unsaved,
         "this devlaunch writes `unsaved` as a {shape:?}, but {UNSAVED} in \
@@ -619,7 +641,6 @@ print(json.dumps({
         installed.unsaved, UNSAVED_IS_AN_OBJECT
     );
 
-    let wire = reported["wire"].to_string();
     let read = read_back(&wire);
     let Some(Unsaved::WouldLose(said)) = read else {
         panic!(
@@ -656,6 +677,130 @@ fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
          every clone it made",
         if object { "writes" } else { "predates" },
         if object { "does not expect" } else { "expects" }
+    );
+}
+
+/// A real clone with a real remote to be behind, and nothing behind it yet.
+///
+/// A bare repository beside it and a path remote: no network, and the clone
+/// genuinely has an upstream. That is the difference the recoverability floor
+/// turns on — "committed" and "exists somewhere else" are not the same fact,
+/// and a checkout whose commits have never left it cannot be staged at all
+/// without a remote for it to be ahead of.
+fn a_clone_with_a_remote(what: &str) -> PathBuf {
+    let root = scratch(what);
+    let (origin, clone) = (root.join("origin.git"), root.join("clone"));
+    for dir in [&origin, &clone] {
+        let _ = std::fs::remove_dir_all(dir);
+        std::fs::create_dir_all(dir).expect("a clone directory");
+    }
+    git(&origin, &["init", "-q", "--bare"]);
+    git(&clone, &["init", "-q"]);
+    git(&clone, &["commit", "-q", "--allow-empty", "-m", "first"]);
+    git(
+        &clone,
+        &["remote", "add", "origin", &origin.to_string_lossy()],
+    );
+    git(
+        &clone,
+        &["push", "-q", "-u", "origin", "HEAD:refs/heads/main"],
+    );
+    clone
+}
+
+/// What the cleanup at the end of an autonomous run would do about one
+/// workspace whose `unsaved` field is `wire` and whose ticket that run closed.
+///
+/// The whole path from the field to the decision: the real parser, the real
+/// plan, and the real narrowing — `wf`'s answer to "may this be deleted with
+/// nobody watching", given what a real `dl` said about a real clone.
+fn cleanup_of(wire: &str) -> Cleanup {
+    let workspaces = parse_workspaces(row(wire).as_bytes())
+        .unwrap_or_else(|e| panic!("`wf` could not read {wire}: {e:#}"));
+    let node = Node {
+        repo: "blooop/wayfinder".to_string(),
+        number: 1,
+    };
+    let known: BTreeMap<Node, NodeFact> = [(node.clone(), NodeFact::Closed)].into_iter().collect();
+    let scope: BTreeSet<Node> = [node].into_iter().collect();
+    decide(&workspaces, &plan(&workspaces, &known, false), &scope)
+}
+
+/// The ids a cleanup cleared for deletion — and nothing, spelt as nothing,
+/// when it stopped instead.
+fn cleared(cleanup: &Cleanup) -> Vec<&str> {
+    match cleanup {
+        Cleanup::Proceed { going, .. } => going.iter().map(Cleared::id).collect(),
+        Cleanup::Abort(_) => Vec::new(),
+    }
+}
+
+#[test]
+fn what_this_dl_says_about_a_pushed_clone_is_what_an_unattended_cleanup_acts_on() {
+    // The recoverability floor (#151) against a real devlaunch, on both sides
+    // of the answer. `wf reap` prints its plan and waits; the cleanup a run
+    // ends with has no reader between "this ticket is finished" and
+    // `dl <ws> rm`, so this field is the whole of what stands between a branch
+    // that never reached a remote and its deletion — and every other test of it
+    // is `wf` reading a fixture `wf` wrote.
+    //
+    // Two real clones of a real repository with a real remote, one holding a
+    // commit that never left it, both inspected by *this* devlaunch's own
+    // `read_clone` and serialised the way this release serialises it.
+    let contract = Contract::read();
+    let Some(installed) = contract.installed() else {
+        return;
+    };
+    let pushed = a_clone_with_a_remote("pushed-clone");
+    let unpushed = a_clone_with_a_remote("unpushed-clone");
+    git(
+        &unpushed,
+        &[
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "never left this machine",
+        ],
+    );
+
+    let (held, _) = what_dl_says_about(&unpushed);
+    assert!(
+        cleared(&cleanup_of(&held)).is_empty(),
+        "this dl says a clone holding an unpushed commit is {held}, and `wf` \
+         cleared it for an unattended deletion"
+    );
+
+    let (safe, _) = what_dl_says_about(&pushed);
+    match installed.unsaved {
+        // A release that answers for every clone it made: the clone is cleared,
+        // and this is the only shape in which an unattended deletion happens at
+        // all. If a future `dl` renames the key, this is where the run stops
+        // collecting — the failure direction the floor is pointed in.
+        Shape::Object => assert_eq!(
+            cleared(&cleanup_of(&safe)),
+            ["ws"],
+            "this dl says a fully pushed clone is {safe}, and `wf` would not \
+             collect it — the cleanup would reclaim nothing on this release"
+        ),
+        // The releases before that wrote `null` for a clean clone. `wf reap`
+        // still reads that as clean, because on those releases it was; the
+        // unattended cleanup wants a fact `dl` said, and a version skew is
+        // exactly the case where the meaning of silence is what is in doubt.
+        Shape::Sentence => assert!(
+            cleared(&cleanup_of(&safe)).is_empty(),
+            "this dl predates the object form, so its {safe} is silence rather \
+             than an answer, and an unattended run must not delete on it"
+        ),
+    }
+
+    // The two clones really are different, whichever release read them — a test
+    // where both answers were the same would pass on a `dl` that had stopped
+    // looking.
+    assert_ne!(
+        held, safe,
+        "this dl says the same thing about a clone holding an unpushed commit \
+         and one holding nothing"
     );
 }
 


### PR DESCRIPTION
Closes #151

The autonomous-cleanup half, graduated from #138's resolution. Interactive `wf reap` keeps its y/N and its `-f` unchanged; what this adds is the step a `wf-auto` run ends with:

```
$ wf reap --finished blooop/wayfinder#151 blooop/wayfinder#160
  kept     wayfinder-…-160-a  (holds 1 unpushed commit(s))
  removed  wayfinder-…-151-b  (wayfinder#151 is closed)
```

## What it is, and what it is not

Same `plan`, same `doomed`, same one definition of what is finished — called, never re-derived (#137's rule). Everything this adds **subtracts**:

- **Scoped, and the scope is the authority.** Only the nodes the run itself drove to done. A finished workspace of a ticket the run never touched is not collected and not mentioned — that is `wf reap`'s business and a person's. #72's no-sweep posture is kept by construction: the step cannot reach a workspace the run did not finish, so there is nothing for a timer to fire.
- **No prompt.** The agent that just settled those facts is the reader there is. `-y` is legitimate in this context and only this one — and there is no `-y` either, because there is no prompt to skip.
- **A recoverability floor, asserted rather than assumed.** `wf reap` keeps a workspace whose `unsaved` *refuses*, so one with **no answer at all** passes it — right for a release that wrote `null` for a clean clone, with a human reading the row. The floor wants a fact `dl` said out loud. That single asymmetry is also the version gate: a `dl` too old to answer for every clone it made, or one `wf` could not probe, collects nothing and says so.
- **Abort-and-report, whole.** A scoped row the step did not expect — a `warn` where it believed the node finished, a ticket state this binary cannot place, a listing that will not parse — and nothing is deleted at all, not even the rows it did understand. Non-zero exit, one sentence naming the workspace and the cause, and a pointer at `wf reap`.
- **`-f` is never automatic, in any mode.** Not a check: `ReapScope::Finished` carries no field a waiver could be set in, and the argv that spells both is rejected before anything runs.

## Pinning

Each of these was mutation-verified — applied, confirmed red under the full CI selection, reverted:

| mutation | red |
|---|---|
| a `dl` that said nothing reads as clean | `a_clone_dl_never_cleared_stops_the_step_even_where_the_plan_would_reap_it`, `a_cleanup_reading_a_dl_too_old_to_answer_deletes_nothing` |
| the floor clears every answer | `a_plan_made_with_the_waiver_in_it_still_collects_nothing_unattended` |
| a scoped `warn` is merely kept | 5 tests, incl. `every_state_a_node_can_be_in_has_a_decided_fate_and_only_two_delete` |
| the scope stops narrowing | 4 tests, both directions (nothing outside is collected; nothing outside stops it) |
| `DoneByMerge`/`Superseded` swapped | `a_merge_finishes_a_node_and_the_closed_prs_beside_it_do_not` + 3 existing |
| the cleanup passes `--force` | `a_cleanup_hands_dl_the_finished_workspace_of_its_own_node_and_no_force` |
| the flag renamed under the skill | `the_cleanup_the_autonomous_skill_prints_is_one_this_binary_accepts` + 4 |
| the state table loses an arm | `every_state_a_node_can_be_in_has_a_decided_fate_and_only_two_delete` |

Answering #132's thin-pinning finding at the deleting end: `arm()` is an exhaustive match with no wildcard, so a seventh `NodeFact` fails to compile until somebody decides what the *unattended* path does with it, and the table beside it states the six fates as literals.

## Against a real `dl`

`what_this_dl_says_about_a_pushed_clone_is_what_an_unattended_cleanup_acts_on` (#147's harness) builds two real clones with a real remote — one holding a commit that never left it — asks *this* devlaunch's own `read_clone`, and drives the answer through `parse_workspaces` → `plan` → `decide`. Green in all four environments; red under the floor mutation in `stale` (the version gate) and in `latest` (the clearing side).

Driven for real as well, against `dl` 0.0.26 and 0.0.23 with a recording `devpod` in front of them, on a scratch machine so no real workspace was touched:

- closed ticket, pushed clone → `removed wf-live-138 (wayfinder#138 is closed)`, rc=0, and the real `dl <id> rm` reached `devpod delete`;
- one unpushed commit injected → `kept wf-live-138 (holds 1 unpushed commit(s))`, rc=0, clone still there;
- the same fixture under `dl` 0.0.23 → `cleanup stopped and deleted nothing: … dl did not say what this clone holds`, rc=1;
- a scoped node the tracker warns about → stopped, rc=1, nothing deleted;
- `-f` beside `--finished` → rejected at the argv, rc=2.

## Also here

`skills/wf-auto/SKILL.md` grows the step (the skills are what `wf` execs, so the command it prints is this binary's behaviour — and a test parses that line with the binary's own parser). README's `wf reap` section documented "`wf` notices; it never reaps unattended", which this makes untrue, so it says what is true now and the new section says how the two commands differ.

Local chain green under `-D warnings` and `RUSTDOCFLAGS=-D warnings`: 420 lib + 24 bin + 14 skill_docs + 7 devcontainer_prebuild. The contract run has one failure on the author's host — `the_dl_under_test_is_the_one_the_environment_installed`, which reads `CONDA_PREFIX` and finds a global pixi env — and it fails identically on `origin/main`, before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an autonomous cleanup mode that reaps only the workspaces of tickets a run has just finished, with strong safety guarantees and version-aware recoverability checks.

New Features:
- Introduce `wf reap --finished` as a scoped, unattended cleanup command for autonomous runs, driven by explicit node references.
- Expose a `Node::parse` API for reading full ticket references from argv in owner/repo#number form.

Enhancements:
- Factor shared cleanup logic into new `Cleanup` and `Cleared` types plus a `decide` function that enforce scope, recoverability, and all-or-nothing behavior.
- Tighten safety around unattended deletions by requiring explicit positive `dl` recoverability signals and aborting on unexpected plan warnings or unreadable states.
- Extend devlaunch contract tests to exercise the autonomous cleanup path against real clones and legacy `unsaved` formats, ensuring correct behavior across versions.

Documentation:
- Document the new `wf reap --finished` command and its semantics in README and wf-auto skill docs, including its scope, safety properties, and absence of `-f`.
- Update usage/help text to list the scoped reap form and clarify that unattended cleanup cannot be forced.

Tests:
- Add comprehensive unit and integration tests covering scoped cleanup behavior, recoverability floor, warning and error handling, state mapping, argv parsing, and skill/CLI alignment.
- Add probe fixtures and contract tests for legacy devlaunch listings and for real clones with pushed vs unpushed work, validating cleanup decisions.
- Extend main.rs guards to pin all code paths that reach reap commands and ensure no accidental unattended forced deletions.

Chores:
- Refactor reap argument parsing into a `ReapScope` enum that separates machine-wide and finished-node modes and structurally forbids `-f`/`-y` on the autonomous path.