### PR TITLE
Never prune a skills copy directory wf cannot prove it made

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ Every name carries the `wf` prefix because both `~/.claude/skills` and
 you have. Unprefixed, `tdd` and `review` are names `wf` would *squat on* rather
 than merely occupy: while it held one, you could not have your own. `wf skills
 install` clears the links an older `wf` left under its old names, and touches
-nothing else — it removes a link only when the link points into a `wf` bundle,
-so a skill of yours can never match however dead it looks.
+nothing else — it removes a link only where the link points at something nothing
+but `wf` writes: the copy below, or a path ending `share/wf/skills`, which is
+`wf`'s own packaging layout. A skill of yours can never match however dead it
+looks, and neither can one of yours that `wf` was merely *pointed at*: a link
+into whatever directory `WF_SKILLS_DIR` names is not evidence `wf` wrote it.
 
 `wf skills install` **symlinks**, so a name under either skills directory is
 `wf`'s only when `wf` put it there and a real directory can go on meaning
@@ -76,6 +79,15 @@ so a skill of yours can never match however dead it looks.
 `~/.claude/wf-skills` and `~/.codex/wf-skills`, **copies** of the package's
 bundle kept beside their links, reached *relatively* —
 `wf-tdd -> ../wf-skills/wf-tdd`.
