### PR TITLE
/wf-mid: the mode between grilling every decision and asking about none

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,19 +58,20 @@ Two things to know about it:
 
 ## The skills are part of this repo
 
-`skills/` holds the five prompts `wf` execs — `wf`, `wf-auto`, `wf-one`,
-`wf-tdd`, `wf-review`. They are not documentation *about* `wf`; they are what it
-runs, named literally in `launch::route`, and the package installs them beside
-the binary so the two cannot drift (`src/skills.rs` says why at length).
+`skills/` holds the six prompts `wf` execs — `wf`, `wf-mid`, `wf-auto`,
+`wf-one`, `wf-tdd`, `wf-review`. They are not documentation *about* `wf`; they
+are what it runs, named literally in `launch::route`, and the package installs
+them beside the binary so the two cannot drift (`src/skills.rs` says why at
+length).
 
 Three consequences for anyone editing here:
 
 - **Editing a skill is editing `wf`'s behaviour.** A change to
   `skills/wf/SKILL.md` ships in the next release exactly as a change to
   `src/` does, and belongs in the same PR as whatever routing change motivated
-  it. `skills/wf-one/SKILL.md` and `wf-auto` link
+  it. `skills/wf-one/SKILL.md`, `wf-mid` and `wf-auto` link
   `../wf/GITHUB_TRACKER.md` and `../wf/LIFECYCLE.md` by relative
-  path, so the five move as a set and the layout under `skills/` is load-bearing.
+  path, so the six move as a set and the layout under `skills/` is load-bearing.
 - **Adding a `Route` means saying which skill it invokes — or that it invokes
   none.** `skills::BUNDLED` lists what ships and `Route::bundled_skill()` is the
   exhaustive answer to which of them a route names; a unit test sweeps

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ links   /home/you/.claude/skills
 copy    /home/you/.claude/wf-skills (what the links point at)
 
   wf              ok
-  wf-mid          ok
   wf-auto         ok
+  wf-mid          ok
   wf-one          outdated — the copy is not this build's
   wf-tdd          stale — links to /home/you/projects/wayfinder/skills
   wf-review       not a link — another tool owns this one

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ this: `wf` reached 0.6.0 still routing `defer` at a `/wf` section that
 `/wf-auto` had superseded weeks earlier, and nothing anywhere could
 notice.
 
-Five skills ship: `wf`, `wf-auto`, `wf-one`, `wf-tdd` and `wf-review` — the four
-`wf` can exec, plus the single-ticket sibling that shares their
+Six skills ship: `wf`, `wf-mid`, `wf-auto`, `wf-one`, `wf-tdd` and `wf-review` —
+the five `wf` can exec, plus the single-ticket sibling that shares their
 `GITHUB_TRACKER.md` and `LIFECYCLE.md`. A unit test asserts every route's skill
 name is one of them, so a route can never name a skill the package does not
 ship.
@@ -97,6 +97,7 @@ links   /home/you/.claude/skills
 copy    /home/you/.claude/wf-skills (what the links point at)
 
   wf              ok
+  wf-mid          ok
   wf-auto         ok
   wf-one          outdated — the copy is not this build's
   wf-tdd          stale — links to /home/you/projects/wayfinder/skills
@@ -637,6 +638,7 @@ the two things still undecided — which agent runs it, and who resolves the nod
 ┌ launch Claude · blooop/wayfinder · #65 Author the wf-tdd skill ───────┐
 │                                                                         │
 │  ▶ interactive   /wf-tdd   you are in the loop; it grills you           │
+│    mid           /wf-mid   it decides what it can and asks only what it…│
 │    auto          /wf-auto  the agent decides alone and drives it to done│
 │    plain         claude    no skill; a bare session on the node's branch│
 │                                                                         │
@@ -691,6 +693,7 @@ navigation:
 │                                                                         │
 │  ▶ new task      /wf-one   one tracked ticket, built and reviewed       │
 │    new map       /wf       chart a new map in this repo, with you       │
+│    new map, mid  /wf-mid   chart a new map in this repo, asking little  │
 │    new map, auto /wf-auto  chart a new map in this repo, alone          │
 │                                                                         │
 │    task   █                                                             │
@@ -704,6 +707,41 @@ there are no launch rows, and `enter` with an empty `task` field refuses on the
 count line rather than filing something blank. Which is why the creating default
 is safe: `enter enter` on a fresh screen does nothing at all.
 
+### `mid`: which questions are worth asking
+
+The mode rows are one axis — who decides — and its two ends were the only
+choices for a long time. `interactive` asks you about every decision on the map;
+`auto` asks you about none of them. Most maps are neither: most of their
+decisions have one defensible answer under the same four principles `wf-auto`
+declares, and two or three genuinely do not.
+
+`mid` is that middle. It does the cheap legwork first — research subagents,
+prototypes, a read of the repo — settles whatever the principles settle, and
+escalates a decision to you only when it passes all three tests:
+
+1. **the legwork is already done** — it never asks what a read can answer or a
+   prototype can show;
+2. **the principles do not settle it** — applied in order, two options are still
+   live and the route already walked does not imply either;
+3. **and it is** a taste or product call, something *expensive to reverse* (a
+   public interface, a wire format, a released name), or something that would
+   redraw the destination.
+
+Cheap-to-reverse decisions are the agent's even when they are close, because the
+recovery is a later commit — and a close call is recorded as one on the ticket,
+so reopening an agent-decided ticket to re-decide it is normal rather than a
+conflict. When it does ask, the question is a decision brief: what it tried, the
+live options, its recommendation, and what a reversal would cost. "Your call" is
+a valid answer.
+
+Two more things follow from where it sits. Escalations that go unanswered
+**park** — it does not quietly fall through to deciding alone, which is the whole
+difference between this mode and `auto`. And, like `wf`, it **plans by default**:
+the map ends where the way is clear, and it drives builds through `wf-tdd` and
+`wf-review` only where the map's `## Notes` or a `steer:` line grants execution.
+That grant is the difference between a run that costs a conversation and a run
+that costs a fleet of subagents.
+
 ### Resuming: picking a conversation back up
 
 A node you have launched an agent on before carries a `⏎` in the list, and its
@@ -714,6 +752,7 @@ picker leads with a **resume** row:
 │                                                                             │
 │  ▶ resume        claude --continue   20m ago · pick the conversation back up│
 │    interactive   /wf-tdd             you are in the loop; it grills you     │
+│    mid           /wf-mid             it decides what it can, asks the rest  │
 │    auto          /wf-auto            the agent decides alone and drives it  │
 │    plain         claude              no skill; a bare session on the branch │
 │                                                                             │
@@ -765,7 +804,7 @@ directories. Coming back on another machine is what the breadcrumbs on the
 ticket are for.
 
 **A node launches and a project creates, and neither does the other's job.** A
-cluster header is a *map*, so its picker is the three modes and wraps, exactly
+cluster header is a *map*, so its picker is the mode rows and wraps, exactly
 like a ticket's — the only difference between the two is what they aim at. The
 creation rows used to ride along on the header, on the grounds that a header was
 the only repo-level stop there was; a project row is a better one, and having
@@ -795,10 +834,12 @@ on what was found — which is what makes the create path work on the first fram
 | `wayfinder:build` | ready · building · needs attention | interactive | `<sigil>wf-tdd <n>` |
 | `wayfinder:build` | in review | interactive | `<sigil>wf-review <n>` |
 | research · prototype · grilling · task | any unfinished stage | interactive | `<sigil>wf <map> <n>` |
+| anything | any unfinished stage | mid | `<sigil>wf-mid <map> [<n>]` |
 | anything | any unfinished stage | auto | `<sigil>wf-auto <map> [<n>]` |
 | anything | any unfinished stage | plain | the selected agent, with no skill; anything typed is the whole prompt |
 | a project row | — | new task | `<sigil>wf-one <task>` |
 | a project row | — | new map | `<sigil>wf [<seed>]` |
+| a project row | — | new map, mid | `<sigil>wf-mid [<seed>]` |
 | a project row | — | new map, auto | `<sigil>wf-auto [<seed>]` |
 | a ticket | done | — | nothing — not launchable |
 
@@ -1165,7 +1206,8 @@ Neither flag can turn a `warn` row into a deletion.
 ### `wf reap --finished` — the cleanup an autonomous run ends with
 
 `wf-auto` walks a map on its own, and a run that works six tickets leaves six
