### PR TITLE
Every offline test binary is enrolled or the build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,24 @@ jobs:
       - name: The Rust pin has one home
         run: cargo test --locked --test toolchain_pin
 
-      # The guard on the exclusion every step around it depends on: the live
-      # binaries are safe to leave out of the unit-test step only because each
-      # of their tests carries `#[ignore]`, and a new one that forgets it is
-      # invisible both here and in `live.yml`, which selects with `--ignored`.
-      # This walks `tests/live_*.rs` and reads the attributes off the source,
-      # which is the only place the omission is visible — running the tests
-      # cannot see it, since running them is the symptom.
-      - name: The live tests are all gated
+      # The guard on the exclusion every step around it depends on, and on the
+      # enrolment that makes the steps above mean anything. The live binaries
+      # are safe to leave out of the unit-test step only because each of their
+      # tests carries `#[ignore]`, and a new one that forgets it is invisible
+      # both here and in `live.yml`, which selects with `--ignored`. Reading the
+      # attributes off the source is the only place that omission is visible —
+      # running the tests cannot see it, since running them is the symptom.
+      #
+      # It also walks every test binary under `tests/` and fails on any that no
+      # command in this file, in `live.yml` or in a `pixi.toml` task the contract
+      # workflow calls ever runs (#189). That closes the hole one level above the
+      # rest of this job: the `--no-run` step below keeps a new `tests/foo.rs`
+      # compiling, so it looks tended while running nowhere — a whole binary of
+      # assertions nobody is told about, which is the "an assertion no workflow
+      # runs is not an assertion" rule the steps above each invoke, applied to
+      # the steps themselves. This step is the reason the guard is not its own
+      # first victim.
+      - name: The live tests are gated and every test binary is enrolled
         run: cargo test --locked --test offline_green
 
       # The live fixture's own diagnostic — offline like its three siblings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,9 +189,36 @@ shims. Three consequences worth knowing before you touch any of this:
   `#[ignore]` it makes a bare `cargo test` fail on any machine lacking what it
   wants; with it and nothing else, it is a test that never runs anywhere.
   `live.yml` names its test binaries one by one for that reason — enrolment is
