### PR TITLE
Give the Rust version one home and have everything read it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install the Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      # No version is named here, and that is the point: rustup reads
+      # `rust-toolchain.toml` and installs exactly the channel and the components
+      # it names. `dtolnay/rust-toolchain` cannot do that — it selects by `@rev`
+      # and has never read that file — so keeping it would mean the compiler
+      # version lived in this file too. That is what `@stable` was: a second
+      # source of truth that moved on its own, and took `main` red with it on a
+      # day nobody committed anything (#173).
+      #
+      # Any rustup command inside the checkout triggers the install. This one is
+      # here so the download is a named step in the log rather than a surprise in
+      # the middle of the first cargo command, and so a channel that cannot be
+      # fetched fails against a step that says why.
+      - name: Install the Rust toolchain rust-toolchain.toml pins
+        run: rustup show active-toolchain
 
       # Keyed on the lockfile and the compiler version, and scoped to this
       # workflow so `package.yml`'s registry cache stays a separate thing.
@@ -103,6 +113,15 @@ jobs:
       # step above — the unit-test step stops at `--lib --bins --examples`.
       - name: Devcontainer prebuild contract
         run: cargo test --locked --test devcontainer_prebuild
+
+      # The third config-as-behavior binary, and the one that keeps this file
+      # honest: the step above that installs the toolchain names no version
+      # because `rust-toolchain.toml` is the only place one is written. Nothing
+      # at runtime notices when a second place appears — a workflow that installs
+      # a toolchain by name still passes every other check here — so the guard
+      # has to read the configuration, which is what this does.
+      - name: The Rust pin has one home
+        run: cargo test --locked --test toolchain_pin
 
       # The guard on the exclusion every step around it depends on: the live
       # binaries are safe to leave out of the unit-test step only because each

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
 
       # First, because it is the one check that cannot be wrong about the code:
       # it either matches `cargo fmt` or it does not. rustfmt.toml holds only
-      # stable options, so this runs on the stable toolchain above rather than
-      # needing nightly.
+      # stable options, so this runs on the pinned release toolchain above rather
+      # than needing nightly.
       - name: Formatting
         run: cargo fmt --all --check
 

--- a/.github/workflows/devlaunch-contract.yml
+++ b/.github/workflows/devlaunch-contract.yml
@@ -53,10 +53,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # The compiler comes from rustup, exactly as in `ci.yml`. pixi supplies
-      # `dl` and nothing else — see the header of `pixi.toml`.
-      - name: Install the Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # The compiler comes from rustup, exactly as in `ci.yml`, and no version is
+      # named here: rustup installs what `rust-toolchain.toml` pins, components
+      # included. pixi supplies `dl` and nothing else — see the header of
+      # `pixi.toml`.
+      - name: Install the Rust toolchain rust-toolchain.toml pins
+        run: rustup show active-toolchain
 
       - name: Cache cargo's registry and the target directory
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -65,8 +65,10 @@ jobs:
       # the runner's own checkout as much as anything.
       - uses: actions/checkout@v7
 
-      - name: Install the Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # No version named here: rustup installs what `rust-toolchain.toml` pins,
+      # components included. The long version of why is in `ci.yml`.
+      - name: Install the Rust toolchain rust-toolchain.toml pins
+        run: rustup show active-toolchain
 
       - name: Cache cargo's registry and the target directory
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,9 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # The recipe carries the version literally (rattler-build can only read it
-      # out of Cargo.toml under --experimental), so the two can drift. Catch it
-      # on every pull request rather than halfway through a release.
+      # The recipe carries the *package* version literally, so the two can drift.
+      # Catch it on every pull request rather than halfway through a release.
+      #
+      # The build below now passes `--experimental` for the Rust pin, so
+      # `load_from_file("../Cargo.toml").package.version` would work here too and
+      # retire this step. Folding it in is a separate change from pinning the
+      # toolchain; until then this check is what holds the line.
       - name: Recipe version tracks Cargo.toml
         run: |
           crate="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -1)"
@@ -96,6 +100,12 @@ jobs:
           # in step with the pin in the release job below.
           rattler-build-version: v0.72.2
           recipe-path: recipe/recipe.yaml
+          # --experimental: `recipe.yaml` reads the Rust version out of
+          # `rust-toolchain.toml` with `load_from_file`, so that the pin has one
+          # home and the conda build is not a second place it is written down.
+          # The function is gated behind this flag; without it the render fails
+          # loudly at that line rather than falling back to anything.
+          #
           # --no-config: rattler-build otherwise discovers any pixi or
           # rattler-build config file in the tree and adopts its default-channels,
           # so this keeps the build resolving against exactly the two channels
