### PR TITLE
Highlighting and widths survive non-ASCII titles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,7 @@ tokio = { version = "1", features = [
 # nucleo's own dependency): the filter has to segment identically to map the
 # grapheme indices nucleo reports back onto the chars the screen underlines by.
 unicode-segmentation = "1"
+# The same table ratatui measures spans with (it is ratatui's own dependency):
+# the modules that fit text to a column budget are not UI modules and must not
+# reach for a `Span` to ask how wide a string is. See `cols`.
+unicode-width = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,7 @@ tokio = { version = "1", features = [
     "sync",
     "time",
 ] }
+# The same grapheme walk nucleo-matcher builds its haystacks with (it is
+# nucleo's own dependency): the filter has to segment identically to map the
+# grapheme indices nucleo reports back onto the chars the screen underlines by.
+unicode-segmentation = "1"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -23,6 +23,7 @@ use std::fmt;
 
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::model::{Map, Ticket};
 
@@ -64,6 +65,14 @@ fn haystack(ticket: &Ticket) -> String {
 ///
 /// A pattern of nothing but negations (`!bread`) lands on no characters at all,
 /// and vacuously passes: there is nothing there to be loose about.
+///
+/// Judged in *grapheme* space: `chars` is one codepoint per grapheme — the
+/// haystack exactly as nucleo matched it — and `indices` are nucleo's own.
+/// That is deliberate rather than incidental: judged against the raw chars, a
+/// decomposed accent (a combining mark is not alphanumeric) would open a word
+/// start in the middle of "naïve", and the loose match this rule exists to
+/// refuse would be back for exactly the titles this module was just taught to
+/// survive.
 fn tight(chars: &[char], indices: &[u32]) -> bool {
     let matched = |i: usize| indices.binary_search(&(i as u32)).is_ok();
     indices.iter().all(|&i| {
@@ -144,28 +153,70 @@ impl Query {
     /// project list that matched loosely would be the second matching
     /// vocabulary this rule exists to prevent.
     pub fn text(&mut self, text: &str) -> Option<(u32, Vec<usize>)> {
-        let (score, indices) = self.matched(text)?;
-        Some((score, indices.into_iter().map(|i| i as usize).collect()))
+        self.matched(text)
     }
 
-    /// The pattern against one haystack: the score and the char indices it
+    /// The pattern against one haystack: the score and the *char* indices it
     /// landed on, sorted, unique and tight — or `None`. The one place a match
     /// is decided, so [`Query::hit`] and [`Query::text`] cannot come to differ
-    /// about what counts as one.
-    fn matched(&mut self, hay: &str) -> Option<(u32, Vec<u32>)> {
+    /// about what counts as one — and the one boundary where nucleo's indices
+    /// are translated into the screen's, so nowhere else has to know they were
+    /// ever anything but char indices.
+    ///
+    /// Nucleo matches one codepoint per grapheme (its `Utf32Str::new` keeps
+    /// only the first), so the indices it reports are *grapheme* indices. The
+    /// haystack is segmented here rather than by `Utf32Str::new` for a second
+    /// reason: that constructor falls back to matching the raw *bytes*
+    /// whenever every grapheme's first codepoint is ASCII — a decomposed
+    /// accent takes exactly that path — and byte indices past the accent point
+    /// past the end of the chars they are supposed to name, which was an
+    /// out-of-bounds panic in the tightness check, not merely a skewed
+    /// underline.
+    fn matched(&mut self, hay: &str) -> Option<(u32, Vec<usize>)> {
+        self.buf.clear();
+        self.buf.extend(
+            hay.graphemes(true)
+                .map(|g| g.chars().next().expect("graphemes are non-empty")),
+        );
+        // The ASCII arm is nucleo's fast path, taken on nucleo's own terms: an
+        // ASCII haystack segments to itself, so both arms match the same text.
+        let utf32 = if hay.is_ascii() {
+            Utf32Str::Ascii(hay.as_bytes())
+        } else {
+            Utf32Str::Unicode(&self.buf)
+        };
         let mut indices = Vec::new();
-        let score = self.pattern.indices(
-            Utf32Str::new(hay, &mut self.buf),
-            &mut self.matcher,
-            &mut indices,
-        )?;
+        let score = self.pattern.indices(utf32, &mut self.matcher, &mut indices)?;
         // Nucleo makes no promise about order and can repeat an index across
         // atoms of a multi-atom pattern; both the tightness rule and the screen
         // walk these in step with the characters, so they have to be sorted and
         // unique before either does.
         indices.sort_unstable();
         indices.dedup();
-        tight(&hay.chars().collect::<Vec<char>>(), &indices).then_some((score, indices))
+        if !tight(&self.buf, &indices) {
+            return None;
+        }
+        // Grapheme indices → char indices, walking the graphemes once. A
+        // matched grapheme lights every char it spans — an underline over half
+        // a flag emoji is not a thing the screen can draw — and everything
+        // after a multi-codepoint grapheme lands where the chars actually are.
+        let lit = if hay.is_ascii() {
+            indices.into_iter().map(|i| i as usize).collect()
+        } else {
+            let mut lit = Vec::with_capacity(indices.len());
+            let mut matched = indices.into_iter().peekable();
+            let mut char_at = 0;
+            for (g, grapheme) in hay.graphemes(true).enumerate() {
+                let len = grapheme.chars().count();
+                if matched.peek() == Some(&(g as u32)) {
+                    matched.next();
+                    lit.extend(char_at..char_at + len);
+                }
+                char_at += len;
+            }
+            lit
+        };
+        Some((score, lit))
     }
 
     /// The match, with the characters it landed on — and `None` when it landed
@@ -179,7 +230,7 @@ impl Query {
             score,
             ..Hit::default()
         };
-        for i in indices.into_iter().map(|i| i as usize) {
+        for i in indices {
             if i < repo_len {
                 hit.in_repo.push(i);
             } else if i > repo_len {
@@ -351,6 +402,55 @@ mod tests {
             (
                 "«w»«a»«y»«f»inder".to_string(),
                 "#«6» Re-entry breadcrumbs".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn a_multi_codepoint_grapheme_does_not_skew_the_highlights_after_it() {
+        // Nucleo hands back *grapheme* indices (its haystack keeps one
+        // codepoint per grapheme), while the screen underlines by char. A flag
+        // emoji is two codepoints in one grapheme, so before the conversion
+        // every index after it landed one char early — here, on the space and
+        // five letters instead of on "Launch".
+        let t = ticket("blooop/wayfinder", 6, "🇺🇸 Launch review");
+        assert_eq!(
+            landed(&t, "launch"),
+            (
+                "wayfinder".to_string(),
+                "#6 🇺🇸 «L»«a»«u»«n»«c»«h» review".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn a_matched_grapheme_is_lit_whole() {
+        // A grapheme matches as one unit, so it lights as one glyph: every
+        // char it spans is lit, or the screen would underline half a flag.
+        let t = ticket("blooop/wayfinder", 6, "🇺🇸 Launch review");
+        assert_eq!(
+            landed(&t, "🇺🇸"),
+            (
+                "wayfinder".to_string(),
+                "#6 «🇺»«🇸» Launch review".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn a_decomposed_accent_neither_panics_nor_shifts_the_marks() {
+        // The sharpest corner of the conversion: when every grapheme's *first*
+        // codepoint is ASCII (a decomposed accent), nucleo's own constructor
+        // falls back to matching the raw bytes, and byte indices past the
+        // accent point past the end of the chars they are supposed to name —
+        // an out-of-bounds panic in the tightness check, not just a skewed
+        // underline. Building the haystack ourselves keeps it off that path.
+        let t = ticket("blooop/wayfinder", 6, "Cafe\u{301} menu");
+        assert_eq!(
+            landed(&t, "menu"),
+            (
+                "wayfinder".to_string(),
+                "#6 Cafe\u{301} «m»«e»«n»«u»".to_string()
             )
         );
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -66,13 +66,14 @@ fn haystack(ticket: &Ticket) -> String {
 /// A pattern of nothing but negations (`!bread`) lands on no characters at all,
 /// and vacuously passes: there is nothing there to be loose about.
 ///
-/// Judged in *grapheme* space: `chars` is one codepoint per grapheme — the
-/// haystack exactly as nucleo matched it — and `indices` are nucleo's own.
-/// That is deliberate rather than incidental: judged against the raw chars, a
-/// decomposed accent (a combining mark is not alphanumeric) would open a word
-/// start in the middle of "naïve", and the loose match this rule exists to
-/// refuse would be back for exactly the titles this module was just taught to
-/// survive.
+/// Judged in nucleo's own index space: `indices` are nucleo's, and `chars` is
+/// the haystack as nucleo indexed it — which [`Query::matched`] guarantees and
+/// is the only thing this rule needs to be true. For a non-ASCII haystack that
+/// is one codepoint per grapheme, deliberately rather than incidentally:
+/// judged against the raw chars, a decomposed accent (a combining mark is not
+/// alphanumeric) would open a word start in the middle of "naïve", and the
+/// loose match this rule exists to refuse would be back for exactly the titles
+/// this module was just taught to survive.
 fn tight(chars: &[char], indices: &[u32]) -> bool {
     let matched = |i: usize| indices.binary_search(&(i as u32)).is_ok();
     indices.iter().all(|&i| {
@@ -164,23 +165,38 @@ impl Query {
     /// ever anything but char indices.
     ///
     /// Nucleo matches one codepoint per grapheme (its `Utf32Str::new` keeps
-    /// only the first), so the indices it reports are *grapheme* indices. The
-    /// haystack is segmented here rather than by `Utf32Str::new` for a second
-    /// reason: that constructor falls back to matching the raw *bytes*
-    /// whenever every grapheme's first codepoint is ASCII — a decomposed
-    /// accent takes exactly that path — and byte indices past the accent point
-    /// past the end of the chars they are supposed to name, which was an
-    /// out-of-bounds panic in the tightness check, not merely a skewed
-    /// underline.
+    /// only the first), so the indices it reports are *grapheme* indices — and
+    /// `Utf32Str` is where that index space is chosen, so `buf` is filled to
+    /// suit whichever arm is taken rather than to one shape for both. That
+    /// pairing is the whole of the invariant this function keeps: `buf` is
+    /// indexed by exactly the numbers nucleo hands back, which is what lets
+    /// `tight` read it and the translation below walk it.
+    ///
+    /// Neither arm may be left to `Utf32Str::new`, and the two fail in
+    /// opposite directions. It returns `Ascii(str.as_bytes())` whenever every
+    /// grapheme's *first* codepoint is ASCII, so a decomposed accent is
+    /// reported in *byte* indices, which run past the end of the graphemes
+    /// they are supposed to name. And `\r\n` is one grapheme of two bytes, so
+    /// an all-ASCII haystack carrying a CRLF — titles arrive from GitHub raw —
+    /// segments *shorter* than the bytes nucleo indexes it by: the same
+    /// overrun from the other side. Choosing the arm here, and filling `buf`
+    /// in the same breath, is what closes both.
     fn matched(&mut self, hay: &str) -> Option<(u32, Vec<usize>)> {
+        // ASCII is nucleo's fast path and the dominant one — `buf` is rebuilt
+        // per row, per frame — so it skips the grapheme walk entirely: for an
+        // ASCII haystack a byte index *is* a char index, and the chars are
+        // exactly the buffer those indices have to name.
+        let ascii = hay.is_ascii();
         self.buf.clear();
-        self.buf.extend(
-            hay.graphemes(true)
-                .map(|g| g.chars().next().expect("graphemes are non-empty")),
-        );
-        // The ASCII arm is nucleo's fast path, taken on nucleo's own terms: an
-        // ASCII haystack segments to itself, so both arms match the same text.
-        let utf32 = if hay.is_ascii() {
+        if ascii {
+            self.buf.extend(hay.chars());
+        } else {
+            self.buf.extend(
+                hay.graphemes(true)
+                    .map(|g| g.chars().next().expect("graphemes are non-empty")),
+            );
+        }
+        let utf32 = if ascii {
             Utf32Str::Ascii(hay.as_bytes())
         } else {
             Utf32Str::Unicode(&self.buf)
@@ -202,7 +218,7 @@ impl Query {
         // matched grapheme lights every char it spans — an underline over half
         // a flag emoji is not a thing the screen can draw — and everything
         // after a multi-codepoint grapheme lands where the chars actually are.
-        let lit = if hay.is_ascii() {
+        let lit = if ascii {
             indices.into_iter().map(|i| i as usize).collect()
         } else {
             let mut lit = Vec::with_capacity(indices.len());
@@ -454,6 +470,23 @@ mod tests {
                 "wayfinder".to_string(),
                 "#6 Cafe\u{301} «m»«e»«n»«u»".to_string()
             )
+        );
+    }
+
+    #[test]
+    fn an_ascii_title_holding_a_crlf_neither_panics_nor_shifts_the_marks() {
+        // The mirror of the accent case, and the reason the haystack is only
+        // segmented when it needs to be: `\r\n` is *one* grapheme and *two*
+        // bytes, so an all-ASCII title carrying one segments shorter than it
+        // measures. Nucleo takes its byte-indexed fast path on any ASCII
+        // haystack, and those indices ran off the end of a grapheme-segmented
+        // slice — the same out-of-bounds the accent case fixed, from the other
+        // side. Titles arrive from GitHub raw, so a CRLF is arbitrary text
+        // like any other.
+        let t = ticket("blooop/wayfinder", 6, "a\r\nzz");
+        assert_eq!(
+            landed(&t, "zz"),
+            ("wayfinder".to_string(), "#6 a\r\n«z»«z»".to_string())
         );
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -186,7 +186,9 @@ impl Query {
             Utf32Str::Unicode(&self.buf)
         };
         let mut indices = Vec::new();
-        let score = self.pattern.indices(utf32, &mut self.matcher, &mut indices)?;
+        let score = self
+            .pattern
+            .indices(utf32, &mut self.matcher, &mut indices)?;
         // Nucleo makes no promise about order and can repeat an index across
         // atoms of a multi-atom pattern; both the tightness rule and the screen
         // walk these in step with the characters, so they have to be sorted and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,24 @@ pub fn emit(text: &str) {
     let _ = std::io::stdout().write_all(text.as_bytes());
 }
 
+/// How many terminal columns `text` occupies.
+///
+/// The one metric anything sizing itself against the screen may use. A count
+/// of chars is not it and never was: a CJK or emoji char is one char and two
+/// columns, so a char count hands a neighbouring segment columns the line does
+/// not have and something falls off the right edge. Titles and repo names come
+/// from GitHub, so this is arbitrary text and the difference is not exotic.
+///
+/// Here, beside [`emit`], for the same reason: the budget is *decided* in
+/// `ui`, but the segments that fit themselves to it live in [`liveness`] and
+/// [`reclaim`], which are not UI modules and must not reach for a ratatui
+/// `Span` to ask how wide a string is. One function, so a measurement and the
+/// render it is a prediction of cannot come to disagree — this is exactly the
+/// same table ratatui itself measures with.
+pub fn cols(text: &str) -> usize {
+    unicode_width::UnicodeWidthStr::width(text)
+}
+
 pub mod app;
 pub mod fetch;
 pub mod filter;

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -194,6 +194,12 @@ impl Liveness {
     /// somebody to press enter in a list is spending the scarcest characters on
     /// the line saying nothing.
     ///
+    /// `width` is columns of terminal, not characters — [`cols`](crate::cols)
+    /// is what the ladder below measures with. A node's name is
+    /// `short_repo#number` and the repo half comes from GitHub, so a name two
+    /// columns to the char is ordinary input, and counting its chars would
+    /// hand the reclaim note columns this segment had already spent.
+    ///
     /// The width is a budget, and this segment is laid down before the reclaim
     /// note — so on a narrowing line the reap pointer and the warned aside go
     /// while stalls are still naming nodes. Deliberate, and the one trade in
@@ -219,11 +225,11 @@ impl Liveness {
                 format!(", +{rest} more")
             };
             let line = format!("{head}: {}{more}", names[..count].join(", "));
-            if line.chars().count() <= width {
+            if crate::cols(&line) <= width {
                 return line;
             }
         }
-        if head.chars().count() <= width {
+        if crate::cols(&head) <= width {
             return head;
         }
         String::new()
@@ -462,6 +468,28 @@ mod tests {
             "· 3 stalled",
             "the count survives after the names are gone"
         );
+    }
+
+    /// The same ladder against a wide name. The number the caller hands down is
+    /// columns of terminal — it is what the count line has left — so a repo
+    /// name whose chars are two columns wide spends twice what it was given,
+    /// and the reclaim note beside it is what loses the difference: two of
+    /// these plus a reclaimable set rendered `· 2 stalled: ..., +1 more · 2
+    /// recla`, the fragment the count line's own test exists to forbid.
+    #[test]
+    fn the_budget_is_columns_of_terminal_even_when_a_stalled_name_is_wide() {
+        let live = Liveness::for_test(
+            &[],
+            &[("blooop/测试仓库仓库", 9), ("blooop/测试仓库仓库", 14)],
+        );
+        for width in 0..60 {
+            let hint = live.hint(width);
+            assert!(
+                crate::cols(&hint) <= width,
+                "width {width} produced {} columns: {hint:?}",
+                crate::cols(&hint)
+            );
+        }
     }
 
     #[test]

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -70,16 +70,37 @@ const POINTER: &str = " — wf reap";
 /// tells two workspaces of one project apart. The tail therefore gets the odd
 /// character when the budget is odd.
 fn abbreviate(id: &str, max: usize) -> String {
-    let len = id.chars().count();
-    if len <= max {
+    if crate::cols(id) <= max {
         return id.to_string();
     }
     let keep = max.saturating_sub(1);
     let tail = keep.div_ceil(2);
-    let head = keep - tail;
-    let front: String = id.chars().take(head).collect();
-    let back: String = id.chars().skip(len - tail).collect();
+    let front = clip(id.chars(), keep - tail);
+    // Taken from the back, then put back in reading order.
+    let back: String = clip(id.chars().rev(), tail).chars().rev().collect();
     format!("{front}…{back}")
+}
+
+/// As much of `chars` as fits `budget` columns, in the order given.
+///
+/// Columns and not chars, because the only budget in this module is a line's
+/// leftover width: a wide char that only half fits is a char that does not
+/// fit, and a slice taken by count is one that overruns the segments beside
+/// it. Stopping a column short of an odd budget is the right answer — there is
+/// no half-column to spend it on.
+fn clip(chars: impl Iterator<Item = char>, budget: usize) -> String {
+    let mut buf = [0u8; 4];
+    let mut out = String::new();
+    let mut spent = 0;
+    for ch in chars {
+        let width = crate::cols(ch.encode_utf8(&mut buf));
+        if spent + width > budget {
+            break;
+        }
+        spent += width;
+        out.push(ch);
+    }
+    out
 }
 
 /// What a reap would claim, ready to say on one line.
@@ -155,11 +176,14 @@ impl Reclaimable {
     /// much yielding is enough. Below it the reader gets `· 2 reclaima`, which
     /// is not a word.
     pub fn min_width(&self) -> usize {
-        format!("· {} reclaimable", self.ids.len()).chars().count()
+        crate::cols(&format!("· {} reclaimable", self.ids.len()))
     }
 
-    /// The count-line segment, in `width` characters: how many, which ones,
-    /// and what to type.
+    /// The count-line segment, in `width` columns of terminal: how many, which
+    /// ones, and what to type. Columns rather than characters throughout —
+    /// [`cols`](crate::cols) is the only metric in here — because a workspace
+    /// id is whatever `dl` listed and this segment goes last on a shared line,
+    /// so its overrun is the one that falls off the right edge.
     ///
     /// The warned count is a parenthesised aside so the leading number cannot
     /// be read as including it — the whole point of the `Warn` arm is that
@@ -200,7 +224,7 @@ impl Reclaimable {
             0 => String::new(),
             n => format!(" (+{n} to check by hand)"),
         };
-        let fixed = head.chars().count() + aside.chars().count() + POINTER.chars().count();
+        let fixed = crate::cols(&head) + crate::cols(&aside) + crate::cols(POINTER);
         // ": " is the cost of naming anything at all.
         let room = width.saturating_sub(fixed + 2);
         let say = |names: &str| format!("{head}: {names}{aside}{POINTER}");
@@ -212,7 +236,7 @@ impl Reclaimable {
                 spelt.push(format!("+{} more", self.ids.len() - count));
             }
             let names = spelt.join(", ");
-            if names.chars().count() <= room {
+            if crate::cols(&names) <= room {
                 return say(&names);
             }
         }
@@ -223,7 +247,7 @@ impl Reclaimable {
             1 => String::new(),
             n => format!(", +{} more", n - 1),
         };
-        let left = room.saturating_sub(rest.chars().count());
+        let left = room.saturating_sub(crate::cols(&rest));
         if left >= READABLE {
             return say(&format!("{}{rest}", abbreviate(&self.ids[0], left)));
         }
@@ -235,11 +259,11 @@ impl Reclaimable {
         // *neighbouring* segments of the count line.
         for tail in [format!("{aside}{POINTER}"), POINTER.to_string()] {
             let line = format!("{head}{tail}");
-            if line.chars().count() <= width {
+            if crate::cols(&line) <= width {
                 return line;
             }
         }
-        head.chars().take(width).collect()
+        clip(head.chars(), width)
     }
 }
 
@@ -671,10 +695,10 @@ mod tests {
                 for width in 0..=140 {
                     let hint = found.hint(width);
                     assert!(
-                        hint.chars().count() <= width,
+                        crate::cols(&hint) <= width,
                         "{count} ids, {warned} warned, width {width}: {hint:?} is \
-                         {} characters",
-                        hint.chars().count()
+                         {} columns",
+                        crate::cols(&hint)
                     );
                 }
             }
@@ -704,7 +728,27 @@ mod tests {
         assert_eq!(abbreviate("devlaunch-wayfinder-127", 12), "devla…er-127");
         for max in 2..30 {
             let out = abbreviate("devlaunch-github-com-blooop-wayfinder-127", max);
-            assert_eq!(out.chars().count(), max, "{max}: {out}");
+            assert_eq!(crate::cols(&out), max, "{max}: {out}");
+        }
+    }
+
+    /// `max` is columns, because the only caller is spending a line's leftover
+    /// width. A wide char is one char and two columns, so a name fitted by
+    /// counting chars is a name that overruns — and this segment goes last on
+    /// the count line, so its overrun is the one that falls off the edge. The
+    /// budget is never overspent, and each end gives up at most one column —
+    /// a two-column char cannot half-fill the last column of an odd split, and
+    /// stopping a column short is right where spilling over is not.
+    #[test]
+    fn abbreviating_spends_the_budget_in_columns_not_characters() {
+        let id = "工作区-github-com-blooop-测试仓库-127";
+        for max in 2..30 {
+            let out = abbreviate(id, max);
+            assert!(crate::cols(&out) <= max, "{max}: {out:?} overruns");
+            assert!(
+                crate::cols(&out) + 2 >= max,
+                "{max}: {out:?} gives up more than the two ends can waste"
+            );
         }
     }
 

--- a/src/reclaim.rs
+++ b/src/reclaim.rs
@@ -63,12 +63,12 @@ const READABLE: usize = 8;
 /// gets clipped: the names are budgeted around them.
 const POINTER: &str = " — wf reap";
 
-/// One id, shortened in the middle to `max` characters if it is longer.
+/// One id, shortened in the middle to `max` columns if it is wider.
 ///
 /// Both ends survive because both carry meaning: `dl` puts the tool and the
 /// repo at the front and the ticket number at the back, and the number is what
 /// tells two workspaces of one project apart. The tail therefore gets the odd
-/// character when the budget is odd.
+/// column when the budget is odd.
 fn abbreviate(id: &str, max: usize) -> String {
     if crate::cols(id) <= max {
         return id.to_string();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1005,10 +1005,8 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     // as one char occupies two columns, so a char count hands the reclaim note
     // columns the line does not have and the tail falls off the right edge.
     let cols = |text: &str| Span::raw(text).width();
-    let spent = cols(&counts)
-        + 2
-        + parts.iter().map(|part| cols(part) + 1).sum::<usize>()
-        + cols(&notice);
+    let spent =
+        cols(&counts) + 2 + parts.iter().map(|part| cols(part) + 1).sum::<usize>() + cols(&notice);
     let mut left = (count_area.width as usize).saturating_sub(spent);
     // Stalls are laid down before the reclaim note, but not at any price: what
     // is held back for the reclaim note is exactly the width at which it stops

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -999,13 +999,16 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     // workspace id is ~40 characters and there can be three of them. It goes
     // last and takes what the rest of the line has left, which is why the rest
     // of the line is measured first.
-    let spent = counts.chars().count()
+    // Everything is measured in display columns — `Span::raw(..).width()`, the
+    // metric ratatui renders in — never chars: the notice and the stall names
+    // carry ticket titles, which are arbitrary text, and a CJK char measured
+    // as one char occupies two columns, so a char count hands the reclaim note
+    // columns the line does not have and the tail falls off the right edge.
+    let cols = |text: &str| Span::raw(text).width();
+    let spent = cols(&counts)
         + 2
-        + parts
-            .iter()
-            .map(|part| part.chars().count() + 1)
-            .sum::<usize>()
-        + notice.chars().count();
+        + parts.iter().map(|part| cols(part) + 1).sum::<usize>()
+        + cols(&notice);
     let mut left = (count_area.width as usize).saturating_sub(spent);
     // Stalls are laid down before the reclaim note, but not at any price: what
     // is held back for the reclaim note is exactly the width at which it stops
@@ -1025,7 +1028,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
         .map_or(0, |found| found.min_width() + 1);
     let stalled = app.liveness.hint(left.saturating_sub(reserved));
     if !stalled.is_empty() {
-        left = left.saturating_sub(stalled.chars().count() + 1);
+        left = left.saturating_sub(cols(&stalled) + 1);
         parts.push(stalled);
     }
     let note = reclaim_note(app, left);
@@ -1686,6 +1689,43 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn a_wide_notice_is_not_clipped_by_the_reclaim_note_beside_it() {
+        // The reclaim note takes whatever the rest of the line has not spent —
+        // so everything else has to be measured in the columns it will
+        // actually occupy. The notice (which carries ticket titles, arbitrary
+        // text) was measured in chars: a CJK notice under-measured by half,
+        // the note was handed columns the notice needed, and the line's tail —
+        // the notice itself — fell off the right edge.
+        let notice = "已经在隔离容器里启动了交互式会话";
+        let mut app = fixture_app();
+        app.notice = Some(notice.to_string());
+        app.reclaimable = Some(Reclaimable::for_test(
+            &[
+                "devlaunch-github-com-blooop-wayfinder-129",
+                "devlaunch-github-com-blooop-wayfinder-127",
+            ],
+            0,
+        ));
+        let drawn: String = notice
+            .chars()
+            .map(|c| format!("{c} "))
+            .collect::<String>()
+            .trim_end()
+            .to_string();
+        for width in [100u16, 120] {
+            let screen = render_at(width, &app);
+            let line = screen
+                .lines()
+                .find(|line| line.contains("reclaimable"))
+                .unwrap_or_else(|| panic!("{width}: no count line: {screen}"));
+            assert!(
+                line.contains(&drawn),
+                "{width}: the notice lost its tail to the reclaim note: {line}"
+            );
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -737,23 +737,23 @@ fn now_secs() -> u64 {
         .map_or(0, |d| d.as_secs())
 }
 
-/// A centered box `width`×`height` (clamped) inside `area`.
 /// A popup's outer width: the widest body row or the border title, whichever
 /// is wider, plus the frame around them. Both are measured in *display
-/// columns* — the same metric ratatui renders in — because GitHub titles are
-/// arbitrary text and a CJK or emoji title is one char, two columns: measured
-/// in chars (or worse, bytes) the border clipped its own title. This is the
-/// one place a popup is measured, so the two pickers cannot drift back onto
-/// two conventions.
+/// columns* — [`cols`](crate::cols) for the title, and `Line::width` for a
+/// row, which is the same table summed over the row's spans — because GitHub
+/// titles are arbitrary text and a CJK or emoji title is one char, two
+/// columns: measured in chars (or worse, bytes) the border clipped its own
+/// title. This is the one place a popup is measured, so the two pickers cannot
+/// drift back onto two conventions.
+///
+/// A popup with no body rows is as wide as its title, which is why there is no
+/// fallback width: the title is always there to fall back *to*.
 fn popup_width(lines: &[Line<'_>], title: &str) -> u16 {
-    lines
-        .iter()
-        .map(|l| l.width() as u16 + 4)
-        .chain(std::iter::once(Span::raw(title).width() as u16 + 4))
-        .max()
-        .unwrap_or(40)
+    let body = lines.iter().map(|l| l.width() as u16).max().unwrap_or(0);
+    body.max(crate::cols(title) as u16) + 4
 }
 
+/// A centered box `width`×`height` (clamped) inside `area`.
 fn centered(area: Rect, width: u16, height: u16) -> Rect {
     let [area] = Layout::horizontal([Constraint::Length(width.min(area.width))])
         .flex(Flex::Center)
@@ -999,12 +999,18 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     // workspace id is ~40 characters and there can be three of them. It goes
     // last and takes what the rest of the line has left, which is why the rest
     // of the line is measured first.
-    // Everything is measured in display columns — `Span::raw(..).width()`, the
-    // metric ratatui renders in — never chars: the notice and the stall names
-    // carry ticket titles, which are arbitrary text, and a CJK char measured
-    // as one char occupies two columns, so a char count hands the reclaim note
-    // columns the line does not have and the tail falls off the right edge.
-    let cols = |text: &str| Span::raw(text).width();
+    // Every width on this line is display columns — `crate::cols`, the same
+    // table ratatui renders with — never chars: a CJK char is one char and two
+    // columns, so a char count hands the reclaim note columns the line does
+    // not have and the tail falls off the right edge. The notice carries
+    // ticket titles, a stall name carries a repo name, and a reclaim id is
+    // whatever `dl` listed — all of it arbitrary text.
+    //
+    // The convention does not stop at this arithmetic: the two segments that
+    // *fit themselves* to what is left — `Liveness::hint` and
+    // `Reclaimable::hint` — measure in the same columns, which is why the
+    // budgets handed to them below mean what they say.
+    let cols = crate::cols;
     let spent =
         cols(&counts) + 2 + parts.iter().map(|part| cols(part) + 1).sum::<usize>() + cols(&notice);
     let mut left = (count_area.width as usize).saturating_sub(spent);
@@ -1694,6 +1700,41 @@ mod tests {
                     assert!(
                         !inner.trim_end().ends_with(fragment),
                         "{width}: {whole:?} was clipped to {fragment:?}: {:?}",
+                        inner.trim_end()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_wide_stalled_name_does_not_clip_the_reclaim_note_beside_it() {
+        // The same claim as the fragment test above, against a repo name whose
+        // chars are two columns each. Stall names are laid down before the
+        // reclaim note and spend from the same budget, so a name measured in
+        // chars spends twice what it was given and the note pays: two of these
+        // plus a reclaimable set rendered `· 2 stalled: 测试仓库仓库#9, +1
+        // more · 2 recla`. Repo names come from GitHub, so this is input and
+        // not a hypothetical.
+        let mut app = fixture_app();
+        app.liveness = crate::liveness::Liveness::for_test(
+            &[],
+            &[("blooop/测试仓库仓库", 9), ("blooop/测试仓库仓库", 14)],
+        );
+        app.reclaimable = Some(Reclaimable::for_test(
+            &["devlaunch-github-blooop-wayfinder-127-ladepomi", "wf-80-x"],
+            1,
+        ));
+        for width in 40..=130u16 {
+            let screen = render_at(width, &app);
+            let line = screen.lines().nth(2).expect("a count line");
+            let inner: String = line.chars().skip(1).take(width as usize - 2).collect();
+            for whole in ["reclaimable", "stalled"] {
+                for cut in 1..whole.len() {
+                    assert!(
+                        !inner.trim_end().ends_with(&whole[..cut]),
+                        "{width}: {whole:?} was clipped to {:?}: {:?}",
+                        &whole[..cut],
                         inner.trim_end()
                     );
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1152,6 +1152,17 @@ mod tests {
         out
     }
 
+    /// How the buffer dump spells a wide string: each wide char reads back
+    /// with its continuation cell, so the chars come out space-separated.
+    fn wide(text: &str) -> String {
+        let mut out = String::new();
+        for c in text.chars() {
+            out.push(c);
+            out.push(' ');
+        }
+        out.trim_end().to_string()
+    }
+
     /// The fixture app, with a conversation left on `number`.
     fn app_resuming(number: u64) -> App {
         fixture_app().with_sessions(vec![crate::projects::Session::new(
@@ -1708,12 +1719,7 @@ mod tests {
             ],
             0,
         ));
-        let drawn: String = notice
-            .chars()
-            .map(|c| format!("{c} "))
-            .collect::<String>()
-            .trim_end()
-            .to_string();
+        let drawn = wide(notice);
         for width in [100u16, 120] {
             let screen = render_at(width, &app);
             let line = screen
@@ -2324,14 +2330,7 @@ mod tests {
             .lines()
             .find(|line| line.contains("launch Claude"))
             .unwrap_or_else(|| panic!("no picker title: {screen}"));
-        // The buffer dump spells a wide char as the char plus its continuation
-        // cell, so the whole title reads back space-separated.
-        let drawn: String = title
-            .chars()
-            .map(|c| format!("{c} "))
-            .collect::<String>()
-            .trim_end()
-            .to_string();
+        let drawn = wide(title);
         assert!(
             line.contains(&drawn),
             "the title is clipped by its own popup: {line}"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -738,6 +738,22 @@ fn now_secs() -> u64 {
 }
 
 /// A centered box `width`×`height` (clamped) inside `area`.
+/// A popup's outer width: the widest body row or the border title, whichever
+/// is wider, plus the frame around them. Both are measured in *display
+/// columns* — the same metric ratatui renders in — because GitHub titles are
+/// arbitrary text and a CJK or emoji title is one char, two columns: measured
+/// in chars (or worse, bytes) the border clipped its own title. This is the
+/// one place a popup is measured, so the two pickers cannot drift back onto
+/// two conventions.
+fn popup_width(lines: &[Line<'_>], title: &str) -> u16 {
+    lines
+        .iter()
+        .map(|l| l.width() as u16 + 4)
+        .chain(std::iter::once(Span::raw(title).width() as u16 + 4))
+        .max()
+        .unwrap_or(40)
+}
+
 fn centered(area: Rect, width: u16, height: u16) -> Rect {
     let [area] = Layout::horizontal([Constraint::Length(width.min(area.width))])
         .flex(Flex::Center)
@@ -833,12 +849,7 @@ fn draw_launch_picker(
         staged.title()
     );
     let title = title.trim_end().to_string() + " ";
-    let width = lines
-        .iter()
-        .map(|l| l.width() as u16 + 4)
-        .chain(std::iter::once(title.chars().count() as u16 + 4))
-        .max()
-        .unwrap_or(40);
+    let width = popup_width(&lines, &title);
     let area = centered(frame.area(), width, lines.len() as u16 + 2);
     frame.render_widget(Clear, area);
     frame.render_widget(
@@ -903,18 +914,14 @@ fn draw_checkout_picker(frame: &mut Frame<'_>, launches: &[Launch], cursor: usiz
     // This asks *which checkout*, so the ticket only needs identifying — its
     // title is already on the row behind the prompt.
     let key = launches.first().map(Launch::key).unwrap_or_default();
-    let width = lines
-        .iter()
-        .map(|l| l.width() as u16 + 4)
-        .chain(std::iter::once(key.len() as u16 + 30))
-        .max()
-        .unwrap_or(40);
+    let title = format!(" which checkout runs {key}? ");
+    let width = popup_width(&lines, &title);
     let area = centered(frame.area(), width, lines.len() as u16 + 2);
     frame.render_widget(Clear, area);
     frame.render_widget(
         Paragraph::new(lines).block(
             Block::bordered()
-                .title(format!(" which checkout runs {key}? "))
+                .title(title)
                 .border_style(Style::new().fg(Color::Cyan)),
         ),
         area,
@@ -2175,6 +2182,42 @@ mod tests {
     }
 
     #[test]
+    fn the_checkout_picker_title_survives_a_non_ascii_key() {
+        // The checkout picker's width once measured the key in *bytes* plus a
+        // magic margin — a third convention beside display columns and char
+        // counts, which happened never to clip only because bytes over-count
+        // every wide char. It measures the actual title in display columns
+        // now, like every other popup; this pins that a non-ASCII key renders
+        // whole so no cheaper metric can come back.
+        let repo = "blooop/测试仓库";
+        let mut map = wf_map();
+        for t in &mut map.tickets {
+            t.repo = repo.to_string();
+        }
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new(repo, 1), map);
+        let mut app = app_on(repo, clusters).with_checkouts(vec![
+            crate::projects::Checkout::new(
+                std::path::PathBuf::from("/data/k1/repo"),
+                repo.to_string(),
+            ),
+            crate::projects::Checkout::new(
+                std::path::PathBuf::from("/data/k2/repo"),
+                repo.to_string(),
+            ),
+        ]);
+        down(&mut app, 2); // past the project row and the cluster header
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // stage
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)); // resolve
+        let screen = render_at(120, &app);
+        // Wide chars read back from the buffer with their continuation cells.
+        assert!(
+            screen.contains("which checkout runs 测 试 仓 库 #6?"),
+            "{screen}"
+        );
+    }
+
+    #[test]
     fn a_project_picker_draws_the_creation_rows_with_their_own_skills() {
         // Creation is an act on a repo, so the rows live on the one stop that
         // is a repo — and every row still names the skill it execs, including
@@ -2222,6 +2265,39 @@ mod tests {
                 mode.label()
             );
         }
+    }
+
+    #[test]
+    fn a_cjk_title_widens_the_picker_to_what_it_actually_displays() {
+        // GitHub titles are arbitrary text, and a CJK char is one char but two
+        // columns. The popup width was taking `chars().count()` for the title
+        // while measuring its body rows in display columns — so a CJK-heavy
+        // title under-measured by half and the border clipped its tail.
+        let title = "弹窗标题宽度必须按显示宽度而不是字符数来测量才能容纳";
+        let mut map = wf_map();
+        map.tickets[1].title = title.to_string(); // #6, the launchable row
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let mut app = app_on("blooop/wayfinder", clusters);
+        down(&mut app, 2); // past the project row and the cluster header
+        app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let screen = render_at(120, &app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("launch Claude"))
+            .unwrap_or_else(|| panic!("no picker title: {screen}"));
+        // The buffer dump spells a wide char as the char plus its continuation
+        // cell, so the whole title reads back space-separated.
+        let drawn: String = title
+            .chars()
+            .map(|c| format!("{c} "))
+            .collect::<String>()
+            .trim_end()
+            .to_string();
+        assert!(
+            line.contains(&drawn),
+            "the title is clipped by its own popup: {line}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #191.

Two families of unicode confusion in the picker, both real on GitHub-arbitrary titles:

- **Grapheme vs char indices.** Nucleo reports *grapheme* indices (its haystack keeps one codepoint per grapheme), while the tightness rule and the screen's underline walk chars — so any title with a flag, ZWJ emoji or combining accent skewed every index after it. Worse than cosmetic: for a decomposed accent, nucleo's own `Utf32Str::new` falls back to byte-indexed ASCII matching, and the byte indices overran the char slice in the tightness check — an out-of-bounds **panic** on a matchable title (pinned by a now-passing test). The filter now segments the haystack itself with the same grapheme walk nucleo uses, judges tightness in grapheme space, and converts to char indices at the one boundary where matches are produced — a matched grapheme lighting every char it spans.

- **Three width metrics in one renderer.** The launch picker measured its title in chars while its rows were measured in display columns (a CJK title clipped its own popup border); the checkout picker used the key's *byte* length plus a magic margin; the count line reserved chars for segments that occupy columns, so a CJK notice lost its tail to the reclaim note. All of it now measures in display columns via ratatui's own span metric — one `popup_width` for the two pickers, one `cols` for the count line.

New dependency edge: `unicode-segmentation` (already in the tree — it is nucleo-matcher's own dependency, same version).

Built test-first per the ticket's seams: a flag-emoji title, a decomposed-accent title, a whole-grapheme highlight, a CJK-heavy launch-picker title, a non-ASCII checkout key, and a CJK notice beside the reclaim note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make picker matching and terminal layout robust for arbitrary Unicode titles and labels.

Bug Fixes:
- Preserve correct match highlighting for titles containing multi-codepoint graphemes, combining accents, and other non-ASCII text without panics or shifted indices.
- Prevent non-ASCII titles and notices from being clipped in pickers and count-line output.

Enhancements:
- Unify text sizing around terminal display columns for popup widths, line budgets, truncation, and reclaim/liveness messages.

Build:
- Add Unicode segmentation and display-width dependencies for consistent matching and terminal sizing.

Tests:
- Add coverage for emoji and decomposed-accent matching, CRLF titles, CJK picker titles, non-ASCII checkout keys, and wide count-line content.