-  a deliberate line, not a side effect. The attribute half is checked rather
-  than remembered: `tests/offline_green.rs` walks `tests/live_*.rs` and fails
-  on any test that is missing it. The workflow half is still on you.
+  a deliberate line, not a side effect. Both halves are checked rather than
+  remembered, and by the same file: `tests/offline_green.rs` walks
+  `tests/live_*.rs` and fails on any test missing the attribute, and it walks
+  every test binary under `tests/` and fails on any that no workflow names.
+  A deliberate line, still — the guard makes you write it, it does not write
+  it for you.
+
+### Every test binary is enrolled or the build fails
+
+The rule is wider than the live tests and it holds for any `tests/*.rs`: a test
+binary that no command anywhere runs fails `offline_green` (#189). Three places
+count as running one, and a binary has to be named in one of them — `ci.yml`
+for an offline check, `live.yml` for the gh-live set, or a `pixi.toml` task the
+contract workflow calls for anything wanting a chosen `dl`. Four things to know
+before adding a test file:
+
+- **Compiling is not running.** `ci.yml`'s `--all-targets --no-run` step keeps
+  every binary building, so rot is caught either way — which is exactly why the
+  gap was invisible. A new `tests/foo.rs` compiled, ran nowhere, and looked
+  fine.
+- **A comment does not enrol anything.** The guard strips full-line comments
+  before looking, because the workflows here are mostly prose and the prose
+  names test binaries.
+- **A rename is caught from the other side too.** A `--test` argument naming no
+  file fails at the commit that moved the file, rather than in whichever
+  workflow was holding the stale line.
+- **`pixi.toml` counts only while a workflow still calls its task.** The
+  manifest has no trigger of its own; `devlaunch-contract.yml` calling
+  `contract` is the whole reason a binary named there is run, and that call is
+  asserted rather than assumed.
 
 ## The devlaunch contract
 

--- a/tests/offline_green.rs
+++ b/tests/offline_green.rs
@@ -15,9 +15,29 @@
 //! attribute, which no run of the tests can notice — the failure is precisely
 //! that they run when they should not, or never run at all.
 //!
+//! **Enrolment is the other half of the same promise (#189), and it lives here
+//! too.** The attribute decides whether a test runs in the default set; a line
+//! in a workflow decides whether the binary holding it is ever run at all, and
+//! that half was prose in AGENTS.md handed back to whoever wrote the test. It
+//! failed the same way and worse: a `tests/foo.rs` with no `live_` prefix wants
+//! no `#[ignore]`, compiles under `ci.yml`'s `--no-run` step, and is selected
+//! by no workflow — run by nothing and flagged by nothing, a whole binary of
+//! assertions rather than one test. "An assertion nothing runs is not an
+//! assertion" is the rule this repo closes everywhere else; this is that hole
+//! one meta-level up, and it is the same kind of invisible-to-a-test-run
+//! failure as the attribute, so it is read off the same kind of text.
+//!
 //! This binary is deliberately not named `live_*`. It is not a live test, and
 //! under that glob the walk below would walk itself and demand its own gating,
 //! which would gate the guard out of the run it exists to guard.
+//!
+//! Two things follow from guarding enrolment in a binary that is itself
+//! enrolled. It reports its own orphaning, which is worth nothing — an
+//! unenrolled `offline_green` is a guard nothing runs, and only `ci.yml`'s step
+//! makes it say so. And every guard here is preventive: on a clean tree they
+//! all pass, so each was proved against the tree state it exists to reject
+//! before being trusted, and the ones that could be pinned on constructed text
+//! rather than on the real files are.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
@@ -31,8 +51,12 @@ use std::path::PathBuf;
 /// Top-level `tests/live_*.rs` files only, and that scope is load-bearing: the
 /// tests compiled in through `mod common;` are deliberately unignored (they
 /// are the offline fixture diagnostics), and a directory-style target
-/// (`tests/live_x/main.rs`) would sit outside this walk — adding one means
-/// teaching this function to descend, or the guard goes quietly blind to it.
+/// (`tests/live_x/main.rs`) sits outside this walk — adding one means teaching
+/// this function to descend, or the guard goes quietly blind to it. That last
+/// is no longer left to whoever adds one:
+/// `no_live_binary_hides_from_the_ignore_walk_in_the_directory_form` compares
+/// this walk against every target cargo actually builds and fails on the
+/// difference, so the blind spot is a red run rather than a comment.
 fn live_sources() -> Vec<(String, String)> {
     let tests = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests"));
     let mut sources: Vec<(String, String)> = std::fs::read_dir(&tests)

--- a/tests/offline_green.rs
+++ b/tests/offline_green.rs
@@ -408,3 +408,192 @@ fn no_runner_names_a_test_binary_that_does_not_exist() {
         stale.join("\n  ")
     );
 }
+
+/// The scan above reads commands, not the prose around them.
+///
+/// The self-check the two sweeps rest on, and they rest on it heavily: both
+/// ask whether a name appears, so anything that over-reports enrolment turns
+/// the forward sweep into a green light wired to nothing — the failure it was
+/// written to prevent, wearing its own badge. Two limits of the scan are
+/// pinned here rather than trusted, on text written in this test so the check
+/// keeps meaning what it says however the real files are edited: a comment
+/// enrols nothing, and `--test-threads` is not a binary called `threads`. The
+/// third assertion is the direct one — a name no file anywhere writes is not
+/// enrolled — because a scan that reported everything as enrolled would pass
+/// both sweeps in silence.
+#[test]
+fn the_scan_reads_commands_rather_than_the_prose_around_them() {
+    assert!(
+        binaries_named_in("      # run: cargo test --locked --test discussed_only\n").is_empty(),
+        "a commented-out or discussed command enrols nothing. The workflows in \
+         this repo are mostly prose and the prose names test binaries; if a \
+         comment counts, the forward sweep above can be satisfied by a \
+         sentence rather than by a step"
+    );
+    assert_eq!(
+        binaries_named_in("run: cargo test --test real_one -- --ignored --test-threads=1"),
+        BTreeSet::from([String::from("real_one")]),
+        "`--test-threads` names no binary, and both files that run gated tests \
+         pass it"
+    );
+    assert!(
+        !enrolment().contains_key("wayfinder_189_no_runner_names_this"),
+        "a binary no file in this repo mentions came back enrolled, so the scan \
+         is reporting enrolment it cannot have read and both sweeps above are \
+         green for no reason"
+    );
+}
+
+/// Every workflow in this repository, as `(file name, contents)`.
+///
+/// Read from the directory rather than from a list, on the same principle as
+/// every other walk in this file: a workflow added later is searched by having
+/// been added.
+fn workflows() -> Vec<(String, String)> {
+    let dir = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/.github/workflows"));
+    let mut found: Vec<(String, String)> = std::fs::read_dir(&dir)
+        .expect("this repo's workflow directory")
+        .map(|entry| entry.expect("a readable directory entry").path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "yml"))
+        .map(|path| {
+            let name = path
+                .file_name()
+                .expect("a path read from a directory has a file name")
+                .to_string_lossy()
+                .into_owned();
+            let text = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("{name} is readable: {e}"));
+            (name, text)
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// The pixi task one command line calls, if it is a `pixi run`.
+///
+/// `-e <environment>` is skipped rather than counted: the environment decides
+/// which `dl` the task meets, not which task runs, and the contract workflow
+/// calls the same task in four of them.
+fn pixi_task_called_on(line: &str) -> Option<String> {
+    let mut tokens = line.split_whitespace().skip_while(|token| *token != "pixi");
+    tokens.next()?;
+    if tokens.next()? != "run" {
+        return None;
+    }
+    let mut next = tokens.next()?;
+    if next == "-e" {
+        tokens.next()?;
+        next = tokens.next()?;
+    }
+    Some(next.to_string())
+}
+
+/// The pixi manifest counts as a runner only because a workflow calls it.
+///
+/// `RUNNERS` lists three files, and this one is the odd one out: the two
+/// workflows carry their own triggers, so a `--test` line in either is a line
+/// GitHub runs, while `pixi.toml` has no trigger at all. Its `--test` lines run
+/// only because `devlaunch-contract.yml` names the task holding them. Drop that
+/// call and the manifest becomes a file full of commands nothing invokes — at
+/// which point the forward sweep above would go on reporting the binaries it
+/// names as enrolled, which is exactly the lie this whole file exists to catch.
+/// So the delegation is asserted, not assumed.
+#[test]
+fn the_pixi_manifest_is_a_runner_only_because_a_workflow_reaches_it() {
+    let tasks_that_run_tests: BTreeSet<String> = repo_file("pixi.toml")
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#') && line.contains("--test "))
+        .filter_map(|line| Some(line.split('=').next()?.trim().to_string()))
+        .filter(|name| !name.is_empty())
+        .collect();
+    assert!(
+        !tasks_that_run_tests.is_empty(),
+        "no pixi task names a test binary any more, so `pixi.toml` has no \
+         business in `RUNNERS` — either the contract run moved somewhere else, \
+         or the way tasks are written changed under the read above"
+    );
+
+    let called: BTreeSet<String> = workflows()
+        .iter()
+        .flat_map(|(_, text)| {
+            text.lines()
+                .filter(|line| !line.trim_start().starts_with('#'))
+                .filter_map(pixi_task_called_on)
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let unreached: Vec<&String> = tasks_that_run_tests
+        .iter()
+        .filter(|task| !called.contains(*task))
+        .collect();
+    assert!(
+        unreached.is_empty(),
+        "these pixi tasks run test binaries and no workflow calls them, so \
+         every binary they name is enrolled on paper and run nowhere — and the \
+         sweep above cannot tell, because it reads the manifest and trusts that \
+         something reaches it. Call the task from a workflow, or stop counting \
+         `pixi.toml` as a runner.\n  unreached: {unreached:?}\n  tasks a \
+         workflow calls: {called:?}"
+    );
+}
+
+/// A test binary's name is the one cargo derives from its path.
+///
+/// The walk above turns `tests/foo.rs` into the name `foo` and then looks for
+/// `--test foo`. That equivalence is auto-discovery's, not a rule of the
+/// language: a `[[test]]` table in the manifest can call any file anything, at
+/// which point a file this guard demands enrolment for is enrolled under a name
+/// it does not know, and a name the workflows use belongs to no file it can
+/// find. It would report both directions wrong at once. This repo declares no
+/// test targets by hand — there is nothing to configure that a file name does
+/// not already say — so the derivation is kept sound by keeping that true.
+#[test]
+fn a_test_binarys_name_is_the_one_cargo_derives_from_its_path() {
+    let manifest = repo_file("Cargo.toml");
+    let declared = manifest
+        .lines()
+        .map(str::trim)
+        .filter(|line| *line == "[[test]]")
+        .count();
+    assert!(
+        declared == 0,
+        "Cargo.toml declares {declared} test target(s) by hand. The walk in this file \
+         reads names off `tests/` and compares them to `--test` arguments, and \
+         a declared target parts those two: it can name `tests/a.rs` `b`, so \
+         `a` is demanded and never enrolled while `b` is enrolled and matches \
+         no file. Either drop the table and let auto-discovery name the target, \
+         or teach the walk to read the manifest first"
+    );
+}
+
+/// No live binary hides from the ignore walk in the directory form.
+///
+/// `live_sources` reads `tests/live_*.rs` and says in as many words that a
+/// `tests/live_x/main.rs` would sit outside it. That admission was the only
+/// thing standing between this repo and a live binary whose tests are
+/// unchecked for `#[ignore]` — and unchecked in the quiet direction, since the
+/// walk would report the file it cannot see as compliant. Now that the walk
+/// above enumerates the directory form, the admission can be enforced instead
+/// of merely written down: a live target in that shape fails here, naming the
+/// two choices.
+#[test]
+fn no_live_binary_hides_from_the_ignore_walk_in_the_directory_form() {
+    let scanned: BTreeSet<String> = live_sources()
+        .into_iter()
+        .map(|(name, _)| name.trim_end_matches(".rs").to_string())
+        .collect();
+    let unscanned: Vec<String> = test_targets()
+        .into_iter()
+        .filter(|target| target.starts_with("live_") && !scanned.contains(target))
+        .collect();
+    assert!(
+        unscanned.is_empty(),
+        "these live test binaries are directory-style targets, so the walk that \
+         checks every live test carries `#[ignore]` never opens them — and a \
+         file it never opens is a file it reports as gated. Flatten each to \
+         `tests/<name>.rs`, or teach `live_sources` to descend into \
+         `tests/<name>/`:\n  {}",
+        unscanned.join("\n  ")
+    );
+}

--- a/tests/offline_green.rs
+++ b/tests/offline_green.rs
@@ -19,6 +19,7 @@
 //! under that glob the walk below would walk itself and demand its own gating,
 //! which would gate the guard out of the run it exists to guard.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 /// One `tests/live_*.rs` source: its file name, and its text.
@@ -228,4 +229,155 @@ fn every_test_attribute_in_a_live_source_is_one_this_guard_can_see() {
              shape, or write the test the way the rest of the file does"
         );
     }
+}
+
+/// One file of this repository, by its path relative to the crate root.
+fn repo_file(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("{relative} ships in this repo: {e}"))
+}
+
+/// Every test binary cargo builds out of `tests/`, by the name `--test` selects
+/// it with.
+///
+/// Read off the directory for the same reason `live_sources` is, and both forms
+/// cargo auto-discovers rather than only the common one: `tests/<name>.rs`, and
+/// `tests/<name>/main.rs`. The directory form is the one the walk above admits
+/// it goes blind to, and blindness is the whole hazard here — a target no walk
+/// sees is a target this guard silently vouches for. A directory with no
+/// `main.rs` is not a target at all (`tests/common/` is a module the live
+/// binaries include), so it is not one this guard demands a workflow line for.
+fn test_targets() -> Vec<String> {
+    let tests = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests"));
+    let mut targets: Vec<String> = std::fs::read_dir(&tests)
+        .expect("this repo's tests directory")
+        .map(|entry| entry.expect("a readable directory entry").path())
+        .filter_map(|path| {
+            let name = path.file_stem()?.to_string_lossy().into_owned();
+            if path.is_dir() {
+                path.join("main.rs").is_file().then_some(name)
+            } else {
+                path.extension()
+                    .is_some_and(|extension| extension == "rs")
+                    .then_some(name)
+            }
+        })
+        .collect();
+    targets.sort();
+    targets
+}
+
+/// Where a test binary can be enrolled: a file that names binaries on a
+/// `cargo test` command line, and what makes the commands in it run.
+///
+/// The third entry is a different kind of thing from the first two, and saying
+/// so is the point of pairing each path with a reason. `ci.yml` and `live.yml`
+/// carry their own triggers, so a `--test` line in either is a line GitHub
+/// executes. `pixi.toml` carries no trigger whatsoever: its tasks run because
+/// `devlaunch-contract.yml` calls them by name, one indirection away. That
+/// makes this list a claim rather than an observation, which is why
+/// `the_pixi_manifest_is_a_runner_only_because_a_workflow_reaches_it` re-checks
+/// the call instead of trusting the row.
+const RUNNERS: &[(&str, &str)] = &[
+    (
+        ".github/workflows/ci.yml",
+        "one `cargo test --test <name>` step, beside the offline binaries already there",
+    ),
+    (
+        ".github/workflows/live.yml",
+        "a `--test <name>` line in the gated set it selects with `--ignored`",
+    ),
+    (
+        "pixi.toml",
+        "a task `devlaunch-contract.yml` calls, for anything wanting a chosen `dl`",
+    ),
+];
+
+/// The test binaries one runner's text names.
+///
+/// Comment lines come out first, and that is load-bearing rather than tidy:
+/// this repo's workflows and its pixi manifest are mostly prose, and the prose
+/// discusses the very binaries being counted — `ci.yml` explains at length why
+/// `live.yml` names its binaries one by one. Counted raw, a comment would
+/// enrol a binary nothing runs, which is precisely the failure this guard
+/// exists to catch, arriving through the guard itself.
+///
+/// The trailing space in the pattern is doing real work too: `--test-threads=1`
+/// appears in both files that run gated tests and names no binary.
+fn binaries_named_in(text: &str) -> BTreeSet<String> {
+    let mut named = BTreeSet::new();
+    for line in text
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+    {
+        let mut rest = line;
+        while let Some(index) = rest.find("--test ") {
+            rest = &rest[index + "--test ".len()..];
+            let end = rest
+                .find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(rest.len());
+            if end > 0 {
+                named.insert(rest[..end].to_string());
+            }
+        }
+    }
+    named
+}
+
+/// Every enrolled test binary, and which runners name it.
+fn enrolment() -> BTreeMap<String, Vec<&'static str>> {
+    let mut enrolled: BTreeMap<String, Vec<&'static str>> = BTreeMap::new();
+    for (path, _) in RUNNERS {
+        for binary in binaries_named_in(&repo_file(path)) {
+            enrolled.entry(binary).or_default().push(path);
+        }
+    }
+    enrolled
+}
+
+/// Every test binary under `tests/` is named by a command something runs.
+///
+/// The sibling above guards the attribute half of enrolment; this guards the
+/// half AGENTS.md used to hand back to a human. A `tests/foo.rs` with no
+/// `live_` prefix compiles under `ci.yml`'s `--no-run` step, carries no
+/// `#[ignore]` for the walk above to want, and is selected by no workflow: it
+/// is run by nothing and flagged by nothing. That is the "an assertion nothing
+/// runs is not an assertion" hole this repo closes everywhere else, reopened
+/// one meta-level up — a whole binary of assertions, rather than one test,
+/// quietly not running.
+#[test]
+fn every_test_binary_is_named_by_a_workflow_that_runs_it() {
+    let targets = test_targets();
+    let enrolled = enrolment();
+    assert!(
+        !targets.is_empty(),
+        "no test binaries were found under `tests/`, so this guard just passed \
+         without looking at anything"
+    );
+    assert!(
+        !enrolled.is_empty(),
+        "no runner names a single test binary, which means the scan below \
+         stopped recognising how they are enrolled rather than that enrolment \
+         is gone: {RUNNERS:?}"
+    );
+
+    let orphans: Vec<String> = targets
+        .iter()
+        .filter(|target| !enrolled.contains_key(*target))
+        .map(|target| format!("tests/{target}"))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        "these test binaries are run by nothing. They compile — `ci.yml`'s \
+         `--all-targets --no-run` step sees to that — so rot is caught, but \
+         every assertion inside them is dead weight nobody is told about, \
+         which is worse than not having written them. Enrol each one, in \
+         whichever of these fits what it needs:\n  {}\nOrphans:\n  {}",
+        RUNNERS
+            .iter()
+            .map(|(path, how)| format!("{path}: {how}"))
+            .collect::<Vec<_>>()
+            .join("\n  "),
+        orphans.join("\n  ")
+    );
 }