@@ -106,7 +116,7 @@ jobs:
           # dependencies). The build needs it for the test environment
           # rattler-build creates from the freshly built package, not for the
           # cargo build itself, which still resolves from conda-forge alone.
-          build-args: --channel https://prefix.dev/blooop --channel conda-forge --no-config
+          build-args: --experimental --channel https://prefix.dev/blooop --channel conda-forge --no-config
           artifact-name: wf-conda-package
 
       - name: Locate the package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ RUSTFLAGS=-D\ warnings RUSTDOCFLAGS=-D\ warnings sh -c '
   cargo test --locked --lib --bins --examples &&
   cargo test --locked --test skill_docs &&
   cargo test --locked --test devcontainer_prebuild &&
+  cargo test --locked --test toolchain_pin &&
   cargo test --locked --test offline_green &&
   cargo test --locked --test live_fetch -- common:: &&
   cargo doc --no-deps --all-features --locked'
@@ -124,15 +125,40 @@ Run the whole chain before pushing, `cargo fmt --all` first — a formatting dif
 fails the build before any of the interesting checks get a chance to run.
 
 The `tests/live_*.rs` files are excluded from that test command on purpose: they
-talk to real GitHub, drive a real pty, or want a chosen `devlaunch`. Three
+talk to real GitHub, drive a real pty, or want a chosen `devlaunch`. Four
 binaries under `tests/` are exceptions and run in the chain (and in CI) like any
