### PR TITLE
Counts and cursor agree on a DAG diamond

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3551,6 +3551,7 @@ mod tests {
                     ticket(PROJECT, 9, "Main screen design", true, true, vec![]),
                     ticket(PROJECT, 14, "Breadcrumb markers", true, false, vec![6, 9]),
                 ],
+                truncated: false,
             },
         );
         app_on(PROJECT, clusters)

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,11 +168,30 @@ pub struct RowKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StopKey {
     Map(MapId),
-    Ticket(RowKey),
+    /// A ticket row, plus **which drawing of it** — the leverage lens
+    /// deliberately draws one ticket under every root that unblocks it, so on
+    /// a DAG diamond the [`RowKey`] alone names two stops. Without the
+    /// occurrence, pinning "the row they chose" resolved to the *first*
+    /// matching drawing, teleporting a cursor parked on the second one on
+    /// every refetch (#188).
+    Ticket(RowKey, usize),
     Group(GroupId),
     /// A whole project, by repo slug — already index-free, like the
     /// map and group keys.
     Project(String),
+}
+
+impl StopKey {
+    /// The first drawing of the same stop — the identity to fall back to when
+    /// the exact drawing left the screen but the ticket did not (a lens
+    /// toggle, a root that closed). Only tickets are ever drawn twice, so the
+    /// other arms are already their own first occurrence.
+    fn first_occurrence(&self) -> StopKey {
+        match self {
+            StopKey::Ticket(row, _) => StopKey::Ticket(row.clone(), 0),
+            other => other.clone(),
+        }
+    }
 }
 
 /// Where the cursor is, and — the part that matters — **whether anyone put it