-workspaces. Its last act is to collect the ones it finished:
+workspaces. Its last act is to collect the ones it finished — as does a `wf-mid`
+run that was granted execution, on whatever build tickets it closed:
 
 ```
 $ wf reap --finished blooop/wayfinder#151 blooop/wayfinder#160

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ the two things still undecided — which agent runs it, and who resolves the nod
 ┌ launch Claude · blooop/wayfinder · #65 Author the wf-tdd skill ───────┐
 │                                                                         │
 │  ▶ interactive   /wf-tdd   you are in the loop; it grills you           │
-│    mid           /wf-mid   it decides what it can and asks only what it…│
+│    mid           /wf-mid   it decides what it can, asks what it can't   │
 │    auto          /wf-auto  the agent decides alone and drives it to done│
 │    plain         claude    no skill; a bare session on the node's branch│
 │                                                                         │

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ this: `wf` reached 0.6.0 still routing `defer` at a `/wf` section that
 notice.
 
 Six skills ship: `wf`, `wf-mid`, `wf-auto`, `wf-one`, `wf-tdd` and `wf-review` —
-the five `wf` can exec, plus the single-ticket sibling that shares their
+every one of them a route `wf` execs: five reached from a node's launch picker,
+and `wf-one` from a project row's `new task`. They share one
 `GITHUB_TRACKER.md` and `LIFECYCLE.md`. A unit test asserts every route's skill
 name is one of them, so a route can never name a skill the package does not
 ship.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -133,10 +133,12 @@ tests:
         - wf
       files:
         # Named individually rather than as a glob: the routing table promises
-        # these four skills exist, so a package that quietly shipped three
-        # must fail here rather than at the moment an agent is launched.
+        # every one of these skills exists, so a package that quietly shipped
+        # one fewer must fail here rather than at the moment an agent is
+        # launched.
         - share/wf/skills/wf/SKILL.md
         - share/wf/skills/wf-auto/SKILL.md
+        - share/wf/skills/wf-mid/SKILL.md
         - share/wf/skills/wf-one/SKILL.md
         - share/wf/skills/wf-tdd/SKILL.md
         - share/wf/skills/wf-review/SKILL.md

--- a/skills/wf-auto/SKILL.md
+++ b/skills/wf-auto/SKILL.md
@@ -14,7 +14,7 @@ Same artifact as `wf` — one map issue with decision tickets as its children �
 - **Answers come from principles, not questions.** The principles below are the human's standing voice. Every resolution cites the one that decided it.
 - **Execution is in scope by default.** `wf` plans and hands off; here the map runs all the way to merged work, so `wayfinder:build` tickets are ordinary citizens and the map is the single place every ticket — decision and build alike — is tracked.
 
-This is for work with **fog in it** — open questions between here and the destination. One piece of already-known work wants `wf-one` instead: a single-ticket map, same gates, no charting.
+This is for work with **fog in it** — open questions between here and the destination. One piece of already-known work wants `wf-one` instead: a single-ticket map, same gates, no charting. A map whose decisions are *mostly* obvious wants `wf-mid`: the same principles, but it stops to ask about the few that are taste, scope, or expensive to reverse rather than deciding them for you.
 
 ## The principles
 

--- a/skills/wf-mid/SKILL.md
+++ b/skills/wf-mid/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: wf-mid
+description: Chart and drive a wayfinder map mostly alone — research and prototype first, settle whatever the guiding principles settle, and spend a small number of high-value questions on the decisions that are genuinely the human's: taste, scope, and anything expensive to reverse. Use when the user wants a map worked with few interruptions, wants the obvious calls made without being asked, or when wf launches a node in mid mode.
+---
+
+## Cross-agent invocation
+
+This bundle runs in both Claude Code and Codex. Mention a wayfinder skill with
+`/` in Claude Code and `$` in Codex; skill names below are written without a
+sigil.
+
+Same artifact as `wf` and `wf-auto` — one map issue with decision tickets as its children — worked from between them. `wf` asks the human about every decision; `wf-auto` asks about none. Most decisions on a real map have one defensible answer under the principles below, and two or three do not. This skill is for spending the human's attention on those two or three.
+
+Two things change from `wf-auto`, and everything else follows:
+
+- **Escalation is earned, not default.** Every decision gets an honest attempt against the principles first. The human is asked only where the attempt genuinely fails — and the [escalation test](#the-escalation-test) is what "genuinely" means, so it is a rule rather than a mood.
+- **Planning is the default, as in `wf`.** The map ends where the way is clear. Execution is in scope only when the map's `## Notes` or a `steer:` line says so — that grant is the difference between a run that plans a map and a run that builds it, and it is the largest single thing this skill spends.
+
+Not for work with no fog in it: one known piece of work is `wf-one`, and a map whose every decision you want taken for you is `wf-auto`.
+
+## The principles
+
+In order. When two pull opposite ways, the earlier wins. Identical to `wf-auto`'s — the same standing voice, so a map can be handed between the two skills without its route changing character mid-way.
+
+1. **Long-term maintainability** — decide for whoever reads this in a year, not for the session in progress.
+2. **Simplicity** — the smallest thing that resolves the question. Deleting beats adding; one concept beats two that overlap.
+3. **Constructive modeling** — illegal states unrepresentable, sum types over tag-plus-parallel-fields, no sentinels. Run `/constructive-modeling` on any ticket that shapes a type.
+4. **Test-first** — behavior arrives with a failing test that proves it was absent. Build tickets go through `wf-tdd`; a decision ticket says how its outcome will be tested.
+
+A map's `## Notes` may add principles or reorder these for that effort; a ticket may not. Where the principles are silent, the route already walked is the tiebreak: pick what the map's Decisions-so-far already implies.
+
+## The escalation test
+
+A decision is the human's **only** if it survives all three of these. Anything that fails one is yours, and taking it is the job — an agent that escalates a decision the principles already answered has only moved its own work onto the human.
+
+1. **The legwork is done.** Never ask what a read can answer or a prototype can show. Research subagents fire and *land* before any question they touch; a prototype gets built and judged before its question is asked. A question asked over missing evidence is answered by whoever guesses best, which is the opposite of why it was asked.
+2. **The principles do not settle it.** Applied in order, two or more options are still live, and the choice between them is not implied by the route already walked. Write the attempt down before deciding it failed — most "ambiguous" decisions resolve the moment simplicity is applied honestly.
+3. **And it is one of:**
+   - a **taste or product** call — how the thing should feel, user-visible naming and wording, which of two real needs matters more;
+   - **expensive to reverse** — a public interface, an on-disk or wire format, a dependency, a released name, a data migration: cheap-to-reverse decisions are yours even when they are close, because the recovery is a later commit;
+   - or it **redraws the destination**, or contradicts a Decisions-so-far entry rather than extending it.
+
+Everything else is agent-decided. A **close call is recorded as a close call** — a breadcrumb saying what nearly won and why it lost — so a human reopening an agent-decided ticket to re-decide it is normal, not a conflict. That trail is what makes deciding alone safe: the decision is cheap to revisit because the reasoning is on the ticket, not in a session that ended.
+
+## How to ask
+
+An escalation is a **decision brief**, not an interrogation. `wf`'s job is to grill; this skill has already done the thinking, and what it needs is a ruling. One question, one decision, carrying:
+
+- **what was already tried** — the research read, the prototype built, the options ruled out and by which principle;
+- **the live options**, and the consequence of each in the terms the choice actually turns on;
+- **the recommendation** and the principle behind it;
+- **the cost of being wrong** — what a later reversal costs, which is usually what makes it worth asking at all.
+
+"Your call" is a valid answer and means the recommendation lands: say so, record it as human-confirmed, and move on. Never ask two things at once, never ask a question whose answer would not change what happens next, and never ask one whose answer you already intend to override.
+
+**The budget.** Aim for a small number of escalations per run — one or two on most maps. If the count keeps climbing, that is not a reason to keep asking: it is evidence the **destination** is wrong, and grinding through its consequences one question at a time will not fix it. Stop, say so, and confirm the destination instead.
+
+## The map
+
+One issue labelled `wayfinder:map`; its tickets are its child issues. The map is an **index**: it gists each closed ticket in one line and links it, so the detail lives in exactly one place — the ticket. Refer to maps and tickets by their titles, never bare numbers; a name wraps its link.
+
+```markdown
+## Destination
+
+<what reaching the end of this map looks like. One or two lines; every run orients to it first.>
+
+## Notes
+
+<domain; skills every run should consult; extra or reordered principles for this effort; whether execution is in scope>
+
+## Decisions so far
+
+- [<closed ticket title>](link) — <one-line gist of the answer> *(agent)*
+
+## Not yet specified
+
+<!-- in-scope fog you can't phrase sharply yet; graduates into tickets as the frontier advances -->
+
+## Out of scope
+
+<!-- work ruled past the destination; closed, never graduates -->
+```
+
+A ticket is a child issue whose body is one `## Question`, sized to a single session, labelled `wayfinder:<type>`. Escalated decisions need no label of their own — a `grilling` ticket is a `grilling` ticket whether the answer came from the principles or from the human, and the resolution comment already says which.
+
+Blocking is the tracker's native dependency edge, so the frontier renders in the tracker's own UI. The **frontier** is the open, unblocked, unclaimed children. Claiming is assigning the ticket to yourself, before any work on it.
+
+**Not yet specified** is in-scope fog you can't yet phrase sharply; **Out of scope** is work past the destination. Ticket it when the question is already sharp, even if blocked and unactionable; leave it as fog when it isn't.
+
+A launch from `wf` reads `<sigil>wf-mid <map> [<ticket>] ctx: <json> [steer: <text>]`. The block is the snapshot `wf` already held — the map's title, and for a ticket its type, stage and linked PRs — so a run can open on the node it was handed without rediscovering it. It is an **accelerator, never a precondition**: orient from it, verify live before any write, ignore it entirely if it is absent or disagrees with your arguments, and never let it survive into a subagent's own invocation unexamined. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
+
+Tracker mechanics — pinning the repo, creating and parenting issues, blocking edges, the frontier query, the local-markdown fallback — live in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md) in the sibling `wf` skill. Pin the repo from the working repo's own remote, pass it explicitly on every call, and push branches by name: a fork's map belongs to the fork, never its parent. State the repo and its visibility in your first line of output — a map on a public repo publishes the whole fog sketch, and a run that will make most of its own decisions is not one the human is watching closely enough to catch that later.
+
+## Where the work happens
+
+The human is in the loop here, so the split is not `wf-auto`'s. Subagents are for work whose **bulk** would otherwise crowd the run's context; the run keeps the decisions, because a conversation cannot be held through a subagent.
+
+| ticket type | resolved | why |
+| --- | --- | --- |
+| **research** | fresh `/research` subagent, in parallel | bulky reading, and it must land before any question it touches |
+| **prototype** | built alone via `/prototype`, judged against the principles | the human sees it only when the judgement is a taste call — and then the artifact *is* the question, which is the cheapest question there is |
+| **grilling** | in this run's own context | the attempt is yours; the escalation, if it is earned, is a live exchange |
+| **task** | alone where it can be; a precise checklist where it needs human hands | |
+| **build** | only under the execution grant, then [LIFECYCLE.md](../wf/LIFECYCLE.md) — `wf-tdd` and `wf-review` in fresh subagents, gates checked between | fresh review context is a correctness requirement, not a luxury: the reviewer must never have written the code |
+
+That split is the cost story: subagents where context isolation is load-bearing, inline where the human already is, and no build fan-out at all unless the map asked for it.
+
+## Chart
+
+`wf-mid <loose idea>`
+
+1. **Draft the destination alone** — from the idea, the repo, its docs, its recent history and its existing maps. Don't grill for it. If the idea admits several, take the smallest one still worth a map (principle 2) and note which ones you set aside.
+2. **Sweep breadth-first** for the open decisions: fan out across the space rather than deep on one thread.
+3. **No fog found** — the way is already clear and the whole job fits one session — means no map. Say so and stop; `wf-one` is the shape that work wants.
+4. **Fire the research subagents** for whatever the sweep showed is unknown-and-readable. They run while step 5 happens.
+5. **Confirm the destination — once.** This is the highest-value question on any map, and the one escalation worth making before a single ticket exists: the destination as drafted, the fog sketch, and what you set aside, in the decision-brief form above. Everything downstream inherits it, so an hour of agent-decided tickets under the wrong destination is the most expensive mistake available.
+6. **Create the map**, then the tickets you can phrase now, then wire the blocking edges in a **second pass** (issues need ids before they can reference each other). Everything you can't phrase yet stays as fog.
+7. Stop, and print the command to work the map. Charting resolves nothing — a run that invents a question and answers it in the same context hasn't used the map, it has written a transcript.
+
+## Work the map
+
+`wf-mid <map> [<ticket>] [steer: <text>]`
+
+A named ticket scopes the run to it and its unblocks-subtree; no ticket means the whole map. Either way, work in **dependency order** and resolve **as many tickets as the run can hold** — that is what this skill is for, and the reason it is not `wf`, which stops after one.
+
+Per ticket:
+
+1. Load the map (low-res; zoom into closed tickets on demand). Claim the ticket. If it was already claimed, read its trail first — the last `### handoff`, then the breadcrumbs after it — and open with a breadcrumb noting resumption.
+2. Resolve it where the table above says it is resolved. Run the escalation test before asking anything; the attempt against the principles is written down either way, because it is the resolution comment when it succeeds and the brief when it does not.
+3. Breadcrumb each decision-grade moment on the ticket — a sub-decision settling, a close call and what nearly won, a direction changing, a stage transition, a gate result.
+4. **Record** the resolution, and say where it came from:
+   - `**agent-decided (<principle>):**` — yours, carrying the reasoning that would have been the grilling. Gist it into Decisions-so-far with an *(agent)* suffix.
+   - `**human-decided:**` — escalated, carrying the question as asked and the answer as given. No suffix: the map should show at a glance which decisions were bought cheaply and which cost the human something.
+
+   Then close the ticket.
+5. **Advance the map**: graduate whatever fog the answer made specifiable into fresh tickets — slicing `wayfinder:build` tickets only where execution is granted — clear those fog patches, and retire tickets the answer invalidated.
+
+Then take the next unblocked ticket. The run ends when the frontier is empty, everything left is parked, or the context is too full to hold another ticket honestly — and it ends with a summary: what closed, what was asked, what parked, what is still open.
+
+A ticket found **effectively complete** — overtaken by another decision, or done as a side effect — skips to step 4: comment why, close, index.
+
+## Where it stops
+
+Park a ticket — a `### handoff` comment on it, then carry on with other unblocked work — when resolving it would:
+
+- need an **answer that hasn't come**. An earned escalation that goes unanswered parks; it does not fall through to being decided alone. That fall-through is the whole difference between this skill and `wf-auto`, and quietly taking it would make every question this skill asks theatre.
+- need **human hands**: credentials, a purchase, physical access, an account only they can open;
+- **redraw a destination a human wrote** — including the one they confirmed at charting;
+- **merge**: the lifecycle ends at *in review, approved* unless the steering line explicitly grants merge-when-green.
+
+Report every park in the closing summary.
+
+Ruling work **out of scope** is not a park and not an escalation: close the ticket, leave a line in **Out of scope** saying why, and keep going. Scope calls come up constantly and blocking on each would spend the budget on the cheapest questions on the map.
+
+A `steer:` line composes *after* the principles — it narrows scope, states preferences, or grants execution. It cannot lift these stops.
+
+## Journal
+
+Breadcrumbs are append-only ticket comments prefixed `**breadcrumb:**`, one or two lines, never edited, never deleted — decision-grade moments only, not narration. On deliberate exit, one `### handoff` comment: where we are, the open thread, the first move on resume. A crash leaves no handoff and the breadcrumb trail is the fallback. Re-entry from the trail is idempotent.
+
+The trail carries more weight here than in `wf`, because most decisions on this map were taken without the human watching: the breadcrumb saying what nearly won is what lets them audit a run they weren't in, and reopen the one call they'd have made differently.
+
+## Clean up what this run finished
+
+Only where the run executed. If it closed build tickets of its own, its last act — once the summary is settled — is to collect those workspaces and nothing else:
+
+```
+wf reap --finished <owner/repo#n> [<owner/repo#n> ...]
+```
+
+Name every ticket this run closed, in full, owner included. A run that closed no build tickets runs nothing. Report what was removed and what was kept, both: a workspace stays when its branch never reached a remote, and that line is the only notice anyone gets that the work exists in one place only. **Never** reach past a refusal — not `-f`, which waives the guard the step rests on, and not an unscoped `wf reap -y`, which is a person's command over their whole machine rather than one run tidying up after itself.

