### PR TITLE
Release 0.19.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.19.2"
+version = "0.19.3"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.19.2"
+  version: "0.19.3"
 
 package:
   name: wf


### PR DESCRIPTION
Patch release. `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` only — the three files a release moves, kept in step because `package.yml` fails the build if the crate and recipe versions drift.

Contents: **the devcontainer image carries a pinned `pixi`** (#181), so the checks that block a pull request can actually be run inside a `dl` workspace. Before it, `pixi run suite` and the four `pixi run -e <env> contract` lanes worked in a workspace only when the developer's dotfiles happened to install a pixi — the same PR gate reproducible on one machine and silently impossible on the next.

**This ships the same binary 0.19.2 did.** Nothing under `src/` or `skills/` changed, so the conda package is byte-identical; the version moves because the image every workspace boots from did.

Publishing is still a separate, deliberate step: this merge does not release anything. Pushing the `v0.19.3` tag is what reaches `package.yml`'s release job and prefix.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Align the crate, lockfile, and conda recipe versions for the 0.19.3 patch release.