### PR TITLE
the prebuild guard claims only what it holds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,11 +77,12 @@ RUN set -eux; \
 #
 # Matched on a word boundary rather than as a substring, because a substring
 # match accepts a version it was never pinned to: `2.1.2234` contains `2.1.223`,
-# as does `12.1.223`. Boundary matching refuses both while staying agnostic about
-# the shape of the line the version arrives in — the three tools pinned in this
-# file each print a different one (`2.1.223 (Claude Code)`, `gh version 2.97.0
-# https://…`, `zellij 0.44.3`), so parsing a field out would be a fourth thing to
-# keep in step with three upstreams.
+# as does `12.1.223`. Boundary matching refuses both. It is not fully
+# shape-proof — `.` and `-` are non-word characters, so a `2.1.223-beta` would
+# still match, and a `v`-prefixed `v2.1.223` would be refused (loudly, the safe
+# direction) — but it stays agnostic about the line the version arrives in
+# (today: `2.1.223 (Claude Code)`), where parsing a field out would be one more
+# format to keep in step with the upstream installer.
 USER vscode
 RUN set -eux; \
     curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_VERSION"; \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -74,13 +74,19 @@ RUN set -eux; \
 # argument would leave this pin buying nothing with the build still green. The
 # comparison also backstops the unpiped `curl | bash` — a truncated script that
 # installed something else fails here.
+#
+# Matched on a word boundary rather than as a substring, because a substring
+# match accepts a version it was never pinned to: `2.1.2234` contains `2.1.223`,
+# as does `12.1.223`. Boundary matching refuses both while staying agnostic about
+# the shape of the line the version arrives in — the three tools pinned in this
+# file each print a different one (`2.1.223 (Claude Code)`, `gh version 2.97.0
+# https://…`, `zellij 0.44.3`), so parsing a field out would be a fourth thing to
+# keep in step with three upstreams.
 USER vscode
 RUN set -eux; \
     curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_VERSION"; \
     installed="$(/home/vscode/.local/bin/claude --version)"; \
-    case "$installed" in \
-      *"$CLAUDE_VERSION"*) ;; \
-      *) echo "pinned CLAUDE_VERSION=$CLAUDE_VERSION but installed: $installed" >&2; exit 1 ;; \
-    esac
+    printf '%s' "$installed" | grep -qwF "$CLAUDE_VERSION" \
+      || { echo "pinned CLAUDE_VERSION=$CLAUDE_VERSION but installed: $installed" >&2; exit 1; }
 ENV PATH=/home/vscode/.local/bin:$PATH
 USER root

