### PR TITLE
A red live or scheduled run files an issue

### DIFF
--- a/.github/scripts/red_run_alert.sh
+++ b/.github/scripts/red_run_alert.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Reconcile the tracking issue for one completed run of a watched workflow
+# (#190). The workflow (`red-run-alert.yml`) decides *which* runs count and
+# hands this script the conclusion; this script's whole job is the idempotent
+# half — one open issue per watched workflow, filed on red, never duplicated,
+# closed on the next green of the same class.
+#
+# A script rather than an inline `run:` block so it can be driven for real:
+# `tests/red_run_alert.rs` runs it against a recording `gh` stub and asserts
+# the create-vs-comment-vs-close decisions at the boundary they cross.
+#
+# Reads: WORKFLOW_NAME, CONCLUSION, RUN_URL, REPO — plus GH_TOKEN, which `gh`
+# itself consumes.
+set -euo pipefail
+
+# The issue's identity. An exact-match title rather than a label, because the
+# search below can then be read literally: rename the workflow and the old
+# issue simply stops matching, which is the correct outcome — a rename also
+# re-points the `workflow_run` subscription (the shape `tests/red_run_alert.rs`
+# holds both ends to).
+title="Red run: ${WORKFLOW_NAME}"
+
+# Exact match on the title, not a substring search: `gh issue list --search`
+# tokenises, and "Red run: live" would find "Red run: live tests, take two".
+# The `--jq` filter is the real gh's own (embedded gojq), so no jq needs to be
+# installed on the runner.
+open_issue="$(gh issue list --repo "${REPO}" --state open --limit 100 \
+  --json number,title \
+  --jq ".[] | select(.title == \"${title}\") | .number" | head -n 1)"
+
+if [ "${CONCLUSION}" = failure ]; then
+  if [ -z "${open_issue}" ]; then
+    gh issue create --repo "${REPO}" --title "${title}" \
+      --body "A non-blocking run of \`${WORKFLOW_NAME}\` went red: ${RUN_URL}
+
+Nothing blocks on this leg, so this issue is the summons. It is updated (not duplicated) while the leg stays red, and closes itself on the next green run of the same class. Filed by \`.github/workflows/red-run-alert.yml\` (#190)."
+  else
+    gh issue comment "${open_issue}" --repo "${REPO}" \
+      --body "Still red: ${RUN_URL}"
+  fi
+else
+  # Green, and only green: the trigger's `types: [completed]` also delivers
+  # cancelled and skipped runs, and those are neither evidence of red nor of
+  # green — closing a summons on a cancelled run would withdraw it on no
+  # evidence at all.
+  if [ "${CONCLUSION}" = success ] && [ -n "${open_issue}" ]; then
+    gh issue close "${open_issue}" --repo "${REPO}" \
+      --comment "Green again: ${RUN_URL}"
+  fi
+fi

--- a/.github/scripts/red_run_alert.sh
+++ b/.github/scripts/red_run_alert.sh
@@ -28,7 +28,27 @@ open_issue="$(gh issue list --repo "${REPO}" --state open --limit 100 \
   --json number,title \
   --jq ".[] | select(.title == \"${title}\") | .number" | head -n 1)"
 
-if [ "${CONCLUSION}" = failure ]; then
+# Red is defined by exclusion — everything that is not one of the three named
+# below — rather than as the single string `failure`. Three conclusions are not
+# red: a green run, and the two non-verdicts, cancelled and skipped, which are
+# evidence of neither red nor green. Every other conclusion GitHub can hand us
+# draws a red X on the Actions tab, and two of those are live on the watched
+# legs: `live.yml` declares no `timeout-minutes`, so the leg that asserts
+# wall-clock budgets overruns into `timed_out` rather than into a failing
+# assertion, and a workflow that stops parsing concludes `startup_failure`
+# before there is a step to fail. Matching on `failure` alone left both of
+# those summoning nobody, which is this workflow's whole subject reintroduced
+# one string comparison in.
+#
+# Naming the exclusions is also safe in a way that naming the inclusions is
+# not: a conclusion GitHub adds later summons somebody by default, and for a
+# leg whose entire point is noticing, that is the right way to be wrong.
+case "${CONCLUSION}" in
+  success | cancelled | skipped) red=false ;;
+  *) red=true ;;
+esac
+
+if [ "${red}" = true ]; then
   if [ -z "${open_issue}" ]; then
     gh issue create --repo "${REPO}" --title "${title}" \
       --body "A non-blocking run of \`${WORKFLOW_NAME}\` went red: ${RUN_URL}
@@ -39,10 +59,10 @@ Nothing blocks on this leg, so this issue is the summons. It is updated (not dup
       --body "Still red: ${RUN_URL}"
   fi
 else
-  # Green, and only green: the trigger's `types: [completed]` also delivers
-  # cancelled and skipped runs, and those are neither evidence of red nor of
-  # green — closing a summons on a cancelled run would withdraw it on no
-  # evidence at all.
+  # Green, and only green, withdraws the summons. The `else` above also holds
+  # the two non-verdicts, and closing on a cancelled run would withdraw a
+  # summons on no evidence at all — so the close is guarded by `success`
+  # itself rather than by "not red".
   if [ "${CONCLUSION}" = success ] && [ -n "${open_issue}" ]; then
     gh issue close "${open_issue}" --repo "${REPO}" \
       --comment "Green again: ${RUN_URL}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       - name: The live tests are all gated
         run: cargo test --locked --test offline_green
 
-      # The live fixture's own diagnostic — offline like its three siblings
+      # The live fixture's own diagnostic — offline like its five siblings
       # above — which decides what a failing live test tells
       # you about a missing GH_TOKEN. It is split from the environment it reads
       # precisely so it can be asserted — and an assertion no workflow runs is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,16 @@ jobs:
       - name: The Rust pin has one home
         run: cargo test --locked --test toolchain_pin
 
+      # The fourth config-as-behavior binary: the red-run alert subscribes to
+      # `live.yml` and `devlaunch-contract.yml` by their *display names*, a
+      # string GitHub never validates, so a rename of either workflow would
+      # disconnect the alert with no symptom anywhere — except here, where the
+      # subscription is compared to the watched files' own `name:` fields. The
+      # same binary drives the reconciliation script against a recording `gh`,
+      # offline like its siblings.
+      - name: The red-run alert stays wired to what it watches
+        run: cargo test --locked --test red_run_alert
+
       # The guard on the exclusion every step around it depends on: the live
       # binaries are safe to leave out of the unit-test step only because each
       # of their tests carries `#[ignore]`, and a new one that forgets it is