-unit test, because all three are offline checks on files-as-behavior:
+unit test, because all four are offline checks on files-as-behavior:
 `tests/skill_docs.rs` (shape checks on the skill docs' snippets),
 `tests/devcontainer_prebuild.rs` (the contract between the devcontainer configs
 and the workflow that publishes the prebuilt image to GHCR — see the comments in
-`.devcontainer/devcontainer.json`), and `tests/offline_green.rs` (the guard on
-the exclusion itself: it reads `tests/live_*.rs` and fails if any test in them
-is missing `#[ignore]`).
+`.devcontainer/devcontainer.json`), `tests/toolchain_pin.rs` (the guard that
+keeps `rust-toolchain.toml` the only place a Rust version is written — see
+**The Rust version is pinned in one place** below), and `tests/offline_green.rs`
+(the guard on the exclusion itself: it reads `tests/live_*.rs` and fails if any
+test in them is missing `#[ignore]`).
+
+### The Rust version is pinned in one place
+
+`rust-toolchain.toml` names the compiler, and nothing else in the repository
+names one. Three of the four consumers get that for free, because rustup reads
+the file for any cargo command inside the checkout: your shell, the
+devcontainer, and the GitHub runners — which is why no workflow installs a
+toolchain any more, and why `mcr.microsoft.com/devcontainers/rust:1-bookworm`'s
+floating `1` tag no longer decides which compiler a container builds with. The
+fourth is `recipe/recipe.yaml`, which resolves `rust` from conda-forge rather
+than rustup and so reads the file explicitly with `load_from_file`; that is what
+`--experimental` in `package.yml` is for.
+
+**Bumping it is one edit to `channel`, and it waits on conda-forge.** The pin is
+the newest version conda-forge packages, deliberately: the recipe compiles the
+binary that ships, so a toolchain CI can install but the release build cannot
+would mean testing with one compiler and shipping another. That gap is what let
+clippy 1.98 reject `main` on a day nobody committed anything while the package
+went on building fine (#173).
+
+`tests/toolchain_pin.rs` is what stops a second home appearing. It fails on a
+workflow that names a toolchain, on a recipe that goes back to a literal, and on
+a `package.yml` that drops the flag the recipe's read needs.
 
 ### The live tests are gated, not absent
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ cargo clippy --all-targets --all-features --locked
 cargo test --locked --lib --bins --examples
 cargo test --locked --test skill_docs
 cargo test --locked --test devcontainer_prebuild
+cargo test --locked --test toolchain_pin
 cargo test --locked --test offline_green
 cargo test --locked --test live_fetch -- common::
 cargo test --locked --all-targets --no-run

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -75,7 +75,15 @@ build:
 
 requirements:
   build:
-    - rust >=1.75
+    # The same pin everything else reads, read rather than repeated. This build
+    # resolves `rust` from conda-forge instead of rustup, so it is the one
+    # consumer that cannot honour `rust-toolchain.toml` on its own — hence the
+    # explicit load, relative to this recipe's own directory.
+    #
+    # `load_from_file` is experimental, which is what `--experimental` in
+    # `package.yml` is for. That coupling cannot rot quietly: without the flag
+    # rattler-build refuses to render this file at all and points at this line.
+    - rust ==${{ load_from_file("../rust-toolchain.toml").toolchain.channel }}
     # Rust links libgcc_s, so without a C compiler's run_exports the package
     # would ship an undeclared dependency on it (rattler-build says so:
     # "Overlinking against libgcc_s.so.1"). This is what adds `libgcc` to the run

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,25 @@
+# The Rust version, written down once. Nothing else in this repository names a
+# version of the compiler; everything that needs one reads this file.
+#
+# Three of the four consumers get that for free, because rustup honours this
+# file for every cargo invocation inside the checkout: a developer's shell, the
+# devcontainer, and the GitHub runners — which is why no workflow installs a
+# toolchain by name any more. It also takes the decision away from
+# `mcr.microsoft.com/devcontainers/rust:1-bookworm`, whose floating `1` tag
+# used to be what chose the compiler inside a devcontainer.
+#
+# The fourth is `recipe/recipe.yaml`, which asks conda-forge rather than rustup
+# and cannot honour this file on its own. It reads it explicitly instead, with
+# `load_from_file("../rust-toolchain.toml")` — see the note beside that line.
+#
+# Why 1.97.1 and not the newest stable: it is the newest conda-forge packages,
+# and the recipe is what compiles the binary that ships. Pinning to a version
+# CI can install but the release build cannot means testing with one compiler
+# and shipping another — the gap that let clippy 1.98 reject `main` on a day
+# nobody committed anything while the package went on building fine (#173).
+# Bumping is one edit to `channel` below, and it waits on conda-forge.
+[toolchain]
+channel = "1.97.1"
+# rustup installs these alongside the compiler, which is what lets the
+# workflows drop `components: rustfmt, clippy` along with the action.
+components = ["clippy", "rustfmt"]

--- a/tests/toolchain_pin.rs
+++ b/tests/toolchain_pin.rs
@@ -121,28 +121,52 @@ fn the_pin_carries_the_components_ci_needs() {
 
 /// No workflow installs a toolchain by name.
 ///
-/// The action is listed by name because naming a version is the only way to use
-/// it — it selects by `@rev` and has never read `rust-toolchain.toml`. The
-/// `rustup` subcommands are the hand-rolled equivalents. `rustup show`, which is
-/// what the workflows run now, takes no version and is deliberately absent.
+/// `dtolnay/rust-toolchain` is refused outright, because naming a version is the
+/// only way to use it: it selects by `@rev` and has never read
+/// `rust-toolchain.toml`.
+///
+/// The rustup subcommands are refused only when they carry an *argument*, which
+/// is the part that makes them a second home. The bare forms are welcome and one
+/// of them is a fair replacement for what the workflows run today: `rustup
+/// toolchain install` with nothing after it installs exactly what the pin names.
+/// Rejecting those too would be a guard that lies — it would report a version
+/// named outside this file when none was.
 #[test]
 fn no_workflow_names_a_toolchain_version() {
-    let banned = [
-        "rust-toolchain@",
+    /// Subcommands whose argument, if any, would be a toolchain.
+    const TAKES_A_TOOLCHAIN: [&str; 4] = [
         "rustup toolchain install",
-        "rustup default ",
-        "rustup override ",
-        "rustup update ",
+        "rustup default",
+        "rustup override set",
+        "rustup update",
     ];
+    /// Shell punctuation and comments are not toolchain names.
+    fn is_an_argument(token: &str) -> bool {
+        !token.is_empty() && !matches!(token, "&&" | "||" | ";" | "|") && !token.starts_with('#')
+    }
+
     for (name, body) in workflows() {
-        for pattern in banned {
-            assert!(
-                !body.contains(pattern),
-                ".github/workflows/{name} contains `{pattern}`, which names a \
-                 toolchain outside rust-toolchain.toml. rustup reads that file \
-                 for any cargo command in the checkout, so the step needs no \
-                 version at all — see the note in ci.yml"
-            );
+        assert!(
+            !body.contains("rust-toolchain@"),
+            ".github/workflows/{name} uses `dtolnay/rust-toolchain`, which selects \
+             by `@rev` and cannot read rust-toolchain.toml — so using it at all \
+             means naming a version here. `rustup show active-toolchain` needs none."
+        );
+
+        for command in TAKES_A_TOOLCHAIN {
+            for line in body.lines() {
+                let Some((_, rest)) = line.split_once(command) else {
+                    continue;
+                };
+                let argument = rest.split_whitespace().next().unwrap_or_default();
+                assert!(
+                    !is_an_argument(argument),
+                    ".github/workflows/{name} runs `{command} {argument}`, which \
+                     names a toolchain outside rust-toolchain.toml. Drop the \
+                     argument: rustup then acts on the pinned toolchain, which is \
+                     the only one a step in this checkout should be reaching for."
+                );
+            }
         }
     }
 }

--- a/tests/toolchain_pin.rs
+++ b/tests/toolchain_pin.rs
@@ -1,0 +1,199 @@
+//! The Rust version has one home, and nothing else names one.
+//!
+//! `rust-toolchain.toml` is what every build reads. rustup honours it directly
+//! for a developer's shell, for the devcontainer, and for the GitHub runners —
+//! which is why no workflow installs a toolchain by name any more — and
+//! `recipe/recipe.yaml`, the one consumer that resolves `rust` from conda-forge
+//! rather than rustup, loads it explicitly.
+//!
+//! What this guards is not a wrong version but a *second* one. A workflow that
+//! installs a toolchain by name, or a recipe that goes back to a literal,
+//! re-creates the split that let `dtolnay/rust-toolchain@stable` move on its own
+//! and take `main` red on a day nobody committed anything (#173). A version can
+//! only be wrong in one place if it is only written in one place.
+//!
+//! Offline by design, like its neighbours in this directory: the seam is the
+//! configuration text itself, so no network and no toolchain are involved.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// A file in this repository, read by its path relative to the crate root.
+fn repo_file(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{} ships in this repo: {e}", path.display()))
+}
+
+/// Every workflow under `.github/workflows`, as `(file name, contents)`.
+///
+/// Read from the directory rather than from a list, so a workflow added later
+/// is held to the same rule without anyone remembering to add it here.
+fn workflows() -> Vec<(String, String)> {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".github/workflows");
+    let mut found: Vec<(String, String)> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("{} is part of this repo: {e}", dir.display()))
+        .map(|entry| entry.expect("the workflow directory is readable").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "yml"))
+        .map(|path| {
+            let name = path
+                .file_name()
+                .expect("a file read from a directory has a name")
+                .to_string_lossy()
+                .into_owned();
+            (
+                name,
+                fs::read_to_string(&path).expect("the workflow is readable"),
+            )
+        })
+        .collect();
+    found.sort();
+    assert!(
+        found.len() >= 4,
+        "expected the workflow directory to hold the CI, live, contract and \
+         package workflows; found {found:?}"
+    );
+    found
+}
+
+/// The value of `channel` in `rust-toolchain.toml` — the pin itself.
+fn pinned_channel() -> String {
+    let toml = repo_file("rust-toolchain.toml");
+    let line = toml
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("channel"))
+        .expect("rust-toolchain.toml names a channel");
+    line.split('=')
+        .nth(1)
+        .expect("`channel` is an assignment")
+        .trim()
+        .trim_matches('"')
+        .to_string()
+}
+
+/// The pin is an exact version, not a moving channel.
+///
+/// `stable` is the specific thing that broke: it is a valid value here and it
+/// would leave every consumer reading this file faithfully and still compiling
+/// with whatever shipped that morning.
+#[test]
+fn the_pin_is_an_exact_version() {
+    let channel = pinned_channel();
+    for moving in ["stable", "beta", "nightly"] {
+        assert!(
+            !channel.starts_with(moving),
+            "rust-toolchain.toml pins `{channel}`, which moves on its own — \
+             name an exact version instead"
+        );
+    }
+    let parts: Vec<&str> = channel.split('.').collect();
+    assert!(
+        parts.len() == 3
+            && parts
+                .iter()
+                .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())),
+        "rust-toolchain.toml should pin a full `major.minor.patch` version, got `{channel}`"
+    );
+}
+
+/// The components the workflows stopped installing are named here instead.
+///
+/// `ci.yml` used to pass `components: rustfmt, clippy` to the action it no
+/// longer uses. Those two steps still run, so the components have to arrive
+/// with the toolchain — and this file is now the only thing that asks for them.
+#[test]
+fn the_pin_carries_the_components_ci_needs() {
+    let toml = repo_file("rust-toolchain.toml");
+    let components = toml
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("components"))
+        .expect("rust-toolchain.toml lists its components");
+    for needed in ["clippy", "rustfmt"] {
+        assert!(
+            components.contains(needed),
+            "`{needed}` has a step of its own in ci.yml, so rust-toolchain.toml \
+             has to install it: {components}"
+        );
+    }
+}
+
+/// No workflow installs a toolchain by name.
+///
+/// The action is listed by name because naming a version is the only way to use
+/// it — it selects by `@rev` and has never read `rust-toolchain.toml`. The
+/// `rustup` subcommands are the hand-rolled equivalents. `rustup show`, which is
+/// what the workflows run now, takes no version and is deliberately absent.
+#[test]
+fn no_workflow_names_a_toolchain_version() {
+    let banned = [
+        "rust-toolchain@",
+        "rustup toolchain install",
+        "rustup default ",
+        "rustup override ",
+        "rustup update ",
+    ];
+    for (name, body) in workflows() {
+        for pattern in banned {
+            assert!(
+                !body.contains(pattern),
+                ".github/workflows/{name} contains `{pattern}`, which names a \
+                 toolchain outside rust-toolchain.toml. rustup reads that file \
+                 for any cargo command in the checkout, so the step needs no \
+                 version at all — see the note in ci.yml"
+            );
+        }
+    }
+}
+
+/// The recipe reads the pin instead of repeating it.
+///
+/// This is the one build that cannot honour `rust-toolchain.toml` implicitly, so
+/// it is the one place the coupling is written down — and the one place a
+/// literal would quietly reappear.
+#[test]
+fn the_recipe_reads_the_pin() {
+    let recipe = repo_file("recipe/recipe.yaml");
+    let requirement = recipe
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("- rust"))
+        .expect("the recipe declares a `rust` build requirement");
+
+    assert!(
+        requirement.contains(r#"load_from_file("../rust-toolchain.toml").toolchain.channel"#),
+        "the recipe's rust requirement should load the pin rather than repeat \
+         it, got: {requirement}"
+    );
+    assert!(
+        requirement.contains("=="),
+        "the recipe should pin rust exactly, not name a floor: {requirement}"
+    );
+    assert!(
+        !requirement.bytes().any(|b| b.is_ascii_digit()),
+        "a version literal has come back into the recipe's rust requirement: \
+         {requirement}"
+    );
+}
+
+/// `package.yml` passes the flag the recipe's read needs.
+///
+/// `load_from_file` is experimental. Without `--experimental` rattler-build
+/// refuses to render the recipe at all, so the build fails loudly rather than
+/// silently resolving some other compiler — but it fails in the one workflow
+/// that publishes, which is a late place to find out.
+#[test]
+fn the_package_workflow_enables_the_recipes_read() {
+    let package = repo_file(".github/workflows/package.yml");
+    let build_args = package
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("build-args:"))
+        .expect("package.yml passes build arguments to rattler-build");
+    assert!(
+        build_args.contains("--experimental"),
+        "recipe.yaml reads the pin with `load_from_file`, which is gated behind \
+         `--experimental`: {build_args}"
+    );
+}


