### PR TITLE
Release 0.19.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.19.1"
+version = "0.19.2"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.19.1"
+  version: "0.19.2"
 
 package:
   name: wf


### PR DESCRIPTION
Patch release for #178: charting files the ticket instead of stopping to ask.

`skills/wf` had two confirmation gates in front of a charting session's first write — an explicit go-ahead whenever the resolved repo was public, and a stop if the pinned repo "isn't the repo they meant". The public one fires on nearly every repo `wf` is used on, so the common path was a question rather than a map.

The pinning those gates hung off is untouched (`$REPO`/`$REMOTE` from the working repo's own remote, `--repo` on every `gh` call, pushes by remote name, the fork rules), and that is what keeps writes out of the wrong repo. Only `visibility` left the `gh repo view` probe, with the paragraph that read it.

Version bumped in `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml`. Nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the package and release recipe versions to 0.19.2.