--- a/.github/workflows/red-run-alert.yml
+++ b/.github/workflows/red-run-alert.yml
@@ -28,10 +28,20 @@ permissions:
   contents: read
 
 concurrency:
-  # Serialised, never cancelled: the reconciliation below is a search-then-act
-  # on the tracker, and two completions racing through it is exactly how "one
-  # open issue per workflow" becomes two. One fixed group — not keyed on the
-  # ref or the event — so every reconciliation queues behind the last.
+  # One fixed group — not keyed on the ref or the event — because the
+  # reconciliation below is a search-then-act on a single tracker issue, and
+  # two completions racing through it is exactly how "one open issue per
+  # workflow" becomes two. `cancel-in-progress: false` keeps the reconciliation
+  # that is already running.
+  #
+  # What this does *not* buy, stated exactly, because the obvious reading is
+  # wrong: reconciliations do not all queue up behind each other. GitHub holds
+  # at most one pending run per group, so a third completion arriving while one
+  # runs and one waits cancels the *waiting* one. That is survivable here, and
+  # only here: the run being cancelled is never the newest, and reconciliation
+  # converges on the current state rather than appending to a log — so the
+  # newest completion always gets its say, and what a burst loses is at most an
+  # interim "Still red" comment.
   group: red-run-alert
   cancel-in-progress: false
 
@@ -46,11 +56,22 @@ jobs:
     # blocks a pull request, so a red one is already holding the merge it
     # belongs to, and the scheduled re-solve is the single leg whose red means
     # devlaunch moved — the one nobody is otherwise summoned to.
+    #
+    # The head-repository clause comes first because it is the only one a fork
+    # cannot choose. A fork's default branch is `main`, so a fork pull request
+    # that adds a `pull_request:` leg to `live.yml` produces a run named `live`
+    # with `head_branch == 'main'` and a conclusion the fork's own code
+    # decides. That run reaches this job, which holds `issues: write` on *this*
+    # repo — and a forged `success` would not merely file noise, it would close
+    # a genuinely red summons. Guarding both legs rather than only the live one:
+    # `event == 'schedule'` is unforgeable today, but a guard that has to be
+    # re-derived per leg is a guard the next leg forgets.
     if: >-
-      (github.event.workflow_run.name == 'live'
-        && github.event.workflow_run.head_branch == 'main')
-      || (github.event.workflow_run.name == 'devlaunch contract'
-        && github.event.workflow_run.event == 'schedule')
+      github.event.workflow_run.head_repository.full_name == github.repository
+      && ((github.event.workflow_run.name == 'live'
+            && github.event.workflow_run.head_branch == 'main')
+        || (github.event.workflow_run.name == 'devlaunch contract'
+            && github.event.workflow_run.event == 'schedule'))
     runs-on: ubuntu-latest
     # Job-scoped and exhaustive: a job-level `permissions` replaces the
     # workflow-level one entirely, so the read the checkout needs is restated
@@ -65,8 +86,18 @@ jobs:
       # The decision logic lives in a script rather than in this block so that
       # `tests/red_run_alert.rs` can run it for real against a recording `gh`
       # stub — the create-vs-comment-vs-close behavior is asserted there, and