@@ -233,7 +252,17 @@ impl Pinned {
     fn resolve(&self, new_order: &[StopKey]) -> usize {
         match self {
             Pinned::Identity(key, fallback) => {
-                crate::refresh::preserve_cursor(Some(key), *fallback, new_order)
+                // The exact drawing when the new order still has it; else the
+                // first drawing of the same ticket — a swap that removed the
+                // root a duplicate hung under took the drawing, not the
+                // ticket, and the cursor's promise is the ticket. Only when
+                // both are gone does the positional fallback apply.
+                let key = if new_order.contains(key) {
+                    key.clone()
+                } else {
+                    key.first_occurrence()
+                };
+                crate::refresh::preserve_cursor(Some(&key), *fallback, new_order)
             }
             Pinned::Position(fallback) => {
                 crate::refresh::preserve_cursor(None, *fallback, new_order)
@@ -614,15 +643,33 @@ impl App {
         }
     }
 
-    /// A stop's durable identity: a ticket by (map, number), a map or a group
-    /// by its own id — both of which already name no indices.
-    fn stop_key(&self, stop: &Stop) -> StopKey {
-        match stop {
-            Stop::Map(id) => StopKey::Map(id.clone()),
-            Stop::Ticket(row) => StopKey::Ticket(self.row_key(row)),
-            Stop::Group(id) => StopKey::Group(id.clone()),
-            Stop::Project(repo) => StopKey::Project(repo.clone()),
+    /// Every stop's durable identity, in on-screen order: a ticket by
+    /// (map, number) plus which drawing of it this is, a map or a group by its
+    /// own id — which already name no indices.
+    ///
+    /// Computed over the whole list rather than stop-by-stop because the
+    /// occurrence *is* list context: a key derived from one stop alone cannot
+    /// know it is the second drawing of a diamond-duplicated ticket, and a key
+    /// that cannot say so pins two stops to one identity (#188).
+    fn stop_keys(&self) -> Vec<StopKey> {
+        let mut keys: Vec<StopKey> = Vec::new();
+        for at in self.stops() {
+            let key = match &at.stop {
+                Stop::Map(id) => StopKey::Map(id.clone()),
+                Stop::Ticket(row) => {
+                    let row_key = self.row_key(row);
+                    let occurrence = keys
+                        .iter()
+                        .filter(|k| matches!(k, StopKey::Ticket(prev, _) if *prev == row_key))
+                        .count();
+                    StopKey::Ticket(row_key, occurrence)
+                }
+                Stop::Group(id) => StopKey::Group(id.clone()),
+                Stop::Project(repo) => StopKey::Project(repo.clone()),
+            };
+            keys.push(key);
         }
+        keys
     }
 
     /// Cursor position clamped into the stop list. An untouched cursor is not a
@@ -672,9 +719,10 @@ impl App {
         })
     }
 
-    /// The cursor's stable identity.
+    /// The cursor's stable identity — read off the whole key list, since which
+    /// drawing the cursor is on is a fact about the list, not the stop.
     fn cursor_key(&self) -> Option<StopKey> {
-        self.cursor_stop().map(|stop| self.stop_key(&stop))
+        self.stop_keys().into_iter().nth(self.cursor_pos())
     }
 
     /// The stop to hold on to while the list is rebuilt underneath the cursor —
@@ -704,10 +752,15 @@ impl App {
     /// Hence the exhaustive match rather than `unwrap_or(0)`: the `None` is the
     /// case that matters here, so it is named instead of being given a value.
     fn point_at(&mut self, key: &StopKey) {
-        let found = self
-            .stops()
+        let keys = self.stop_keys();
+        // The exact drawing first; failing that, any drawing of the same
+        // ticket — a lens toggle deletes the duplicates the leverage screen
+        // drew, and losing the drawing must not mean losing the ticket.
+        let first = key.first_occurrence();
+        let found = keys
             .iter()
-            .position(|at| &self.stop_key(&at.stop) == key);
+            .position(|k| k == key)
+            .or_else(|| keys.iter().position(|k| *k == first));
         self.cursor = match found {
             Some(pos) => Cursor::Chosen(pos),
             None => Cursor::Untouched,
@@ -858,11 +911,7 @@ impl App {
         let Some(pinned) = pinned else {
             return;
         };
-        let new_order: Vec<StopKey> = self
-            .stops()
-            .iter()
-            .map(|at| self.stop_key(&at.stop))
-            .collect();
+        let new_order = self.stop_keys();
         self.cursor = Cursor::Chosen(pinned.resolve(&new_order));
     }
 
@@ -3509,6 +3558,69 @@ mod tests {
             (3, 4),
             "three distinct tickets shown, of the map's four"
         );
+    }
+
+    /// Positions in the stop list of every drawing of ticket `number` — plural
+    /// on purpose: on a diamond the same ticket is drawn more than once, and
+    /// which drawing the cursor is on is exactly what these tests are about.
+    fn drawings_of(app: &App, number: u64) -> Vec<usize> {
+        app.stops()
+            .iter()
+            .enumerate()
+            .filter_map(|(i, at)| match &at.stop {
+                Stop::Ticket(row) if app.ticket(row).number == number => Some(i),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_cursor_on_the_second_drawing_of_a_diamond_ticket_survives_a_swap() {
+        // Identity pinning exists so a refetch never teleports the selection —
+        // and an identity that cannot tell the two drawings of #14 apart
+        // teleports a cursor from the second drawing to the first on every
+        // swap, breaking the guarantee precisely on diamonds.
+        let mut app = diamond_app();
+        let drawings = drawings_of(&app, 14);
+        assert_eq!(drawings.len(), 2, "the diamond draws #14 twice");
+        app.cursor = Cursor::Chosen(drawings[1]);
+        let same = app.clusters.clone();
+        app.replace_clusters(same);
+        assert_eq!(
+            app.cursor_pos(),
+            drawings[1],
+            "the drawing that was chosen, not the first one"
+        );
+    }
+
+    #[test]
+    fn a_drawing_that_vanishes_degrades_to_the_ticket_not_the_top() {
+        // #9 closes, its root leaves the leverage screen and takes the second
+        // drawing of #14 with it — but the ticket is still drawn under #6, so
+        // the cursor follows the ticket rather than falling back to a bare
+        // position or the top of the list.
+        let mut app = diamond_app();
+        let drawings = drawings_of(&app, 14);
+        app.cursor = Cursor::Chosen(drawings[1]);
+        let mut swapped = app.clusters.clone();
+        let map = swapped
+            .get_mut(&MapId::new(PROJECT, 1))
+            .expect("the diamond map");
+        map.tickets[2] = ticket(PROJECT, 9, "Main screen design", false, true, vec![]);
+        app.replace_clusters(swapped);
+        assert_eq!(at(&app), "#14", "the ticket outlives its second drawing");
+    }
+
+    #[test]
+    fn a_lens_toggle_keeps_the_cursor_on_the_ticket_when_its_drawing_leaves() {
+        // The forest lens draws every ticket exactly once, so toggling away
+        // from the leverage screen deletes the second drawing. The ticket is
+        // still on screen, and the cursor's promise is the ticket.
+        let mut app = diamond_app();
+        let drawings = drawings_of(&app, 14);
+        app.cursor = Cursor::Chosen(drawings[1]);
+        app.handle_key(key(KeyCode::Tab));
+        assert_eq!(at(&app), "#14", "the other lens still shows the ticket");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -578,13 +578,26 @@ impl App {
     /// nine projects on it: a fetch that has not landed and a repo with
     /// nothing open would look identical to the screen being empty, and the
     /// number a query narrows would not be the number the query narrowed.
+    ///
+    /// On a project's screen both halves count **tickets**, so the numerator
+    /// dedups the drawn rows: the leverage lens deliberately draws a ticket
+    /// under *every* root that unblocks it, and counting rows there let a
+    /// diamond in the DAG claim more tickets shown than the map holds — the
+    /// same nodes-not-rows discipline the rollups already keep.
     pub fn counts(&self) -> (usize, usize) {
         match self.level {
             Level::Projects => (
                 self.stops().len(),
                 projects::mru_repos(&self.checkouts).len(),
             ),
-            Level::Project { .. } => (self.visible().len(), self.scoped().len()),
+            Level::Project { .. } => {
+                let shown: BTreeSet<(MapId, usize)> = self
+                    .visible()
+                    .into_iter()
+                    .map(|row| (row.map, row.index))
+                    .collect();
+                (shown.len(), self.scoped().len())
+            }
         }
     }
 
@@ -3455,6 +3468,47 @@ mod tests {
         assert_eq!(app.counts(), (2, 2), "wayfinder and dotfiles");
         type_str(&mut app, "dotf");
         assert_eq!(app.counts(), (1, 2), "narrowed, out of all of them");
+    }
+
+    /// A map with a diamond in its DAG: #14 needs both #6 and #9, and both
+    /// are takeable roots, so the leverage lens deliberately draws #14 under
+    /// each of them — four rows for three shown tickets (the done #2 is
+    /// folded away). The shape the count and cursor claims below are about.
+    fn diamond_app() -> App {
+        let mut clusters = BTreeMap::new();
+        clusters.insert(
+            MapId::new(PROJECT, 1),
+            Map {
+                title: "Map: diamond".to_string(),
+                last_activity: None,
+                tickets: vec![
+                    ticket(PROJECT, 2, "Choose the stack", false, true, vec![]),
+                    ticket(PROJECT, 6, "Re-entry breadcrumbs", true, false, vec![]),
+                    ticket(PROJECT, 9, "Main screen design", true, true, vec![]),
+                    ticket(PROJECT, 14, "Breadcrumb markers", true, false, vec![6, 9]),
+                ],
+            },
+        );
+        app_on(PROJECT, clusters)
+    }
+
+    #[test]
+    fn a_ticket_a_diamond_draws_twice_is_counted_once() {
+        // The count line reads `shown/total` **of tickets** — the same
+        // nodes-not-rows discipline the rollups already keep. The diamond
+        // renders #14 twice, so counting drawn rows would claim four tickets
+        // shown out of four while the done one sits folded off screen.
+        let app = diamond_app();
+        assert_eq!(
+            app.visible().len(),
+            4,
+            "the lens draws four rows: #14 under both roots"
+        );
+        assert_eq!(
+            app.counts(),
+            (3, 4),
+            "three distinct tickets shown, of the map's four"
+        );
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -429,6 +429,9 @@ impl Survey {
 /// Generic over the key so the caller decides what identity *is* — since #50
 /// that is `(MapId, ticket number)`: the same ticket listed on two maps of one
 /// repo is two rows, and the map half is what keeps the cursor on the right one.
+/// Since #188 the caller's key also says *which drawing*: the leverage lens
+/// draws one ticket under every root that unblocks it, and matching the bare
+/// ticket teleported a cursor from the second drawing to the first.
 pub fn preserve_cursor<K: PartialEq>(
     old_selected: Option<&K>,
     old_index: usize,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1910,7 +1910,7 @@ mod tests {
     #[test]
     fn the_chrome_has_count_prompt_and_hint_lines() {
         let screen = render(&fixture_app());
-        assert!(screen.contains("5/5"));
+        assert!(screen.contains("4/5"));
         assert!(screen.contains("> █"));
         assert!(screen.contains("enter launch"));
         assert!(screen.contains("tab structure"));
@@ -1932,7 +1932,7 @@ mod tests {
         let lines: Vec<&str> = screen.lines().collect();
         assert!(lines[0].contains("wf · blooop/wayfinder"), "{screen}");
         assert!(lines[1].contains("> █"), "{screen}");
-        assert!(lines[2].contains("5/5"), "{screen}");
+        assert!(lines[2].contains("4/5"), "{screen}");
         // The body follows, still opening on its own blank spacer line — which
         // now reads as the gap between the chrome and the first cluster.
         // The project row leads the body, with the spacer that separates it
@@ -1981,9 +1981,10 @@ mod tests {
         assert!(!screen.contains("Choose the stack"), "{screen}");
         assert!(!screen.contains("Supervising AFK agents"), "{screen}");
         assert!(!screen.contains("done"), "{screen}");
-        // Count line and prompt reflect the live query; the denominator is
-        // the map's tickets, not the leverage rows.
-        assert!(screen.contains("3/5"), "{screen}");
+        // Count line and prompt reflect the live query; both halves count
+        // tickets, not leverage rows — #14 is drawn twice but is one match,
+        // and the context row placing it is not a match at all.
+        assert!(screen.contains("2/5"), "{screen}");
         assert!(screen.contains("> bread█"), "{screen}");
         // Clearing the query restores the lens whole.
         app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -2315,14 +2316,14 @@ mod tests {
 
         // The count line was never taken away — the picker covers the rows, not
         // the chrome that says how many there are.
-        assert!(screen.contains("5/5"), "{screen}");
+        assert!(screen.contains("4/5"), "{screen}");
 
         // Esc closes it and gives the whole screen back.
         app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         let screen = render(&app);
         assert!(!screen.contains("launch Claude"), "{screen}");
         assert!(!screen.contains("launch Codex"), "{screen}");
-        assert!(screen.contains("5/5"), "{screen}");
+        assert!(screen.contains("4/5"), "{screen}");
     }
 
     #[test]
@@ -2385,7 +2386,7 @@ mod tests {
         assert_eq!(failure_note(&app), "· blooop/dotfiles#4 failed");
         let screen = render(&app);
         assert!(
-            screen.contains("5/5  · blooop/dotfiles#4 failed"),
+            screen.contains("4/5  · blooop/dotfiles#4 failed"),
             "{screen}"
         );
 
@@ -2428,7 +2429,7 @@ mod tests {
             .record_arrival(&MapId::new("blooop/wayfinder", 1));
         let screen = render(&app);
         assert!(screen.contains("#6 Re-entry breadcrumbs"), "{screen}");
-        assert!(screen.contains("5/5  · loading maps 1/3"), "{screen}");
+        assert!(screen.contains("4/5  · loading maps 1/3"), "{screen}");
         // Rows exist, so the title names the project rather than the wait.
         assert!(screen.contains("wf · blooop/wayfinder"), "{screen}");
     }


### PR DESCRIPTION
Closes #188.

The leverage lens deliberately draws one ticket under every root that unblocks it. Two consumers didn't compensate; both now count and pin **tickets, not drawn rows**.

## Count line

`counts()` used `visible().len()` — drawn rows — as the numerator over a ticket denominator, so a diamond inflated "shown": a sifted query matching 2 tickets claimed 3, and the unsifted fixture read a coincidentally-round 5/5 off five rows of four distinct shown tickets. The numerator now dedups rows by `(map, index)` — the same nodes-not-rows discipline the rollups keep. The rendered pins move with it: the sifted `3/5` becomes `2/5`, the unsifted `5/5`s become `4/5`.

## Cursor identity

`StopKey`'s ticket arm gains an occurrence index — which drawing of the ticket the stop is — computed over the whole stop list, since a key derived from one stop alone cannot know it is the second drawing. `point_at` and the swap-time resolve match the exact drawing first, and degrade to the first drawing of the same ticket when that drawing left the screen (a lens toggle to forest, a root that closed) — so a cursor parked on the second rendering no longer teleports to the first on every `replace_clusters`, and losing a drawing never means losing the ticket. Only a ticket gone entirely falls back to position, as before.

The deeper redesign of row identity stays out per the map's *Not yet specified*.

## Tests

- `a_ticket_a_diamond_draws_twice_is_counted_once` — red first against the row-count numerator
- `a_cursor_on_the_second_drawing_of_a_diamond_ticket_survives_a_swap` — red first against the occurrence-blind key
- `a_drawing_that_vanishes_degrades_to_the_ticket_not_the_top`, `a_lens_toggle_keeps_the_cursor_on_the_ticket_when_its_drawing_leaves` — guard the degrade path
- existing count-line pins corrected to the ticket-true numbers

Full local chain green (fmt, clippy, lib/bins/examples, skill_docs, devcontainer_prebuild, toolchain_pin, offline_green, live_fetch common, doc) with `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make ticket counts and cursor preservation consistent when the leverage lens renders the same ticket under multiple DAG roots.

Bug Fixes:
- Correct ticket count displays so duplicate DAG-diamond drawings are counted once.
- Preserve cursor identity for duplicate ticket drawings across refreshes, while falling back to another drawing of the same ticket when needed.

Enhancements:
- Align count and cursor behavior around ticket identity rather than rendered row identity.

Tests:
- Add coverage for deduplicated diamond counts and cursor preservation and fallback behavior across swaps and lens changes.