### PR TITLE
The screen says when a map fetch was truncated

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1407,6 +1407,7 @@ mod tests {
             Map {
                 title: "Map: wf".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![
                     ticket(
                         "blooop/wayfinder",
@@ -1448,6 +1449,7 @@ mod tests {
             Map {
                 title: "Map: dotfiles".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket(
                     "blooop/dotfiles",
                     103,
@@ -1468,6 +1470,7 @@ mod tests {
             Map {
                 title: format!("Map: {repo}"),
                 last_activity: stamp.map(|s| Activity::parse(s).expect("fixture stamp parses")),
+                truncated: false,
                 tickets: vec![ticket(repo, 1, "only ticket", open, false, vec![])],
             },
         )
@@ -1657,6 +1660,7 @@ mod tests {
                     ticket(PROJECT, 1, "takeable", true, false, vec![]),
                     ticket(PROJECT, 2, "finished", false, false, vec![]),
                 ],
+                truncated: false,
             },
         )])
     }
@@ -1718,6 +1722,7 @@ mod tests {
             Map {
                 title: "Map: late arrival".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket(PROJECT, 200, "zzz sleeper", true, false, vec![])],
             },
         );
@@ -1754,6 +1759,7 @@ mod tests {
                     Activity::parse("2026-08-07T00:00:00Z").expect("fixture stamp parses"),
                 ),
                 tickets: vec![ticket(PROJECT, 200, "breadwinner", true, false, vec![])],
+                truncated: false,
             },
         );
         app.replace_clusters(fresher);