-      # the same test holds this env block and the script's reads to exactly
-      # match each other.
+      # the same test holds this env block and the script's reads to match in
+      # both directions: the key names against what the script actually reads,
+      # and each *expression* against the run it has to describe.
+      #
+      # That second half is the one worth stating. In a `workflow_run` run the
+      # context carries two runs — the watched one under
+      # `github.event.workflow_run`, and this alert's own under the bare
+      # `github.*` keys — so every variable below has to name the first.
+      # `${{ github.workflow }}` in place of the run's `name` is always
+      # `red-run alert`, which would quietly collapse both watched legs into a
+      # single summons titled for the alert itself; and `html_url` rather than
+      # `url`, because the summons points a human at a run page, not at JSON.
       - name: Reconcile the tracking issue
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/red-run-alert.yml
+++ b/.github/workflows/red-run-alert.yml
@@ -1,0 +1,77 @@
+name: red-run alert
+
+# A red non-blocking run summons somebody (#190). Two legs of this repo's CI
+# are non-blocking on purpose — `live.yml` runs after the merge because it
+# asserts the tracker's present contents, and `devlaunch-contract.yml`'s
+# weekly re-solve is the only thing that can discover a devlaunch release
+# published since the lock — which means both depend entirely on a human
+# noticing a red run. Nothing did the noticing. This workflow reconciles one
+# tracking issue per watched workflow: filed when a run goes red, commented
+# rather than duplicated while it stays red, closed on the next green of the
+# same class.
+on:
+  workflow_run:
+    # By *display name*, because that is the only thing `workflow_run` can
+    # subscribe by — a rename of either watched workflow would disconnect this
+    # silently. `tests/red_run_alert.rs` derives these strings from the watched
+    # files' own `name:` fields, so a rename either moves both ends or fails CI.
+    workflows: ["live", "devlaunch contract"]
+    # `completed` and only `completed`: it is the one type that carries a
+    # conclusion, and a run that has not concluded has nothing to reconcile.
+    types: [completed]
+
+# Read-only for the workflow as a whole; the one grant beyond that sits on the
+# job that needs it, matching `package.yml` and `devcontainer.yml`. What the
+# split buys is the blast radius of a step added later: it could read this
+# public repo, not file or close issues on it.
+permissions:
+  contents: read
+
+concurrency:
+  # Serialised, never cancelled: the reconciliation below is a search-then-act
+  # on the tracker, and two completions racing through it is exactly how "one
+  # open issue per workflow" becomes two. One fixed group — not keyed on the
+  # ref or the event — so every reconciliation queues behind the last.
+  group: red-run-alert
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: file, update or close the tracking issue
+    # The subscription above is wider than the promise, so the job narrows it
+    # to the runs nothing else stands behind. `live` counts only on `main`:
+    # its push trigger only fires there, and a `workflow_dispatch` aimed at a
+    # topic branch is somebody's experiment, not the world moving. The
+    # contract workflow counts only from its weekly schedule: every other leg
+    # blocks a pull request, so a red one is already holding the merge it
+    # belongs to, and the scheduled re-solve is the single leg whose red means
+    # devlaunch moved — the one nobody is otherwise summoned to.
+    if: >-
+      (github.event.workflow_run.name == 'live'
+        && github.event.workflow_run.head_branch == 'main')
+      || (github.event.workflow_run.name == 'devlaunch contract'
+        && github.event.workflow_run.event == 'schedule')
+    runs-on: ubuntu-latest
+    # Job-scoped and exhaustive: a job-level `permissions` replaces the
+    # workflow-level one entirely, so the read the checkout needs is restated
+    # here beside the one write this whole workflow exists for.
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # Only for the script below — this job builds nothing.
+      - uses: actions/checkout@v7
+
+      # The decision logic lives in a script rather than in this block so that
+      # `tests/red_run_alert.rs` can run it for real against a recording `gh`
+      # stub — the create-vs-comment-vs-close behavior is asserted there, and
+      # the same test holds this env block and the script's reads to exactly
+      # match each other.
+      - name: Reconcile the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          REPO: ${{ github.repository }}
+        run: .github/scripts/red_run_alert.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ RUSTFLAGS=-D\ warnings RUSTDOCFLAGS=-D\ warnings sh -c '
   cargo test --locked --test skill_docs &&
   cargo test --locked --test devcontainer_prebuild &&
   cargo test --locked --test toolchain_pin &&
+  cargo test --locked --test red_run_alert &&
   cargo test --locked --test offline_green &&
   cargo test --locked --test live_fetch -- common:: &&
   cargo doc --no-deps --all-features --locked'
@@ -125,15 +126,19 @@ Run the whole chain before pushing, `cargo fmt --all` first — a formatting dif
 fails the build before any of the interesting checks get a chance to run.
 
 The `tests/live_*.rs` files are excluded from that test command on purpose: they
-talk to real GitHub, drive a real pty, or want a chosen `devlaunch`. Four
+talk to real GitHub, drive a real pty, or want a chosen `devlaunch`. Five
 binaries under `tests/` are exceptions and run in the chain (and in CI) like any
-unit test, because all four are offline checks on files-as-behavior:
+unit test, because all five are offline checks on files-as-behavior:
 `tests/skill_docs.rs` (shape checks on the skill docs' snippets),
 `tests/devcontainer_prebuild.rs` (the contract between the devcontainer configs
 and the workflow that publishes the prebuilt image to GHCR — see the comments in
 `.devcontainer/devcontainer.json`), `tests/toolchain_pin.rs` (the guard that
 keeps `rust-toolchain.toml` the only place a Rust version is written — see
-**The Rust version is pinned in one place** below), and `tests/offline_green.rs`
+**The Rust version is pinned in one place** below), `tests/red_run_alert.rs`
+(the contract of `.github/workflows/red-run-alert.yml`: that its `workflow_run`
+subscription matches the watched workflows' declared names, and that its
+reconciliation script files, updates and closes the tracking issue — driven
+against a recording `gh` stub), and `tests/offline_green.rs`
 (the guard on the exclusion itself: it reads `tests/live_*.rs` and fails if any
 test in them is missing `#[ignore]`).
 