### PR DESCRIPTION
## What broke

`main` went red on 2026-08-21 with no commit in between. clippy 1.98.0 shipped three days earlier, `dtolnay/rust-toolchain@stable` picked it up, and a lint that did not exist on Friday rejected `src/picker.rs` on Monday. #173 silenced the lint; this removes the mechanism.

## What chose a compiler before this

Four things, none pinned, no two agreeing:

| surface | how it picked | what it got |
|---|---|---|
| `ci.yml` | `dtolnay/rust-toolchain@stable` | whatever shipped that morning |
| `live.yml` | same | same |
| `devlaunch-contract.yml` | same | same |
| `recipe/recipe.yaml` | `rust >=1.75` from conda-forge | 1.97.1 |
| `.devcontainer/Dockerfile` | `devcontainers/rust:1-bookworm` | whatever the image had |

The recipe divergence is not incidental — it compiles the binary that ships, so the release build was already a compiler behind everything that tested it. That is why #173's `allow` needed `unknown_lints` beside it: it had to name a lint half the builds had never heard of.

## What it is now

**`rust-toolchain.toml` is the only place a Rust version is written.**

Three consumers need nothing else, because rustup honours the file for any cargo command inside the checkout. The workflows therefore install no toolchain *by name* — they run `rustup show active-toolchain`, which downloads what the file names, `components` included. The step exists only so the download is a named line in the log instead of a surprise inside the first cargo command. The same file takes the decision away from the devcontainer's floating `1` image tag.

