### PR TITLE
fix: carry a pinned pixi in the devcontainer image so a workspace can run the PR gates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,6 +28,15 @@
 # machine and impossible on the next, with nothing saying why.
 # `tests/devcontainer_prebuild.rs` holds the pin and the install location.
 #
+# It is the largest single binary in here and the number belongs next to the
+# decision: 78 MB, taking the tool layer from 93 MB to 171 MB, measured against
+# the published image on 2026-08-22. The paragraph at the top of this file
+# rejects cargo-chef and sccache on exactly this ground, so this download has to
+# answer that argument rather than sidestep it — and it does, because what the
+# rejected mechanisms would have bought was 9 seconds, while what this buys is a
+# PR-blocking check being runnable at all on a machine whose dotfiles happen not
+# to carry pixi.
+#
 # `zellij` is here for a different reason and it is worth saying so, because
 # this comment used to justify it by a test file that no longer exists: `wf`
 # stopped launching zellij sessions in 9ae2897 and no code or test in this repo

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@
 # could save. If that number ever grows into the minutes, this is the file to
 # revisit — see blooop/wayfinder#39 for the measurements.
 #
-# What it *does* carry is three binaries, for two different reasons.
+# What it *does* carry is four binaries, for three different reasons.
 #
 # `gh` and the agent CLI are things `wf` itself shells out to and discovers on
 # PATH, so a workspace without them cannot run `wf` at all. They are not here
@@ -18,6 +18,15 @@
 # reason (see the Checks section of README.md). Running that gated set inside a
 # workspace is a thing you can choose to do — `cargo test -- --ignored` — and
 # `gh` being present is what makes the choice available.
+#
+# `pixi` is here for the other half of the gated set: the devlaunch contract
+# lanes (`pixi run suite`, `pixi run -e <env> contract`), which block every
+# pull request and which `pixi.toml` exists solely to run. Those lanes are how
+# an agent working inside a workspace reproduces the PR gate before pushing,
+# and before this pin they were runnable only when the developer's dotfiles
+# happened to install a pixi of their own — the same check reproducible on one
+# machine and impossible on the next, with nothing saying why.
+# `tests/devcontainer_prebuild.rs` holds the pin and the install location.
 #
 # `zellij` is here for a different reason and it is worth saying so, because
 # this comment used to justify it by a test file that no longer exists: `wf`
@@ -39,6 +48,7 @@ FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
 # that two workspaces created from the same image *start* from the same version.
 ARG GH_VERSION=2.97.0
 ARG ZELLIJ_VERSION=0.44.3
+ARG PIXI_VERSION=0.77.0
 ARG CLAUDE_VERSION=2.1.223
 
 # One layer, and the tarballs are deleted in it: an unpacked tarball left behind
@@ -47,8 +57,8 @@ ARG CLAUDE_VERSION=2.1.223
 RUN set -eux; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-      amd64) gh_arch=linux_amd64; zj_arch=x86_64-unknown-linux-musl ;; \
-      arm64) gh_arch=linux_arm64; zj_arch=aarch64-unknown-linux-musl ;; \
+      amd64) gh_arch=linux_amd64; musl_arch=x86_64-unknown-linux-musl ;; \
+      arm64) gh_arch=linux_arm64; musl_arch=aarch64-unknown-linux-musl ;; \
       *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
     esac; \
     tmp="$(mktemp -d)"; \
@@ -57,11 +67,18 @@ RUN set -eux; \
     tar -xzf "$tmp/gh.tar.gz" -C "$tmp"; \
     install -Dm755 "$tmp/gh_${GH_VERSION}_${gh_arch}/bin/gh" /usr/local/bin/gh; \
     curl -fsSL -o "$tmp/zellij.tar.gz" \
-      "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-${zj_arch}.tar.gz"; \
+      "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-${musl_arch}.tar.gz"; \
     tar -xzf "$tmp/zellij.tar.gz" -C "$tmp"; \
     install -Dm755 "$tmp/zellij" /usr/local/bin/zellij; \
+    # pixi publishes the bare binary beside its tarball; taking it directly is
+    # one fewer unpack in the layer. /usr/local/bin, not ~/.pixi/bin: the image
+    # must not squat on the prefix a developer's own dotfiles may populate, and
+    # the tests distinguish the two by exactly that path.
+    curl -fsSL -o "$tmp/pixi" \
+      "https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/pixi-${musl_arch}"; \
+    install -Dm755 "$tmp/pixi" /usr/local/bin/pixi; \
     rm -rf "$tmp"; \