--- a/tests/red_run_alert.rs
+++ b/tests/red_run_alert.rs
@@ -1,0 +1,421 @@
+//! A red live or scheduled run files an issue (#190).
+//!
+//! The live tier is deliberately non-blocking, and the weekly devlaunch
+//! contract re-solve is the only leg that can discover a new devlaunch
+//! release — so both depend entirely on somebody *noticing* a red run. The
+//! alert workflow is what does the noticing: it reconciles one tracking issue
+//! per watched workflow, filing on red, updating rather than duplicating, and
+//! closing on the next green of the same class.
+//!
+//! Offline by design, like its neighbours: half the seam is the workflow text
+//! itself (what it subscribes to, what it may write, which runs it reacts to),
+//! and the other half is the reconciliation script, driven here against a
+//! recording `gh` stub — the same shim ethos `tests/live_devlaunch.rs` applies
+//! to `devpod` — so the create-vs-comment-vs-close decisions are asserted at
+//! the boundary they cross, with no network and no real tracker involved.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// A file in this repository, read by its path relative to the crate root.
+fn repo_file(rel: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(rel);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{} ships in this repo: {e}", path.display()))
+}
+
+/// A workflow with its full-line comments removed, as in
+/// `tests/devcontainer_prebuild.rs` and for the same reason: this repo's
+/// workflows discuss their own triggers at length, so a substring check
+/// against the raw text would be reading the commentary.
+fn workflow(rel: &str) -> String {
+    repo_file(rel)
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// A top-level block of a workflow file — `on:`, `permissions:`, `jobs:` —
+/// from its key to the next line that starts in column zero.
+fn top_level_block(workflow: &str, key: &str) -> String {
+    let start = workflow.find(&format!("\n{key}:")).map_or_else(
+        || {
+            assert!(
+                workflow.starts_with(&format!("{key}:")),
+                "the workflow declares `{key}:`"
+            );
+            0
+        },
+        |index| index + 1,
+    );
+    let rest = &workflow[start..];
+    let mut block = String::new();
+    for (number, line) in rest.lines().enumerate() {
+        let starts_new_block =
+            number > 0 && !line.starts_with([' ', '\t']) && !line.trim().is_empty();
+        if starts_new_block {
+            break;
+        }
+        block.push_str(line);
+        block.push('\n');
+    }
+    block
+}
+
+/// The `name:` a workflow declares — the string `workflow_run` subscribes by.
+fn declared_name(rel: &str) -> String {
+    workflow(rel)
+        .lines()
+        .find_map(|line| line.strip_prefix("name:"))
+        .unwrap_or_else(|| panic!("{rel} declares a `name:`"))
+        .trim()
+        .trim_matches('"')
+        .to_string()
+}
+
+const ALERT: &str = ".github/workflows/red-run-alert.yml";
+
+/// `workflow_run` subscribes by *display name*, not by file name — so the
+/// subscription is a string that nothing at GitHub's end validates, and a
+/// rename of either watched workflow would disconnect the alert without a
+/// word. This derives the expected names from the watched files' own `name:`
+/// fields, so a rename either moves both ends or fails here.
+#[test]
+fn the_alert_watches_both_nonblocking_legs_by_their_declared_names() {
+    let triggers = top_level_block(&workflow(ALERT), "on");
+    assert!(
+        triggers.contains("workflow_run:"),
+        "the alert is triggered by the watched runs completing, not by a \
+         schedule of its own:\n{triggers}"
+    );
+    assert!(
+        triggers.contains("completed"),
+        "`completed` is the only type that carries a conclusion — `requested` \
+         fires before there is anything to reconcile:\n{triggers}"
+    );
+    for watched in [
+        ".github/workflows/live.yml",
+        ".github/workflows/devlaunch-contract.yml",
+    ] {
+        let name = declared_name(watched);
+        assert!(
+            triggers.contains(&format!("\"{name}\"")),
+            "the alert subscribes to {watched} by its declared name \
+             `{name}`:\n{triggers}"
+        );
+    }
+}
+
+/// The narrow-job pattern the repo's other workflows already follow: the
+/// workflow as a whole can only read, and the ability to write issues is
+/// granted to the one job that reconciles the tracking issue. The distinction
+/// is what a step added later in some unrelated job could do — file and close
+/// issues on this repo, or not.
+#[test]
+fn only_the_reconciling_job_may_write_issues() {
+    let alert = workflow(ALERT);
+    let workflow_level = top_level_block(&alert, "permissions");
+    assert!(
+        workflow_level.contains("contents: read"),
+        "the default for the whole workflow is read-only:\n{workflow_level}"
+    );
+    assert!(
+        !workflow_level.contains("issues:"),
+        "issue write is never a workflow-wide grant — every job added later \
+         would inherit it silently:\n{workflow_level}"
+    );
+    assert_eq!(
+        top_level_block(&alert, "jobs")
+            .matches("issues: write")
+            .count(),
+        1,
+        "exactly one job may write issues: the one that reconciles the \
+         tracking issue"
+    );
+}
+
+/// The subscription above is wider than the promise: `live.yml` can be
+/// dispatched at any branch, and `devlaunch-contract.yml` completes on every
+/// pull request. The ticket's claim is about the runs nothing else stands
+/// behind — live runs on `main` (the merge-then-run leg plus a dispatch aimed
+/// there), and the contract workflow's scheduled re-solve, the one leg that
+/// can discover a new devlaunch release. A red PR run of the contract already
+/// blocks its PR; filing an issue for it would page the repo about something
+/// the merge gate is holding anyway.
+#[test]
+fn the_alert_reacts_only_to_the_runs_nothing_else_stands_behind() {
+    let jobs = top_level_block(&workflow(ALERT), "jobs");
+    assert!(
+        jobs.contains("github.event.workflow_run.head_branch == 'main'"),
+        "live runs count only on main — a dispatch aimed at a topic branch is \
+         somebody's experiment, not the world moving:\n{jobs}"
+    );
+    assert!(
+        jobs.contains("github.event.workflow_run.event == 'schedule'"),
+        "contract runs count only from the weekly re-solve — every other leg \
+         blocks a pull request and needs no summons:\n{jobs}"
+    );
+}
+
+/// The reconciliation script, run for real against a recording `gh`.
+///
+/// The stub answers `gh issue list` with whatever the caller says the tracker
+/// holds (the text a real `gh --jq` would print: matching issue numbers, one
+/// per line, or nothing) and records every call's full argv — so each test
+/// states a tracker state and a run conclusion, and asserts the writes that
+/// crossed the boundary. Everything the script needs arrives in its
+/// environment, exactly as the workflow hands it.
+fn reconcile(test: &str, workflow_name: &str, conclusion: &str, open_issues: &str) -> Vec<String> {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(test);
+    fs::create_dir_all(&dir).expect("the test scratch directory is writable");
+    let log = dir.join("gh.log");
+    let _ = fs::remove_file(&log);
+
+    let stub = dir.join("gh");
+    fs::write(
+        &stub,
+        "#!/usr/bin/env bash\n\
+         printf '%s\\n' \"$*\" >> \"$GH_LOG\"\n\
+         case \"$1 $2\" in\n\
+         \x20 'issue list') printf '%s' \"$GH_OPEN_ISSUES\" ;;\n\
+         \x20 'issue create') echo 'https://github.invalid/issues/999' ;;\n\
+         esac\n",
+    )
+    .expect("the gh stub is writable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&stub, fs::Permissions::from_mode(0o755))
+            .expect("the gh stub can be made executable");
+    }
+
+    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SCRIPT);
+    let path = format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").expect("a test process has a PATH")
+    );
+    let output = std::process::Command::new(&script)
+        .env("PATH", path)
+        .env("GH_LOG", &log)
+        .env("GH_OPEN_ISSUES", open_issues)
+        .env("WORKFLOW_NAME", workflow_name)
+        .env("CONCLUSION", conclusion)
+        .env("RUN_URL", "https://github.invalid/actions/runs/1")
+        .env("REPO", "blooop/wayfinder")
+        .output()
+        .unwrap_or_else(|e| panic!("{SCRIPT} ships in this repo and runs: {e}"));
+    assert!(
+        output.status.success(),
+        "the script reconciles without error:\n{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    match fs::read_to_string(&log) {
+        Ok(calls) => calls.lines().map(str::to_string).collect(),
+        // No log file means the stub was never invoked: zero gh calls.
+        Err(_) => Vec::new(),
+    }
+}
+
+const SCRIPT: &str = ".github/scripts/red_run_alert.sh";
+
+/// A red run of a watched workflow with nothing already open files the
+/// tracking issue, titled for the workflow so each watched leg reconciles
+/// against its own issue and nobody has to read the body to know which leg is
+/// red.
+#[test]
+fn a_red_run_with_no_open_issue_files_one() {
+    let calls = reconcile("red_files", "live", "failure", "");
+    let creates: Vec<&String> = calls
+        .iter()
+        .filter(|call| call.starts_with("issue create"))
+        .collect();
+    assert_eq!(creates.len(), 1, "one red run, one filed issue: {calls:?}");
+    assert!(
+        creates[0].contains("Red run: live"),
+        "the title names the workflow that went red: {}",
+        creates[0]
+    );
+    assert!(
+        creates[0].contains("https://github.invalid/actions/runs/1"),
+        "the issue points at the run it summons somebody to: {}",
+        creates[0]
+    );
+    assert!(
+        !calls.iter().any(|call| call.starts_with("issue comment")),
+        "nothing existed to update: {calls:?}"
+    );
+}
+
+/// A leg that stays red across several runs keeps a single summons: the
+/// existing issue gains a comment pointing at the newest red run, and no
+/// second issue appears. This is the idempotence the ticket asks for — the
+/// failure mode it forecloses is a weekly schedule papering the tracker with
+/// one issue per red Monday.
+#[test]
+fn a_red_run_with_an_open_issue_updates_it_instead_of_duplicating() {
+    let calls = reconcile("red_updates", "live", "failure", "42\n");
+    assert!(
+        !calls.iter().any(|call| call.starts_with("issue create")),
+        "the open issue is the summons — no duplicate: {calls:?}"
+    );
+    let comments: Vec<&String> = calls
+        .iter()
+        .filter(|call| call.starts_with("issue comment 42"))
+        .collect();
+    assert_eq!(
+        comments.len(),
+        1,
+        "the existing issue is pointed at the newest red run: {calls:?}"
+    );
+    assert!(
+        comments[0].contains("https://github.invalid/actions/runs/1"),
+        "the update carries the run it reports: {}",
+        comments[0]
+    );
+}
+
+/// The next green run of the same class closes the summons itself, pointing
+/// at the run that cleared it — the other half of idempotence: the issue's
+/// open/closed state tracks the leg's red/green state with no human in the
+/// loop.
+#[test]
+fn a_green_run_closes_the_open_summons() {
+    let calls = reconcile("green_closes", "live", "success", "42\n");
+    let closes: Vec<&String> = calls
+        .iter()
+        .filter(|call| call.starts_with("issue close 42"))
+        .collect();
+    assert_eq!(closes.len(), 1, "the summons is withdrawn: {calls:?}");
+    assert!(
+        closes[0].contains("https://github.invalid/actions/runs/1"),
+        "the close names the green run that cleared it: {}",
+        closes[0]
+    );
+    assert!(
+        !calls.iter().any(|call| call.starts_with("issue create")),
+        "a green run never files anything: {calls:?}"
+    );
+}
+
+/// A green run with nothing open is the steady state — every merge to `main`
+/// lands here — and it writes nothing at all: no issue, no comment, no noise
+/// in the tracker for the ordinary case of things working.
+#[test]
+fn a_green_run_with_nothing_open_writes_nothing() {
+    let calls = reconcile("green_quiet", "live", "success", "");
+    assert!(
+        !calls.iter().any(|call| !call.starts_with("issue list")),
+        "the steady state is silent — the only gh call is the lookup: {calls:?}"
+    );
+}
+
+/// A cancelled run is neither red nor green — the trigger's `completed` type
+/// delivers it anyway — and it must move nothing: filing on it would summon
+/// somebody to a run that was superseded, and closing on it would withdraw a
+/// summons on no evidence. Both directions are asserted, each against the
+/// tracker state where the wrong write is possible.
+#[test]
+fn a_cancelled_run_is_neither_red_nor_green() {
+    let with_summons = reconcile("cancelled_open", "live", "cancelled", "42\n");
+    assert!(
+        !with_summons
+            .iter()
+            .any(|call| !call.starts_with("issue list")),
+        "an open summons survives a cancelled run: {with_summons:?}"
+    );
+    let without = reconcile("cancelled_quiet", "live", "cancelled", "");
+    assert!(
+        !without.iter().any(|call| !call.starts_with("issue list")),
+        "a cancelled run files nothing: {without:?}"
+    );
+}
+
+/// Each watched workflow reconciles against its own issue: the title embeds
+/// the workflow's name, and the lookup matches that title exactly — not as a
+/// substring, and not against the other leg's issue. A red contract re-solve
+/// while the live summons is open must file a second issue, not comment on
+/// the first.
+#[test]
+fn each_watched_workflow_has_a_summons_of_its_own() {
+    let calls = reconcile("own_summons", "devlaunch contract", "failure", "");
+    let lookup = calls
+        .iter()
+        .find(|call| call.starts_with("issue list"))
+        .expect("the reconciliation starts from what the tracker holds");
+    assert!(
+        lookup.contains(r#"select(.title == "Red run: devlaunch contract")"#),
+        "the lookup is an exact-title match for this workflow's own summons: \
+         {lookup}"
+    );
+    let create = calls
+        .iter()
+        .find(|call| call.starts_with("issue create"))
+        .expect("a red run with no matching summons files one");
+    assert!(
+        create.contains("Red run: devlaunch contract"),
+        "the filed issue is titled for the leg that went red: {create}"
+    );
+}
+
+/// The two halves tested above only meet if the job really invokes the script
+/// and their environment contract holds in both directions: a variable the
+/// script reads but the job never sets is an empty title or a `set -u` abort
+/// on the runner, and one the job sets but nothing reads is a claim the
+/// script silently stopped honouring. `GH_TOKEN` is the one deliberate
+/// asymmetry — the job hands it for `gh` itself to consume, so no line of the
+/// script names it.
+#[test]
+fn the_job_hands_the_script_exactly_what_it_reads() {
+    let jobs = top_level_block(&workflow(ALERT), "jobs");
+    assert!(
+        jobs.contains(SCRIPT),
+        "the reconciling job runs the script the tests above drove:\n{jobs}"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SCRIPT))
+            .expect("the script ships in this repo")
+            .permissions()
+            .mode();
+        assert!(
+            mode & 0o111 != 0,
+            "the runner invokes the script directly, so the executable bit \
+             has to survive the checkout: mode {mode:o}"
+        );
+    }
+
+    let mut handed: Vec<&str> = jobs
+        .lines()
+        .filter_map(|line| {
+            let name = line.trim().split(':').next()?;
+            (!name.is_empty() && name.chars().all(|c| c.is_ascii_uppercase() || c == '_'))
+                .then_some(name)
+        })
+        .filter(|name| *name != "GH_TOKEN")
+        .collect();
+    handed.sort_unstable();
+
+    let script = repo_file(SCRIPT);
+    let mut read: Vec<&str> = script
+        .match_indices("${")
+        .filter_map(|(index, _)| {
+            let rest = &script[index + 2..];
+            let name = &rest[..rest.find('}')?];
+            (!name.is_empty() && name.chars().all(|c| c.is_ascii_uppercase() || c == '_'))
+                .then_some(name)
+        })
+        .collect();
+    read.sort_unstable();
+    read.dedup();
+
+    assert_eq!(
+        handed, read,
+        "what the job hands (left) is exactly what the script reads (right), \
+         GH_TOKEN aside"
+    );
+}