The fourth, the recipe, resolves `rust` from conda-forge rather than rustup and cannot honour the file implicitly, so it reads it: `load_from_file("../rust-toolchain.toml").toolchain.channel`, gated behind `--experimental`, now passed in `package.yml`.

## Why 1.97.1 and not the newest stable

It is the newest conda-forge packages, and the recipe builds the artifact. Pinning above what the release build can install would preserve exactly the gap this closes — testing with one compiler, shipping another. **This does mean CI now runs 1.97.1 where it ran 1.98.0 yesterday.** That is the trade pinning makes: a new stable's lints arrive when someone bumps `channel`, on a branch, instead of on a random Tuesday. Bumping is one edit, and it waits on conda-forge.

## Verification

Not argued from the docs — run:

- **rustup honours the file**: uninstalled 1.97.1, ran one rustup command in the checkout, watched it re-sync the channel and download 5 components; `rustup show active-toolchain` reports `1.97.1 (overridden by '.../rust-toolchain.toml')`, and `cargo clippy --version` / `cargo fmt --version` both answer 1.97.
- **the recipe renders**: `rust ==1.97.1`, against the rattler-build `package.yml` pins (**v0.72.2**, not just the newest). Without `--experimental` the render fails and names that line, so the coupling cannot rot quietly.
- **conda's cargo ignores the file it just read from**: it is a real binary, not a rustup shim, so the hermetic build does not try to fetch a toolchain. Checked, not assumed.
- **the full chain** from `AGENTS.md` is green on 1.97.1 under `-D warnings` / `RUSTDOCFLAGS=-D warnings`: fmt, clippy, 430 unit, `skill_docs` (17), `devcontainer_prebuild` (7), `toolchain_pin` (5), `offline_green` (2), `live_fetch -- common::`, `--all-targets --no-run`, doc.