@@ -1869,6 +1875,7 @@ mod tests {
             Map {
                 title: "Map: wf".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![
                     ticket("blooop/wayfinder", 6, "root", true, false, vec![]),
                     ticket("blooop/wayfinder", 7, "dep a", true, false, vec![6]),
@@ -1901,6 +1908,7 @@ mod tests {
             Map {
                 title: "Map: endgame".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![
                     ticket("blooop/bencher", 1, "done", false, false, vec![]),
                     ticket("blooop/bencher", 10, "root, chained", true, false, vec![]),
@@ -2038,6 +2046,7 @@ mod tests {
             Map {
                 title: "Map: endgame".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![
                     ticket("blooop/bencher", 1069, "root", true, false, vec![]),
                     ticket(
@@ -2443,6 +2452,7 @@ mod tests {
                 Map {
                     title: format!("Map: {map_number}"),
                     last_activity: None,
+                    truncated: false,
                     tickets: vec![ticket(
                         "blooop/wayfinder",
                         6,
@@ -3255,6 +3265,7 @@ mod tests {
                 Map {
                     title: "Map: the spine".to_string(),
                     last_activity: None,
+                    truncated: false,
                     tickets: vec![t],
                 },
             );
@@ -3358,6 +3369,7 @@ mod tests {
             Map {
                 title: "Map: wf".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket("blooop/wayfinder", 6, "t6", true, false, vec![])],
             },
         );
@@ -3366,6 +3378,7 @@ mod tests {
             Map {
                 title: "Map: selection view".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket("blooop/wayfinder", 50, "t50", true, false, vec![])],
             },
         );
@@ -3374,6 +3387,7 @@ mod tests {
             Map {
                 title: "Map: dotfiles".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket("blooop/dotfiles", 103, "t103", true, false, vec![])],
             },
         );
@@ -3394,6 +3408,7 @@ mod tests {
                 Map {
                     title: "Map: dotfiles".to_string(),
                     last_activity: None,
+                    truncated: false,
                     tickets: vec![ticket(
                         &format!("{owner}/dotfiles"),
                         5,

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -729,7 +729,10 @@ mod tests {
 
         // And the label page being cut short is not the *tree* being cut
         // short: nothing ticket-bearing was truncated here.
-        assert!(!map.truncated, "a truncated label page is not a partial tree");
+        assert!(
+            !map.truncated,
+            "a truncated label page is not a partial tree"
+        );
     }
 
     /// One sub-issue carrying the full PR-badge matrix (#52).
@@ -871,8 +874,8 @@ mod tests {
                 "subIssues more: {subs}, blockers more: {blockers} — the map must say so"
             );
         }
-        let map = parse_map(truncated_response(false, false).as_bytes(), &wf_map_id())
-            .expect("parse");
+        let map =
+            parse_map(truncated_response(false, false).as_bytes(), &wf_map_id()).expect("parse");
         assert!(!map.truncated, "full pages are not a truncation");
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -888,64 +888,150 @@ mod tests {
         assert!(!map.truncated);
     }
 
-    /// The brace-balanced block a named connection selects in `query` —
-    /// `field(…) { … }` from the first `{` to its close. Panics if the field
-    /// is missing or its braces never balance, because a guard that returns
-    /// `None` quietly is a guard that stops guarding when the query is
-    /// reworded.
-    fn connection_block<'q>(query: &'q str, field: &str) -> &'q str {
-        let from = query
-            .find(field)
-            .unwrap_or_else(|| panic!("the query no longer selects {field}"));
-        let mut depth = 0usize;
-        for (offset, ch) in query[from..].char_indices() {
+    /// One field of a GraphQL selection: the arguments it was called with, and
+    /// the fields selected under it — which is to say, the shape an answer to
+    /// that selection has.
+    #[derive(Default)]
+    struct Selected {
+        arguments: String,
+        fields: std::collections::BTreeMap<String, Selected>,
+    }
+
+    impl Selected {
+        /// The field reached by following `path` from here, or `None` if the
+        /// query does not select it *there*.
+        ///
+        /// Position is the whole point. The sub-issue block contains the
+        /// linked-PR block, whose own `pageInfo` (#183) would answer on behalf
+        /// of a connection that never asked if the question were "does this
+        /// name appear anywhere below".
+        fn at(&self, path: &[&str]) -> Option<&Selected> {
+            match path {
+                [] => Some(self),
+                [step, rest @ ..] => self.fields.get(*step)?.at(rest),
+            }
+        }
+
+        /// The field at `path`, created empty if the walk has not reached it
+        /// yet — how the parse below fills the tree in as it descends.
+        fn under(&mut self, path: &[String]) -> &mut Selected {
+            let mut at = self;
+            for step in path {
+                at = at.fields.entry(step.clone()).or_default();
+            }
+            at
+        }
+    }
+
+    /// Read the subset of GraphQL selection syntax [`MAP_QUERY`] is written in
+    /// — names, optional `(arguments)`, optional nested `{ blocks }` — as the
+    /// tree of fields it selects.
+    ///
+    /// Derived rather than matched, and that is the point of it. A guard that
+    /// searches the query text for a spelling is satisfied by any text carrying
+    /// that spelling: `pageInfo { endCursor }` passed a guard looking for
+    /// `pageInfo` while answering none of the questions the parse asks of it.
+    /// Walking the tree asks the parse's own question instead — is this field
+    /// selected at this path — which no rewording can answer by accident.
+    ///
+    /// Panics on unbalanced braces, because a guard that gives up quietly on a
+    /// query it cannot read is a guard that stops guarding the moment the query
+    /// is reworded.
+    fn selected(text: &str) -> Selected {
+        let mut root = Selected::default();
+        let mut path: Vec<String> = Vec::new();
+        let mut last: Option<String> = None;
+        let mut chars = text.chars().peekable();
+        while let Some(ch) = chars.next() {
             match ch {
-                '{' => depth += 1,
+                '{' => path.push(last.take().expect("a block follows the field it selects")),
                 '}' => {
-                    depth = depth
-                        .checked_sub(1)
-                        .unwrap_or_else(|| panic!("unbalanced braces in {query}"));
-                    if depth == 0 {
-                        return &query[from..=from + offset];
+                    path.pop().expect("a block was opened before it closed");
+                    last = None;
+                }
+                // Arguments say nothing about the shape of the answer, but they
+                // do say how much of it there is, which is its own assertion
+                // below.
+                '(' => {
+                    let mut arguments = String::new();
+                    for skipped in chars.by_ref() {
+                        if skipped == ')' {
+                            break;
+                        }
+                        arguments.push(skipped);
                     }
+                    let named = last
+                        .clone()
+                        .expect("arguments follow the field they qualify");
+                    root.under(&path).fields.entry(named).or_default().arguments = arguments;
+                }
+                ch if ch.is_alphanumeric() || ch == '_' => {
+                    let mut name = String::from(ch);
+                    while chars
+                        .peek()
+                        .is_some_and(|c| c.is_alphanumeric() || *c == '_')
+                    {
+                        name.push(chars.next().expect("peeked"));
+                    }
+                    root.under(&path).fields.entry(name.clone()).or_default();
+                    last = Some(name);
                 }
                 _ => {}
             }
         }
-        panic!("{field}'s block never closes in {query}")
-    }
-
-    /// Whether `block` selects `pageInfo` on the connection itself — at brace
-    /// depth 1, not anywhere in the nested tree. Depth matters: the sub-issue
-    /// block *contains* the linked-PR block, whose own `pageInfo` (#183) would
-    /// otherwise satisfy this test on behalf of a connection that never asked.
-    fn asks_its_own_page_info(block: &str) -> bool {
-        let mut depth = 0usize;
-        let mut at = 0;
-        while let Some(found) = block[at..].find("pageInfo") {
-            depth += block[at..at + found].matches('{').count();
-            depth -= block[at..at + found].matches('}').count();
-            if depth == 1 {
-                return true;
-            }
-            at += found + "pageInfo".len();
-        }
-        false
+        assert!(path.is_empty(), "unbalanced braces in {text}");
+        root
     }
 
     #[test]
     fn the_query_asks_for_every_page_boundary_the_parse_reads() {
-        // The truncation tests above feed `parse_map` hand-written fixtures,
-        // so they cannot notice the live query never requesting the field —
-        // the same hole #132 closed for reap's batch, guarded the same way:
-        // against the query text. Drop `pageInfo` from either ticket-bearing
-        // connection and every map fetched live reads as complete forever,
-        // silently, which is exactly the pre-#184 behaviour.
-        for field in ["subIssues", "blockedBy"] {
-            let block = connection_block(MAP_QUERY, field);
+        // The truncation tests above feed `parse_map` hand-written fixtures, so
+        // they cannot notice the live query never requesting the field — the
+        // same hole #132 closed for reap's batch, guarded the same way: against
+        // the query text. Drop the boundary from any of these three and every
+        // map fetched live reads as complete forever, silently, which is
+        // exactly the pre-#184 behaviour.
+        //
+        // `hasNextPage` by name, at the path the parse reads it from, because
+        // that field *is* the answer: `Paged::page_info` and
+        // `PageInfo::has_next_page` both default, so a `pageInfo` block
+        // selecting anything else — `endCursor`, say — deserialises as a silent
+        // "no claim of more". Asserting the connection asks for `pageInfo` is
+        // not enough; that reword left all 443 tests green.
+        let query = selected(MAP_QUERY);
+        for path in [
+            &[
+                "query",
+                "repository",
+                "issue",
+                "labels",
+                "pageInfo",
+                "hasNextPage",
+            ][..],
+            &[
+                "query",
+                "repository",
+                "issue",
+                "subIssues",
+                "pageInfo",
+                "hasNextPage",
+            ][..],
+            &[
+                "query",
+                "repository",
+                "issue",
+                "subIssues",
+                "nodes",
+                "blockedBy",
+                "pageInfo",
+                "hasNextPage",
+            ][..],
+        ] {
             assert!(
-                asks_its_own_page_info(block),
-                "{field} no longer asks whether its page was all of it: {block}"
+                query.at(path).is_some(),
+                "the query no longer asks for {}, so nothing it fetches can \
+                 report a page cut short: {MAP_QUERY}",
+                path.join(".")
             );
         }
     }
@@ -955,16 +1041,17 @@ mod tests {
         // The other half of the un-mapping fix: the parse forgives a truncated
         // label page, and the query makes truncation implausible in the first
         // place — 100 is the GraphQL page maximum, five times the old cap that
-        // a label-heavy map actually overflowed. The first `labels` selection
-        // in the query is the map issue's own, the one re-verification reads.
-        let block = connection_block(MAP_QUERY, "labels");
-        assert!(
-            block.starts_with("labels(first: 100)"),
-            "the map's label page shrank below the tracker's maximum: {block}"
-        );
-        assert!(
-            asks_its_own_page_info(block),
-            "the label page no longer says whether it was all of it: {block}"
+        // a label-heavy map actually overflowed. Addressed by path rather than
+        // by "the first `labels` in the text", so the sub-issue labels selected
+        // further down cannot be mistaken for the map issue's own.
+        let query = selected(MAP_QUERY);
+        let labels = query
+            .at(&["query", "repository", "issue", "labels"])
+            .expect("the map query selects the map issue's own labels");
+        assert_eq!(
+            labels.arguments.trim(),
+            "first: 100",
+            "the map's label page shrank below the tracker's maximum: {MAP_QUERY}"
         );
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -64,7 +64,7 @@ query($owner: String!, $name: String!, $number: Int!) {
           number title state
           labels(first: 10) { nodes { name } }
           assignees(first: 5) { nodes { login } }
-          blockedBy(first: 50) { nodes { number state } }
+          blockedBy(first: 50) { nodes { number state } pageInfo { hasNextPage } }
           closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
             nodes {
               number state isDraft reviewDecision
@@ -74,6 +74,7 @@ query($owner: String!, $name: String!, $number: Int!) {
             pageInfo { hasNextPage }
           }
         }
+        pageInfo { hasNextPage }
       }
     }
   }
@@ -848,6 +849,68 @@ mod tests {
         // selection follows.
         let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
         assert!(!map.truncated);
+    }
+
+    /// The brace-balanced block a named connection selects in `query` —
+    /// `field(…) { … }` from the first `{` to its close. Panics if the field
+    /// is missing or its braces never balance, because a guard that returns
+    /// `None` quietly is a guard that stops guarding when the query is
+    /// reworded.
+    fn connection_block<'q>(query: &'q str, field: &str) -> &'q str {
+        let from = query
+            .find(field)
+            .unwrap_or_else(|| panic!("the query no longer selects {field}"));
+        let mut depth = 0usize;
+        for (offset, ch) in query[from..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth = depth
+                        .checked_sub(1)
+                        .unwrap_or_else(|| panic!("unbalanced braces in {query}"));
+                    if depth == 0 {
+                        return &query[from..=from + offset];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("{field}'s block never closes in {query}")
+    }
+
+    /// Whether `block` selects `pageInfo` on the connection itself — at brace
+    /// depth 1, not anywhere in the nested tree. Depth matters: the sub-issue
+    /// block *contains* the linked-PR block, whose own `pageInfo` (#183) would
+    /// otherwise satisfy this test on behalf of a connection that never asked.
+    fn asks_its_own_page_info(block: &str) -> bool {
+        let mut depth = 0usize;
+        let mut at = 0;
+        while let Some(found) = block[at..].find("pageInfo") {
+            depth += block[at..at + found].matches('{').count();
+            depth -= block[at..at + found].matches('}').count();
+            if depth == 1 {
+                return true;
+            }
+            at += found + "pageInfo".len();
+        }
+        false
+    }
+
+    #[test]
+    fn the_query_asks_for_every_page_boundary_the_parse_reads() {
+        // The truncation tests above feed `parse_map` hand-written fixtures,
+        // so they cannot notice the live query never requesting the field —
+        // the same hole #132 closed for reap's batch, guarded the same way:
+        // against the query text. Drop `pageInfo` from either ticket-bearing
+        // connection and every map fetched live reads as complete forever,
+        // silently, which is exactly the pre-#184 behaviour.
+        for field in ["subIssues", "blockedBy"] {
+            let block = connection_block(MAP_QUERY, field);
+            assert!(
+                asks_its_own_page_info(block),
+                "{field} no longer asks whether its page was all of it: {block}"
+            );
+        }
     }
 
     #[test]

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -115,12 +115,34 @@ struct MapIssue {
     updated_at: Option<String>,
     labels: Nodes<Label>,
     #[serde(rename = "subIssues")]
-    sub_issues: Nodes<SubIssue>,
+    sub_issues: Paged<SubIssue>,
 }
 
 #[derive(Deserialize)]
 pub(crate) struct Nodes<T> {
     pub(crate) nodes: Vec<T>,
+}
+
+/// A connection read *with* the tracker's word on whether the page was all of
+/// it (#184) — for the ticket-bearing connections, where a missing node is a
+/// missing ticket or a missing blocking edge, not a cosmetic gap. [`Nodes`]
+/// stays the shape for the connections whose truncation changes nothing a
+/// consumer would assert on; giving every reader the flag would invite readers
+/// that do not need it.
+#[derive(Deserialize)]
+struct Paged<T> {
+    nodes: Vec<T>,
+    /// Defaulted so a response without the selection (an older fixture, a
+    /// GitHub edition without it) reads as "no claim of more" — the same rule
+    /// every other optional selection here follows.
+    #[serde(rename = "pageInfo", default)]
+    page_info: PageInfo,
+}
+
+#[derive(Deserialize, Default)]
+struct PageInfo {
+    #[serde(rename = "hasNextPage", default)]
+    has_next_page: bool,
 }
 
 impl<T> Default for Nodes<T> {
@@ -137,7 +159,7 @@ struct SubIssue {
     labels: Nodes<Label>,
     assignees: Nodes<Assignee>,
     #[serde(rename = "blockedBy")]
-    blocked_by: Nodes<Blocker>,
+    blocked_by: Paged<Blocker>,
     /// Defaulted so a response without the selection (older fixtures, a
     /// GitHub edition without the field) parses as "no linked PRs" rather
     /// than failing the whole map.
@@ -346,11 +368,16 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
         );
     }
 
+    // Truncation folds over the whole read: the sub-issue page itself, and
+    // every ticket's blocker page. Any one of them cut short means the tree —
+    // or the classification drawn from its edges — is partial (#184).
+    let mut truncated = issue.sub_issues.page_info.has_next_page;
     let mut tickets: Vec<Ticket> = issue
         .sub_issues
         .nodes
         .into_iter()
         .map(|sub| {
+            truncated |= sub.blocked_by.page_info.has_next_page;
             // One pass over the same edges yields both facts: the open subset
             // is status, the whole set is structure (#50).
             let open_blockers: Vec<u64> = sub
@@ -391,6 +418,7 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
         // Interpreted here and nowhere inward, like every other tracker string.
         last_activity: issue.updated_at.as_deref().and_then(Activity::parse),
         tickets,
+        truncated,
     })
 }
 
@@ -769,6 +797,57 @@ mod tests {
         let old = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
         assert_eq!(old.last_activity, None);
         assert_eq!(old.tickets.len(), 3, "the rest of the map is unaffected");
+    }
+
+    /// The tracker's own word that a page was not all of it, on each
+    /// ticket-bearing connection in turn — the two ways a map can arrive
+    /// silently partial (#184).
+    fn truncated_response(sub_issues_more: bool, blockers_more: bool) -> String {
+        format!(
+            r#"{{"data": {{"repository": {{"issue": {{
+            "title": "Map: wf",
+            "state": "OPEN",
+            "labels": {{"nodes": [{{"name": "wayfinder:map"}}]}},
+            "subIssues": {{
+                "nodes": [
+                    {{"number": 19, "title": "Build 6", "state": "OPEN",
+                     "labels": {{"nodes": []}},
+                     "assignees": {{"nodes": []}},
+                     "blockedBy": {{"nodes": [{{"number": 3, "state": "OPEN"}}],
+                                   "pageInfo": {{"hasNextPage": {blockers_more}}}}}}}
+                ],
+                "pageInfo": {{"hasNextPage": {sub_issues_more}}}
+            }}
+        }}}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn a_map_the_tracker_could_not_send_all_of_says_it_arrived_truncated() {
+        // A 101st sub-issue or a 51st blocker does not fit the page, and until
+        // #184 the map rendered without it and without a trace. The parse now
+        // keeps the tracker's own word on it: either connection reporting a
+        // next page marks the whole map truncated.
+        for (subs, blockers) in [(true, false), (false, true), (true, true)] {
+            let map = parse_map(truncated_response(subs, blockers).as_bytes(), &wf_map_id())
+                .expect("a truncated map still parses — partial beats absent");
+            assert!(
+                map.truncated,
+                "subIssues more: {subs}, blockers more: {blockers} — the map must say so"
+            );
+        }
+        let map = parse_map(truncated_response(false, false).as_bytes(), &wf_map_id())
+            .expect("parse");
+        assert!(!map.truncated, "full pages are not a truncation");
+    }
+
+    #[test]
+    fn a_response_without_page_info_reads_as_complete() {
+        // Older fixtures and GitHub editions without the selection: absent is
+        // "no claim of more", not "more" — the same defaulting rule the PR
+        // selection follows.
+        let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
+        assert!(!map.truncated);
     }
 
     #[test]

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -58,7 +58,7 @@ query($owner: String!, $name: String!, $number: Int!) {
       title
       state
       updatedAt
-      labels(first: 20) { nodes { name } }
+      labels(first: 100) { nodes { name } pageInfo { hasNextPage } }
       subIssues(first: 100) {
         nodes {
           number title state
@@ -114,7 +114,7 @@ struct MapIssue {
     /// the PR selection follows.
     #[serde(rename = "updatedAt", default)]
     updated_at: Option<String>,
-    labels: Nodes<Label>,
+    labels: Paged<Label>,
     #[serde(rename = "subIssues")]
     sub_issues: Paged<SubIssue>,
 }
@@ -361,7 +361,16 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
     // as stale, which is honest, instead of rendering some unrelated issue's
     // sub-issues as its map. The unconditional search corrects the number
     // moments later.
-    if !is_open(&issue.state) || !issue.labels.nodes.iter().any(|l| l.name == MAP_LABEL) {
+    //
+    // The label half of the proof needs the tracker's *whole* answer: a label
+    // page cut short cannot prove the label is gone, only a complete page
+    // without it can (#184). Without that qualifier, a map wearing more labels
+    // than one page holds was rejected here as "no longer a map" on every
+    // refresh, while discovery's label-scoped search — which no page cap can
+    // blind — kept re-finding it.
+    let map_label_disproven = !issue.labels.nodes.iter().any(|l| l.name == MAP_LABEL)
+        && !issue.labels.page_info.has_next_page;
+    if !is_open(&issue.state) || map_label_disproven {
         bail!(
             "{}#{} is no longer an open `{MAP_LABEL}` issue",
             id.repo,
@@ -698,6 +707,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn a_maps_own_label_count_can_never_unmap_it() {
+        // The worst of #184's three findings: a map wearing more labels than
+        // one page holds, with `wayfinder:map` not on the page the fetch got,
+        // used to fail re-verification as "no longer a map" — while discovery,
+        // whose label-scoped search is immune to the cap, kept re-finding it.
+        // Permanently, on every refresh.
+        //
+        // An unseen label on a *truncated* page proves nothing, so it keeps
+        // the map. Only a complete page without the label — the tracker's
+        // whole answer — may reject.
+        let body = map_response_with("OPEN", r#"{"name": "enhancement"}"#).replacen(
+            r#""labels": {"nodes": [{"name": "enhancement"}]},"#,
+            r#""labels": {"nodes": [{"name": "enhancement"}], "pageInfo": {"hasNextPage": true}},"#,
+            1,
+        );
+        let map = parse_map(body.as_bytes(), &wf_map_id())
+            .expect("a label page the tracker cut short cannot prove the label is gone");
+        assert_eq!(map.title, "Map: wf", "the map renders as itself");
+
+        // And the label page being cut short is not the *tree* being cut
+        // short: nothing ticket-bearing was truncated here.
+        assert!(!map.truncated, "a truncated label page is not a partial tree");
+    }
+
     /// One sub-issue carrying the full PR-badge matrix (#52).
     const PR_RESPONSE: &str = r#"{"data": {"repository": {"issue": {
         "title": "Map: wf",
@@ -911,6 +945,24 @@ mod tests {
                 "{field} no longer asks whether its page was all of it: {block}"
             );
         }
+    }
+
+    #[test]
+    fn the_maps_own_label_page_is_as_deep_as_the_tracker_allows() {
+        // The other half of the un-mapping fix: the parse forgives a truncated
+        // label page, and the query makes truncation implausible in the first
+        // place — 100 is the GraphQL page maximum, five times the old cap that
+        // a label-heavy map actually overflowed. The first `labels` selection
+        // in the query is the map issue's own, the one re-verification reads.
+        let block = connection_block(MAP_QUERY, "labels");
+        assert!(
+            block.starts_with("labels(first: 100)"),
+            "the map's label page shrank below the tracker's maximum: {block}"
+        );
+        assert!(
+            asks_its_own_page_info(block),
+            "the label page no longer says whether it was all of it: {block}"
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -544,6 +544,13 @@ pub struct Map {
     /// ([`Activity`]) — the cluster sort key.
     pub last_activity: Option<Activity>,
     pub tickets: Vec<Ticket>,
+    /// The tracker said a ticket-bearing page was not all of it (#184): a
+    /// 101st sub-issue or a 51st blocking edge did not fit the fetch, so
+    /// `tickets` — and the classification drawn from the edges — is partial.
+    /// Carried on the map rather than swallowed, because the only honest
+    /// render of a partial tree is one that says so; the count line is where
+    /// it is said.
+    pub truncated: bool,
 }
 
 impl Map {
@@ -1066,12 +1073,14 @@ mod tests {
         let live = Map {
             title: "Map: wf".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![ticket(2, false, vec![]), ticket(6, true, vec![])],
         };
         assert!(live.has_open_work());
         let finished = Map {
             title: "Map: wf".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![ticket(2, false, vec![]), ticket(6, false, vec![])],
         };
         assert!(!finished.has_open_work(), "every ticket done is finished");
@@ -1080,6 +1089,7 @@ mod tests {
         let empty = Map {
             title: "Map: wf".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![],
         };
         assert!(!empty.has_open_work());
@@ -1122,6 +1132,7 @@ mod tests {
         let map = Map {
             title: "Map: selection view".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![
                 ticket(48, false, vec![]),
                 ticket(50, true, vec![48]),
@@ -1152,6 +1163,7 @@ mod tests {
         let map = Map {
             title: "Map: wf".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![ticket(6, true, vec![]), claimed, blocked, done],
         };
         assert_eq!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1084,6 +1084,7 @@ mod tests {
         Map {
             title: "Map: wf".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![
                 t(2, "Choose the stack", false, true, vec![]),
                 t(6, "Re-entry breadcrumbs", true, false, vec![]),
@@ -1778,6 +1779,7 @@ mod tests {
             Map {
                 title: "Map: the archive".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     103,
@@ -1816,6 +1818,7 @@ mod tests {
             Map {
                 title: "Map: the selection view".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     50,
@@ -1854,6 +1857,7 @@ mod tests {
             Map {
                 title: "Map: the archive".to_string(),
                 last_activity: Activity::parse("2026-08-06T12:00:00Z"),
+                truncated: false,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     88,
@@ -1869,6 +1873,7 @@ mod tests {
             Map {
                 title: "Map: the selection view".to_string(),
                 last_activity: Activity::parse("2026-08-01T12:00:00Z"),
+                truncated: false,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     50,
@@ -2445,6 +2450,7 @@ mod tests {
             Map {
                 title: "Map: wf".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: (1..=30)
                     .map(|n| {
                         ticket(
@@ -2464,6 +2470,7 @@ mod tests {
             Map {
                 title: "Map: the selection view".to_string(),
                 last_activity: None,
+                truncated: false,
                 tickets: vec![ticket(
                     "blooop/wayfinder",
                     50,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -586,6 +586,24 @@ pub fn failure_note(app: &App) -> String {
     }
 }
 
+/// The `· … truncated` segment on the count line (#184): a map the tracker
+/// could not send all of — more sub-issues or blocking edges than one page
+/// holds, per [`Map`]'s `truncated` — named where the reader is, because the
+/// body draws a normal-looking tree either way and this line is the only
+/// place left to say the tree is partial.
+///
+/// Shaped exactly like [`failure_note`], its nearest kin: both are persistent
+/// facts about a whole map that the rows cannot carry, one map is named, more
+/// collapse to a count.
+pub fn truncated_note(app: &App) -> String {
+    let mut truncated = app.clusters.iter().filter(|(_, map)| map.truncated);
+    match (truncated.next(), truncated.count()) {
+        (None, _) => String::new(),
+        (Some((id, _)), 0) => format!("· {}#{} truncated", id.repo, id.number),
+        (Some(_), more) => format!("· {} maps truncated", more + 1),
+    }
+}
+
 /// The `· N reclaimable: …` segment on the count line (#137): what a
 /// `wf reap` would claim, once the background reading has landed.
 ///
@@ -976,10 +994,15 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     // staged — the staged launch is a modal now (#62's line became
     // [`draw_launch_picker`]), and a modal does not need the row it covers to
     // move out of its way.
-    let mut parts: Vec<String> = [app.startup.hint(), failure_note(app), idle_note(&plan)]
-        .into_iter()
-        .filter(|part| !part.is_empty())
-        .collect();
+    let mut parts: Vec<String> = [
+        app.startup.hint(),
+        failure_note(app),
+        truncated_note(app),
+        idle_note(&plan),
+    ]
+    .into_iter()
+    .filter(|part| !part.is_empty())
+    .collect();
     let (shown, total) = app.counts();
     let counts = format!("  {shown}/{total}");
     let notice = app
@@ -1766,6 +1789,64 @@ mod tests {
                 "{width}: and a workspace is still named: {line}"
             );
         }
+    }
+
+    /// A map the tracker could not send all of is named on the count line
+    /// (#184): the body draws a perfectly normal tree either way, so this
+    /// segment is the only trace that tickets — or the blocking edges their
+    /// classification is drawn from — are missing from it.
+    #[test]
+    fn the_count_line_says_when_a_map_arrived_truncated() {
+        let mut clusters = BTreeMap::new();
+        let mut map = wf_map();
+        map.truncated = true;
+        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let app = app_on("blooop/wayfinder", clusters);
+        let screen = render(&app);
+        let line = screen
+            .lines()
+            .find(|line| line.contains("truncated"))
+            .unwrap_or_else(|| panic!("no truncation segment: {screen}"));
+        assert!(
+            line.contains("blooop/wayfinder#1 truncated"),
+            "one truncated map is named, like one failed map is: {line}"
+        );
+
+        // A complete map says nothing — silence is the ordinary case.
+        let mut clusters = BTreeMap::new();
+        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        let app = app_on("blooop/wayfinder", clusters);
+        assert!(!render(&app).contains("truncated"));
+    }
+
+    #[test]
+    fn several_truncated_maps_collapse_to_a_count() {
+        let mut clusters = BTreeMap::new();
+        let mut first = wf_map();
+        first.truncated = true;
+        clusters.insert(MapId::new("blooop/wayfinder", 1), first);
+        clusters.insert(
+            MapId::new("blooop/wayfinder", 47),
+            Map {
+                title: "Map: the selection view".to_string(),
+                last_activity: None,
+                truncated: true,
+                tickets: vec![ticket(
+                    "blooop/wayfinder",
+                    50,
+                    "Build: clusters",
+                    true,
+                    false,
+                    vec![],
+                )],
+            },
+        );
+        let app = app_on("blooop/wayfinder", clusters);
+        let screen = render(&app);
+        assert!(
+            screen.contains("· 2 maps truncated"),
+            "several collapse to a count, like failures do: {screen}"
+        );
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -1138,6 +1138,7 @@ mod tests {
         Map {
             title: "Map: fixture".to_string(),
             last_activity: None,
+            truncated: false,
             tickets,
         }
     }
@@ -1472,6 +1473,7 @@ mod tests {
         let m = Map {
             title: "Map: fixture".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![
                 ticket(6, true, false, vec![]),
                 ticket(7, true, false, vec![999]),
@@ -1614,6 +1616,7 @@ mod tests {
         let m = Map {
             title: "Map: fixture".to_string(),
             last_activity: None,
+            truncated: false,
             tickets: vec![
                 ticket(6, true, false, vec![]),
                 ticket(7, true, false, vec![999]),


### PR DESCRIPTION
Closes #184.

**Stacked on #199** (`wayfinder/wayfinder-183`) and should merge after it — this branch depends on the query text #183 changed (the shared linked-PR selection block that `reap` byte-compares against the map query). Retargeting to `main` happens automatically when #199 merges.

## What arrived silently partial, and where it now shows

The map fetch capped `subIssues(first: 100)`, `blockedBy(first: 50)`, and `labels(first: 20)` with no `pageInfo` and no indicator, so:

- a 101st ticket was dropped without a trace;
- a 51st blocking edge could misclassify a node as unblocked;
- worst, a map wearing 21+ labels with `wayfinder:map` off the fetched page failed re-verification as "no longer a map" on every refresh, while discovery's label-scoped search kept re-finding it — permanently.

## The three seams, test-first

1. **The parse boundary** (`parse_map`): the two ticket-bearing connections — the sub-issue page and each ticket's blocker page — now report `pageInfo.hasNextPage`, folded into `Map::truncated`. Absent `pageInfo` reads as complete, the same defaulting rule the PR selection follows. Partial still beats absent: a truncated map parses and renders.
2. **The query text**: `MAP_QUERY` asks for every page boundary the parse reads, guarded against the query source the way #132 guards reap's batch — fixture-fed parse tests cannot notice a live query that stopped asking. The guard is depth-aware so the linked-PR block's own `pageInfo` (#183's, deliberately untouched here) cannot answer for a connection that never asked. The map's own label page runs to the GraphQL page maximum (100) and carries `pageInfo`; only a *complete* page without the label may reject a cached number — a truncated one keeps the map, so label count can never un-map a map.
3. **The count line**: a truncated map is named there (`· repo#n truncated`; several collapse to `· N maps truncated`), symmetric with the failed-map segment — the body draws a normal-looking tree either way, so the count line is the only place left to say the tree is partial.

The shared PR selection block is byte-identical to #199's; `both_queries_ask_for_a_linked_pr_in_exactly_the_same_words` stays green.

Full AGENTS.md check chain green locally (fmt, clippy, tests, doc — all under `-D warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Track and visibly report partial map fetches without rejecting maps based on incomplete label data.

New Features:
- Expose when fetched maps are partial due to truncated sub-issue or blocker data.
- Display truncation status on the map count line, naming a single map or collapsing multiple maps into a count.

Bug Fixes:
- Prevent incomplete label pages from incorrectly invalidating cached maps that still have the map label.
- Preserve and surface pagination signals so missing tickets or blocking edges are not silently treated as complete data.

Enhancements:
- Expand map queries to request pagination metadata for ticket-bearing connections and fetch the map's labels up to the GraphQL page maximum.
- Add query-shape checks ensuring all pagination boundaries consumed by map parsing remain selected.

Tests:
- Add coverage for truncated sub-issue and blocker pages, missing pagination metadata, label-heavy maps, query pagination selections, and truncation rendering.