--- a/tests/red_run_alert.rs
+++ b/tests/red_run_alert.rs
@@ -158,6 +158,29 @@ fn the_alert_reacts_only_to_the_runs_nothing_else_stands_behind() {
     );
 }
 
+/// Every guard above reads a field of the *watched* run, and a fork pull
+/// request gets to choose most of them. A fork's default branch is `main`, so
+/// a fork that adds a `pull_request:` leg to `live.yml` produces a run named
+/// `live` whose `head_branch` is `main` and whose conclusion the fork's own
+/// code decides — and this repo is public with first-time-contributor approval
+/// only, so a prior contributor needs nobody's click. The consequence is worse
+/// than a spurious summons: a forged `success` reaches the reconciling job,
+/// which holds `issues: write` on the *base* repo, and **closes** a genuinely
+/// red summons. The one field a fork cannot forge is which repository the run
+/// belongs to, so that is what the job is required to check — and requiring it
+/// of both legs rather than only the live one, because a guard that has to be
+/// re-derived per leg is a guard the next leg forgets.
+#[test]
+fn a_run_from_a_fork_can_neither_file_nor_withdraw_a_summons() {
+    let jobs = top_level_block(&workflow(ALERT), "jobs");
+    assert!(
+        jobs.contains("github.event.workflow_run.head_repository.full_name == github.repository"),
+        "only runs belonging to this repository are reconciled — every other \
+         field of a watched run is a fork's to choose, and a forged green \
+         would withdraw a real summons:\n{jobs}"
+    );
+}
+
 /// The reconciliation script, run for real against a recording `gh`.
 ///
 /// The stub answers `gh issue list` with whatever the caller says the tracker
