### PR TITLE
Keep clippy 1.98 off the arm that is async on the trait's orders

### DIFF
--- a/src/picker.rs
+++ b/src/picker.rs
@@ -141,6 +141,13 @@ trait Keys {
 struct Typed;
 
 impl Keys for Typed {
+    // No `.await` in here, and there cannot be one: this is the arm that blocks
+    // the thread inside `poll`, which is the whole reason the trait is `async`
+    // (see [`Keys`]). `unused_async_trait_impl` — new in clippy 1.98 — reads the
+    // body alone and cannot see the obligation the trait imposes; taking its
+    // suggestion would mean hand-desugaring a `Future` to satisfy a lint about
+    // tidiness.
+    #[allow(clippy::unused_async_trait_impl)]
     async fn next_press(&mut self, _app: &App, timeout: Duration) -> Result<Option<KeyEvent>> {
         if !event::poll(timeout)? {
             return Ok(None);


### PR DESCRIPTION
`clippy::unused_async_trait_impl` is new in 1.98.0, released 2026-08-18, and CI installs the toolchain with `dtolnay/rust-toolchain@stable` — so main went red three days after its last green run without a commit in between. Every open pull request inherits it.

It fires once, on `Typed::next_press`. The body has no `.await` and cannot grow one: this is the arm that blocks the thread inside `event::poll`, and `Keys` is `async` for the *other* implementation's sake — the scripted probe sleeps there, which is what lets a current-thread runtime poll the background reading between frames. The trait's doc comment has said so since the probe was written. Clippy reads the body alone and cannot see that obligation, and its suggestion — return `impl Future` and wrap three expressions in `std::future::ready` — hand-desugars a coroutine to settle a question about tidiness.

So: `#[allow]` at the one site, with the reason next to it rather than in the lint table, because the reason is local. Nothing is silenced crate-wide, and a second impl that drifts into pointless `async` will still be caught.

## Checks

Run against the toolchain CI actually uses — 1.98.0 / clippy 0.1.98, installed via rustup, since conda-forge still tops out at 1.97.1. The whole chain from `AGENTS.md` is green: `cargo fmt --all --check`, `cargo clippy --all-targets --all-features --locked`, `cargo test --locked --lib --bins --examples` (427), `--test skill_docs` (14), `--test devcontainer_prebuild` (7), `--test offline_green` (2), `cargo doc --no-deps --all-features --locked`, all under `RUSTFLAGS=-D warnings RUSTDOCFLAGS=-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Allow the new Clippy async-trait lint only for the intentionally synchronous key-reading implementation, preserving the trait’s existing design without weakening lint coverage elsewhere.