### PR TITLE
A bare cargo test is green, and the live tests have a runner

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,10 +9,22 @@
 # could save. If that number ever grows into the minutes, this is the file to
 # revisit — see blooop/wayfinder#39 for the measurements.
 #
-# What it *does* carry is the three binaries `wf` shells out to and discovers on
-# PATH — `gh`, `zellij`, and the agent CLI — because `cargo test` here is not
-# hermetic: tests/live_fetch.rs drives `gh` against the real tracker and
-# tests/live_zellij_launch.rs starts real zellij sessions.
+# What it *does* carry is three binaries, for two different reasons.
+#
+# `gh` and the agent CLI are things `wf` itself shells out to and discovers on
+# PATH, so a workspace without them cannot run `wf` at all. They are not here
+# for the tests: `cargo test` in here is hermetic and stays green with no
+# network, because every test that reaches a real GitHub is `#[ignore]`d with a
+# reason (see the Checks section of README.md). Running that gated set inside a
+# workspace is a thing you can choose to do — `cargo test -- --ignored` — and
+# `gh` being present is what makes the choice available.
+#
+# `zellij` is here for a different reason and it is worth saying so, because
+# this comment used to justify it by a test file that no longer exists: `wf`
+# stopped launching zellij sessions in 9ae2897 and no code or test in this repo
+# names it now. It stays for interactive use — a workspace is somewhere a
+# person works, and splitting the terminal inside one is worth carrying a
+# single static binary for.
 FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
 
 # Pinned rather than "latest" so an image rebuild is a deliberate version bump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
 # Formatting, lints, tests and docs — everything that can be judged with
-# nothing but a compiler and this checkout. Two other workflows cover what
-# cannot: `package.yml` proves the recipe still installs and runs, and
+# nothing but a compiler and this checkout. Three other workflows cover what
+# cannot: `package.yml` proves the recipe still installs and runs,
 # `devlaunch-contract.yml` runs `wf` against a real `dl` at three chosen
-# versions. All three are kept apart on purpose, and for one reason — a rattler
+# versions, and `live.yml` runs the gh-live tests against the real tracker
+# after a merge. All four are kept apart on purpose, and for one reason — a rattler
 # build and a conda solve each take minutes and download a toolchain of their
 # own, so folding `cargo fmt` into either would make the cheapest possible
 # failure the slowest one to hear about.
@@ -116,8 +117,8 @@ jobs:
         run: "cargo test --locked --test live_fetch -- common::"
 
       # Compiled but not run: a test that no longer builds is rot, and this is
-      # what catches it at the commit that caused it rather than the next time
-      # somebody runs them by hand.
+      # what catches it at the commit that caused it rather than at the next
+      # `live.yml` run after a merge.
       - name: The live tests still compile
         run: cargo test --locked --all-targets --no-run
 

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -1,0 +1,88 @@
+name: live
+
+# The four test binaries that need a real GitHub: `wf`'s fetch, discovery,
+# streaming startup and launch paths, run against this project's own tracker
+# rather than a fixture. `ci.yml` compiles them and never runs them; without
+# this workflow nothing ever did, and the only thing standing behind them was
+# somebody remembering to run them by hand.
+#
+# `tests/live_devlaunch.rs` is the fifth gated binary and is deliberately not
+# here: it wants a chosen `devlaunch` from a pixi environment, which is
+# `devlaunch-contract.yml`'s whole job.
+#
+# ## Not on pull requests, on purpose
+#
+# This is a non-blocking leg and the trigger list is what makes it one. Two of
+# these tests assert the tracker's present contents — that this repo has more
+# than one open map, that the first one has at least seven tickets — and
+# `live_streaming_startup` asserts wall-clock budgets, which are the first
+# thing to flake on a shared runner under a noisy neighbour. All three are
+# right to assert what they assert (asserting reality is the point of a live
+# test), and none of them is a reason to block an unrelated merge. Running
+# after the merge instead means a red run here says "the world moved" at a
+# moment when that is information rather than an obstacle.
+on:
+  push:
+    branches: [main]
+  # The trigger a human pulls after changing the fetch or launch path, when
+  # they want the answer before the merge rather than after it. Same reason
+  # `ci.yml` carries one, plus this one: a leg that only ever fires on `main`
+  # is a leg nobody can aim at a branch.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # As in `ci.yml`. A superseded run on `main` has nothing to say that its
+  # successor will not say better, and the tests here are the slow ones.
+  group: live-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUSTFLAGS: -D warnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  live:
+    name: the live tests, against the real tracker
+    runs-on: ubuntu-latest
+    env:
+      # Every `gh` call this repo makes is a read-only API GET, so the token
+      # the workflow is handed anyway is enough and no secret needs to exist
+      # for this to run. `tests/common` turns a missing one into a diagnostic
+      # rather than a confusing failure, which is why that module is the one
+      # part of `tests/` `ci.yml` already runs.
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      # The checkout is load-bearing beyond supplying the source:
+      # `live_discovery` and `live_launch_exec` resolve this directory's git
+      # `origin` and require it to be `blooop/wayfinder`, so they are testing
+      # the runner's own checkout as much as anything.
+      - uses: actions/checkout@v7
+
+      - name: Install the Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo's registry and the target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: live
+
+      # `--ignored` is how the gated set is selected at all: each of these
+      # tests carries an `#[ignore]` naming what it needs, so a bare
+      # `cargo test` skips them and this is the caller that supplies it. Named
+      # binary by binary rather than `--tests`, so adding a live binary is a
+      # deliberate line here instead of a silent enrolment.
+      #
+      # `--test-threads=1` because `live_streaming_startup`'s budgets are
+      # wall-clock: run beside the pty harness on two shared cores they measure
+      # the runner's load rather than `wf`'s startup.
+      - name: The live tests
+        run: >-
+          cargo test --locked
+          --test live_fetch
+          --test live_discovery
+          --test live_streaming_startup
+          --test live_launch_exec
+          -- --ignored --test-threads=1

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -12,13 +12,13 @@ name: live
 #
 # ## Not on pull requests, on purpose
 #