@@ -313,25 +336,68 @@ fn a_green_run_with_nothing_open_writes_nothing() {
     );
 }
 
-/// A cancelled run is neither red nor green — the trigger's `completed` type
-/// delivers it anyway — and it must move nothing: filing on it would summon
-/// somebody to a run that was superseded, and closing on it would withdraw a
-/// summons on no evidence. Both directions are asserted, each against the
-/// tracker state where the wrong write is possible.
+/// Red is not spelled one way. A red X on the Actions tab is `failure`,
+/// `timed_out` *or* `startup_failure`, and both of the latter are reachable on
+/// the very legs this alert watches: `live.yml` declares no `timeout-minutes`,
+/// so the leg whose whole job is asserting wall-clock budgets overruns into
+/// GitHub's own timeout rather than into a test assertion, and a workflow that
+/// stops parsing concludes `startup_failure` before there is a step to fail. A
+/// summons that answers only to the literal string `failure` leaves exactly
+/// those two unnoticed — the failure this whole workflow exists to foreclose,
+/// reintroduced one string comparison in.
 #[test]
-fn a_cancelled_run_is_neither_red_nor_green() {
-    let with_summons = reconcile("cancelled_open", "live", "cancelled", "42\n");
-    assert!(
-        !with_summons
-            .iter()
-            .any(|call| !call.starts_with("issue list")),
-        "an open summons survives a cancelled run: {with_summons:?}"
-    );
-    let without = reconcile("cancelled_quiet", "live", "cancelled", "");
-    assert!(
-        !without.iter().any(|call| !call.starts_with("issue list")),
-        "a cancelled run files nothing: {without:?}"
-    );
+fn every_red_conclusion_summons_somebody() {
+    for conclusion in ["failure", "timed_out", "startup_failure"] {
+        let calls = reconcile(&format!("red_{conclusion}"), "live", conclusion, "");
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|call| call.starts_with("issue create"))
+                .count(),
+            1,
+            "`{conclusion}` renders as a red run and files a summons: {calls:?}"
+        );
+        let open = reconcile(
+            &format!("red_open_{conclusion}"),
+            "live",
+            conclusion,
+            "42\n",
+        );
+        assert_eq!(
+            open.iter()
+                .filter(|call| call.starts_with("issue comment 42"))
+                .count(),
+            1,
+            "and it updates the standing summons rather than withdrawing it: \
+             {open:?}"
+        );
+    }
+}
+
+/// A cancelled or skipped run is neither red nor green — the trigger's
+/// `completed` type delivers both anyway — and neither may move anything:
+/// filing on one would summon somebody to a run that was superseded, and
+/// closing on one would withdraw a summons on no evidence at all. Both
+/// directions are asserted for each, against the tracker state where the wrong
+/// write is possible. These two exclusions are also what keeps the test above
+/// honest: red is defined as "not green", so a conclusion not named here
+/// becomes a summons.
+#[test]
+fn a_run_with_no_verdict_is_neither_red_nor_green() {
+    for conclusion in ["cancelled", "skipped"] {
+        let with_summons = reconcile(&format!("{conclusion}_open"), "live", conclusion, "42\n");
+        assert!(
+            !with_summons
+                .iter()
+                .any(|call| !call.starts_with("issue list")),
+            "an open summons survives a {conclusion} run: {with_summons:?}"
+        );
+        let without = reconcile(&format!("{conclusion}_quiet"), "live", conclusion, "");
+        assert!(
+            !without.iter().any(|call| !call.starts_with("issue list")),
+            "a {conclusion} run files nothing: {without:?}"
+        );
+    }
 }
 
 /// Each watched workflow reconciles against its own issue: the title embeds
