### PR TITLE
The picker opens one way, and the hold resolves itself

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -228,11 +228,8 @@ enum Pinned {
 
 impl Pinned {
     /// Where the hold lands once `new_order` is the order on screen.
-    ///
-    /// Each arm answers for itself rather than being taken apart into the
-    /// `Option` it was made to replace: [`crate::refresh::preserve_cursor`] is *told*
-    /// what is pinned here, so the two shapes stay two shapes all the way down
-    /// to the one call that needs them to be one.
+    /// Each arm answers for itself, so the two shapes stay two shapes all
+    /// the way down to the one call that needs them to be one.
     fn resolve(&self, new_order: &[StopKey]) -> usize {
         match self {
             Pinned::Identity(key, fallback) => {
@@ -868,7 +865,7 @@ impl App {
     /// has no blockers and no stage, and a finished one is not drawn.
     ///
     /// Staging **chooses the stop it acts on** (#148), and every arm that
-    /// opens the picker goes through [`App::open_picker`] to do it — the
+    /// opens the picker goes through [`App::open_launch_picker`] to do it — the
     /// refusals do not, because nothing was staged, so nothing was chosen.
     fn request_launch(&mut self) -> Outcome {
         match self.cursor_stop() {
@@ -888,7 +885,7 @@ impl App {
                 // resumable as a build one — and rather more worth resuming.
                 let staged = self.resumable(staged, id.number);
                 self.prewarm(&staged);
-                self.open_picker(staged);
+                self.open_launch_picker(staged);
                 Outcome::Continue
             }
             // One stop, two screens, and the screen decides — which is the
@@ -906,7 +903,7 @@ impl App {
                     self.enter(&repo);
                     return Outcome::Continue;
                 }
-                self.open_picker(Staged::project(&repo));
+                self.open_launch_picker(Staged::project(&repo));
                 Outcome::Continue
             }
             Some(Stop::Ticket(row)) => self.request_ticket_launch(&row),
@@ -942,7 +939,7 @@ impl App {
             Some(staged) => {
                 let staged = self.resumable(staged, ticket.number);
                 self.prewarm(&staged);
-                self.open_picker(staged);
+                self.open_launch_picker(staged);
                 Outcome::Continue
             }
         }
@@ -961,7 +958,7 @@ impl App {
     /// one statement pair in one function precisely so that they cannot come
     /// apart: a new stop worth staging reaches the picker through here, and
     /// arrives with its row already chosen.
-    fn open_picker(&mut self, staged: Staged) {
+    fn open_launch_picker(&mut self, staged: Staged) {
         self.cursor = Cursor::Chosen(self.cursor_pos());
         self.overlay = Overlay::PickLaunch {
             candidate: staged.default_candidate(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,6 +226,25 @@ enum Pinned {
     Position(usize),
 }
 
+impl Pinned {
+    /// Where the hold lands once `new_order` is the order on screen.
+    ///
+    /// Each arm answers for itself rather than being taken apart into the
+    /// `Option` it was made to replace: [`crate::refresh::preserve_cursor`] is *told*
+    /// what is pinned here, so the two shapes stay two shapes all the way down
+    /// to the one call that needs them to be one.
+    fn resolve(&self, new_order: &[StopKey]) -> usize {
+        match self {
+            Pinned::Identity(key, fallback) => {
+                crate::refresh::preserve_cursor(Some(key), *fallback, new_order)
+            }
+            Pinned::Position(fallback) => {
+                crate::refresh::preserve_cursor(None, *fallback, new_order)
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct App {
     /// The clusters on screen: every open map that has arrived, keyed by id.
@@ -834,14 +853,7 @@ impl App {
             .iter()
             .map(|at| self.stop_key(&at.stop))
             .collect();
-        self.cursor = Cursor::Chosen(match pinned {
-            Pinned::Identity(key, fallback) => {
-                crate::refresh::preserve_cursor(Some(&key), fallback, &new_order)
-            }
-            Pinned::Position(fallback) => {
-                crate::refresh::preserve_cursor(None, fallback, &new_order)
-            }
-        });
+        self.cursor = Cursor::Chosen(pinned.resolve(&new_order));
     }
 
     /// The first enter (#62): stage a launch of whatever the cursor is on by
@@ -855,13 +867,9 @@ impl App {
     /// on a still-open ticket refuses too. Neither can arise on a map: a map
     /// has no blockers and no stage, and a finished one is not drawn.
     ///
-    /// Staging **chooses the stop it acts on** (#148): every arm that opens
-    /// the picker records the cursor as [`Cursor::Chosen`] there. To the human
-    /// the launch *is* a selection of that row, however the cursor arrived on
-    /// it — an untouched cursor sitting on the first match is enough — and
-    /// without the write a refresh would re-derive "the top" and carry the
-    /// cursor off the very row whose launch is being picked. The refusals do
-    /// not write: nothing was staged, so nothing was chosen.
+    /// Staging **chooses the stop it acts on** (#148), and every arm that
+    /// opens the picker goes through [`App::open_picker`] to do it — the
+    /// refusals do not, because nothing was staged, so nothing was chosen.
     fn request_launch(&mut self) -> Outcome {
         match self.cursor_stop() {
             // On a group line there is no agent to run, and exactly one thing
@@ -880,13 +888,7 @@ impl App {
                 // resumable as a build one — and rather more worth resuming.
                 let staged = self.resumable(staged, id.number);
                 self.prewarm(&staged);
-                self.cursor = Cursor::Chosen(self.cursor_pos());
-                self.overlay = Overlay::PickLaunch {
-                    candidate: staged.default_candidate(),
-                    staged,
-                    agent: Agent::default(),
-                    steer: String::new(),
-                };
+                self.open_picker(staged);
                 Outcome::Continue
             }
             // One stop, two screens, and the screen decides — which is the
@@ -904,14 +906,7 @@ impl App {
                     self.enter(&repo);
                     return Outcome::Continue;
                 }
-                let staged = Staged::project(&repo);
-                self.cursor = Cursor::Chosen(self.cursor_pos());
-                self.overlay = Overlay::PickLaunch {
-                    candidate: staged.default_candidate(),
-                    staged,
-                    agent: Agent::default(),
-                    steer: String::new(),
-                };
+                self.open_picker(Staged::project(&repo));
                 Outcome::Continue
             }
             Some(Stop::Ticket(row)) => self.request_ticket_launch(&row),
@@ -947,16 +942,33 @@ impl App {
             Some(staged) => {
                 let staged = self.resumable(staged, ticket.number);
                 self.prewarm(&staged);
-                self.cursor = Cursor::Chosen(self.cursor_pos());
-                self.overlay = Overlay::PickLaunch {
-                    candidate: staged.default_candidate(),
-                    staged,
-                    agent: Agent::default(),
-                    steer: String::new(),
-                };
+                self.open_picker(staged);
                 Outcome::Continue
             }
         }
+    }
+
+    /// Put the launch picker up on `staged` — **the only place it opens**, as
+    /// distinct from the key handler that re-seats one already up, so the
+    /// cursor write below cannot be forgotten by an arm added later.
+    ///
+    /// Staging chooses the stop it acts on (#148): the cursor is recorded as
+    /// [`Cursor::Chosen`] *before* the overlay is set. To the human the launch
+    /// *is* a selection of that row, however the cursor arrived on it — an
+    /// untouched cursor sitting on the first match is enough — and without the
+    /// write a refresh would re-derive "the top" and carry the cursor off the
+    /// very row whose launch is being picked. The write and the overlay are
+    /// one statement pair in one function precisely so that they cannot come
+    /// apart: a new stop worth staging reaches the picker through here, and
+    /// arrives with its row already chosen.
+    fn open_picker(&mut self, staged: Staged) {
+        self.cursor = Cursor::Chosen(self.cursor_pos());
+        self.overlay = Overlay::PickLaunch {
+            candidate: staged.default_candidate(),
+            staged,
+            agent: Agent::default(),
+            steer: String::new(),
+        };
     }
 
     /// Start warming the staged node's container while the launch picker is


### PR DESCRIPTION
Closes #156

Two shape refactors recorded from PR #155's review. Behaviour is unchanged and the existing suite is what pins it: **478 passed / 32 ignored before, 478 passed / 32 ignored after, with no test edited**. That is the acceptance criterion for this ticket — a test that had to move would have meant behaviour moved with it.

## `open_picker`: the invariant is structural now

#148 established that staging chooses the stop it acts on — the picker cannot open without the cursor being written as `Cursor::Chosen`, or a refresh re-derives "the top" and carries the cursor off the very row whose launch is being picked. That rule was enforced by a doc comment on `request_launch` asking each of the three opening arms (map, project, ticket) to remember a five-line block. The block is one `open_picker` call now, so a fourth stop worth staging reaches the picker with its row already chosen, or does not reach the picker at all.

The doc comment moved with the code it describes: the invariant paragraph is on `open_picker`, and `request_launch` keeps a one-sentence pointer rather than restating it. The helper's prose is explicit that it is the *opening* site, as distinct from the launch-picker key handler, which re-seats an overlay already up and correctly does not write the cursor.

## `Pinned::resolve`

`Pinned` was built as a sum type in #155 to stop "pinned by identity" and "pinned by position" sharing one shape told apart by reading an inner `Option`. It was then matched straight back into `Some(&key)` / `None` at the `preserve_cursor` call site. `resolve` moves that match onto the type, so the two arms stay two arms down to the one call that needs them to be one, and the call site is a single expression.

## Judgement call: no new tests

The instinct is to add a test that the map and project arms also choose their row — `staging_a_launch_chooses_the_row_it_acts_on` only exercises the ticket arm. I did not, for two reasons. First, it would pin the same claim a third time without covering the failure mode this ticket exists to prevent: a test can only assert about arms that exist, and the arm that forgets the write is by definition the one nobody wrote a test for. The structure is the guard; a test is not. Second, it would be new behavioural coverage smuggled into a behaviour-preserving diff, which is exactly the confusion the "no test changed" criterion is there to make visible.

`Pinned::resolve` is likewise a pure move of an expression, already covered through `replace_clusters` by the empty-list and reorder tests, and directly by `refresh::preserve_cursor`'s own unit tests.

A reviewer who disagrees on either point is disagreeing about coverage the ticket did not ask for, not about this diff's correctness — worth saying out loud rather than leaving implicit.

## Checks

Full AGENTS.md chain with `RUSTFLAGS=-D warnings` and `RUSTDOCFLAGS=-D warnings`: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --locked`, the three test commands, `cargo doc --no-deps --all-features --locked`. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refactor launch staging and cursor preservation logic without changing behaviour.

Enhancements:
- Introduce a Pinned::resolve helper to encapsulate cursor preservation based on pinned identity or position.
- Centralize launch picker initialization into an App::open_picker helper to ensure the cursor is marked as chosen whenever the picker opens.
- Update documentation comments to describe the staging invariant and the picker opening site in one place, keeping request_launch as a thin delegator.