## The guard

`tests/toolchain_pin.rs` holds the one invariant nothing at runtime can see: that a *second* home never appears. Five mutations were applied and each failed exactly the one test that owns it —

| mutation | test that caught it |
|---|---|
| a workflow reinstalls `dtolnay/rust-toolchain@stable` | `no_workflow_names_a_toolchain_version` |
| the recipe goes back to a literal | `the_recipe_reads_the_pin` |
| `package.yml` drops `--experimental` | `the_package_workflow_enables_the_recipes_read` |
| `channel = "stable"` | `the_pin_is_an_exact_version` |
| the pin stops carrying `clippy` | `the_pin_carries_the_components_ci_needs` |

It reads the workflow *directory*, so a workflow added later is held to the rule without anyone remembering to add it.

## Known costs

- **A fresh devcontainer now downloads the pinned toolchain on its first cargo command.** The image's own Rust is no longer the one used. `.devcontainer/` is deliberately untouched — its build context is that directory alone, so editing it would invalidate the published prebuild — and the correctness win is that a container compiles with the same compiler as CI and the release.
- `package.yml` now passes `--experimental`, so `load_from_file("../Cargo.toml").package.version` would work too and retire the "Recipe version tracks Cargo.toml" step. Folding that in is a separate change from pinning the toolchain; the comment there says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin the Rust toolchain in one shared configuration and make every build and validation path consume it.

Bug Fixes:
- Prevent unexpected compiler and lint changes from floating toolchain selections by pinning Rust to a known compatible release across CI and packaging.

Enhancements:
- Centralize the Rust compiler version and required components in rust-toolchain.toml for developer, container, workflow, and release-build consistency.
- Make the conda recipe read the shared Rust pin and update package builds to enable that configuration.
- Add automated configuration checks ensuring workflows and packaging do not introduce a second toolchain version source.

CI:
- Update CI, live, and devlaunch workflows to use the repository's pinned rustup toolchain rather than a floating stable toolchain.

Documentation:
- Document the single-source Rust pin, upgrade policy, and toolchain validation in contributor and user verification guidance.

Tests:
- Include the toolchain pin guard in the standard verification chain and CI.