@@ -361,6 +427,106 @@ fn each_watched_workflow_has_a_summons_of_its_own() {
     );
 }
 
+/// The reconciliation is a search-then-act on one issue, so two of them
+/// running at once is how "one open issue per workflow" becomes two — the
+/// exact outcome the ticket names as the thing to avoid. A single fixed
+/// concurrency group is what forecloses it, and nothing else in this file
+/// notices if it goes: deleting the block leaves every behavioural test above
+/// green, because they drive the script one call at a time and the race lives
+/// above the script entirely.
+#[test]
+fn two_completions_cannot_reconcile_at_once() {
+    let group = top_level_block(&workflow(ALERT), "concurrency");
+    assert!(
+        group.contains("group: red-run-alert") && !group.contains("${{"),
+        "one fixed group, not keyed on the ref or the event — a group per run \
+         serialises nothing:\n{group}"
+    );
+    assert!(
+        group.contains("cancel-in-progress: false"),
+        "the reconciliation already running is the one holding the tracker \
+         mid-decision; cancelling it is what leaves a duplicate:\n{group}"
+    );
+}
+
+/// The lookup's flag surface, which the tests above cannot see: the stub
+/// answers `issue list` whatever follows, so the flags that decide *which*
+/// issues can match are asserted here or nowhere. `--state open` is the one
+/// that carries weight, and dropping it to `--state all` is a silent break
+/// rather than a loud one — a *closed* summons matches the exact title just as
+/// well, so a leg that re-reddens after a green comments on an issue nobody is
+/// watching and never files a fresh one. Reopening is a human's call; from
+/// this script's side a closed summons is not a summons.
+#[test]
+fn the_lookup_asks_only_for_a_summons_that_is_still_open() {
+    let calls = reconcile("lookup_state", "live", "failure", "");
+    let lookup = calls
+        .iter()
+        .find(|call| call.starts_with("issue list"))
+        .expect("the reconciliation starts from what the tracker holds");
+    assert!(
+        lookup.contains("--state open"),
+        "only an open issue can be the standing summons: {lookup}"
+    );
+}
+
+/// The `NAME: value` pairs a job block hands a step. Uppercase-with-underscore
+/// names only, which is unambiguous in a workflow file: every key YAML itself
+/// owns is lowercase or kebab-case, so anything shouting is an environment
+/// variable.
+fn handed_env(jobs: &str) -> Vec<(&str, &str)> {
+    jobs.lines()
+        .filter_map(|line| {
+            let (name, value) = line.trim().split_once(':')?;
+            (!name.is_empty() && name.chars().all(|c| c.is_ascii_uppercase() || c == '_'))
+                .then_some((name, value.trim()))
+        })
+        .collect()
+}
+
+/// Which run each variable describes — the half of the env contract that
+/// comparing key *names* cannot see, and the half where being wrong is
+/// invisible. In a `workflow_run` run the context holds *two* runs: the
+/// watched one, under `github.event.workflow_run`, and the alert's own, under
+/// the bare `github.*` keys. Every variable here has to name the first. The
+/// mistake is one token wide and silent in both directions:
+/// `${{ github.workflow }}` in place of the watched run's `name` is always
+/// `red-run alert`, so both watched legs reconcile against a single summons
+/// titled for the alert itself — which is exactly what
+/// `each_watched_workflow_has_a_summons_of_its_own` says is foreclosed, and it
+/// stays green because that test drives the script with a name the test picked
+/// rather than one the job derived. `html_url` likewise: `url` is the REST
+/// endpoint, so the summons would point a human at JSON.
+///
+/// Asserted as literals, as `tests/devcontainer_prebuild.rs` asserts the
+/// published image tag in both of the files that must agree on it.
+#[test]
+fn every_variable_describes_the_watched_run_and_not_the_alerts_own() {
+    let jobs = top_level_block(&workflow(ALERT), "jobs");
+    let handed = handed_env(&jobs);
+    for (name, expression) in [
+        // `github.token`, not a PAT: the job-scoped `issues: write` above is
+        // the whole permission story, and a secret would route around it.
+        ("GH_TOKEN", "${{ github.token }}"),
+        ("WORKFLOW_NAME", "${{ github.event.workflow_run.name }}"),
+        ("CONCLUSION", "${{ github.event.workflow_run.conclusion }}"),
+        ("RUN_URL", "${{ github.event.workflow_run.html_url }}"),
+        // The one that is legitimately about the alert's own run: the tracker
+        // written to is this repo, which is also where the alert lives.
+        ("REPO", "${{ github.repository }}"),
+    ] {
+        let handed_value = handed
+            .iter()
+            .find(|(key, _)| *key == name)
+            .map(|(_, value)| *value);
+        assert_eq!(
+            handed_value,
+            Some(expression),
+            "the job hands {name} the expression that names the watched run"
+        );
+    }
+}
+
 /// The two halves tested above only meet if the job really invokes the script
 /// and their environment contract holds in both directions: a variable the
 /// script reads but the job never sets is an empty title or a `set -u` abort