-# This is a non-blocking leg and the trigger list is what makes it one. Two of
-# these tests assert the tracker's present contents — that this repo has more
-# than one open map, that the first one has at least seven tickets — and
-# `live_streaming_startup` asserts wall-clock budgets, which are the first
-# thing to flake on a shared runner under a noisy neighbour. All three are
-# right to assert what they assert (asserting reality is the point of a live
-# test), and none of them is a reason to block an unrelated merge. Running
+# This is a non-blocking leg and the trigger list is what makes it one. Three
+# of these tests assert the tracker's present contents — that this repo has
+# more than one open map, that the first one has at least seven tickets — and
+# `live_streaming_startup` asserts wall-clock budgets besides, which are the
+# first thing to flake on a shared runner under a noisy neighbour. All of them
+# are right to assert what they assert (asserting reality is the point of a
+# live test), and none of them is a reason to block an unrelated merge. Running
 # after the merge instead means a red run here says "the world moved" at a
 # moment when that is information rather than an obstacle.
 on:
@@ -32,6 +32,10 @@ on:
 
 permissions:
   contents: read
+  # The tests read issues and search via GraphQL. Public data likely answers a
+  # bare token anyway, but this leg only fires after a merge — a wrong guess
+  # here surfaces late and red, so the read is granted rather than gambled on.
+  issues: read
 
 concurrency:
   # As in `ci.yml`. A superseded run on `main` has nothing to say that its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ in the next session, however you launch.
 
 ## Checks
 
-CI runs four things, in the order they are cheap to fix, with **both**
+CI runs the checks below, in the order they are cheap to fix, with **both**
 `RUSTFLAGS=-D warnings` and `RUSTDOCFLAGS=-D warnings` — so anything that warns
 locally fails there. Set them when you run the checks, or the last one lies to
 you: a doc comment linking to a private item is a warning locally and a failed
@@ -150,9 +150,10 @@ shims. Three consequences worth knowing before you touch any of this:
   gh-live four on push to `main` and on `workflow_dispatch`, not on pull
   requests, because two of them assert the tracker's present contents and a
   third asserts wall-clock budgets — a red run means the world moved.
-  `.github/workflows/devlaunch-contract.yml` runs `live_devlaunch` at four
-  devlaunch versions and does block a pull request, because nothing in it
-  depends on the tracker.
+  `.github/workflows/devlaunch-contract.yml` runs `live_devlaunch` in four
+  pixi environments — three pinned devlaunch versions plus `default`, which
+  pins none — and does block a pull request, because nothing in it depends on
+  the tracker.
 - **A new live test needs the attribute and a workflow line.** Without the
   `#[ignore]` it makes a bare `cargo test` fail on any machine lacking what it
   wants; with it and nothing else, it is a test that never runs anywhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,13 +121,43 @@ Run the whole chain before pushing, `cargo fmt --all` first — a formatting dif
 fails the build before any of the interesting checks get a chance to run.
 
 The `tests/live_*.rs` files are excluded from that test command on purpose: they
