### PR TITLE
Let an agent invoke wf, not just a human typing it

### DIFF
--- a/skills/wf/SKILL.md
+++ b/skills/wf/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: wf
 description: Plan a huge chunk of work — more than one agent session can hold — as a shared map of decision tickets on your issue tracker, and resolve them one at a time until the way to the destination is clear.
-disable-model-invocation: true
 ---
 
 ## Cross-agent invocation


### PR DESCRIPTION
`skills/wf/SKILL.md` carried `disable-model-invocation: true`, which hides a skill from the model's skill list while leaving `/wf` in the UI's picker. The two halves of that are what made it hard to see: the human sees `/wf` sitting there and an agent in the same session reports the skill does not exist, so the disagreement reads as a broken environment rather than a flag. It was diagnosed as a devcontainer mount problem first — `~/.claude/skills` is a read-only bind mount, so a missing skill in there is a plausible story — and the mounts were fine; every machine, container or not, had the same file.

The line was never chosen for `wf`. It arrived in #101, the commit that moved the five skills out of dotfiles and into this package, carried over wholesale from the `wayfinder` skill it was renamed from. Nothing since has touched it: `git log -S disable-model-invocation -- skills/` has exactly one commit.

`wf` is the only skill in the bundle that has it — `wf-mid` arrived in #173 without one — and being the human's entry point is not a reason to keep it. An agent that is *told* to run `wf`, in a subagent, in an isolated launch, or by a human who typed the name into a prompt instead of the picker, could not, and got a wrong answer about why. The HITL guarantee does not live in this flag and never did: it lives in the skill's own text, which says a HITL ticket only resolves through a live exchange and that handing judgement to the agent is never a variant of this skill.

## Checks

Rebased onto main after #173. Run against the toolchain CI uses — 1.98.0 / clippy 0.1.98 — with `RUSTFLAGS=-D warnings RUSTDOCFLAGS=-D warnings`: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --locked`, `cargo test --locked --lib --bins --examples` (430), `--test skill_docs` (17), `--test devcontainer_prebuild` (7), `--test offline_green` (2), `cargo doc --no-deps --all-features --locked`. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow agents to invoke the `wf` skill directly while retaining its human-in-the-loop workflow requirements.

Bug Fixes:
- Allow agents to invoke the `wf` skill directly instead of restricting it to human selection through the UI.

Enhancements:
- Remove the model-invocation restriction from `wf` while preserving its human-in-the-loop safeguards in the skill guidance.