--- a/tests/offline_green.rs
+++ b/tests/offline_green.rs
@@ -381,3 +381,30 @@ fn every_test_binary_is_named_by_a_workflow_that_runs_it() {
         orphans.join("\n  ")
     );
 }
+
+/// Nothing is enrolled that does not exist.
+///
+/// The other direction of the same contract, and the one a rename leaves
+/// behind: `--test gone_away` makes `cargo test` fail loudly, so this would be
+/// caught — but only by the workflow holding the stale line, and `live.yml`
+/// runs after a merge while `pixi.toml`'s tasks run in a workflow whose red
+/// runs already mean "the other repo moved". Caught here, it is caught at the
+/// commit that renamed the file, in the same run as the forward sweep, and by
+/// the same reading of the same two facts.
+#[test]
+fn no_runner_names_a_test_binary_that_does_not_exist() {
+    let targets: BTreeSet<String> = test_targets().into_iter().collect();
+    let stale: Vec<String> = enrolment()
+        .iter()
+        .filter(|(binary, _)| !targets.contains(*binary))
+        .map(|(binary, runners)| format!("{binary} (named in {})", runners.join(", ")))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "these `--test` arguments name no test binary in this repo, so the \
+         command carrying them cannot run at all — a rename that moved the \
+         file and left the enrolment, most likely. Point each at the binary \
+         it meant, or drop the argument:\n  {}",
+        stale.join("\n  ")
+    );
+}