@@ -368,6 +534,11 @@ fn each_watched_workflow_has_a_summons_of_its_own() {
 /// script silently stopped honouring. `GH_TOKEN` is the one deliberate
 /// asymmetry — the job hands it for `gh` itself to consume, so no line of the
 /// script names it.
+///
+/// This is the *names*, and names alone; which run each one describes is
+/// `every_variable_describes_the_watched_run_and_not_the_alerts_own` above,
+/// because a set of key names is identical whether the values are right or
+/// point at the alert's own run.
 #[test]
 fn the_job_hands_the_script_exactly_what_it_reads() {
     let jobs = top_level_block(&workflow(ALERT), "jobs");
@@ -389,16 +560,16 @@ fn the_job_hands_the_script_exactly_what_it_reads() {
         );
     }
 
-    let mut handed: Vec<&str> = jobs
-        .lines()
-        .filter_map(|line| {
-            let name = line.trim().split(':').next()?;
-            (!name.is_empty() && name.chars().all(|c| c.is_ascii_uppercase() || c == '_'))
-                .then_some(name)
-        })
+    let mut handed: Vec<&str> = handed_env(&jobs)
+        .into_iter()
+        .map(|(name, _)| name)
         .filter(|name| *name != "GH_TOKEN")
         .collect();
     handed.sort_unstable();
+    // Deduped like `read` below. A job with two steps could legitimately hand
+    // the same variable twice, and without this the comparison fails on the
+    // repeat rather than on anything either side got wrong.
+    handed.dedup();
 
     let script = repo_file(SCRIPT);
     let mut read: Vec<&str> = script


### PR DESCRIPTION
Closes #190. Part of map #182.

## What

Nothing summoned anybody when a non-blocking run went red: `live.yml` (post-merge, asserts the tracker's present contents) and `devlaunch-contract.yml`'s weekly re-solve (the only leg that can discover a new devlaunch release) both depended entirely on a human noticing.

- **`.github/workflows/red-run-alert.yml`** — triggered by `workflow_run: completed` of both workflows, subscribed by their declared names. Reacts only to the runs nothing else stands behind: live runs on `main`, and the contract workflow's scheduled leg (every other contract leg blocks a pull request already). Workflow-level permissions are read-only; `issues: write` sits on the one reconciling job. A single fixed concurrency group serialises reconciliations so two completions cannot race one-issue-per-workflow into two.
- **`.github/scripts/red_run_alert.sh`** — the idempotent half: one open tracking issue per watched workflow (exact-title match), filed on red, commented rather than duplicated while the leg stays red, closed with a pointer to the run that cleared it on the next green, untouched by cancelled runs.
- **`tests/red_run_alert.rs`** — the fifth offline files-as-behavior binary. Half of it holds the workflow text: the `workflow_run` subscription is compared to the watched files' own `name:` fields (the subscription is by display name, which GitHub never validates — a rename would disconnect the alert silently), the write grant stays job-scoped, the guards keep it to the non-blocking legs, and the job's env block is held to exactly match the script's reads in both directions. The other half drives the script for real against a recording `gh` stub and asserts the create-vs-comment-vs-close decisions at the boundary they cross.
- Enrolled in `ci.yml` and AGENTS.md's check chain — an assertion no workflow runs is not an assertion.

## Why a script, not an inline run block

So the reconciliation can be executed under test. The recording-`gh` shim follows the same ethos `tests/live_devlaunch.rs` applies to `devpod`: the real decision code runs, and what is asserted is the calls that crossed the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Automatically track red non-blocking workflow runs with idempotent GitHub issue alerts and guard the integration with offline contract tests.

New Features:
- Add automated issue alerts for red non-blocking live and scheduled workflow runs, with per-workflow tracking issues that are created, updated, and closed as runs change state.

Bug Fixes:
- Ensure failures such as timeouts and startup failures, rather than only ordinary failed conclusions, summon maintainers while cancelled and skipped runs remain neutral.

Enhancements:
- Restrict alerts to trusted runs that are not already covered by pull-request gating and serialize reconciliation to prevent duplicate issues.

CI:
- Run the red-run alert contract and behavior tests in CI and include them in the documented verification chain.

Documentation:
- Document the additional offline workflow-behavior test in AGENTS.md.

Tests:
- Add offline tests covering workflow subscriptions, permissions, run guards, environment wiring, concurrency, and issue reconciliation behavior.