### PR TITLE
Release 0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.19.0"
+  version: "0.19.1"
 
 package:
   name: wf


### PR DESCRIPTION
Patch: `wf` is invocable by an agent, not only by a human typing it (#174).

`skills/wf/SKILL.md` carried `disable-model-invocation: true`, which hides a skill from the model's list while leaving `/wf` in the picker — so a human looking at the UI and an agent in the same session disagreed about whether the skill existed, and the disagreement read as a broken devcontainer rather than a flag. The line was never chosen for `wf`: it rode in with #101, the commit that moved the skills out of dotfiles into this package, carried over from the `wayfinder` skill it was renamed from, and no commit has touched it since. It was the only one in the bundle to have it; `wf-mid` arrived a release ago without one. Nothing about the HITL guarantee lived in it — that is the skill's own text, which says a HITL ticket only resolves through a live exchange.

Nothing else changed. 0.19.0 shipped an hour earlier and #174 is the one commit on top of it.

Tagging `v0.19.1` after this merges is what actually publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the package and recipe versions from 0.19.0 to 0.19.1.