### PR DESCRIPTION
Closes #189

`ci.yml` names its offline test binaries one by one, and `offline_green.rs` guarded only the *attribute* half of enrolment — every test in `tests/live_*.rs` carries `#[ignore]`. The other half was prose in AGENTS.md, which said in as many words that "the workflow half is still on you".

So a `tests/foo.rs` with no `live_` prefix wanted no `#[ignore]`, compiled cleanly under the `--all-targets --no-run` step, and was selected by no workflow: **run by nothing and flagged by nothing.** Compiling kept it looking tended, which is why the gap was invisible. That is the "an assertion nothing runs is not an assertion" rule this repo invokes at four separate `ci.yml` steps, reopened one meta-level up — a whole binary of assertions quietly not running rather than one test.

## What now fails the build

Four guards, in the same file and for the same reason the one already there is: the seam is source text, because no run of the tests can see a binary that never runs.

- **Every test binary under `tests/` is named by a command something runs.** Both forms cargo auto-discovers — `tests/<name>.rs` and `tests/<name>/main.rs`. Three files count as runners: `ci.yml`, `live.yml`, and a `pixi.toml` task the contract workflow calls. The failure lists the orphans and what each runner is for.
- **No `--test` argument names a binary that does not exist.** The other direction, and the one a rename leaves behind. Such a line does make `cargo test` fail — but only in the workflow holding it, and `live.yml` runs after a merge while the contract workflow's red runs already mean the other repo moved. Read here it lands at the commit that renamed the file.
- **The pixi manifest is a runner only while a workflow reaches it.** `pixi.toml` has no trigger of its own; `devlaunch-contract.yml` calling `contract` is the entire reason a binary named there is run. Drop that call and the sweep would go on reporting those binaries as enrolled — the exact lie this file exists to catch, wearing the guard's own badge. So the delegation is asserted.
- **A binary's name stays the one cargo derives from its path.** A `[[test]]` table can call any file anything, which would part the two facts the sweeps compare and report *both* directions wrong at once: the file demanded and never enrolled, the name enrolled and matching no file.