+
+The copy directory is held to the same rule as a name under `skills/`, and it
+has to be, because `wf` *prunes* it — anything in there that this build does not
+ship is a leftover of an older one. So it prunes only a `wf-skills` it can show
+it made, by the record it writes inside it when it creates it. Find one already
+there carrying no such record — a directory or a link into your dotfiles, made
+by you or by another tool — and `wf skills install` reports it and stops, having
+written nothing anywhere, and every launch leaves it alone too. Move it aside
+and run the install again.
 
 That indirection exists for containers. An isolated Claude launch
 ([Isolation](#isolation-claude-runs-in-the-repos-devcontainer)) mounts your

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,23 @@ fn run_skills(install: bool) -> Result<()> {
             // ships under a new spelling, and clearing the old link first keeps
             // the two steps from racing over the same directory entry.
             let swept = skills::sweep(&bundle, &target)?;
-            let done = skills::install(&bundle, &target)?;
+            // A copy directory `wf` cannot prove it made stops the install
+            // whole, so it is reported once — against the path in question —
+            // rather than six times over skills none of which was touched.
+            let done = match skills::install(&bundle, &target)? {
+                skills::Installed::Done(done) => done,
+                skills::Installed::CopyUnmanaged => {
+                    let _ = writeln!(
+                        out,
+                        "  NOT INSTALLED — {} already exists and carries no record wf \
+                         wrote, so wf did not make it. Nothing was touched. Move it aside \
+                         (chezmoi may own it) and run this again",
+                        target.mirror().display()
+                    );
+                    blocked = true;
+                    Vec::new()
+                }
+            };
             for link in &swept {
                 let _ = writeln!(
                     out,

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,7 @@ fn run_skills(install: bool) -> Result<()> {
             // Before linking, not after: a swept name could be one this build
             // ships under a new spelling, and clearing the old link first keeps
             // the two steps from racing over the same directory entry.
-            let swept = skills::sweep(&bundle, &target)?;
+            let swept = skills::sweep(&target)?;
             // A copy directory `wf` cannot prove it made stops the install
             // whole, so it is reported once — against the path in question —
             // rather than six times over skills none of which was touched.

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -370,6 +370,46 @@ pub fn installed_from(target: &Target) -> Option<PathBuf> {
     (!recorded.is_empty()).then(|| PathBuf::from(recorded))
 }
 
+/// What sits where the copy of the bundle goes, and whether `wf` can prove it
+/// put it there.
+///
+/// The distinction is the whole permission argument for [`prune_mirror`], which
+/// deletes every entry it does not recognise. `create_dir_all` cannot tell a
+/// directory it just made from one it merely found, so a `~/.claude/wf-skills`
+/// a user or another tool already had was *adopted* by the first install and
+/// then emptied by it (#187) — and the module's own promise, that a name is
+/// `wf`'s only when `wf` put it there, was false on exactly that path.
+///
+/// Provenance is the record [`install`] already writes, so the answer is
+/// evidence rather than an assumption: [`MIRROR`] and [`SOURCE`] arrived in one
+/// commit, so a copy `wf` made has always carried one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mirror {
+    /// Nothing is there. An install creates it, so what it then holds is
+    /// `wf`'s — and a link into it is `wf`'s to reclaim.
+    Absent,
+    /// A directory carrying `wf`'s own record of the bundle it was copied
+    /// from. The only shape [`install`] may prune.
+    Ours,
+    /// Something is there that carries no such record. Reported and left
+    /// exactly as found, the way a real directory under `skills/` already is:
+    /// deleting what it did not create is not `wf`'s call to make.
+    Adopted,
+}
+
+impl Mirror {
+    /// What the copy directory amounts to right now.
+    fn inspect(target: &Target) -> Mirror {
+        if std::fs::symlink_metadata(&target.mirror).is_err() {
+            return Mirror::Absent;
+        }
+        if installed_from(target).is_none() {
+            return Mirror::Adopted;
+        }
+        Mirror::Ours
+    }
+}
+
 /// Classify one link. `symlink_metadata` rather than `metadata`, so a link is
 /// seen as a link instead of as whatever it points at — the whole distinction
 /// this function exists to draw.
@@ -494,6 +534,19 @@ pub enum Outcome {
     NotInBundle,
 }
 
+/// What an install amounted to — one answer for the whole run, because a copy
+/// directory `wf` cannot prove it made stops all of it rather than one skill's
+/// share of it: the links are written *into* that copy, so there is no such
+/// thing as installing five skills correctly beside a copy somebody else owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Installed {
+    /// The copy is `wf`'s, and here is what each bundled skill did.
+    Done(Vec<(String, Outcome)>),
+    /// Something else owns the copy directory: nothing was written, linked or
+    /// removed anywhere. See [`Mirror::Adopted`].
+    CopyUnmanaged,
+}
+
 /// Copy every bundled skill beside `target`'s links and link each one to its
 /// copy, creating both directories if needed.
 ///
@@ -501,16 +554,35 @@ pub enum Outcome {
 /// alone rather than rewritten, and a copy that already matches the bundle is
 /// not re-copied, so running it twice is indistinguishable from running it once.
 ///
+/// The one thing it will not do is install *at all* where the copy directory is
+/// one `wf` cannot prove it made — [`Installed::CopyUnmanaged`], reported and
+/// nothing touched, because the alternative is adopting somebody's directory
+/// and then pruning it.
+///
 /// # Errors
 ///
 /// When a directory cannot be created, a copy cannot be written, or a link
 /// cannot be replaced. A skill that is merely *blocked* or absent from the
 /// bundle is not an error — it is an [`Outcome`], so one bad skill never costs
 /// the other four their install.
-pub fn install(bundle: &Bundle, target: &Target) -> Result<Vec<(String, Outcome)>> {
+pub fn install(bundle: &Bundle, target: &Target) -> Result<Installed> {
+    // Asked before anything is created, because creating it is what makes the
+    // answer unknowable: past `create_dir_all` there is nothing left to tell a
+    // directory `wf` made from one it adopted.
+    if Mirror::inspect(target) == Mirror::Adopted {
+        return Ok(Installed::CopyUnmanaged);
+    }
     for dir in [&target.links, &target.mirror] {
         std::fs::create_dir_all(dir).with_context(|| format!("cannot create {}", dir.display()))?;
     }
+    // Written before a single skill is copied, and unconditionally: from here
+    // on, *this* is the bundle the copy tracks and the launches that follow
+    // refresh it from there — and it is also what makes the copy provably
+    // `wf`'s, so an install interrupted halfway leaves a directory the next one
+    // still recognises as its own rather than as somebody else's to keep off.
+    let record = target.mirror.join(SOURCE);
+    std::fs::write(&record, format!("{}\n", bundle.path.display()))
+        .with_context(|| format!("cannot record the skills source in {}", record.display()))?;
     let mut done = Vec::new();
     for name in BUNDLED {
         let source = bundle.path.join(name);
@@ -554,12 +626,7 @@ pub fn install(bundle: &Bundle, target: &Target) -> Result<Vec<(String, Outcome)
         done.push((name.to_string(), outcome));
     }
     prune_mirror(&target.mirror)?;
-    // Written last, and unconditionally: from here on, *this* is the bundle the
-    // copy tracks, and the launches that follow refresh it from there.
-    let record = target.mirror.join(SOURCE);
-    std::fs::write(&record, format!("{}\n", bundle.path.display()))
-        .with_context(|| format!("cannot record the skills source in {}", record.display()))?;
-    Ok(done)
+    Ok(Installed::Done(done))
 }
 
 /// What a launch put right on one skill's behalf — reported rather than
@@ -675,9 +742,12 @@ pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
 
 /// Drop copies of skills this build no longer ships, leaving the source record.
 ///
-/// Unlike [`sweep`], which has to *prove* a link is `wf`'s before removing it,
-/// everything in here is `wf`'s by construction: the mirror is a directory `wf`
-/// creates, fills and owns, and nothing else has a reason to write to it.
+/// Everything in here is `wf`'s — but by *evidence*, not by construction, and
+/// the difference is a defect this comment once papered over: the mirror is a
+/// directory `wf` creates and fills, and `create_dir_all` was just as happy to
+/// adopt one it found. So this is reached only past [`Mirror::inspect`], which
+/// is [`install`]'s proof that the directory it is about to empty is the one
+/// `wf` recorded making (#187).
 ///
 /// # Errors
 ///
@@ -871,6 +941,17 @@ mod tests {
         std::fs::write(dir.join("SKILL.md"), body).expect("SKILL.md");
     }
 
+    /// The per-skill outcomes of an install that was allowed to proceed. Every
+    /// test that reads them goes through this, so the arm where the copy
+    /// directory is not `wf`'s can never be mistaken for a clean install — it
+    /// is asserted only where it is the subject.
+    fn done(installed: Installed) -> Vec<(String, Outcome)> {
+        match installed {
+            Installed::Done(done) => done,
+            Installed::CopyUnmanaged => panic!("the copy directory is wf's own here"),
+        }
+    }
+
     /// Copy a tree the way a bind mount presents one: at a different absolute
     /// path, with symlinks carried across as symlinks rather than followed.
     /// This is how the container is reproduced in a unit test.
@@ -897,7 +978,7 @@ mod tests {
         let bundle = scratch.bundle(&[]);
         let target = scratch.target();
 
-        let first = install(&bundle, &target).expect("install");
+        let first = done(install(&bundle, &target).expect("install"));
         assert!(
             first
                 .iter()
@@ -910,7 +991,7 @@ mod tests {
 
         // Twice is once: nothing is relinked and nothing is re-copied, so a
         // link is never briefly absent and no run reports work it did not do.
-        let second = install(&bundle, &target).expect("reinstall");
+        let second = done(install(&bundle, &target).expect("reinstall"));
         assert!(
             second.iter().all(|(_, o)| *o == Outcome::AlreadyCurrent),
             "{second:?}"
@@ -967,7 +1048,7 @@ mod tests {
             link_state("wf", &target.links().join("wf")),
             Link::Stale(old.clone())
         );
-        let done = install(&bundle, &target).expect("install");
+        let done = done(install(&bundle, &target).expect("install"));
         let wf_skill = done.iter().find(|(n, _)| n == "wf").expect("entry");
         assert_eq!(wf_skill.1, Outcome::Linked { was: Some(old) });
         assert_eq!(link_state("wf", &target.links().join("wf")), Link::Current);
@@ -1015,7 +1096,7 @@ mod tests {
 
         // And `install` says so rather than reporting a no-op.
         write_skill(&bundle.path, "wf-tdd", "---\n---\nnewer still\n");
-        let done = install(&bundle, &target).expect("install");
+        let done = done(install(&bundle, &target).expect("install"));
         assert_eq!(
             done.iter().find(|(n, _)| n == "wf-tdd").expect("entry").1,
             Outcome::Refreshed
@@ -1210,7 +1291,7 @@ mod tests {
         std::fs::create_dir_all(&real).expect("real dir");
         std::fs::write(real.join("SKILL.md"), "someone else's").expect("write");
 
-        let done = install(&bundle, &target).expect("install");
+        let done = done(install(&bundle, &target).expect("install"));
         let tdd = done.iter().find(|(n, _)| n == "wf-tdd").expect("entry");
         assert_eq!(tdd.1, Outcome::Blocked);
         assert!(real.join("SKILL.md").is_file(), "the file must survive");
@@ -1246,7 +1327,7 @@ mod tests {
         let bundle = scratch.bundle(&["wf-review"]);
         let target = scratch.target();
 
-        let done = install(&bundle, &target).expect("install");
+        let done = done(install(&bundle, &target).expect("install"));
         let review = done.iter().find(|(n, _)| n == "wf-review").expect("entry");
         assert_eq!(review.1, Outcome::NotInBundle);
         assert!(!target.links().join("wf-review").exists());
@@ -1322,6 +1403,40 @@ mod tests {
         install(&bundle, &target).expect("reinstall");
         assert!(!orphan.exists());
         assert!(target.mirror().join("wf-tdd").is_dir(), "and only that");
+    }
+
+    #[test]
+    fn a_copy_directory_wf_did_not_make_is_reported_and_left_alone() {
+        // #187: `create_dir_all` cannot tell a directory it just made from one
+        // it merely found, so a `wf-skills` a user or another tool already had
+        // was *adopted* by the first install — and then emptied by the prune
+        // that assumes everything in there is wf's by construction. Provenance
+        // is the record install already writes, so the answer is evidence.
+        let scratch = Scratch::new("adopted");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        let theirs = target.mirror().join("their-skill");
+        std::fs::create_dir_all(&theirs).expect("somebody else's directory");
+        std::fs::write(theirs.join("SKILL.md"), "mine\n").expect("their prompt");
+
+        assert_eq!(
+            install(&bundle, &target).expect("install"),
+            Installed::CopyUnmanaged,
+            "an install that cannot prove the copy is wf's does nothing at all"
+        );
+        assert_eq!(
+            std::fs::read_to_string(theirs.join("SKILL.md")).expect("still theirs"),
+            "mine\n",
+            "the prune must not reach a directory wf did not make"
+        );
+        assert!(
+            !target.mirror().join(SOURCE).exists(),
+            "and nothing is recorded in it, which would claim it next time"
+        );
+        assert!(
+            !target.links().join("wf-tdd").exists(),
+            "nor is a link written into a copy that is not wf's"
+        );
     }
 
     #[test]

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -399,11 +399,19 @@ enum Mirror {
 
 impl Mirror {
     /// What the copy directory amounts to right now.
+    ///
+    /// `symlink_metadata`, so the second adoption shape is caught too: a
+    /// `wf-skills` that is a *link* into somebody's dotfile tree takes a
+    /// `create_dir_all` without complaint, and then every copy lands in their
+    /// tree and the prune deletes out of it. `wf` only ever makes a real
+    /// directory here, so a link is proof it did not — which is why the record
+    /// is not consulted first: a link carrying one is a link carrying somebody
+    /// else's file.
     fn inspect(target: &Target) -> Mirror {
-        if std::fs::symlink_metadata(&target.mirror).is_err() {
+        let Ok(meta) = std::fs::symlink_metadata(&target.mirror) else {
             return Mirror::Absent;
-        }
-        if installed_from(target).is_none() {
+        };
+        if !meta.is_dir() || installed_from(target).is_none() {
             return Mirror::Adopted;
         }
         Mirror::Ours
@@ -542,8 +550,9 @@ pub enum Outcome {
 pub enum Installed {
     /// The copy is `wf`'s, and here is what each bundled skill did.
     Done(Vec<(String, Outcome)>),
-    /// Something else owns the copy directory: nothing was written, linked or
-    /// removed anywhere. See [`Mirror::Adopted`].
+    /// Something already sits where the copy goes and carries no record `wf`
+    /// wrote — a directory, or a link into one, that somebody else made.
+    /// Nothing was written, linked or removed anywhere.
     CopyUnmanaged,
 }
 
@@ -677,7 +686,8 @@ pub enum Healed {
 /// created here points at a copy of the recorded source like every other.
 ///
 /// Nothing else is touched: a machine that never ran `wf skills install`, a
-/// directory chezmoi owns, a link pointing somewhere `wf` never links, and a
+/// copy directory `wf` cannot prove it made, a directory chezmoi
+/// owns, a link pointing somewhere `wf` never links, and a
 /// recorded source that has since been deleted are all left exactly as they are
 /// — a prompt one release behind still beats no prompt at all, and a name that
 /// is not `wf`'s is not `wf`'s to take.
@@ -686,6 +696,12 @@ pub enum Healed {
 ///
 /// When a copy cannot be rewritten, or a link cannot be created.
 pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
+    // The same proof [`install`] demands before it writes here, for the same
+    // reason: a copy `wf` cannot show it made is somebody else's tree, and a
+    // launch recopying into it would rewrite their files on the way past.
+    if Mirror::inspect(target) != Mirror::Ours {
+        return Ok(Vec::new());
+    }
     let Some(bundle) = installed_from(target).filter(|source| source.is_dir()) else {
         return Ok(Vec::new());
     };
@@ -1436,6 +1452,38 @@ mod tests {
         assert!(
             !target.links().join("wf-tdd").exists(),
             "nor is a link written into a copy that is not wf's"
+        );
+    }
+
+    #[test]
+    fn a_copy_directory_that_is_a_link_is_never_wfs() {
+        // The other adoption shape the same `create_dir_all` swallowed:
+        // `~/.claude/wf-skills` pointing into a dotfile tree. It succeeds on a
+        // link, so every copy lands in somebody's tree and the prune deletes
+        // out of it. `wf` only ever *makes a directory* here, so a link is
+        // proof it did not — even one whose target carries a record, which is
+        // otherwise the only proof there is.
+        let scratch = Scratch::new("linked-copy");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        let theirs = scratch.0.join("their-dotfiles/skills");
+        std::fs::create_dir_all(theirs.join("their-skill")).expect("their tree");
+        std::fs::write(theirs.join(SOURCE), format!("{}\n", bundle.path.display()))
+            .expect("a record that came along with their tree");
+        std::os::unix::fs::symlink(&theirs, target.mirror()).expect("their link");
+
+        assert_eq!(
+            install(&bundle, &target).expect("install"),
+            Installed::CopyUnmanaged
+        );
+        assert!(
+            refresh(&target).expect("refresh").is_empty(),
+            "and no launch writes through it either"
+        );
+        assert!(theirs.join("their-skill").is_dir(), "their tree, as found");
+        assert!(
+            !theirs.join("wf-tdd").exists(),
+            "with nothing of wf's copied into it"
         );
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -699,7 +699,8 @@ pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
     // The same proof [`install`] demands before it writes here, for the same
     // reason: a copy `wf` cannot show it made is somebody else's tree, and a
     // launch recopying into it would rewrite their files on the way past.
-    if Mirror::inspect(target) != Mirror::Ours {
+    let mirror = Mirror::inspect(target);
+    if mirror != Mirror::Ours {
         return Ok(Vec::new());
     }
     let Some(bundle) = installed_from(target).filter(|source| source.is_dir()) else {
@@ -723,7 +724,7 @@ pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
             // into the package prefix every `wf` before #110 wrote — the one
             // that resolves on the host and dangles in the container — and it
             // can never match a link somebody else left, however dead it looks.
-            Link::Stale(points_at) if is_ours(&points_at, &bundle) => Some(Some(points_at)),
+            Link::Stale(points_at) if is_ours(&points_at, mirror) => Some(Some(points_at)),
             Link::Stale(_) | Link::Unmanaged => continue,
         };
         // Always the copy before the link, so a link this function creates
@@ -794,17 +795,29 @@ fn prune_mirror(mirror: &Path) -> Result<Vec<PathBuf>> {
 /// it points at a place nothing but `wf` ever links to, so a skill the user
 /// wrote, a plugin's, or a link some other tool left behind can never match
 /// however dead it looks.
-fn is_ours(target: &Path, bundle: &Path) -> bool {
+///
+/// Which is why *pointing into the bundle* is no longer one of those places. It
+/// used to be, to cover a pre-copy install made from a checkout — but the bundle
+/// is whatever directory `$WF_SKILLS_DIR` names, and pointing `wf` at a
+/// directory is not evidence `wf` wrote what is in it: a skill of your own,
+/// hand-linked into your own directory under a name this build does not ship,
+/// matched (#187). The two shapes left are ones nothing else produces, and the
+/// cost is exact: a link an old `wf` wrote into a *checkout* bundle is no longer
+/// reclaimed or swept. That is a dangling link left alone, which is the side to
+/// err on.
+fn is_ours(target: &Path, mirror: Mirror) -> bool {
     let Some(parent) = target.parent() else {
         return false;
     };
-    // What this build writes: relative, into the copy beside the links.
-    parent == Path::new("..").join(MIRROR)
-        // What older builds wrote: straight into a bundle. The first covers
-        // `$WF_SKILLS_DIR` pointing at a checkout, whose path ends in `skills`
-        // and not in `share/wf/skills`; the suffix covers every installed
-        // prefix, including the older ones this is here to clear.
-        || parent == bundle
+    // What this build writes: relative, into the copy beside the links — and
+    // only while that copy is one `wf` can show it made, or the shape is proof
+    // of nothing but a name somebody else chose. A copy that is *gone* still
+    // counts: a relative link into a `wf-skills` that is not there is residue
+    // nothing but `wf` leaves.
+    (parent == Path::new("..").join(MIRROR) && mirror != Mirror::Adopted)
+        // What older builds wrote: straight into an installed prefix. A path
+        // ending `share/wf/skills` is `wf`'s own packaging layout, and clearing
+        // those is what #104's rename left to do.
         || parent.ends_with("share/wf/skills")
 }
 
@@ -825,10 +838,14 @@ fn is_ours(target: &Path, bundle: &Path) -> bool {
 ///
 /// When the links directory cannot be read, or a link cannot be removed. A
 /// missing directory is not an error — there is nothing to sweep.
-pub fn sweep(bundle: &Bundle, target: &Target) -> Result<Vec<PathBuf>> {
+pub fn sweep(target: &Target) -> Result<Vec<PathBuf>> {
     let Ok(entries) = std::fs::read_dir(&target.links) else {
         return Ok(Vec::new());
     };
+    // Read once, before anything is removed: what the copy directory is settles
+    // whether a link naming it is `wf`'s at all, and nothing in a loop that only
+    // deletes links can change the answer.
+    let mirror = Mirror::inspect(target);
     let mut swept = Vec::new();
     for entry in entries {
         let entry = entry.with_context(|| format!("cannot read {}", target.links.display()))?;
@@ -846,7 +863,7 @@ pub fn sweep(bundle: &Bundle, target: &Target) -> Result<Vec<PathBuf>> {
         let Ok(points_at) = std::fs::read_link(&link) else {
             continue;
         };
-        if !is_ours(&points_at, &bundle.path) {
+        if !is_ours(&points_at, mirror) {
             continue;
         }
         std::fs::remove_file(&link)
@@ -1382,7 +1399,7 @@ mod tests {
         std::os::unix::fs::symlink(&elsewhere, target.links().join("other-tool"))
             .expect("other link");
 
-        let mut swept = sweep(&bundle, &target).expect("sweep");
+        let mut swept = sweep(&target).expect("sweep");
         swept.sort();
 
         assert_eq!(
@@ -1485,6 +1502,50 @@ mod tests {
             !theirs.join("wf-tdd").exists(),
             "with nothing of wf's copied into it"
         );
+    }
+
+    #[test]
+    fn a_link_into_a_directory_wf_was_merely_pointed_at_is_not_swept() {
+        // `$WF_SKILLS_DIR` names any directory you like, including one full of
+        // your own skills — and "the link points into the bundle" was enough to
+        // make sweep delete it. Pointing `wf` at a directory is not evidence
+        // `wf` wrote what is in it, so the bundle path cannot be what makes a
+        // link sweepable.
+        let scratch = Scratch::new("their-bundle");
+        let bundle = scratch.bundle(&[]);
+        let target = scratch.target();
+        done(install(&bundle, &target).expect("install"));
+
+        write_skill(&bundle.path, "grill-me", "---\n---\n");
+        let theirs = target.links().join("grill-me");
+        std::os::unix::fs::symlink(bundle.path.join("grill-me"), &theirs).expect("their link");
+
+        assert!(sweep(&target).expect("sweep").is_empty());
+        assert!(
+            theirs.symlink_metadata().is_ok(),
+            "a skill of theirs, in a directory of theirs, under a name wf does not ship"
+        );
+    }
+
+    #[test]
+    fn a_link_into_a_copy_directory_wf_did_not_make_is_not_swept() {
+        // The link shape is `wf`'s own, so it reads as `wf`'s — but only while
+        // the copy it names is one `wf` recorded making. Adopted, the name is
+        // somebody's own choice and the link is theirs.
+        let scratch = Scratch::new("their-copy");
+        let target = scratch.target();
+        std::fs::create_dir_all(target.mirror().join("mine")).expect("their copy directory");
+        let link = target.links().join("mine");
+        std::os::unix::fs::symlink(Target::link_target("mine"), &link).expect("their link");
+
+        assert!(sweep(&target).expect("sweep").is_empty());
+        assert!(link.symlink_metadata().is_ok(), "not wf's to remove");
+
+        // With the copy gone the same shape is `wf`'s residue again: nothing
+        // but `wf` writes a relative link into a `wf-skills` that is not there,
+        // and leaving it would put sweep back where #104 found it.
+        std::fs::remove_dir_all(target.mirror()).expect("their tree, moved aside");
+        assert_eq!(sweep(&target).expect("sweep"), vec![link]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #187

`wf skills install` ran `create_dir_all` on `~/.claude/wf-skills` and then pruned every entry in it that was not a bundled skill. `create_dir_all` cannot tell a directory it made from one it merely found, so a `wf-skills` a user or another tool already had — a directory, or a link into a dotfile tree — was silently **adopted** by the first install and then emptied by it. The comment saying "everything in here is `wf`'s by construction" was false on exactly that path, and it contradicted the promise the README makes: a name is `wf`'s only when `wf` put it there.

The same over-claim lived one function along. `is_ours`, the whole permission argument for removing a link, counted "points into the bundle" as proof `wf` wrote it — and the bundle is whatever directory `WF_SKILLS_DIR` names, so with it aimed at a directory of your own, a symlink you hand-made into it under a name this build does not ship was swept.

## What changed

**Provenance is evidence, not an assumption.** The copy directory now has three states rather than exists-or-not: nothing there (an install creates it, so what it then holds is `wf`'s), a real directory carrying the `.source` record `install` writes (the only shape prune may touch), or anything else — reported and left exactly as found, the way a real directory under `skills/` already is. `MIRROR` and `SOURCE` arrived in one commit, so a copy `wf` made has always carried a record; absence of one is a real answer.

`install` therefore returns one verdict for the run — `Installed::Done(..)` or `Installed::CopyUnmanaged` — because the links are written *into* that copy, so there is no such thing as installing five skills correctly beside a copy somebody else owns. `wf skills install` prints it once against the path in question and exits non-zero, and the other agent's install still proceeds. The record moves to the front of the install for the same reason it is now load-bearing: an install interrupted between the `create_dir_all` and the record would otherwise leave a copy the next one could not recognise as its own.

**A link where the copy goes is never `wf`'s.** `create_dir_all` takes a link to a directory without complaint, so every copy landed in somebody's tree and the prune deleted out of it. `wf` only ever makes a real directory there, checked before the record is consulted — a link carrying a record is a link carrying somebody else's file. The launch-time `refresh` is gated on the same proof; it writes into the copy on every `enter`, so it had the same reach.

**`is_ours` keeps only the shapes nothing else produces**: the relative link into a copy `wf` can show it made, and a path ending `share/wf/skills`, which is `wf`'s own packaging layout. An adopted copy withdraws the first — the link merely names it, so the name is somebody's own choice — while a copy that is *gone* keeps it, because a relative link into a `wf-skills` that is not there is residue nothing but `wf` leaves, and clearing that is what sweep is for. `sweep` no longer needs the bundle at all.

The cost is exact and deliberate: a link a pre-#110 `wf` wrote into a **checkout** bundle is no longer reclaimed by a launch or swept. That leaves a dangling link alone rather than deleting a link out of a directory of yours, which is the side to err on.

## Tests

Three new tests, one per adoption shape the ticket named, each red before the fix:

- a copy directory `wf` did not make is reported and left alone — their prompt intact, no record written into it that would claim it next time, and no link into it
- a copy directory that is a *link* is never `wf`'s, even one whose target carries a record — and no launch writes through it either
- a link into a directory `wf` was merely pointed at is not swept; nor is a link into an adopted copy — while the same shape over a copy that is gone still sweeps

The existing rename/prune/repoint tests stay as the regression that the tightening did not overshoot. Full chain from AGENTS.md is green: fmt, clippy, `--lib --bins --examples`, `skill_docs`, `devcontainer_prebuild`, `toolchain_pin`, `offline_green`, `live_fetch -- common::`, `cargo doc`. Driven for real against a scratch `CLAUDE_CONFIG_DIR`: Claude blocked with the message and the directory untouched, Codex installed beside it, exit 1, and a clean install once the directory is moved aside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Protect user-managed skill directories and links by requiring verifiable wf ownership before installation, refresh, pruning, or cleanup.

Bug Fixes:
- Prevent installs and launch-time refreshes from adopting or modifying unmanaged skill copy directories.
- Stop pruning links merely because they point into the configured skills bundle unless their destination is independently attributable to wf.

Enhancements:
- Track copy-directory provenance with an install record and distinguish absent, owned, and unmanaged copies.
- Report unmanaged copy directories once, leave them untouched, and preserve cleanup for links into owned or removed wf copies.

Documentation:
- Document the ownership and provenance rules for skill copy directories and symlinks.

Tests:
- Add regression coverage for pre-existing copy directories, symlinked copy directories, and links into unmanaged bundles or copies.