-    gh --version; zellij --version
+    gh --version; zellij --version; pixi --version
 
 # The agent CLI installs per-user into ~/.local/bin, so it is installed as the
 # user that will run it. `~/.claude` is a bind mount from the host (see

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,9 @@
   // A prebuilt image, not a build from `Dockerfile` — blooop/wayfinder#43 is
   // settled and this is its answer (blooop/wayfinder#150). What a prebuild saves
   // was never the crate build: a cold `cargo build` here is 9 seconds
-  // (blooop/wayfinder#39). It is the *image* build — the pinned `gh`, `zellij`
-  // and agent-CLI downloads in `Dockerfile`, which every branch's first `dl`
-  // paid for again. `devcontainer.yml` publishes this tag on any push to `main`
+  // (blooop/wayfinder#39). It is the *image* build — the pinned `gh`, `zellij`,
+  // `pixi` and agent-CLI downloads in `Dockerfile`, which every branch's first
+  // `dl` paid for again. `devcontainer.yml` publishes this tag on any push to `main`
   // that touches this directory.
   //
   // `image:` rather than the `build:` block plus `cacheFrom`, which is what #43

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
   // was never the crate build: a cold `cargo build` here is 9 seconds
   // (blooop/wayfinder#39). It is the *image* build — the pinned `gh`, `zellij`,
   // `pixi` and agent-CLI downloads in `Dockerfile`, which every branch's first
-  // `dl` paid for again. `devcontainer.yml` publishes this tag on any push to `main`
-  // that touches this directory.
+  // `dl` paid for again. `devcontainer.yml` publishes this tag on any push to
+  // `main` that touches this directory.
   //
   // `image:` rather than the `build:` block plus `cacheFrom`, which is what #43
   // expected, and the difference is a probed fact rather than a preference:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,8 +1,9 @@
 name: Devcontainer image
 
 # Publishes the image every `dl blooop/wayfinder@<branch>` boots from, so that
-# the pinned `gh`, `zellij` and agent-CLI downloads in `.devcontainer/Dockerfile`
-# are paid for once here instead of once per branch on every developer's machine.
+# the pinned `gh`, `zellij`, `pixi` and agent-CLI downloads in
+# `.devcontainer/Dockerfile` are paid for once here instead of once per branch on
+# every developer's machine.
 # The crate build was never the cost — a cold `cargo build` is 9 seconds
 # (blooop/wayfinder#39) — which is why this publishes a thin image and warms no
 # cargo cache at all (blooop/wayfinder#38, reaffirmed on #43).

--- a/tests/devcontainer_prebuild.rs
+++ b/tests/devcontainer_prebuild.rs
@@ -395,6 +395,56 @@ fn the_workflow_publishes_exactly_the_reference_the_default_config_boots_from() 
     );
 }
 
+/// The image carries a pinned `pixi`, because without one a workspace cannot
+/// run the PR gates.
+///
+/// `devlaunch-contract.yml` blocks every pull request with `pixi run suite`
+/// and the four `pixi run -e <env> contract` lanes — that is the entire reason
+/// `pixi.toml` exists (its header says so). The image already carries `gh` on
+/// exactly this reasoning: not because `wf` needs it at build time, but because
+/// its presence is what makes running the gated tests inside a workspace *a
+/// choice* rather than an impossibility (the Dockerfile's own words). `pixi`
+/// was the one tool that reasoning missed: it used to arrive only when the
+/// developer's personal dotfiles happened to install one into `~/.pixi/bin`,
+/// which made a PR-blocking check reproducible inside a workspace on one
+/// machine and silently impossible on the next — probed on 2026-08-22 inside a
+/// fresh `dl blooop/wayfinder` workspace, where every contract lane passed and
+/// `command -v pixi` answered from the dotfiles' prefix, not the image.
+///
+/// Three facts are held, each against a failure that stays green without it:
+/// the version is a pinned literal (a floating install drifts on rebuild, which
+/// is what every other pin in that file exists to prevent); the download URL
+/// embeds the pin (the gh/zellij pattern — a wrong version cannot resolve, so
+/// the pin cannot silently buy nothing); and the binary lands in
+/// `/usr/local/bin` (a home-directory install would be shadowed by, and
+/// confusable with, the dotfiles prefix this test exists to stop depending on).
+#[test]
+fn the_image_carries_a_pinned_pixi_so_a_workspace_can_run_the_pr_gates() {
+    let dockerfile = repo_file(".devcontainer/Dockerfile");
+
+    let pin = dockerfile
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("ARG PIXI_VERSION="))
+        .expect("the Dockerfile pins pixi with `ARG PIXI_VERSION=<version>`");
+    assert!(
+        !pin.is_empty() && pin.chars().all(|c| c.is_ascii_digit() || c == '.'),
+        "the pin is a literal version, not a channel name: {pin:?}"
+    );
+
+    assert!(
+        dockerfile.contains("releases/download/v${PIXI_VERSION}/pixi-"),
+        "the download URL embeds the pin, so a wrong version fails the build \
+         instead of resolving to something else"
+    );
+
+    assert!(
+        dockerfile.contains("/usr/local/bin/pixi"),
+        "pixi is installed to /usr/local/bin — on PATH for every user, and \
+         distinct from the ~/.pixi/bin prefix a developer's dotfiles may also \
+         populate"
+    );
+}
+
 /// The built-in token, not a long-lived secret. It is scoped to this repository,
 /// it expires with the run, and it means publishing keeps working without a
 /// credential anybody has to rotate.