-talk to real GitHub and drive a real pty. Run them by name when the thing you
-changed is what they cover. Two binaries under `tests/` are exceptions and run
-in the chain (and in CI) like any unit test, because both are offline checks on
-files-as-behavior: `tests/skill_docs.rs` (shape checks on the skill docs'
-snippets) and `tests/devcontainer_prebuild.rs` (the contract between the
-devcontainer configs and the workflow that publishes the prebuilt image to
-GHCR — see the comments in `.devcontainer/devcontainer.json`).
+talk to real GitHub, drive a real pty, or want a chosen `devlaunch`. Two
+binaries under `tests/` are exceptions and run in the chain (and in CI) like any
+unit test, because both are offline checks on files-as-behavior:
+`tests/skill_docs.rs` (shape checks on the skill docs' snippets) and
+`tests/devcontainer_prebuild.rs` (the contract between the devcontainer configs
+and the workflow that publishes the prebuilt image to GHCR — see the comments in
+`.devcontainer/devcontainer.json`).
+
+### The live tests are gated, not absent
+
+All 25 of them carry `#[ignore]` with a reason string saying what they need, so
+a bare `cargo test` is green in a fresh checkout or a fresh devcontainer and
+prints them as skipped — 25 of the 32 a full run reports ignored, the other
+seven being the probe children in `src/` that only mean anything under recording
+shims. Three consequences worth knowing before you touch any of this:
+
+- **`cargo test -- --ignored` runs both halves of the gated set and only one of
+  them can pass.** The eight that need a real GitHub (`live_fetch`,
+  `live_discovery`, `live_streaming_startup`, `live_launch_exec`) want network,
+  an authenticated `gh` and a checkout whose `origin` is `blooop/wayfinder`; the
+  17 in `live_devlaunch` want a pixi environment and the `WF_CONTRACT_*` block,
+  and panic rather than test whatever `dl` is on PATH. Run the first group by
+  name — `cargo test --test live_fetch --test live_discovery -- --ignored` — and
+  the second through `pixi run -e <env> contract`, which supplies the flag
+  itself.
+- **Each group has exactly one workflow.** `.github/workflows/live.yml` runs the
+  gh-live four on push to `main` and on `workflow_dispatch`, not on pull
+  requests, because two of them assert the tracker's present contents and a
+  third asserts wall-clock budgets — a red run means the world moved.
+  `.github/workflows/devlaunch-contract.yml` runs `live_devlaunch` at four
+  devlaunch versions and does block a pull request, because nothing in it
+  depends on the tracker.
+- **A new live test needs the attribute and a workflow line.** Without the
+  `#[ignore]` it makes a bare `cargo test` fail on any machine lacking what it
+  wants; with it and nothing else, it is a test that never runs anywhere.
+  `live.yml` names its test binaries one by one for that reason — enrolment is
+  a deliberate line, not a side effect.
 
 ## The devlaunch contract
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ arguable rather than accumulating.
 
 `cargo test` in a fresh checkout is green with no network, no authenticated
 `gh` and no `devlaunch` installed. Not because the tests that need those are
-missing — there are 25 of them — but because each carries an `#[ignore]`
+missing — there are 25 of them, 25 of the 32 a full run reports ignored, the
+other seven being probe children in `src/` — but because each carries an `#[ignore]`
 naming what it wants, so a default run lists them as skipped instead of
 running them and failing:
 
@@ -175,10 +176,10 @@ any given machine:
   `live_streaming_startup` and `live_launch_exec` want network, an
   authenticated `gh`, a checkout whose `origin` is this repo, and — for the
   launch harness — a real pty. `.github/workflows/live.yml` runs them on every
-  push to `main` and on demand, deliberately not on pull requests: two of them
-  assert this tracker's present contents and one asserts wall-clock budgets, so
-  a red run there means the world moved, which is not a reason to block an
-  unrelated merge. Locally:
+  push to `main` and on demand, deliberately not on pull requests: three of
+  them assert this tracker's present contents and the startup one asserts
+  wall-clock budgets besides, so a red run there means the world moved, which
+  is not a reason to block an unrelated merge. Locally:
 
   ```
   cargo test --test live_fetch --test live_discovery -- --ignored
@@ -187,9 +188,10 @@ any given machine:
 - **The 17 that need a chosen `devlaunch`.** `live_devlaunch` wants a pixi
   environment holding a specific `dl` plus the `WF_CONTRACT_*` facts that
   describe it, and fails closed rather than testing whichever `dl` happens to
-  be installed. `.github/workflows/devlaunch-contract.yml` runs it at four
-  versions; locally that is `pixi run -e floor contract` and its siblings,
-  which pass `--ignored` themselves.
+  be installed. `.github/workflows/devlaunch-contract.yml` runs it in four
+  pixi environments (three pinned versions plus the unpinned `default`);
+  locally that is `pixi run -e floor contract` and its siblings, which pass
+  `--ignored` themselves.
 
 Three things under `tests/` are not gated and run in the default suite like any
 unit test, because all three are offline checks on files-as-behavior:

--- a/README.md
+++ b/README.md
@@ -124,14 +124,18 @@ through the picker, and model invocation needs a file on disk with frontmatter.
 
 ## Checks
 
-`.github/workflows/ci.yml` runs four things on every pull request and every push
-to main, in the order they are cheap to fix:
+`.github/workflows/ci.yml` runs everything that can be judged with nothing but a
+compiler and this checkout, on every pull request and every push to main, in the
+order the steps are cheap to fix:
 
 ```
 cargo fmt --all --check
 cargo clippy --all-targets --all-features --locked
 cargo test --locked --lib --bins --examples
+cargo test --locked --test skill_docs
+cargo test --locked --test devcontainer_prebuild
 cargo test --locked --test live_fetch -- common::
+cargo test --locked --all-targets --no-run
 cargo doc --no-deps --all-features --locked
 ```
 
@@ -144,17 +148,55 @@ file-level `allow` and a reason. `rustfmt.toml` and `clippy.toml` hold the rest;
 every lint that is switched off carries a comment saying why, so the list stays
 arguable rather than accumulating.
 
-Everything under `tests/` is a `live_*` integration test — a real `gh`, real
-network, real assertions against this project's own tracker — so CI compiles
-them but does not run them, and a moving map never breaks a build. The one
-exception is the fourth command above: `tests/common`'s diagnostic, which
-decides what a failing live test tells you about a missing `GH_TOKEN`, is pure
-and needs no network, and an assertion nothing runs is not an assertion. Run
-the rest yourself when the fetch or launch path changes:
+### What a default run covers, and what it skips
+
+`cargo test` in a fresh checkout is green with no network, no authenticated
+`gh` and no `devlaunch` installed. Not because the tests that need those are
+missing — there are 25 of them — but because each carries an `#[ignore]`
+naming what it wants, so a default run lists them as skipped instead of
+running them and failing:
 
 ```
-cargo test --test live_fetch --test live_discovery
+cargo test --locked              # the hermetic suite; the live set is reported ignored
+cargo test --locked -- --ignored # the live set instead — but see the split below
 ```
+
+The reason strings appear in the run, so a skipped test says what it was
+waiting for rather than only that it was skipped. `#[ignore]` and not an
+environment-variable skip, because a skip that reports as a pass is a green
+nobody can trust; and not a feature gate, because the compile-only step above
+is what stops these tests bit-rotting and a gated-out test compiles nowhere.
+
+The gated set splits in two, along the line the workflows are drawn on — so
+`-- --ignored` on its own runs both halves and only one of them can succeed on
+any given machine:
+
+- **The eight that need a real GitHub.** `live_fetch`, `live_discovery`,
+  `live_streaming_startup` and `live_launch_exec` want network, an
+  authenticated `gh`, a checkout whose `origin` is this repo, and — for the
+  launch harness — a real pty. `.github/workflows/live.yml` runs them on every
+  push to `main` and on demand, deliberately not on pull requests: two of them
+  assert this tracker's present contents and one asserts wall-clock budgets, so
+  a red run there means the world moved, which is not a reason to block an
+  unrelated merge. Locally:
+
+  ```
+  cargo test --test live_fetch --test live_discovery -- --ignored
+  ```
+
+- **The 17 that need a chosen `devlaunch`.** `live_devlaunch` wants a pixi
+  environment holding a specific `dl` plus the `WF_CONTRACT_*` facts that
+  describe it, and fails closed rather than testing whichever `dl` happens to
+  be installed. `.github/workflows/devlaunch-contract.yml` runs it at four
+  versions; locally that is `pixi run -e floor contract` and its siblings,
+  which pass `--ignored` themselves.
+
+Three things under `tests/` are not gated and run in the default suite like any
+unit test, because all three are offline checks on files-as-behavior:
+`tests/skill_docs.rs`, `tests/devcontainer_prebuild.rs`, and `tests/common`'s
+own diagnostic — the part that decides what a failing live test tells you about
+a missing `GH_TOKEN`, which is why `ci.yml` names it by filter above. An
+assertion nothing runs is not an assertion.
 
 ## Releasing
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -77,9 +77,10 @@ wf = "scripts/without-dl.sh cargo run --locked --bin wf --"
 # The environment with no `dl` at all is a role like any other, and its
 # contract run goes through the scrubber — otherwise `pixi run` hands it the
 # developer's own devlaunch and the "absent" case is a fiction. Its own task
-# rather than the shared one below, for exactly that reason.
+# rather than the shared one below, for exactly that reason. `--ignored` carries
+# the same meaning here as it does there.
 [feature.none.tasks]
-contract = "scripts/without-dl.sh cargo test --locked --test live_devlaunch -- --test-threads=1"
+contract = "scripts/without-dl.sh cargo test --locked --test live_devlaunch -- --ignored --test-threads=1"
 
 [feature.none.activation.env]
 # Only the role. The absent case is declared by the *silence* of the other
@@ -89,10 +90,18 @@ contract = "scripts/without-dl.sh cargo test --locked --test live_devlaunch -- -
 WF_CONTRACT_ROLE = "none"
 
 [feature.contract.tasks]
+# `--ignored` because every test in that file carries an `#[ignore]` naming what
+# it needs — pixi and the `WF_CONTRACT_*` block below — so that a bare
+# `cargo test` skips them instead of running them against whatever `dl` happens
+# to be installed. These environments are the ones that supply what they need,
+# so they are the ones that ask for them. Without the flag this task selects
+# nothing and reports `ok` for it, which is the failure mode the gate exists to
+# avoid.
+#
 # One `--test-threads=1`: the tests here each spawn `dl`, and a real devlaunch
 # start is ~90 ms of Python. Serial keeps the failure output in an order a human
 # can read.
-contract = "cargo test --locked --test live_devlaunch -- --test-threads=1"
+contract = "cargo test --locked --test live_devlaunch -- --ignored --test-threads=1"
 
 [feature.floor.dependencies]
 devlaunch = "==0.0.24"

--- a/tests/live_devlaunch.rs
+++ b/tests/live_devlaunch.rs
@@ -430,6 +430,7 @@ print(json.dumps({
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn the_dl_under_test_is_the_one_the_environment_installed() {
     // `pixi run` prepends its prefix to the *inherited* PATH, so a developer's
     // own `~/.pixi/bin/dl` is still on it, several entries later. If the
@@ -454,6 +455,7 @@ fn the_dl_under_test_is_the_one_the_environment_installed() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn wf_can_read_the_version_this_dl_prints() {
     // `Devlaunch::Unreadable` is the arm for a `--version` this binary cannot
     // parse, and it sends every isolated launch to the host. It has never been
@@ -488,6 +490,7 @@ fn wf_can_read_the_version_this_dl_prints() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn the_floor_environment_is_pinned_to_the_floor() {
     // The claim AGENTS.md makes, stated as an assertion rather than as a guard.
     //
@@ -532,6 +535,7 @@ fn the_floor_environment_is_pinned_to_the_floor() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn a_listing_from_a_real_dl_is_one_wf_can_read() {
     // `parse_workspaces` is all-or-nothing: a listing with one field `wf`
     // cannot read is a listing it reads *none* of, and `wf reap` then collects
@@ -556,6 +560,7 @@ fn a_listing_from_a_real_dl_is_one_wf_can_read() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn every_unsaved_answer_this_dl_can_give_is_one_wf_reads() {
     // The field that has already broken once, asked of the code that writes it.
     //
@@ -608,6 +613,7 @@ for answer in (
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn what_this_dl_says_about_a_clone_holding_work_is_what_wf_reads() {
     // The whole path, on both sides of the version boundary: a real checkout
     // with a real uncommitted file, inspected by *this* devlaunch's own
@@ -657,6 +663,7 @@ fn what_this_dl_says_about_a_clone_holding_work_is_what_wf_reads() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn whether_wf_trusts_a_missing_unsaved_follows_the_release() {
     // The decision `answers_unsaved` exists for, and the most dangerous one in
     // the pair: on a release that answers for every clone of its own, a `null`
@@ -741,6 +748,7 @@ fn cleared(cleanup: &Cleanup) -> Vec<&str> {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn what_this_dl_says_about_a_pushed_clone_is_what_an_unattended_cleanup_acts_on() {
     // The recoverability floor (#151) against a real devlaunch, on both sides
     // of the answer. `wf reap` prints its plan and waits; the cleanup a run
@@ -832,6 +840,7 @@ fn git(dir: &Path, args: &[&str]) {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn the_environment_without_devlaunch_really_has_none() {
     // The premise every assertion in the `none` environment rests on, and the
     // one that is easiest to lose: `pixi run` prepends its prefix to the
@@ -856,6 +865,7 @@ fn the_environment_without_devlaunch_really_has_none() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn a_devcontainer_repo_is_isolated_only_when_a_real_dl_can_carry_it() {
     // The fallback itself, rather than the reading that decides it.
     //
@@ -896,6 +906,7 @@ fn a_devcontainer_repo_is_isolated_only_when_a_real_dl_can_carry_it() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn a_launch_that_fell_back_says_why_and_names_the_version() {
     // The half of a degradation a missing `(devlaunch)` suffix cannot carry.
     //
@@ -937,6 +948,7 @@ fn a_launch_that_fell_back_says_why_and_names_the_version() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn a_reap_with_no_dl_refuses_instead_of_guessing() {
     // `wf reap` is the one path in this crate that deletes, and it decides what
     // to delete from what `dl --ls --json` told it. With no `dl` there is no
@@ -1295,6 +1307,7 @@ exit 0
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn the_removal_wf_sends_reaches_devpod_as_a_delete() {
     // `wf reap`'s argv, run by the real `dl`, on every release: reap deletes
     // through whichever `dl` is on PATH, so this has to hold below the floor
@@ -1328,6 +1341,7 @@ fn the_removal_wf_sends_reaches_devpod_as_a_delete() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn the_prewarm_wf_sends_is_the_verb_the_floor_exists_for() {
     // The 0.14.0 regression, as a test.
     //
@@ -1397,6 +1411,7 @@ fn the_prewarm_wf_sends_is_the_verb_the_floor_exists_for() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn an_isolated_launch_arrives_as_one_shell_command() {
     // `wf`'s quoting against `dl`'s shell, with nothing between them.
     //
@@ -1513,6 +1528,7 @@ fn an_isolated_launch_arrives_as_one_shell_command() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn every_subprocess_this_file_starts_itself_goes_through_hermetic() {
     // A guard on this file's own source — and only on this file's own source,
     // which is a real limit rather than an oversight. `Isolation::detect` and
@@ -1564,6 +1580,7 @@ fn every_subprocess_this_file_starts_itself_goes_through_hermetic() {
 }
 
 #[test]
+#[ignore = "live: contract run — needs pixi and WF_CONTRACT_* (see pixi contract tasks)"]
 fn the_sanitised_spawn_hands_on_nothing_it_was_not_given() {
     // The allowlist, read off a real child rather than off the source.
     //

--- a/tests/live_discovery.rs
+++ b/tests/live_discovery.rs
@@ -11,6 +11,7 @@ use wf::projects::{discover_checkout, ProjectsCache};
 mod common;
 
 #[tokio::test]
+#[ignore = "live: needs network, gh, and a blooop/wayfinder checkout with >1 open map"]
 async fn registering_this_checkout_finds_and_fetches_its_map() {
     // Discover: this checkout's toplevel and origin-derived slug.
     let here = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -12,6 +12,7 @@ use wf::model::{Status, TicketType};
 mod common;
 
 #[tokio::test]
+#[ignore = "live: needs network + an authenticated gh"]
 async fn fetches_the_live_wayfinder_map() {
     let map_id = common::a_live_map().await;
     let map = wf::fetch::fetch_map(&map_id)

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -516,6 +516,7 @@ fn flags(stty: &str) -> Vec<&str> {
 // launch. Splitting it to satisfy a line count would mean three real starts.
 #[allow(clippy::too_many_lines)]
 #[test]
+#[ignore = "live: needs network, gh, a blooop/wayfinder checkout, and a pty"]
 fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
     let scratch = Scratch::new("exec");
     scratch.write_shims();
@@ -1006,6 +1007,7 @@ fn launch_the_first_ticket(keys: &mut std::fs::File, seen: &Arc<Mutex<Vec<u8>>>,
 /// *started* the work is the one that returns to it — which is the claim the
 /// whole feature is for.
 #[test]
+#[ignore = "live: needs network, gh, a blooop/wayfinder checkout, and a pty"]
 fn coming_back_to_a_node_rejoins_the_conversation_the_first_launch_started() {
     let scratch = Scratch::new("resume");
     scratch.write_shims();

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -38,6 +38,7 @@ fn scratch_cache(tag: &str) -> PathBuf {
 }
 
 #[tokio::test]
+#[ignore = "live: needs network + gh; asserts wall-clock budgets"]
 async fn discovery_then_every_map_arrives_through_one_channel() {
     let (tx, mut rx) = mpsc::unbounded_channel();
     let cache_path = scratch_cache("discovery");
@@ -104,6 +105,7 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
 }
 
 #[tokio::test]
+#[ignore = "live: needs network + gh; asserts wall-clock budgets"]
 async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
     // The #28 claim, end to end: with the map id already in hand, the map
     // itself lands in one round trip — no ~2.5s search in front of it.
@@ -135,6 +137,7 @@ async fn a_cached_seed_fetches_the_map_without_waiting_for_the_search() {
 }
 
 #[tokio::test]
+#[ignore = "live: needs network + gh; asserts wall-clock budgets"]
 async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
     // A cached id that no longer names a map — here `#2`, a closed sub-issue
     // that exists and is not a map, which is refused for either reason alone.
@@ -178,6 +181,7 @@ async fn a_stale_seed_reports_failure_and_is_replaced_by_the_search() {
 }
 
 #[tokio::test]
+#[ignore = "live: needs network + gh; asserts wall-clock budgets"]
 async fn shutdown_leaves_nothing_in_flight() {
     // The launch path awaits this immediately before `exec`. An in-flight `gh`
     // that outlives the exec is inherited by the agent as a zombie holding its

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -54,9 +54,9 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // go round and wait for the next event.
             LoadEvent::SearchFailed => {}
             // Named rather than `_`, so a seventh kind of arrival is a compile
-            // error here and a decision someone makes — this file is compiled
-            // but never run by CI, which makes a wildcard in it the least
-            // observed thing in the tree.
+            // error here and a decision someone makes — this file runs only
+            // after a merge (`live.yml`), which would make a wildcard in it
+            // the slowest-observed thing in the tree.
             other @ (LoadEvent::Fetched { .. } | LoadEvent::Surveyed { .. }) => {
                 panic!("expected discovery first, got {other:?}")
             }


### PR DESCRIPTION
Closes #42

A bare `cargo test` in a fresh checkout was red — the contract tests failed
closed with 15 panics — because nothing separated the tests that need only a
compiler from the 25 that need network, an authenticated `gh`, a pty, or a
chosen `devlaunch`. Built to the decisions in the ticket's grilling resolution,
not to the ticket body: two of the five files it names (`live_zellij_launch.rs`,
`live_poll.rs`) were deleted in 9ae2897, so the whole zellij branch of the
question was moot.

## What changed

- **All 25 live tests get `#[ignore]` with a per-file reason string.** An
  env-var skip was rejected because a skip that reports as a pass is a green
  nobody can trust; a feature gate was rejected because CI's
  `cargo test --all-targets --no-run` is the only thing keeping these tests from
  bit-rotting and a gated-out test compiles nowhere. Test bodies are untouched —
  the assertions about the real tracker stay exactly as they were (decision 3:
  asserting reality is the point of a live test).
- **The pixi `contract` tasks pass `--ignored`.** They are the callers that
  supply what `live_devlaunch` needs, so they are the ones that ask for it.
  Worth naming the near-miss: without the flag those tasks select nothing and
  libtest prints `ok` for the empty selection, so `devlaunch-contract.yml` would
  have stayed green while checking nothing.
- **New `.github/workflows/live.yml`** runs the eight gh-live tests on push to
  `main` and on `workflow_dispatch`, serially, with `GH_TOKEN: ${{ github.token }}`
  — every `gh` call in this repo is a read-only GET, so no secret is needed.
  Deliberately not on pull requests: two of these tests assert the tracker's
  present contents and one asserts wall-clock budgets, so a red run means the
  world moved, which should not block an unrelated merge. `live_devlaunch` stays
  out of it — it has `devlaunch-contract.yml`.
- **The devcontainer says why zellij is in it, truthfully.** Its justification
  cited `tests/live_zellij_launch.rs`, deleted a while ago. Zellij stays, for
  interactive use in a workspace, and the comment now says that.
- **README and AGENTS.md** state what `cargo test`, `cargo test -- --ignored`
  and each of the two live workflows covers — including that `-- --ignored`
  selects both halves of the gated set and only one half can pass on a given
  machine.

## Verified locally

| check | result |
| --- | --- |
| `cargo test --locked` (bare) | green, **32 ignored** — see the note below |
| `cargo test --locked --all-targets --no-run` | compiles, bit-rot guard intact |
| `ci.yml`'s `--test live_fetch -- common::` step | green, 3 passed / 1 filtered |
| the whole AGENTS.md check chain, `-D warnings` on both | green |
| `pixi run lint`, `pixi run suite` | green |
| `pixi run -e default contract` | **17 passed** — the `--ignored` change proven end to end |
| the 4 gh-live files, `-- --ignored --test-threads=1` | **8 passed, 0 failed** (rc=0) |

**The ignored count is 32, not the 25 the resolution predicted.** Seven tests in
`src/` were already `#[ignore]`d before this branch — the probe children that
only mean anything under recording shims. 25 of the 32 are the live set this PR
gates; nothing was double-counted and nothing else changed. Those seven no-op
under `cargo test -- --ignored` (they check `probe::is_child()` first), so
documenting that command as a way to reach the live set is safe.

**One environmental failure, pre-existing and not fixed here.**
`pixi run -e floor contract` fails one of its 17 on the machine this was built
on: `the_dl_under_test_is_the_one_the_environment_installed` compares the
resolved `dl` against `CONDA_PREFIX`, and on this host `cargo` is a pixi-global
trampoline (`~/.pixi/bin/cargo`) that overwrites `CONDA_PREFIX` with its own
`rust` environment for every process below it. The `dl` under test is in fact
the right one. Reproduced identically with `main`'s `tests/live_devlaunch.rs`
and `main`'s command form, so it predates this branch; CI takes `cargo` from
rustup rather than a trampoline, which is why `devlaunch-contract.yml` is green
there. Weakening the assertion would have been the wrong fix — it is the one
that makes the version pin mean anything.

## Post-merge acceptance step

`workflow_dispatch` only becomes available once `live.yml` is on the default
branch, so "green on a manual dispatch" — the last line of the resolution's
acceptance list — cannot be demonstrated from this PR. The push-to-`main`
trigger fires on merge and is the first real run either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Gate all live integration tests behind #[ignore] and add targeted workflows and documentation so default test runs are hermetic while still exercising live paths in CI and via pixi contract tasks.

New Features:
- Add a dedicated live GitHub workflow that runs the gh-based integration tests against the real tracker on pushes to main and manual dispatch.
- Document the behavior and usage of live tests and gated test runs in README and AGENTS, including how cargo test and cargo test -- --ignored split the suite.

Bug Fixes:
- Ensure pixi devlaunch contract tasks actually execute the live_devlaunch tests by selecting ignored tests instead of silently running nothing.
- Make a bare cargo test in a fresh checkout or devcontainer succeed by marking all live tests as ignored with explicit reason strings.

Enhancements:
- Extend CI test coverage by explicitly running skill_docs and devcontainer_prebuild tests, and adding a compile-only all-targets no-run step as a bit-rot guard.
- Clarify the devcontainer Dockerfile rationale for shipping gh, the agent CLI, and zellij, decoupling zellij from now-removed tests and framing it as an interactive workspace tool.

Documentation:
- Update README and AGENTS to explain CI coverage, the hermetic default test suite, the gated live test set, and the responsibilities of live.yml and devlaunch-contract.yml.

Tests:
- Mark all live GitHub and devlaunch contract tests with #[ignore] annotations that describe their environmental requirements, keeping their bodies intact while controlling when they run.
- Run live devlaunch contract tests serially via pixi tasks and ensure they are only executed in environments that satisfy the WF_CONTRACT_* requirements.