## Self-checks on the checker

Both sweeps ask whether a name appears, so anything that over-reports enrolment turns the forward sweep into a green light wired to nothing. Two limits of the scan are pinned on text written inside the test rather than trusted against the real files — a comment enrols nothing (these workflows are mostly prose, and the prose names test binaries), and `--test-threads` is not a binary called `threads` — plus the direct check that a name no file writes comes back unenrolled.

One more, which turns an existing admission into a failure: `live_sources`' doc comment said a directory-style `tests/live_x/main.rs` would sit outside its walk, "or the guard goes quietly blind to it". Now that a walk enumerates every real target, the two are compared. A file the ignore walk never opens is a file it reports as gated — the quiet direction, so it fails loudly instead.

## Proving preventive guards

On a clean tree all of these pass, which makes "it passes" worth nothing. Each was run red against the tree state it exists to reject before being trusted: an unenrolled `tests/ghost_binary.rs` **and** a `tests/ghost_dir/main.rs` (both reported); a stale `--test renamed_away` in `ci.yml`; the comment filter deleted from the scan; the contract calls swapped out of `devlaunch-contract.yml`; a hand-declared `[[test]]` in `Cargo.toml`; and a `tests/live_ghost/main.rs`. Then reverted.

The `[[test]]` case was the most instructive: staging it renamed the target and `cargo test --test offline_green` stopped resolving at all, so `ci.yml`'s own step would have failed. That is the hazard the guard describes, demonstrated by accident.