--- a/tests/devcontainer_prebuild.rs
+++ b/tests/devcontainer_prebuild.rs
@@ -1,10 +1,11 @@
 //! The devcontainer prebuild contract (#150).
 //!
 //! Offline by design, like `skill_docs.rs` and for the same reason: the seam is
-//! the config text itself. What a workspace boots from, and what the publishing
-//! workflow is allowed to write to, are promises made in two files that no
-//! compiler reads — so they are asserted here rather than discovered by a cold
-//! `devpod up` on somebody's laptop.
+//! the config text itself. What a workspace boots from, what the image has to
+//! carry for a workspace to be usable, and what the publishing workflow is
+//! allowed to write to, are promises made in three files that no compiler reads
+//! — so they are asserted here rather than discovered by a cold `devpod up` on
+//! somebody's laptop.
 
 use serde_json::Value;
 


### PR DESCRIPTION
## What

Adds a pinned `pixi` (0.77.0) to the devcontainer image, following the exact pattern `gh` and `zellij` already use: pinned `ARG`, version-carrying download URL (a wrong pin cannot resolve), installed to `/usr/local/bin`, verified in the same layer. A new test in `tests/devcontainer_prebuild.rs` holds the pin, the URL embedding, and the install location.

## Why

Investigated whether an agent changing wayfinder inside a `dl blooop/wayfinder` workspace can fully test the change in isolation. Every lane was run manually inside a fresh workspace:

- `cargo fmt/clippy/test/doc` chain (ci.yml): **pass**
- `pixi run lint` / `suite` / all four `contract` environments (devlaunch-contract.yml — the PR-blocking matrix): **pass**
- gh-live set (live.yml): identical results to the host — the current failures (`live_fetch`, `live_discovery`, 1 of 4 in `live_streaming_startup`, both `live_launch_exec`) reproduce bit-for-bit on the host and pre-date this work (live.yml red on main since Aug 18: the tracker has one open map, #159, idle with 2 tickets — the documented "world moved" mode, not a container gap).

One real gap surfaced: the pixi lanes passed only because this machine's **personal dotfiles** install pixi into `~/.pixi/bin`. The image never promised one, so on a machine without those dotfiles the PR-blocking contract lanes are silently impossible inside a workspace. The image already carries `gh` on exactly the reasoning that presence makes running the gated set inside a workspace *a choice* (its own header says so); pixi was the one tool that reasoning missed.

## Verification

TDD: the prebuild-contract test was written first and failed against the old Dockerfile; the Dockerfile change turned it green. Then the image was rebuilt for real from this branch via `dl blooop/wayfinder@fix/devcontainer-pixi --devcontainer local`, and with the dotfiles prefix stripped from PATH (`pixi` resolving only to `/usr/local/bin/pixi`), `pixi run lint`, `pixi run suite`, `pixi run -e default contract` and `pixi run -e floor contract` all pass inside the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Carry a pinned Pixi installation in the devcontainer image so every workspace can run the pull request gates reproducibly.

New Features:
- Add a pinned Pixi 0.77.0 binary to the devcontainer image so workspaces can run the PR-blocking Pixi gates independently of host dotfiles.

Bug Fixes:
- Ensure Pixi is consistently available on the image PATH rather than relying on a developer-specific installation.

Enhancements:
- Document the devcontainer tool rationale and account for Pixi's image size impact.

CI:
- Update the devcontainer publishing workflow documentation to include Pixi among the pinned tools.

Tests:
- Add an offline prebuild contract test covering the Pixi version pin, versioned download URL, and installation path.