--- a/skills/wf-one/SKILL.md
+++ b/skills/wf-one/SKILL.md
@@ -49,7 +49,7 @@ Breadcrumb the ticket at each stage transition and gate result — `**breadcrumb
 
 ## Don't let it fan out
 
-The one rule that keeps this skill small: **this map never gets a second ticket.** If the work turns out to need decisions made, or to be too big for one ticket, that is the signal it was never single-ticket work. Say so, leave a `### handoff` on the ticket, and hand it to `wf` (to chart properly, with you) or `wf-auto` (to chart and drive it alone). Don't grow this map into a real one — a map charted backwards out of work already underway is the thing wayfinding exists to avoid.
+The one rule that keeps this skill small: **this map never gets a second ticket.** If the work turns out to need decisions made, or to be too big for one ticket, that is the signal it was never single-ticket work. Say so, leave a `### handoff` on the ticket, and hand it to `wf` (to chart properly, with you), `wf-mid` (to chart it mostly alone, asking only about the decisions that are genuinely yours) or `wf-auto` (to chart and drive it alone). Don't grow this map into a real one — a map charted backwards out of work already underway is the thing wayfinding exists to avoid.
 
 Decisions small enough to take alone are yours, in this order when they collide: **long-term maintainability**, **simplicity** (smallest thing that works; deleting beats adding), **constructive modeling** (illegal states unrepresentable — `/constructive-modeling` where a type is at stake), **test-first**. Note in a breadcrumb which one decided anything non-obvious. Anything needing credentials, a purchase, or a human-only action parks with a handoff.
 

--- a/skills/wf/LIFECYCLE.md
+++ b/skills/wf/LIFECYCLE.md
@@ -1,6 +1,6 @@
 # The manager protocol — a node's lifecycle, one fresh subagent per stage
 
-How a launched session drives a node (or a whole subtree of nodes) through its stages without anyone watching. This is referenced by the `wf-auto` skill and honored by `wf-tdd` and `wf-review`; nothing launches "the manager" directly — **the launched session is the manager**. wf itself never is: it exec'd and exited.
+How a launched session drives a node (or a whole subtree of nodes) through its stages without anyone watching. This is referenced by the `wf-auto` and `wf-mid` skills and honored by `wf-tdd` and `wf-review`; nothing launches "the manager" directly — **the launched session is the manager**. wf itself never is: it exec'd and exited.
 
 ## The stage lattice (decided on blooop/wayfinder#61)
 
@@ -16,7 +16,7 @@ Each **open PR** linked to the node maps to one stage:
 
 The node takes the **max over its open PRs** in the constant order `needs attention > in review > building`. No open PRs: any merged PR → done; otherwise derive from ticket state — ready (open, unblocked, unclaimed) / in progress (claimed) / done (closed). PR state dominates ticket state when present.
 
-Routing — what a stage launches: build nodes at ready/building/needs-attention → `wf-tdd`; build nodes at in-review → `wf-review`; decision-type nodes → the `wf` skill. Done is not launchable.
+Routing — what a stage launches: build nodes at ready/building/needs-attention → `wf-tdd`; build nodes at in-review → `wf-review`; decision-type nodes → the `wf` skill. Done is not launchable. That is the *interactive* table; the `mid` and `auto` modes collapse it, routing every node to their own skill, which then drives these stages itself.
 
 ## The protocol, per node
 

--- a/skills/wf/SKILL.md
+++ b/skills/wf/SKILL.md
@@ -86,7 +86,7 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 ## Ticket Types
 
-Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this). Handing judgement to the agent wholesale is `/wf-auto`'s job, never a variant of this skill.
+Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this). Handing judgement to the agent is never a variant of this skill: wholesale it is `/wf-auto`'s job, and for the decisions the principles already settle — most of them — it is `/wf-mid`'s, which asks about taste, scope and what is expensive to reverse and decides the rest.
 
 - **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases to surface a fact a decision waits on. Resolved by a `/research` **subagent**. Use when knowledge outside the current working directory is required.
 - **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2566,6 +2566,7 @@ mod tests {
             mode,
             route: match mode {
                 Mode::Interactive => Route::Wayfinder,
+                Mode::Mid => Route::WayfinderMid,
                 Mode::Auto => Route::WayfinderAuto,
                 Mode::Plain => Route::Plain,
             },
@@ -2576,8 +2577,12 @@ mod tests {
         app.handle_key(key(KeyCode::Up));
         assert_eq!(choice(&app), (Agent::Claude, launch(Mode::Auto)));
         app.handle_key(key(KeyCode::Up));
+        assert_eq!(choice(&app), (Agent::Claude, launch(Mode::Mid)));
+        app.handle_key(key(KeyCode::Up));
         assert_eq!(choice(&app), (Agent::Claude, launch(Mode::Interactive)));
         app.handle_key(key(KeyCode::Tab));
+        assert_eq!(choice(&app), (Agent::Claude, launch(Mode::Mid)));
+        app.handle_key(key(KeyCode::Down));
         assert_eq!(choice(&app), (Agent::Claude, launch(Mode::Auto)));
         app.handle_key(key(KeyCode::Down));
         assert_eq!(choice(&app), (Agent::Claude, launch(Mode::Plain)));
@@ -2648,10 +2653,12 @@ mod tests {
     fn picking_auto_in_the_overlay_launches_the_manager_with_steering() {
         // The acceptance shape (#96), through the picker: enter → move to the
         // `auto` row → type the steer → enter produces the manager skill
-        // carrying `steer: something`.
+        // carrying `steer: something`. Two downs, because `mid` sits between
+        // the default and `auto` on the one axis the rows are ordered by.
         let mut app = launchable_app();
         go_to(&mut app, "#6"); // wayfinder#6, one checkout
         app.handle_key(key(KeyCode::Enter));
+        app.handle_key(key(KeyCode::Down));
         app.handle_key(key(KeyCode::Down));
         type_str(&mut app, "something");
         let launch = match app.handle_key(key(KeyCode::Enter)) {
@@ -2672,7 +2679,8 @@ mod tests {
         let mut app = two_checkout_app();
         go_to(&mut app, "#103");
         app.handle_key(key(KeyCode::Enter)); // dotfiles#103: stage
-        app.handle_key(key(KeyCode::Down)); // to the auto row
+        app.handle_key(key(KeyCode::Down)); // past `mid`…
+        app.handle_key(key(KeyCode::Down)); // …to the auto row
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         assert!(matches!(app.overlay, Overlay::PickCheckout { .. }));
         let launch = match app.handle_key(key(KeyCode::Enter)) {
@@ -2695,7 +2703,8 @@ mod tests {
             let mut app = launchable_app();
             go_to(&mut app, "#6");
             app.handle_key(key(KeyCode::Enter));
-            app.handle_key(key(KeyCode::Down)); // to the auto row
+            app.handle_key(key(KeyCode::Down)); // past `mid`…
+            app.handle_key(key(KeyCode::Down)); // …to the auto row
             app
         };
         let wf = MapId::new("blooop/wayfinder", 1);
@@ -2932,6 +2941,7 @@ mod tests {
                 assert_eq!(staged.key(), "#1");
                 assert_eq!(staged.title(), "Map: wf", "the picker names the map");
                 assert_eq!(staged.route(Mode::Interactive), Some(Route::Wayfinder));
+                assert_eq!(staged.route(Mode::Mid), Some(Route::WayfinderMid));
                 assert_eq!(staged.route(Mode::Auto), Some(Route::WayfinderAuto));
             }
             other => panic!("expected the launch picker, got {other:?}"),
@@ -2949,7 +2959,8 @@ mod tests {
         let mut app = launchable_app();
         go_to(&mut app, "map #1");
         app.handle_key(key(KeyCode::Enter));
-        app.handle_key(key(KeyCode::Down)); // to the auto row
+        app.handle_key(key(KeyCode::Down)); // past `mid`…
+        app.handle_key(key(KeyCode::Down)); // …to the auto row
         let launch = match app.handle_key(key(KeyCode::Enter)) {
             Outcome::Launch(launch) => launch,
             other => panic!("expected a launch, got {other:?}"),
@@ -3011,8 +3022,8 @@ mod tests {
     #[test]
     fn a_mapless_repo_offers_creation_and_nothing_to_launch() {
         // There is no node here, so there is nothing to launch: the picker is
-        // the three creation rows alone. A launch row would name a skill with
-        // no argument to give it.
+        // the creation rows alone. A launch row would name a skill with no
+        // argument to give it.
         let mut app = mapless_app();
         assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
         match &app.overlay {
@@ -3024,6 +3035,7 @@ mod tests {
                     vec![
                         Candidate::Create(CreationKind::Task),
                         Candidate::Create(CreationKind::Map),
+                        Candidate::Create(CreationKind::MapMid),
                         Candidate::Create(CreationKind::MapAuto),
                     ]
                 );
@@ -3095,8 +3107,8 @@ mod tests {
     fn only_the_project_stop_reaches_the_creation_rows() {
         // Creation is a repo-level act, so the rows exist exactly where the
         // stop is a repo — and nowhere else. A cluster header is a *map*, so
-        // its picker walks the three modes and wraps, exactly as a ticket's
-        // does: the only difference between the two is what they aim at.
+        // its picker walks the modes and wraps, exactly as a ticket's does:
+        // the only difference between the two is what they aim at.
         let picked = |app: &App| match &app.overlay {
             Overlay::PickLaunch { candidate, .. } => *candidate,
             other => panic!("expected the launch picker, got {other:?}"),
@@ -3109,6 +3121,8 @@ mod tests {
         app.handle_key(key(KeyCode::Down));
         assert_eq!(picked(&app), Candidate::Create(CreationKind::Map));
         app.handle_key(key(KeyCode::Down));
+        assert_eq!(picked(&app), Candidate::Create(CreationKind::MapMid));
+        app.handle_key(key(KeyCode::Down));
         assert_eq!(picked(&app), Candidate::Create(CreationKind::MapAuto));
         app.handle_key(key(KeyCode::Down));
         assert_eq!(
@@ -3117,13 +3131,13 @@ mod tests {
             "and wraps: there is nothing else on a project's picker"
         );
 
-        // A header and a ticket both walk only the modes: three downs is a
-        // full lap on either.
+        // A header and a ticket both walk only the modes: a lap of `Mode::all`
+        // lands back on the default on either.
         for stop in ["map #1", "#6"] {
             let mut app = launchable_app();
             go_to(&mut app, stop);
             app.handle_key(key(KeyCode::Enter));
-            for _ in 0..3 {
+            for _ in 0..Mode::all().len() {
                 app.handle_key(key(KeyCode::Down));
             }
             assert!(

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -213,9 +213,9 @@ impl Route {
         match self {
             Route::Tdd => Route::Review,
             Route::Review => Route::Wayfinder,
-            Route::Wayfinder => Route::WayfinderAuto,
-            Route::WayfinderAuto => Route::WayfinderMid,
-            Route::WayfinderMid => Route::One,
+            Route::Wayfinder => Route::WayfinderMid,
+            Route::WayfinderMid => Route::WayfinderAuto,
+            Route::WayfinderAuto => Route::One,
             Route::One => Route::Plain,
             Route::Plain => Route::Tdd,
         }
@@ -345,7 +345,7 @@ pub enum CreationKind {
 
 impl CreationKind {
     /// Every kind, in picker order. Written out rather than derived from an
-    /// `after` cycle: three variants with one call site is below the size
+    /// `after` cycle: four variants with one call site is below the size
     /// where the cycle device earns its ceremony.
     pub fn all() -> Vec<CreationKind> {
         vec![
@@ -3765,10 +3765,10 @@ mod tests {
 
     #[test]
     fn plain_launches_a_session_with_no_skill_in_it() {
-        // The third mode collapses the table the way `auto` does, and for the
-        // opposite reason: `auto` picks one skill for every node, `plain` picks
-        // none. Which node it was aimed at cannot change that, so every cell
-        // answers the same.
+        // The last mode collapses the table the way `auto` and `mid` do, and
+        // for the opposite reason: they pick one skill for every node, `plain`
+        // picks none. Which node it was aimed at cannot change that, so every
+        // cell answers the same.
         for ticket_type in DECISION_TYPES.into_iter().chain([TicketType::Build]) {
             for stage in LAUNCHABLE {
                 assert_eq!(

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -154,6 +154,13 @@ pub enum Route {
     /// decisions settled against the skill's guiding principles, and the whole
     /// remaining lifecycle driven unattended (#96).
     WayfinderAuto,
+    /// `/wf-mid <map> [<n>]` — the same map with the human in it for the few
+    /// decisions that are genuinely theirs: the skill settles whatever its
+    /// principles settle and escalates only taste, scope, and what is
+    /// expensive to reverse. A third skill rather than a flag on either
+    /// neighbour, for the reason [`Mode`] gives: who decides is the whole
+    /// difference between these prompts, so it is spent at the exec.
+    WayfinderMid,
     /// `/wf-one <task>` — one tracked ticket, filed and driven by the skill:
     /// its own single-ticket map, `/wf-tdd` build, `/wf-review` review (#114).
     /// The only route reached by a creation candidate rather than a mode.
@@ -172,6 +179,7 @@ impl Route {
             Route::Review => Some("wf-review"),
             Route::Wayfinder => Some("wf"),
             Route::WayfinderAuto => Some("wf-auto"),
+            Route::WayfinderMid => Some("wf-mid"),
             Route::One => Some("wf-one"),
             Route::Plain => None,
         }
@@ -194,6 +202,7 @@ impl Route {
             Route::Review => "/wf-review",
             Route::Wayfinder => "/wf",
             Route::WayfinderAuto => "/wf-auto",
+            Route::WayfinderMid => "/wf-mid",
             Route::One => "/wf-one",
             Route::Plain => "claude",
         }
@@ -205,7 +214,8 @@ impl Route {
             Route::Tdd => Route::Review,
             Route::Review => Route::Wayfinder,
             Route::Wayfinder => Route::WayfinderAuto,
-            Route::WayfinderAuto => Route::One,
+            Route::WayfinderAuto => Route::WayfinderMid,
+            Route::WayfinderMid => Route::One,
             Route::One => Route::Plain,
             Route::Plain => Route::Tdd,
         }
@@ -238,6 +248,13 @@ pub enum Mode {
     /// The default: the human is in the loop, and the session grills them.
     #[default]
     Interactive,
+    /// The agent settles what `/wf-mid`'s principles settle and asks about
+    /// the rest — the few decisions that are taste, scope, or expensive to
+    /// reverse. Sits between the two neighbours on the one axis this picker
+    /// is about: `interactive` spends the human's attention on every decision,
+    /// `auto` spends none of it, and neither is the right price for a map
+    /// whose decisions are mostly obvious and occasionally not.
+    Mid,
     /// The agent decides alone, under `/wf-auto`'s declared principles, and
     /// drives the node's remaining lifecycle unattended. Replaced `defer`,
     /// which routed to `/wf`'s own deferred mode before that skill existed
@@ -255,6 +272,7 @@ impl Mode {
     pub fn label(self) -> &'static str {
         match self {
             Mode::Interactive => "interactive",
+            Mode::Mid => "mid",
             Mode::Auto => "auto",
             Mode::Plain => "plain",
         }
@@ -266,6 +284,7 @@ impl Mode {
     pub fn blurb(self) -> &'static str {
         match self {
             Mode::Interactive => "you are in the loop; it grills you",
+            Mode::Mid => "it decides what it can and asks only what it cannot",
             Mode::Auto => "the agent decides alone and drives it to done",
             Mode::Plain => "no skill; a bare session on the node's branch",
         }
@@ -279,7 +298,8 @@ impl Mode {
     /// place to add it.
     fn after(self) -> Mode {
         match self {
-            Mode::Interactive => Mode::Auto,
+            Mode::Interactive => Mode::Mid,
+            Mode::Mid => Mode::Auto,
             Mode::Auto => Mode::Plain,
             Mode::Plain => Mode::Interactive,
         }
@@ -305,16 +325,20 @@ impl Mode {
 /// Which kind, not yet what: the typed text that completes it (the task, or a
 /// map seed) arrives at the second enter, as [`Creation`].
 ///
-/// Three hand-listed kinds rather than a creation × [`Mode`] product, because
-/// the product is dishonest: charting a map with no skill (`plain`) is
-/// meaningless, and a task's lifecycle is `/wf-one`'s own. These are exactly
-/// the combinations that mean something.
+/// Hand-listed kinds rather than a creation × [`Mode`] product, because the
+/// product is dishonest: charting a map with no skill (`plain`) is meaningless,
+/// and a task's lifecycle is `/wf-one`'s own. These are exactly the
+/// combinations that mean something — the three charting modes plus the task,
+/// and no cell for the one that would mean nothing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreationKind {
     /// One tracked ticket via `/wf-one`: filed, built, reviewed.
     Task,
     /// Chart a new map via `/wf`, with the human in the loop.
     Map,
+    /// Chart a new map via `/wf-mid`, mostly alone: it drafts the destination
+    /// and confirms it once, which is the highest-value question on any map.
+    MapMid,
     /// Chart a new map via `/wf-auto`, alone.
     MapAuto,
 }
@@ -324,7 +348,12 @@ impl CreationKind {
     /// `after` cycle: three variants with one call site is below the size
     /// where the cycle device earns its ceremony.
     pub fn all() -> Vec<CreationKind> {
-        vec![CreationKind::Task, CreationKind::Map, CreationKind::MapAuto]
+        vec![
+            CreationKind::Task,
+            CreationKind::Map,
+            CreationKind::MapMid,
+            CreationKind::MapAuto,
+        ]
     }
 
     /// How the row reads in the picker.
@@ -332,6 +361,7 @@ impl CreationKind {
         match self {
             CreationKind::Task => "new task",
             CreationKind::Map => "new map",
+            CreationKind::MapMid => "new map, mid",
             CreationKind::MapAuto => "new map, auto",
         }
     }
@@ -341,6 +371,7 @@ impl CreationKind {
         match self {
             CreationKind::Task => "one tracked ticket, built and reviewed",
             CreationKind::Map => "chart a new map in this repo, with you",
+            CreationKind::MapMid => "chart a new map in this repo, asking little",
             CreationKind::MapAuto => "chart a new map in this repo, alone",
         }
     }
@@ -352,6 +383,7 @@ impl CreationKind {
         match self {
             CreationKind::Task => Route::One,
             CreationKind::Map => Route::Wayfinder,
+            CreationKind::MapMid => Route::WayfinderMid,
             CreationKind::MapAuto => Route::WayfinderAuto,
         }
     }
@@ -360,7 +392,7 @@ impl CreationKind {
     pub fn field(self) -> &'static str {
         match self {
             CreationKind::Task => "task",
-            CreationKind::Map | CreationKind::MapAuto => "seed",
+            CreationKind::Map | CreationKind::MapMid | CreationKind::MapAuto => "seed",
         }
     }
 
@@ -377,6 +409,7 @@ impl CreationKind {
                 task: text.to_string(),
             }),
             CreationKind::Map => Some(Creation::Map { seed: seed() }),
+            CreationKind::MapMid => Some(Creation::MapMid { seed: seed() }),
             CreationKind::MapAuto => Some(Creation::MapAuto { seed: seed() }),
         }
     }
@@ -391,6 +424,8 @@ pub enum Creation {
     Task { task: String },
     /// `/wf [<seed>]` — charting with the human; the seed is the loose idea.
     Map { seed: Option<String> },
+    /// `/wf-mid [<seed>]` — charting mostly alone.
+    MapMid { seed: Option<String> },
     /// `/wf-auto [<seed>]` — charting alone.
     MapAuto { seed: Option<String> },
 }
@@ -401,6 +436,7 @@ impl Creation {
         match self {
             Creation::Task { .. } => CreationKind::Task,
             Creation::Map { .. } => CreationKind::Map,
+            Creation::MapMid { .. } => CreationKind::MapMid,
             Creation::MapAuto { .. } => CreationKind::MapAuto,
         }
     }
@@ -417,6 +453,7 @@ impl Creation {
         match self {
             Creation::Task { task } => format!("{} {task}", Route::One.invocation(agent)),
             Creation::Map { seed } => seeded(&Route::Wayfinder.invocation(agent), seed),
+            Creation::MapMid { seed } => seeded(&Route::WayfinderMid.invocation(agent), seed),
             Creation::MapAuto { seed } => seeded(&Route::WayfinderAuto.invocation(agent), seed),
         }
     }
@@ -748,6 +785,13 @@ pub fn route(aim: &Aim, mode: Mode) -> Route {
     match (aim, mode) {
         (Aim::Map, Mode::Interactive) => Route::Wayfinder,
         (Aim::Map | Aim::Ticket { .. }, Mode::Auto) => Route::WayfinderAuto,
+        // `Mid` collapses the table for `Auto`'s reason: the launched session
+        // manages whatever the node needs — deciding, asking, and driving a
+        // build's stages through `wf-tdd` and `wf-review` itself — so the
+        // stage's own skill would do one stage and stop. Routing a build node
+        // to `Tdd` here would also draw two picker rows naming `/wf-tdd` with
+        // different blurbs, which is exactly what a per-row route prevents.
+        (Aim::Map | Aim::Ticket { .. }, Mode::Mid) => Route::WayfinderMid,
         // `Plain` collapses the table for the opposite reason `Auto` does:
         // `Auto` picks one skill for every node, `Plain` picks none, and
         // neither the aim nor the stage can change that.
@@ -967,7 +1011,7 @@ impl Staged {
     /// grounds that a header was the only repo-level stop there was; a project
     /// row is a *better* one, and having both would put "new map" on every
     /// header of a repo that has three maps open — three doors to one act,
-    /// none of them the repo. So the header's picker is the three modes again,
+    /// none of them the repo. So the header's picker is the mode rows again,
     /// exactly like a ticket's, and the only difference between them is what
     /// they aim at.
     ///
@@ -989,7 +1033,7 @@ impl Staged {
                 }))
                 .collect(),
             // A project names nothing that exists yet, so there is nothing to
-            // launch — only the three ways to start something.
+            // launch — only the ways to start something.
             StagedAt::Project => CreationKind::all()
                 .into_iter()
                 .map(Candidate::Create)
@@ -1765,7 +1809,10 @@ impl Launch {
             (Route::One, _) => return Some(skill),
             (_, Aim::Map) => format!("{skill} {}", map.id.number),
             (Route::Tdd | Route::Review, Aim::Ticket { number, .. }) => format!("{skill} {number}"),
-            (Route::Wayfinder | Route::WayfinderAuto, Aim::Ticket { number, .. }) => {
+            (
+                Route::Wayfinder | Route::WayfinderMid | Route::WayfinderAuto,
+                Aim::Ticket { number, .. },
+            ) => {
                 format!("{skill} {} {number}", map.id.number)
             }
             (Route::Plain, _) => return None,
@@ -2376,8 +2423,8 @@ mod tests {
                 agent: Agent::Claude
             }
         );
-        // And the three ways to start fresh are all still there, in order,
-        // one arrow away.
+        // And every way to start fresh is still there, in order, one arrow
+        // away.
         let modes: Vec<Candidate> = staged.candidates().into_iter().skip(1).collect();
         assert_eq!(modes, staged_with(None).candidates());
     }
@@ -2738,9 +2785,11 @@ mod tests {
     }
 
     #[test]
-    fn a_ticket_picker_lists_exactly_the_three_launch_modes() {
+    fn a_ticket_picker_lists_exactly_the_launch_modes() {
         // #114: creation is a repo-level act, and a ticket is not a repo-level
-        // stop — its picker stays the pure mode list, concerns unmerged.
+        // stop — its picker stays the pure mode list, concerns unmerged. The
+        // rows are `Mode::all` in its own order, so they read as rising
+        // autonomy rather than as the order the modes were added in.
         let staged = Staged::ticket(&ticket("blooop/wayfinder", 16), &map_ref(1), Stage::Ready)
             .expect("launchable");
         assert_eq!(
@@ -2749,6 +2798,10 @@ mod tests {
                 Candidate::Launch {
                     mode: Mode::Interactive,
                     route: Route::Wayfinder
+                },
+                Candidate::Launch {
+                    mode: Mode::Mid,
+                    route: Route::WayfinderMid
                 },
                 Candidate::Launch {
                     mode: Mode::Auto,
@@ -2778,6 +2831,10 @@ mod tests {
                     route: Route::Wayfinder
                 },
                 Candidate::Launch {
+                    mode: Mode::Mid,
+                    route: Route::WayfinderMid
+                },
+                Candidate::Launch {
                     mode: Mode::Auto,
                     route: Route::WayfinderAuto
                 },
@@ -2795,6 +2852,7 @@ mod tests {
             vec![
                 Candidate::Create(CreationKind::Task),
                 Candidate::Create(CreationKind::Map),
+                Candidate::Create(CreationKind::MapMid),
                 Candidate::Create(CreationKind::MapAuto),
             ]
         );
@@ -2804,7 +2862,7 @@ mod tests {
             .iter()
             .map(|c| c.invocation(Agent::Claude))
             .collect();
-        assert_eq!(shown, ["/wf-one", "/wf", "/wf-auto"]);
+        assert_eq!(shown, ["/wf-one", "/wf", "/wf-mid", "/wf-auto"]);
     }
 
     #[test]
@@ -2828,6 +2886,10 @@ mod tests {
     fn creation_rows_read_as_what_they_start() {
         assert_eq!(Candidate::Create(CreationKind::Task).label(), "new task");
         assert_eq!(Candidate::Create(CreationKind::Map).label(), "new map");
+        assert_eq!(
+            Candidate::Create(CreationKind::MapMid).label(),
+            "new map, mid"
+        );
         assert_eq!(
             Candidate::Create(CreationKind::MapAuto).label(),
             "new map, auto"
@@ -2853,6 +2915,7 @@ mod tests {
         );
         assert_eq!(Candidate::Create(CreationKind::Task).field(), "task");
         assert_eq!(Candidate::Create(CreationKind::Map).field(), "seed");
+        assert_eq!(Candidate::Create(CreationKind::MapMid).field(), "seed");
         assert_eq!(Candidate::Create(CreationKind::MapAuto).field(), "seed");
     }
 
@@ -2879,6 +2942,10 @@ mod tests {
             Some(Creation::Map {
                 seed: Some("a caching layer".to_string())
             })
+        );
+        assert_eq!(
+            CreationKind::MapMid.with_text(""),
+            Some(Creation::MapMid { seed: None })
         );
         assert_eq!(
             CreationKind::MapAuto.with_text(""),
@@ -2921,6 +2988,18 @@ mod tests {
                 .last()
                 .expect("prompt"),
             "/wf a caching layer"
+        );
+        assert_eq!(
+            creation_argv(CreationKind::MapMid, "")
+                .last()
+                .expect("prompt"),
+            "/wf-mid"
+        );
+        assert_eq!(
+            creation_argv(CreationKind::MapMid, "a caching layer")
+                .last()
+                .expect("prompt"),
+            "/wf-mid a caching layer"
         );
         assert_eq!(
             creation_argv(CreationKind::MapAuto, "")
@@ -3005,7 +3084,7 @@ mod tests {
         // mode nothing on screen can reach.
         assert_eq!(
             Mode::all(),
-            vec![Mode::Interactive, Mode::Auto, Mode::Plain]
+            vec![Mode::Interactive, Mode::Mid, Mode::Auto, Mode::Plain]
         );
         assert_eq!(
             Mode::all().first(),
@@ -3496,6 +3575,7 @@ mod tests {
         for (kind, text) in [
             (CreationKind::Task, "wire the exporter"),
             (CreationKind::Map, "a caching layer"),
+            (CreationKind::MapMid, "a caching layer"),
             (CreationKind::MapAuto, ""),
         ] {
             assert_eq!(ctx_of(&creation_argv(kind, text).join(" ")), None);
@@ -3648,6 +3728,39 @@ mod tests {
         }
         assert_eq!(route(&Aim::Map, Mode::Auto), Route::WayfinderAuto);
         assert_eq!(route(&Aim::Map, Mode::Interactive), Route::Wayfinder);
+    }
+
+    #[test]
+    fn mid_routes_every_node_to_wayfinder_mid() {
+        // `mid` collapses the table for `auto`'s reason: the launched session
+        // manages whatever the node needs — settling what the principles
+        // settle, asking where they don't, and handing a build's stages to
+        // `wf-tdd` and `wf-review` itself. Routing a build node to its stage
+        // skill instead would draw two picker rows naming the same skill,
+        // which is the one thing a per-row route exists to prevent.
+        for ticket_type in DECISION_TYPES.into_iter().chain([TicketType::Build]) {
+            for stage in LAUNCHABLE {
+                assert_eq!(
+                    route(&aim(ticket_type, stage), Mode::Mid),
+                    Route::WayfinderMid,
+                    "{ticket_type:?} at {stage:?}"
+                );
+            }
+        }
+        assert_eq!(route(&Aim::Map, Mode::Mid), Route::WayfinderMid);
+    }
+
+    #[test]
+    fn the_mid_route_names_the_wf_mid_skill() {
+        // The mode is a *skill*, not a flag on one, so the route has to name a
+        // prompt the package carries — the sweep over `Route::all` is what
+        // fails the build if it does not.
+        assert_eq!(Route::WayfinderMid.label(), "/wf-mid");
+        assert_eq!(Route::WayfinderMid.bundled_skill(), Some("wf-mid"));
+        assert!(
+            Route::all().contains(&Route::WayfinderMid),
+            "reachable in the cycle"
+        );
     }
 
     #[test]

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -284,7 +284,7 @@ impl Mode {
     pub fn blurb(self) -> &'static str {
         match self {
             Mode::Interactive => "you are in the loop; it grills you",
-            Mode::Mid => "it decides what it can and asks only what it cannot",
+            Mode::Mid => "it decides what it can, asks what it can't",
             Mode::Auto => "the agent decides alone and drives it to done",
             Mode::Plain => "no skill; a bare session on the node's branch",
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -859,46 +859,64 @@ mod tests {
     }
 
     #[test]
-    fn the_cleanup_the_autonomous_skill_prints_is_one_this_binary_accepts() {
-        // The skills are what `wf` execs, so the command `wf-auto` tells an
-        // unattended run to end with is this binary's behaviour as much as the
-        // parser is — and the two ship in one package and can drift in one
-        // edit. So the documented line is read out of the skill and handed to
-        // the real parser, with its placeholders filled in and nothing else
-        // changed.
+    fn the_cleanup_every_skill_prints_is_one_this_binary_accepts() {
+        // The skills are what `wf` execs, so the command a skill tells a run to
+        // end with is this binary's behaviour as much as the parser is — and
+        // the two ship in one package and can drift in one edit. So the
+        // documented line is read out of every skill that prints one, and
+        // handed to the real parser with its placeholders filled in and
+        // nothing else changed.
         //
         // Both directions bite. Renaming the flag here without touching the
-        // skill leaves every autonomous run ending in a rejection; editing the
-        // skill to say `-f` — the one thing that must never be automatic —
-        // fails on the rejection the parser already makes.
-        let skill = include_str!("../skills/wf-auto/SKILL.md");
-        let block = skill
-            .split_once("## Clean up what this run finished")
-            .expect("wf-auto documents the cleanup step")
-            .1
-            .split("```")
-            .nth(1)
-            .expect("and gives it as a command block");
-        let filled = block
-            .replace(
-                "<owner/repo#n> [<owner/repo#n> ...]",
-                "blooop/wayfinder#151",
-            )
-            .trim()
-            .to_string();
-        assert_eq!(filled, "wf reap --finished blooop/wayfinder#151");
-        let typed: Vec<String> = filled
-            .split_whitespace()
-            .skip(1)
-            .map(String::from)
-            .collect();
+        // skills leaves those runs ending in a rejection; editing a skill to
+        // say `-f` — the one thing that must never be automatic — fails on the
+        // rejection the parser already makes.
+        //
+        // Swept over `BUNDLED` rather than naming one skill, because the
+        // second skill to print this command shipped with the line unchecked:
+        // `wf-mid` could have told every run it executed to end in a rejection
+        // and this file would still have been green.
+        let mut checked = 0;
+        for name in skills::BUNDLED {
+            let path = format!("{}/skills/{name}/SKILL.md", env!("CARGO_MANIFEST_DIR"));
+            let skill = std::fs::read_to_string(&path).expect("every bundled skill ships here");
+            let Some((_, after)) = skill.split_once("## Clean up what this run finished") else {
+                continue;
+            };
+            let block = after
+                .split("```")
+                .nth(1)
+                .expect("a documented cleanup step gives it as a command block");
+            let filled = block
+                .replace(
+                    "<owner/repo#n> [<owner/repo#n> ...]",
+                    "blooop/wayfinder#151",
+                )
+                .trim()
+                .to_string();
+            assert_eq!(
+                filled, "wf reap --finished blooop/wayfinder#151",
+                "in {name}"
+            );
+            let typed: Vec<String> = filled
+                .split_whitespace()
+                .skip(1)
+                .map(String::from)
+                .collect();
+            assert!(
+                matches!(
+                    parse_args(typed),
+                    Invocation::Reap(ReapScope::Finished(ref nodes)) if nodes.len() == 1
+                ),
+                "the command {name} prints is not one this binary parses as a \
+                 scoped cleanup: {filled}"
+            );
+            checked += 1;
+        }
+        // A sweep that found nothing to read would be green forever.
         assert!(
-            matches!(
-                parse_args(typed),
-                Invocation::Reap(ReapScope::Finished(ref nodes)) if nodes.len() == 1
-            ),
-            "the command wf-auto prints is not one this binary parses as a \
-             scoped cleanup: {filled}"
+            checked >= 2,
+            "two skills document the cleanup; the sweep found {checked}"
         );
     }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -145,10 +145,16 @@ impl Keys for Typed {
     // crossterm's blocking calls, and blocking the thread inside them *is*
     // this impl's behaviour (see the trait's own note above). The `async` is
     // the trait's, not this function's — dropping it would mean dropping it
-    // from the trait, which the probe's impl needs to sleep. Newer clippy
-    // reads an await-free async trait impl as an accident; here it is the
+    // from the trait, which the probe's impl needs to sleep. Clippy 1.98 reads
+    // an await-free async trait impl as an accident; here it is the
     // arrangement being described.
-    #[allow(clippy::unused_async)]
+    //
+    // `unknown_lints` rides along because the lint below does not exist before
+    // 1.98, and `recipe/recipe.yaml` builds on an older toolchain than CI's
+    // stable: without it, naming the lint fails the build everywhere it is not
+    // yet known. Both attributes go together or neither works.
+    #[allow(unknown_lints)]
+    #[allow(clippy::unused_async_trait_impl)]
     async fn next_press(&mut self, _app: &App, timeout: Duration) -> Result<Option<KeyEvent>> {
         if !event::poll(timeout)? {
             return Ok(None);

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -141,6 +141,14 @@ trait Keys {
 struct Typed;
 
 impl Keys for Typed {
+    // No `.await` here, and there cannot be one: `poll` and `read` are
+    // crossterm's blocking calls, and blocking the thread inside them *is*
+    // this impl's behaviour (see the trait's own note above). The `async` is
+    // the trait's, not this function's — dropping it would mean dropping it
+    // from the trait, which the probe's impl needs to sleep. Newer clippy
+    // reads an await-free async trait impl as an accident; here it is the
+    // arrangement being described.
+    #[allow(clippy::unused_async)]
     async fn next_press(&mut self, _app: &App, timeout: Duration) -> Result<Option<KeyEvent>> {
         if !event::poll(timeout)? {
             return Ok(None);

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -55,7 +55,7 @@ use crate::launch::Agent;
 /// refuse to link over theirs if they made one (#104).
 ///
 /// Renaming this list is what [`sweep`] exists to clean up after.
-pub const BUNDLED: [&str; 5] = ["wf", "wf-auto", "wf-one", "wf-tdd", "wf-review"];
+pub const BUNDLED: [&str; 6] = ["wf", "wf-auto", "wf-mid", "wf-one", "wf-tdd", "wf-review"];
 
 /// Overrides the bundle location. The escape hatch for a build that is not
 /// installed — `wf-next` copied onto `PATH`, or a test — and the way to point
@@ -1403,7 +1403,7 @@ mod tests {
         // route missing from the cycle would be silently skipped above.
         assert_eq!(
             Route::all().len(),
-            6,
+            7,
             "every route must be in the cycle `Route::all` walks"
         );
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2200,6 +2200,31 @@ mod tests {
     }
 
     #[test]
+    fn no_mode_row_widens_the_picker_past_the_terminal_that_fits_the_rest() {
+        // 83 columns is what the picker's widest row has always needed — the
+        // route column plus `the agent decides alone and drives it to done`.
+        // A blurb longer than that does not wrap; the popup is clamped to the
+        // frame and the tail of the row is simply gone, so the row that says
+        // what a mode *does* is the one that loses its ending. The `mid` row
+        // arrived six columns over that budget, which clipped it on every
+        // terminal between 83 and 88 columns where nothing clipped before.
+        let app = {
+            let mut app = fixture_app();
+            down(&mut app, 2);
+            app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+            app
+        };
+        let screen = render_at(83, &app);
+        for mode in crate::launch::Mode::all() {
+            assert!(
+                screen.contains(mode.blurb()),
+                "{} is clipped at 83 columns:\n{screen}",
+                mode.label()
+            );
+        }
+    }
+
+    #[test]
     fn a_ticket_picker_draws_no_creation_rows() {
         // The other half of the rule: a ticket is not a repo-level stop, so
         // its picker is the modes and nothing else.
@@ -2241,7 +2266,7 @@ mod tests {
         assert!(screen.contains("/wf-auto"), "{screen}");
         // The middle row's blurb is the whole reason it is a separate mode:
         // it decides what it can and asks about what it cannot.
-        assert!(screen.contains("asks only what it cannot"), "{screen}");
+        assert!(screen.contains("asks what it can't"), "{screen}");
         // The skill-free mode (#112) reads as what it execs — a bare `claude`,
         // no slash command — and says what picking it costs you. The route
         // column is asserted too: it is the half of the row that says what will

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -757,8 +757,8 @@ fn centered(area: Rect, width: u16, height: u16) -> Rect {
 /// options are rows now: each one names its mode, the skill that mode routes the
 /// staged node to, and who ends up deciding. Which is also why the route is
 /// drawn per option rather than once for the cursor's — the difference between
-/// `/wf`, `/wf-auto` and no skill at all (#112) *is* the choice being made, so
-/// every one of them is on screen.
+/// `/wf`, `/wf-mid`, `/wf-auto` and no skill at all (#112) *is* the choice
+/// being made, so every one of them is on screen.
 /// The agent is in the title rather than another row: it applies to every
 /// candidate, and horizontal keys can change it without moving the vertical
 /// cursor.
@@ -2190,6 +2190,7 @@ mod tests {
         assert!(screen.contains("/wf-one"), "{screen}");
         assert!(screen.contains("one tracked ticket"), "{screen}");
         assert!(screen.contains("new map"), "{screen}");
+        assert!(screen.contains("new map, mid"), "{screen}");
         assert!(screen.contains("new map, auto"), "{screen}");
         // The field is named for the row it fills: `task` on the first one,
         // which is the only thing telling you the text is not steering.
@@ -2201,7 +2202,7 @@ mod tests {
     #[test]
     fn a_ticket_picker_draws_no_creation_rows() {
         // The other half of the rule: a ticket is not a repo-level stop, so
-        // its picker is the three modes and nothing else.
+        // its picker is the modes and nothing else.
         let app = {
             let mut app = fixture_app();
             down(&mut app, 2); // past the project row and the cluster header
@@ -2234,8 +2235,13 @@ mod tests {
         // on the interactive default.
         assert!(screen.contains("▶ interactive"), "{screen}");
         assert!(screen.contains("/wf "), "{screen}");
+        assert!(screen.contains("mid"), "{screen}");
+        assert!(screen.contains("/wf-mid"), "{screen}");
         assert!(screen.contains("auto"), "{screen}");
         assert!(screen.contains("/wf-auto"), "{screen}");
+        // The middle row's blurb is the whole reason it is a separate mode:
+        // it decides what it can and asks about what it cannot.
+        assert!(screen.contains("asks only what it cannot"), "{screen}");
         // The skill-free mode (#112) reads as what it execs — a bare `claude`,
         // no slash command — and says what picking it costs you. The route
         // column is asserted too: it is the half of the row that says what will
@@ -2256,14 +2262,19 @@ mod tests {
             "{screen}"
         );
         assert!(screen.contains("$wf "), "{screen}");
+        assert!(screen.contains("$wf-mid"), "{screen}");
         assert!(screen.contains("$wf-auto"), "{screen}");
 
         // Down moves the pick; the marker moves with it and nothing about the
         // route line is stale, since each row draws its own.
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let screen = render(&app);
-        assert!(screen.contains("▶ auto"), "{screen}");
+        assert!(screen.contains("▶ mid"), "{screen}");
         assert!(!screen.contains("▶ interactive"), "{screen}");
+        app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        let screen = render(&app);
+        assert!(screen.contains("▶ auto"), "{screen}");
+        assert!(!screen.contains("▶ mid"), "{screen}");
         app.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         let screen = render(&app);
         assert!(screen.contains("▶ plain"), "{screen}");

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -663,3 +663,52 @@ fn every_bundled_skill_documents_the_context_in_its_grammar() {
         );
     }
 }
+
+/// The ordered principle list under one skill doc's `## The principles`
+/// heading: the bold name of each numbered item, in the order the doc numbers
+/// them. Order is the whole content of the list — "when two pull opposite ways,
+/// the earlier wins" — so it is kept, not sorted away.
+fn principles(name: &str) -> Vec<String> {
+    let doc = skill_doc(name);
+    let section = doc
+        .split("## The principles")
+        .nth(1)
+        .unwrap_or_else(|| panic!("{name} declares the principles it decides by"))
+        .split("\n## ")
+        .next()
+        .expect("split always yields a first piece");
+    section
+        .lines()
+        .filter_map(|line| {
+            let numbered = line.trim_start();
+            numbered
+                .split_once(". **")
+                .filter(|(n, _)| n.chars().all(char::is_numeric) && !n.is_empty())
+                .and_then(|(_, rest)| rest.split_once("**"))
+                .map(|(name, _)| name.to_string())
+        })
+        .collect()
+}
+
+/// `wf-mid` decides by `wf-auto`'s principles, in `wf-auto`'s order — the same
+/// standing voice, so a map can be handed between the two skills without its
+/// route changing character half way along it.
+///
+/// Pinned as a list rather than a phrase, because the failure this guards
+/// against is silent: an edit that adds a principle to one doc, or reorders the
+/// two that most often collide, leaves both files reading perfectly well while
+/// the same ticket now resolves differently depending on which skill picked it
+/// up. The tiebreak order is load-bearing and only a comparison can hold it.
+#[test]
+fn wf_mid_decides_by_the_same_principles_in_the_same_order_as_wf_auto() {
+    let auto = principles("wf-auto");
+    assert!(
+        auto.len() >= 4,
+        "the extraction found nothing to compare: {auto:?}"
+    );
+    assert_eq!(
+        principles("wf-mid"),
+        auto,
+        "wf-mid and wf-auto must decide by one list, in one order"
+    );
+}

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -754,3 +754,38 @@ fn the_documented_status_report_lists_the_bundle_in_its_own_order() {
         .collect();
     assert_eq!(documented_status_rows(), bundled);
 }
+
+/// The skills the conda recipe names in `package_contents`, which is the check
+/// that a built package really carries them.
+fn packaged_skills() -> BTreeSet<String> {
+    let recipe =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/recipe/recipe.yaml"))
+            .expect("the recipe ships in this repo");
+    recipe
+        .lines()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix("- share/wf/skills/")?
+                .strip_suffix("/SKILL.md")
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// The package's own file list is the bundle: every skill `wf` can exec is
+/// named there, and nothing is named that does not ship.
+///
+/// The recipe says a package that quietly shipped one fewer "must fail here
+/// rather than at the moment an agent is launched" — and until this test that
+/// claim held only for whoever remembered to edit the list. Dropping the
+/// `wf-mid` line left the whole suite green, and the symptom lands a release
+/// later as `Unknown command: /wf-mid` inside a devcontainer, which is the one
+/// place nobody is reading a build log.
+#[test]
+fn every_bundled_skill_is_named_in_the_package_contents() {
+    let bundled: BTreeSet<String> = wf::skills::BUNDLED
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    assert_eq!(packaged_skills(), bundled);
+}

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -712,3 +712,45 @@ fn wf_mid_decides_by_the_same_principles_in_the_same_order_as_wf_auto() {
         "wf-mid and wf-auto must decide by one list, in one order"
     );
 }
+
+/// The skill names in the README's `wf skills` sample, in the order it prints
+/// them: the indented rows of the fenced block under the paragraph that
+/// introduces the report.
+fn documented_status_rows() -> Vec<String> {
+    let readme = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))
+        .expect("the README ships in this repo");
+    let block = readme
+        .split_once("`wf skills` reports a copy that is not")
+        .expect("the README shows what `wf skills` reports")
+        .1
+        .split("```")
+        .nth(1)
+        .expect("as a fenced sample");
+    block
+        .lines()
+        .filter_map(|line| {
+            line.strip_prefix("  ")
+                .filter(|row| !row.starts_with(' '))
+                .and_then(|row| row.split_whitespace().next())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+/// The sample report lists the skills `wf skills` actually walks, in the order
+/// it actually walks them — [`wf::skills::BUNDLED`], which is what both
+/// `status` and `install` iterate.
+///
+/// Order, not just membership: the sample is a screen a reader compares their
+/// own terminal against, and one that interleaves the names differently reads
+/// as a different build rather than as a stale doc. `wf-mid` was first written
+/// into this block in the position the prose lists it in, which is not the
+/// position the binary prints it in.
+#[test]
+fn the_documented_status_report_lists_the_bundle_in_its_own_order() {
+    let bundled: Vec<String> = wf::skills::BUNDLED
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    assert_eq!(documented_status_rows(), bundled);
+}


### PR DESCRIPTION
## Summary

- **New skill `wf-mid`**, and a `mid` mode row in the launch picker between `interactive` and `auto`. `/wf` asks the human about every decision; `/wf-auto` asks about none and fans out subagents to drive a whole map. Most maps are neither: most of their decisions have one defensible answer under the four principles `wf-auto` already declares, and two or three genuinely do not.
- **Escalation is earned, not default.** A decision reaches the human only if it passes all three: the cheap legwork is done (never ask what a read or a prototype can answer), the principles don't settle it, *and* it is taste/product, expensive to reverse, or destination-redrawing. Questions arrive as decision briefs with a recommendation; "your call" is a valid answer. A close call is recorded as one, so reopening an agent-decided ticket is normal rather than a conflict.
- **An unanswered escalation parks.** It never falls through to being decided alone — that is the whole difference from `auto`.
- **Plans by default, like `wf`.** Execution is granted per map in `## Notes` or by a `steer:` line, which is what keeps a run from inheriting `wf-auto`'s build fan-out. Subagents go where context isolation is load-bearing (research, prototypes, build stages); decisions resolve in the run's own context, because a conversation cannot be held through a subagent.
- `Mode::Mid` collapses the route table for `Auto`'s reason — the launched session manages whatever the node needs, so a stage skill would do one stage and stop, and routing a build node to `Tdd` would draw two picker rows naming `/wf-tdd` with different blurbs. A `new map, mid` creation row joins the project picker, since charting is where the mode's one high-value question lives.

## Self-review findings, fixed on the branch

Each is its own commit with the failing test first.

- **`wf-mid`'s reap command was documented with nothing checking `wf` parses it.** Editing its block to `--finish` left the whole suite green, so an executing run would have ended in a parser rejection. The test now sweeps `BUNDLED` instead of naming `wf-auto`, and asserts it found at least two skills — a sweep that reads nothing is green forever.
- **The package could ship five of six skills, green.** recipe.yaml says a package that shipped one fewer "must fail here rather than at the moment an agent is launched"; nothing enforced it. Deleting the `wf-mid` line was green, and the symptom lands a release later as `Unknown command: /wf-mid` inside a devcontainer. Now bound to `BUNDLED` in both directions.
- **The mid row's blurb clipped the picker.** 83 columns is what the widest row has always needed; the first blurb needed 89, and the popup doesn't wrap — between 83 and 88 columns the row lost the word it exists to say. New render-at-83 test walks `Mode::all()`; the blurb is now shorter than `auto`'s, so the picker needs exactly the width it did before.
- **The README's `wf skills` sample printed an order `wf` never prints** (`wf-mid` second, where the prose lists it; `BUNDLED` prints it third). Pinned as a sequence.
- **Claims the new mode falsified**: `CreationKind::all`'s "three variants", `Route::after`'s cycle order against its own "derived picker order" doc, a test comment calling `plain` "the third mode", and the README's "the five `wf` can exec" — `wf` has exec'd `/wf-one` since #114 gave the `new task` row its route.

## Test plan

- `cargo test --locked --lib --bins --examples`, `--test skill_docs`, `--test devcontainer_prebuild`, `--test offline_green`, `--test live_fetch -- common::` — all green; `cargo clippy --all-targets --all-features` and `cargo doc` with `-D warnings` clean.
- New coverage: the mid route names a bundled skill; the collapse holds across every ticket type × stage; `Mode::all()` order; both picker screens; the creation prompts (`/wf-mid`, `/wf-mid <seed>`, no `ctx:` block on a creation); no mode blurb clips at 83 columns.
- `tests/skill_docs.rs` binds `wf-mid`'s principle list to `wf-auto`'s **in order** — the tiebreak order is what decides contested tickets, and two docs drifting apart would resolve the same ticket differently depending on which skill picked it up.
- Drove the real binary: `WF_SKILLS_DIR=$PWD/skills ./target/release/wf skills` lists `wf-mid` as a bundle member.

## Review notes

- `wf skills install` was deliberately **not** run here — it would repoint the live `~/.claude` copies at this checkout. A reviewer wanting to try the mode needs `WF_SKILLS_DIR=$PWD/skills wf skills install` first.
- Unverified by any test, and unverifiable by one: whether a run actually *obeys* the escalation test rather than asking about everything or nothing. Same limit `tests/skill_docs.rs` already states out loud for the review stage's handoff rules — only a human watching a real run can see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a middle workflow mode that resolves straightforward decisions autonomously while escalating only high-value choices and preserving human control over execution.

New Features:
- Add the `wf-mid` skill, enabling mostly autonomous map work with targeted human escalation for unresolved, high-impact decisions.
- Add mid-mode routing and picker entries for existing nodes and new map creation, including `/wf-mid` invocations and context-aware launch behavior.

Bug Fixes:
- Keep bundled skill packaging, documentation, cleanup commands, and picker rendering synchronized with the expanded skill set.

Enhancements:
- Align mid-mode decision principles with `wf-auto` while retaining planning-by-default execution semantics.
- Collapse mid-mode routing across node types and stages so the launched session manages decisions and any granted build lifecycle.
- Expand launch and creation coverage to validate mode ordering, invocations, package contents, documentation consistency, and terminal-width rendering.

Build:
- Include the new `wf-mid` skill in packaged recipe contents.

Documentation:
- Document mid mode, its escalation and parking behavior, launch options, lifecycle, and cleanup semantics.
- Update project and skill documentation to reflect six bundled skills and the new routing choices.

Tests:
- Add coverage for mid-mode routes, picker and creation flows, bundled-skill packaging, documented principle alignment, cleanup command parsing, README ordering, and picker rendering width.

Chores:
- Update skill bundle metadata and route-cycle expectations for the additional skill.