### PR TITLE
Release 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.17.2"
+version = "0.18.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.17.2"
+  version: "0.18.0"
 
 package:
   name: wf


### PR DESCRIPTION
Release 0.18.0

Minor: a launch now heals the skill *links*, not only the copies behind them
(#171, closing #170). `refresh` considered a skill only where the link was
already the one it writes, so the set of skills a machine had was frozen at
whatever `wf skills install` last saw — and since `pixi global update wf`
rewrites the bundle in the prefix while writing nothing under an agent's config
directory, a skill a new build ships stayed unlinked through every launch that
followed. It surfaced as an unknown-skill prompt inside a devcontainer, nowhere
near the update that caused it. A missing link is now created and a stale one
repointed only where `is_ours` proves `wf` wrote it, which reclaims the
pre-#110 absolute link into the prefix; a real directory another tool owns, a
link `wf` cannot claim, and a machine that never installed are all still
untouched.

Also carries the picker's single door and its self-resolving hold (#167), the
staging cursor modelled as a write with the empty list pinned (#155), reap
collecting what an autonomous run finished (#163), the launch `t0` stamped and
handed across the exec seam (#162), and the manager handing pointers rather
than readings (#154) with its ctx guards holding what they claim (#157).

The rest is the test and CI chain: a bare `cargo test` is green with a runner
for the live suite (#164), every test in `tests/live_*.rs` carries `#[ignore]`
structurally (#168), the prebuild guard claims only what it holds (#166), and
the devcontainer boots from a published image rather than a build (#152).

Tagging `v0.18.0` after this merges is what actually publishes.

## Summary by Sourcery

Enhancements:
- Bump the project and package recipe versions to 0.18.0.