## Docs moved because the code made them false

`AGENTS.md`'s "The workflow half is still on you" is no longer true, so it changes here rather than later, and gains a section stating the wider rule — it holds for any `tests/*.rs`, not only the live ones. `ci.yml`'s step name and `offline_green`'s module doc each described the attribute half only.

Worth noting what this cannot do for itself: it reports its own orphaning, which is worthless — an unenrolled `offline_green` is a guard nothing runs. Only `ci.yml`'s existing step makes it speak, and the module doc says so.

Full local chain green, `cargo fmt` first, with `RUSTFLAGS=-D warnings` and `RUSTDOCFLAGS=-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce that every discovered test binary is both correctly named and executed by an enrolled workflow, failing the build when test coverage is silently omitted.

New Features:
- Add build-time validation that every test binary under `tests/` is enrolled by an executing CI, live-test, or contract workflow command.
- Validate both directions of test enrollment so stale workflow references and untracked test binaries fail early.
- Verify contract task reachability, Cargo test-target naming assumptions, and directory-style live test coverage.

Bug Fixes:
- Prevent test binaries from compiling successfully while being run by no workflow.
- Prevent ignored or stale workflow enrollment references from going undetected until later workflow execution.

Enhancements:
- Strengthen `offline_green` with source-based enrollment checks and self-tests for parser behavior and guard blind spots.
- Update repository guidance and guard documentation to describe the enforced enrollment contract.

CI:
- Make the existing offline guard CI step enforce enrollment of every test binary.

Documentation:
- Document that all test binaries must be explicitly enrolled by a workflow or reachable contract task.

Tests:
- Add coverage for orphaned binaries, stale `--test` arguments, comment and option parsing, unreachable Pixi tasks, hand-declared test targets, and directory-style live binaries.