--- a/tests/devcontainer_prebuild.rs
+++ b/tests/devcontainer_prebuild.rs
@@ -301,9 +301,19 @@ fn only_the_publishing_job_can_write_a_package() {
 
 /// Every argument to `docker push` in the workflow, in order. Collected by
 /// what the command *does*, not by what the reference is expected to look
-/// like: a push target renamed to anything at all — another repository,
-/// another registry, a bare local tag — still lands here, where a filter on
-/// the expected name would let it vanish from the comparison entirely.
+/// like: rename the existing push's argument to anything at all — another
+/// repository, another registry, a bare local tag — and it still lands here,
+/// where a filter on the expected name would let it vanish from the comparison
+/// entirely.
+///
+/// That rename is the whole of the scope, and the wording used to claim more
+/// (#158). This matches three whitespace-separated tokens, so it sees a push
+/// only where `docker push <ref>` is written as three tokens: splitting the
+/// command across a line continuation (`docker \` then `push …`) hides it, as
+/// does publishing by some other mechanism entirely — a `build-push-action`
+/// step, `buildx --push`, a `curl` to the registry API. Those are additions
+/// rather than drift, and adding one takes push access to this repository,
+/// which is also enough to edit this file.
 fn pushed_references(workflow: &str) -> Vec<String> {
     workflow
         .split_whitespace()
@@ -316,8 +326,14 @@ fn pushed_references(workflow: &str) -> Vec<String> {
 
 /// Every reference to a container image anywhere in the workflow: each
 /// `docker push` argument, each tag handed to `docker build -t`, and any
-/// `ghcr.io/`-prefixed token besides (a login line, a second tag, a stray
-/// env value). Unfiltered on purpose — see `pushed_references`.
+/// `ghcr.io/`-prefixed token besides (a second tag, a stray env value).
+/// Unfiltered on purpose — see `pushed_references`.
+///
+/// Not the registry login, though this comment used to say so (#158): the
+/// login names the registry host bare, `docker login ghcr.io`, with no
+/// repository path after it — no slash, no prefix match, never collected. It
+/// is not unguarded, it is guarded elsewhere, by
+/// `the_push_authenticates_with_the_runs_own_token`.
 fn published_references(workflow: &str) -> std::collections::BTreeSet<String> {
     let mut references: std::collections::BTreeSet<String> =
         pushed_references(workflow).into_iter().collect();
@@ -363,7 +379,11 @@ fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() 
         std::collections::BTreeSet::from([booted.clone()]),
         "the workflow must name exactly the reference the default config boots \
          from ({booted}) and no other — one mutable tag, `latest`, per the \
-         decision on #150"
+         decision on #150. The limit of that claim (#158): this guards \
+         accidental drift of the ghcr publish — a renamed argument, a deleted \
+         step, a second `ghcr.io/` tag. A deliberately added publish to \
+         another registry is outside this tokenizer's sight, and outside what \
+         a test can hold against someone who already has push access"
     );
 }
 

--- a/tests/devcontainer_prebuild.rs
+++ b/tests/devcontainer_prebuild.rs
@@ -359,6 +359,13 @@ fn published_references(workflow: &str) -> std::collections::BTreeSet<String> {
 /// workflow, and the workflow's own push renamed (or deleted) away from the
 /// config — the second is what the first review of #152 mutation-checked
 /// straight through a prefix-filtered version of this test.
+///
+/// The limit of the claim (#158): this holds every publish the tokenizers can
+/// see — any `docker push <ref>` written as three tokens, whatever the
+/// registry, and any `-t`/`--tag` — but not one added by a mechanism they do
+/// not see (a line continuation, a `build-push-action` step, `buildx --push`,
+/// a `curl` to the registry API). Those are additions rather than drift, and
+/// adding one takes push access, which is also enough to edit this file.
 #[test]
 fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() {
     let workflow = publishing_workflow();
@@ -380,10 +387,11 @@ fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() 
         "the workflow must name exactly the reference the default config boots \
          from ({booted}) and no other — one mutable tag, `latest`, per the \
          decision on #150. The limit of that claim (#158): this guards \
-         accidental drift of the ghcr publish — a renamed argument, a deleted \
-         step, a second `ghcr.io/` tag. A deliberately added publish to \
-         another registry is outside this tokenizer's sight, and outside what \
-         a test can hold against someone who already has push access"
+         drift of any publish the tokenizers can see — a renamed argument, a \
+         deleted step, a second tag, whatever the registry. A publish added \
+         by a mechanism they do not see (a line continuation, a \
+         build-push-action step) is outside it, and outside what a test can \
+         hold against someone who already has push access"
     );
 }
 


### PR DESCRIPTION
Closes #158

Per the grilling resolution on the ticket: **narrow the wording, do not widen the guard.**

The blind spot #152's re-review found — a deliberately added non-ghcr publish — is sabotage rather than drift, and sabotage takes push access, which is also enough to edit the test. Widening the tokenizer (continuation-aware parsing, `build-push-action` steps, buildx `--push`) would buy nothing durable, since the next publish shape escapes it again, while adding false-red surface on legitimate workflow refactors. So the claims move to meet the mechanism instead.

Three text changes and one behavioural one:

- The **"and no other"** assert message gains the limit it actually holds: accidental drift of the ghcr publish — a renamed argument, a deleted step, a second `ghcr.io/` tag. A publish deliberately added to another registry is stated as out of sight and out of scope.
- **`pushed_references`** claimed a push target "renamed to anything at all" still lands there. The continuation-split mutant (`docker \` newline `push …`) showed that is false as written, so the claim is scoped to renames of the existing `docker push` command's argument, with the token-matching limit spelled out.
- **`published_references`** claimed the sweep catches "a login line". It does not — the login names the registry host bare (`docker login ghcr.io`), no slash, so the `ghcr.io/` prefix never matches and the token is never collected. Corrected to what the sweep really sees, and pointed at `the_push_authenticates_with_the_runs_own_token`, which is what actually guards that step.
- **Rider, executable:** the Dockerfile pin check compared with a substring `case`, so a version merely *containing* the pin satisfied it — `2.1.2234` passed a pin of `2.1.223`, as did `12.1.223`. Replaced with word-boundary matching:

  ```sh
  printf %s "$installed" | grep -qwF "$CLAUDE_VERSION" \
    || { echo "pinned CLAUDE_VERSION=$CLAUDE_VERSION but installed: $installed" >&2; exit 1; }
  ```

  Boundary matching stays agnostic about the shape of the version line, which matters because the three tools pinned in this file each print a different one (`2.1.223 (Claude Code)`, `gh version 2.97.0 https://…`, `zellij 0.44.3`) — parsing a field out would be a fourth thing to keep in step with three upstreams.

## Verification

The pin check only runs inside `docker build`, so its new form was checked directly in a shell against both tools' real output shapes: the exact pin, a bare version, and a name-prefixed version all accept; `2.1.2234`, `12.1.223` and `2.1.22` all refuse. The old `case` form accepts the first two of those three, which is the bug.

All 7 prebuild tests stay green, and the full AGENTS.md chain (fmt, clippy, suite, skill docs, prebuild, doc — both `-D warnings` flags set) is clean. The guard was re-mutated to confirm the wording change left it real rather than vacuous: renaming the workflow's push target still reddens `the_workflow_publishes_exactly_the_reference_the_default_config_boots_from`.

As the resolution states, the two mutants that escaped #152's re-review are **not** expected to redden — the wording now says as much, which was the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify and narrow the devcontainer prebuild guard’s assertions to match what the workflow tokenizer actually observes, and tighten the devcontainer tool version pin check.

Bug Fixes:
- Ensure the devcontainer CLAUDE_VERSION pin check rejects versions that only contain the pinned value as a substring, preventing false positives for mismatched versions.

Enhancements:
- Refine pushed and published reference collection comments to accurately describe the scope and limitations of the workflow analysis, including exclusions like registry logins and non-docker-push publish mechanisms.
- Clarify the workflow publish assertion message so it explicitly scopes its guarantee to accidental drift of the ghcr publish rather than deliberate publishes to other registries.