### PR TITLE
Charting files the ticket instead of stopping to ask

### DIFF
--- a/skills/wf/GITHUB_TRACKER.md
+++ b/skills/wf/GITHUB_TRACKER.md
@@ -9,15 +9,13 @@ Every command below targets `$REPO` **explicitly**. Never let `gh` resolve the t
 ```bash
 REMOTE=origin   # the remote for the repo being mapped — see Forks if origin points at the parent
 REPO=$(git remote get-url "$REMOTE" | sed -E 's#^(ssh://)?(git@github\.com[:/]|https://github\.com/)##; s#\.git$##')
-gh repo view "$REPO" --json nameWithOwner,visibility,isFork,parent,hasIssuesEnabled \
-  --jq '"\(.nameWithOwner) \(.visibility)\(if .isFork then " fork-of:\(.parent.nameWithOwner)" else "" end)\(if .hasIssuesEnabled then "" else " ISSUES-DISABLED" end)"'
+gh repo view "$REPO" --json nameWithOwner,isFork,parent,hasIssuesEnabled \
+  --jq '"\(.nameWithOwner)\(if .isFork then " fork-of:\(.parent.nameWithOwner)" else "" end)\(if .hasIssuesEnabled then "" else " ISSUES-DISABLED" end)"'
 ```
 
 `$REMOTE` and `$REPO` are the session's two anchors: `$REPO` on every `gh` call, `$REMOTE` on every `git push`. Neither has a default worth trusting.
 
-Show that line to the human before the first write of a charting session and stop if it isn't the repo they meant — the map body carries the Destination and the whole fog sketch, so it is both the most revealing artifact in the flow and the first one created. If `origin` isn't a GitHub remote, use the local-markdown fallback at the bottom of this file rather than reaching for another repo.
-
-The `visibility` field is why that line includes it: if it reads `PUBLIC`, every issue this session files is world-readable. Call it out and get an explicit go-ahead before the first write — see **Keep the map inside its repo** in [SKILL.md](SKILL.md).
+Say that line to the human as the session's first words, then write — it is narration, not a gate. An invocation is a request for a map, so don't stall it on a confirmation; the pinning above is what keeps the writes in the right repo. If `origin` isn't a GitHub remote, use the local-markdown fallback at the bottom of this file rather than reaching for another repo.
 
 ## Forks
 

--- a/skills/wf/SKILL.md
+++ b/skills/wf/SKILL.md
@@ -35,8 +35,6 @@ The map belongs to **one** repo — the one being mapped — and every write goe
 
 **A fork is its own repo.** Its map, tickets, and research branches belong on the fork being mapped, never on its parent — `gh` and `git push` both drift upstream when left to their defaults, and the parent is the repo you have least claim on. See **Forks** in [GITHUB_TRACKER.md](GITHUB_TRACKER.md).
 
-A map is thinking out loud — a Destination, a fog sketch, half-formed questions — and the tracker of a public repo publishes all of it. If the resolved repo is **public**, say so and confirm with the human before the first write; see **Pin the repo first** in [GITHUB_TRACKER.md](GITHUB_TRACKER.md). That's a check on where tickets are *filed*, not on what they may discuss: research tickets search the open web with the real question, identifiers and all.
-
 ### The map body
 
 The whole map at low resolution, loaded once per session. Open tickets are **not** listed — they are open child issues, found by query.
@@ -141,7 +139,7 @@ User invokes with a loose idea.
 
 1. **Name the destination.** Run a `/grill-me` and `/constructive-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
 2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
-3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**. **Pin and name the target repo first** — this is the session's first write, and it carries the Destination and the whole fog sketch (see [Keep the map inside its repo](#keep-the-map-inside-its-repo)).
+3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**. **Pin and name the target repo first** — this is the session's first write (see [Keep the map inside its repo](#keep-the-map-inside-its-repo)).
 4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
 5. **Fire the research subagents.** For each `research` ticket you just created, spin up a `/research` subagent to resolve it in parallel, capturing its findings on a throwaway `research/<name>` branch — pushed by name to the pinned remote, never with a bare `git push` — with a context pointer from the ticket.
 6. Stop — charting is one session's work; it hand-resolves nothing.


### PR DESCRIPTION
## What

`skills/wf` had two confirmation gates in front of a charting session's first write:

- **the public-repo gate** — if the resolved repo was public, say so and get an explicit go-ahead before creating the map;
- **the wrong-repo gate** — show the pinned repo line and *stop* if it isn't the one they meant.

Both sit between an invocation and the map it asked for, and the public one fires on nearly every repo `wf` is used on, so the common path was a question rather than a ticket. Invoking `wf` is the consent.

## What survives

All of the pinning the gates hung off:

- `$REPO`/`$REMOTE` resolved once from the working repo's own remote,
- `--repo` on every `gh` call, `git push "$REMOTE" <branch>` by name,
- the fork rules (`isFork`/`parent`, ambient `gh` resolution, `ISSUES-DISABLED` → enable or fall back to local markdown).

That is what keeps writes out of the wrong repo, and none of it needs an answer from anyone. The pin line still names the repo it resolved, now as narration rather than a gate.

`visibility` leaves the `gh repo view` probe along with the paragraph that read it — no rule consumes it any more, and a field printed for no reader is drift waiting to happen.

## Checks

Full pre-push chain green (`fmt --check`, `clippy --all-targets --all-features`, `test --lib --bins --examples`, `skill_docs`, `devcontainer_prebuild`, `offline_green`, `live_fetch -- common::`, `doc`), with `RUSTFLAGS`/`RUSTDOCFLAGS=-D warnings`.

Docs-only under `skills/wf/`; no route, no `BUNDLED` entry, no name changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Streamline charting sessions by replacing pre-write repository confirmations with narrated repository pinning.

Enhancements:
- Remove confirmation gates from charting sessions so an invocation proceeds directly to creating the map while still announcing the resolved repository.
- Retain explicit repository and remote pinning for GitHub and fork workflows, including local-markdown fallback behavior.
- Remove the unused repository visibility probe and related public-repository confirmation guidance.

Documentation:
- Update charting workflow documentation to describe repository identification as narration rather than a confirmation gate.