### PR TITLE
Release 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.18.0"
+  version: "0.19.0"
 
 package:
   name: wf


### PR DESCRIPTION
## Summary

- Version bump only: `Cargo.toml`, `Cargo.lock`, `recipe/recipe.yaml` → `0.19.0`. `package.yml` fails the build if the recipe and crate versions drift, so all three move together.
- **Minor**, because 0.19.0 adds `/wf-mid` and its `mid` picker row (#173): the mode between grilling every decision and asking about none. It settles what the four principles settle, escalates only taste, scope and what is expensive to reverse, and parks an escalation nobody answered rather than deciding it alone.
- Carries #173's self-review fixes too: the reap command every skill prints is now checked against the parser for every skill rather than `wf-auto` alone; the recipe's file list is bound to `skills::BUNDLED` both directions; and no mode blurb may widen the launch picker past the 83 columns its widest row has always needed.
- Also carries the one thing #173 did not cause: clippy 1.98's `unused_async_trait_impl` had stopped `main` building on stable, proven by re-running main's own last green run on the unchanged commit.

## Test plan

- `cargo test --locked --lib --bins`, `--test skill_docs` green; `cargo clippy --all-targets --all-features` and `cargo doc` clean under `-D warnings`.
- `cargo build --release --locked --bin wf && ./target/release/wf --version` → `wf 0.19.0`.
- CI's `build + install-test` re-installs the built package into a throwaway environment and runs `wf --version`, which is the check that the recipe version and the crate version agree.

Tagging `v0.19.0` after this merges is what publishes the package to prefix.dev/blooop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Align the crate, lockfile, and package recipe versions for the 0.19.0 release.