### PR TITLE
Robustness sweep: blocking probe, exec bit, backoff, stale prose

### DIFF
--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1955,7 +1955,12 @@ impl Launch {
     }
 }
 
-/// Find `program` on `$PATH`, skipping empty entries.
+/// Find `program` on `$PATH`, skipping empty entries and any candidate the OS
+/// would not execute.
+///
+/// The execute bit matters because this stands in for execvp, which keeps
+/// searching past a file it cannot run — so a stray non-executable `claude`
+/// early on PATH must not fail a launch the OS would have made.
 ///
 /// A name containing a separator is a path already and is taken as given —
 /// that is the caller naming a file, not `$PATH` resolution.
@@ -1965,15 +1970,33 @@ impl Launch {
 /// wants only a path to run `--version` on and treats a miss as "no `dl` here",
 /// which [`Isolation::detect`] answers with [`Isolation::Host`].
 fn resolve_on_path(program: &str) -> Result<PathBuf, anyhow::Error> {
+    resolve_in(program, &std::env::var_os("PATH").unwrap_or_default())
+}
+
+/// [`resolve_on_path`] against a given `PATH` value — the part with rules worth
+/// testing, split from the one line that reads the environment so the tests
+/// never have to mutate it under a parallel suite.
+fn resolve_in(program: &str, path: &std::ffi::OsStr) -> Result<PathBuf, anyhow::Error> {
     if program.contains('/') {
         return Ok(PathBuf::from(program));
     }
-    let path = std::env::var_os("PATH").unwrap_or_default();
-    std::env::split_paths(&path)
+    std::env::split_paths(path)
         .filter(|dir| !dir.as_os_str().is_empty())
         .map(|dir| dir.join(program))
-        .find(|candidate| candidate.is_file())
+        .find(|candidate| executable(candidate))
         .ok_or_else(|| anyhow::anyhow!("`{program}` is not on PATH — is it installed?"))
+}
+
+/// Would execvp accept this candidate? A regular file with any execute bit
+/// set. Mode bits rather than `access(2)`'s exact answer, which is the same
+/// approximation `which` makes — close enough for a search whose miss is
+/// reported, and whose false positive still fails loudly at the `exec` itself.
+fn executable(candidate: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    candidate
+        .metadata()
+        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
 }
 
 /// A launch prompt with the JSON of every `ctx:` block replaced by `…` (#124).
@@ -4590,5 +4613,58 @@ mod tests {
             Targets::One(launch) => assert_eq!(launch.key(), "wayfinder#2"),
             other => panic!("a done ticket still launches, got {other:?}"),
         }
+    }
+
+    /// A scratch directory of PATH entries, removed on drop. Real files rather
+    /// than a mock, because the question under test — would the OS execute
+    /// this candidate? — is a fact about an inode's mode bits.
+    struct FakePath(PathBuf);
+
+    impl FakePath {
+        fn new(name: &str) -> FakePath {
+            let dir = std::env::temp_dir().join(format!("wf-launch-{}-{name}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("scratch");
+            FakePath(dir)
+        }
+
+        /// One PATH entry holding one file named `program`, with `mode`.
+        fn entry(&self, dir: &str, program: &str, mode: u32) -> PathBuf {
+            use std::os::unix::fs::PermissionsExt;
+            let entry = self.0.join(dir);
+            std::fs::create_dir_all(&entry).expect("entry");
+            let file = entry.join(program);
+            std::fs::write(&file, "#!/bin/sh\n").expect("candidate");
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode))
+                .expect("mode");
+            entry
+        }
+    }
+
+    impl Drop for FakePath {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn path_resolution_skips_a_candidate_the_os_would_not_execute() {
+        // execvp keeps searching past a file it cannot execute; a stray
+        // non-executable `claude` early on PATH must not fail a launch the OS
+        // would have made.
+        let scratch = FakePath::new("skips-non-executable");
+        let decoy = scratch.entry("decoy", "agent", 0o644);
+        let real = scratch.entry("real", "agent", 0o755);
+        let path = std::env::join_paths([&decoy, &real]).expect("a PATH");
+        let resolved = resolve_in("agent", &path).expect("the executable is on PATH");
+        assert_eq!(resolved, real.join("agent"));
+    }
+
+    #[test]
+    fn a_name_found_only_as_a_non_executable_file_is_not_on_path() {
+        let scratch = FakePath::new("only-non-executable");
+        let decoy = scratch.entry("decoy", "agent", 0o644);
+        let path = std::env::join_paths([&decoy]).expect("a PATH");
+        assert!(resolve_in("agent", &path).is_err());
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -1426,8 +1426,25 @@ pub const UNSAVED_IS_AN_OBJECT: DlVersion = DlVersion(0, 0, 24);
 /// Split from the probe for the same reason [`Devlaunch::from_version_output`]
 /// is — the rule is the part worth testing, and it is testable without a `dl`
 /// on the machine running the tests.
-pub(crate) fn devlaunch_answers_unsaved() -> bool {
-    devlaunch_on_path().answers_unsaved()
+pub(crate) async fn devlaunch_answers_unsaved() -> bool {
+    off_runtime(|| devlaunch_on_path().answers_unsaved()).await
+}
+
+/// Run one blocking call without stalling the async runtime it is awaited on.
+///
+/// The version probe starts a Python interpreter and waits ~90ms for it
+/// (devlaunch#53), and [`reap::workspaces`](crate::reap::workspaces) reaches it
+/// from a tokio worker inside the picker's background survey — memoized, so it
+/// is one stall per process, but one stall of a worker thread is still every
+/// timer and channel on that worker arriving late.
+async fn off_runtime<T, F>(work: F) -> T
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(work)
+        .await
+        .expect("the blocking call does not panic")
 }
 
 /// Wrap one argument so a POSIX shell hands it back unchanged.
@@ -4666,5 +4683,34 @@ mod tests {
         let decoy = scratch.entry("decoy", "agent", 0o644);
         let path = std::env::join_paths([&decoy]).expect("a PATH");
         assert!(resolve_in("agent", &path).is_err());
+    }
+
+    #[tokio::test]
+    async fn a_blocking_call_through_the_probe_seam_does_not_stall_the_runtime() {
+        // `#[tokio::test]` is a current-thread runtime, so if the blocking
+        // work ran on the worker, the timer spawned here could not fire until
+        // it finished — and the flag it sets would still be unset when the
+        // work reads it. The margins are 20ms against 300ms, so a slow CI
+        // machine moves both the same way rather than flipping the verdict.
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+        let ticked = Arc::new(AtomicBool::new(false));
+        let for_timer = Arc::clone(&ticked);
+        let timer = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            for_timer.store(true, Ordering::SeqCst);
+        });
+        let for_work = Arc::clone(&ticked);
+        let timer_fired_while_blocked = off_runtime(move || {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            for_work.load(Ordering::SeqCst)
+        })
+        .await;
+        timer.await.expect("the timer task completes");
+        assert!(
+            timer_fired_while_blocked,
+            "the runtime's timers stood still while the blocking call ran — \
+             the probe is stalling the worker thread"
+        );
     }
 }

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -2012,8 +2012,7 @@ fn executable(candidate: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
     candidate
         .metadata()
-        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
+        .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
 }
 
 /// A launch prompt with the JSON of every `ctx:` block replaced by `…` (#124).

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -4651,8 +4651,7 @@ mod tests {
             std::fs::create_dir_all(&entry).expect("entry");
             let file = entry.join(program);
             std::fs::write(&file, "#!/bin/sh\n").expect("candidate");
-            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode))
-                .expect("mode");
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(mode)).expect("mode");
             entry
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -445,8 +445,8 @@ mod tests {
     /// list into a pin on the wrapping: rewording the `wf reap` paragraph — no
     /// capability changed, the same code, the same seven sites — failed the
     /// guard, and failed it with a message saying the file wrote `reap`
-    /// somewhere new, which was not true. Cutting the literal out leaves the
-    /// list five lines of code, which is what the guard is about.
+    /// somewhere new, which was not true. Cutting the literal out leaves
+    /// only lines of code in the list, which is what the guard is about.
     ///
     /// # Panics
     ///
@@ -585,7 +585,7 @@ mod tests {
                 "Invocation::Reap(ReapScope::Machine { yes, insist }) => reap::run(yes, insist).await,",
                 "Invocation::Reap(ReapScope::Finished(nodes)) => reap::cleanup(&nodes).await,",
             ],
-            "the lines of code in this file that write `reap` are no longer the five \
+            "the lines of code in this file that write `reap` are no longer the ones \
              listed here. A line that is not in the list is a way this binary reaches \
              `wf::reap::run`, which is a forced deletion when it is called with both \
              flags; a listed line that is gone means the list is stale. Read the diff \

--- a/src/model.rs
+++ b/src/model.rs
@@ -277,7 +277,7 @@ pub enum TicketType {
     Grilling,
     /// `wayfinder:prototype` — HITL by definition (someone has to look at it).
     Prototype,
-    /// The ticket carries none of the four types `wf` knows. Covers both a
+    /// The ticket carries none of the types `wf` knows. Covers both a
     /// ticket with no `wayfinder:*` label at all and one labelled with
     /// something newer than this binary — one meaning ("no recognised type"),
     /// not a sentinel standing in for several.

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -548,9 +548,9 @@ pub async fn run_picker() -> Result<()> {
             // And record the conversation this launch is about to start, so a
             // later run can offer the way back into it (#35).
             //
-            // Written **here**, immediately before the terminal is restored
-            // and the image replaced, because this is the last moment `wf`
-            // exists — and written from the resolved launch rather than from
+            // Written **here**, after the terminal is restored and immediately
+            // before the image is replaced, because this is the last moment
+            // `wf` exists — and written from the resolved launch rather than from
             // the picker, so what is remembered is the tree the agent actually
             // gets. A creation records nothing: it has no node to key on until
             // its skill files one.

--- a/src/reap.rs
+++ b/src/reap.rs
@@ -1013,7 +1013,7 @@ pub async fn workspaces() -> Result<Vec<Workspace>> {
         );
     }
     let mut workspaces = parse_workspaces(&output.stdout)?;
-    answered_where_dl_answers(&mut workspaces, devlaunch_answers_unsaved());
+    answered_where_dl_answers(&mut workspaces, devlaunch_answers_unsaved().await);
     Ok(workspaces)
 }
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -43,9 +43,10 @@ use crate::model::{Map, MapId, MapSet};
 use crate::projects::ProjectsCache;
 use crate::reclaim::Reading;
 
-/// How long the map search waits before trying again. The only recurring timer
-/// left: nothing polls, but a search that never answers would leave `wf`
-/// permanently empty.
+/// The map search's first wait, and the unit every later one doubles from —
+/// `retry_delay` carries the schedule and the ceiling it stops at. The only
+/// recurring timer left: nothing polls, but a search that never answers would
+/// leave `wf` permanently empty.
 pub const RETRY_INTERVAL: Duration = Duration::from_secs(4);
 
 /// One map's load. Two states, because with the conditional probe gone
@@ -346,9 +347,9 @@ pub fn spawn_discovery(
 /// them apart: a network blip deserves the quick retry the early steps give,
 /// while a structural failure — no `gh` on PATH, an unauthenticated one — used
 /// to cost a respawned `gh` process every four seconds for the whole session.
-/// The ceiling keeps the recovery property (a `gh auth login` run mid-session
-/// is still found within the minute) at a session-long cost of one process a
-/// minute instead of fifteen.
+/// The ceiling keeps the recovery property — a `gh auth login` run mid-session
+/// is still found, one capped wait later rather than never — at a session-long
+/// cost of roughly one process a minute instead of fifteen.
 fn retry_delay(failures: u32) -> Duration {
     RETRY_INTERVAL * 2u32.saturating_pow(failures.saturating_sub(1)).min(16)
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -300,7 +300,7 @@ fn spawn_load(id: MapId, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()>
 /// Find every open `wayfinder:map` across the cached repos, off the path to
 /// the first frame (#27).
 ///
-/// It **retries** rather than giving up — on [`retry_delay`]'s doubling
+/// It **retries** rather than giving up — on `retry_delay`'s doubling
 /// schedule, [`RETRY_INTERVAL`] first — and that is now the only recovery a
 /// session has. A single failed search would otherwise leave `wf` empty for
 /// the whole run with no way back: the only other thing that fetches is the

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -300,11 +300,11 @@ fn spawn_load(id: MapId, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()>
 /// Find every open `wayfinder:map` across the cached repos, off the path to
 /// the first frame (#27).
 ///
-/// It **retries** on [`RETRY_INTERVAL`] rather than giving up, and that is now
-/// the only recovery a session has. A single failed search would otherwise
-/// leave `wf` empty for the whole run with no way back: the only other thing
-/// that fetches is the cached seed, a cold start has none, and no key asks
-/// again.
+/// It **retries** rather than giving up — on [`retry_delay`]'s doubling
+/// schedule, [`RETRY_INTERVAL`] first — and that is now the only recovery a
+/// session has. A single failed search would otherwise leave `wf` empty for
+/// the whole run with no way back: the only other thing that fetches is the
+/// cached seed, a cold start has none, and no key asks again.
 ///
 /// It runs **unconditionally**, warm cache or cold (#28). The cache is a head
 /// start, never a skip: this is the one thing that can add a map opened since
@@ -321,6 +321,7 @@ pub fn spawn_discovery(
     tx: mpsc::UnboundedSender<LoadEvent>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        let mut failures = 0u32;
         loop {
             match fetch::find_maps(&repos).await {
                 Ok(found) => {
@@ -331,11 +332,25 @@ pub fn spawn_discovery(
                     return; // the set of open maps is fixed for this run
                 }
                 Err(_) if tx.send(LoadEvent::SearchFailed).is_err() => return, // UI is gone
-                Err(_) => {}
+                Err(_) => failures += 1,
             }
-            tokio::time::sleep(RETRY_INTERVAL).await;
+            tokio::time::sleep(retry_delay(failures)).await;
         }
     })
+}
+
+/// How long the map search waits after its `failures`-th consecutive miss.
+///
+/// Doubles from [`RETRY_INTERVAL`] and stops growing at sixteen times it,
+/// because the two kinds of miss want opposite treatments and this cannot tell
+/// them apart: a network blip deserves the quick retry the early steps give,
+/// while a structural failure — no `gh` on PATH, an unauthenticated one — used
+/// to cost a respawned `gh` process every four seconds for the whole session.
+/// The ceiling keeps the recovery property (a `gh auth login` run mid-session
+/// is still found within the minute) at a session-long cost of one process a
+/// minute instead of fifteen.
+fn retry_delay(failures: u32) -> Duration {
+    RETRY_INTERVAL * 2u32.saturating_pow(failures.saturating_sub(1)).min(16)
 }
 
 /// Take the background reading of what a `wf reap` would claim, off the path to
@@ -445,6 +460,26 @@ pub fn preserve_cursor<K: PartialEq>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn discovery_retries_back_off_by_doubling() {
+        // The first retry is the old cadence — a blip costs nothing extra —
+        // and each miss after that doubles the wait.
+        assert_eq!(retry_delay(1), Duration::from_secs(4));
+        assert_eq!(retry_delay(2), Duration::from_secs(8));
+        assert_eq!(retry_delay(3), Duration::from_secs(16));
+        assert_eq!(retry_delay(4), Duration::from_secs(32));
+    }
+
+    #[test]
+    fn the_backoff_stops_growing_at_its_ceiling() {
+        // A structurally broken `gh` settles at one respawn a minute for the
+        // rest of the session — never more, and never so rare that a mid-run
+        // `gh auth login` goes unnoticed.
+        assert_eq!(retry_delay(5), Duration::from_secs(64));
+        assert_eq!(retry_delay(6), Duration::from_secs(64));
+        assert_eq!(retry_delay(u32::MAX), Duration::from_secs(64));
+    }
 
     /// A reading that never answers — the reading `wf` must be able to draw
     /// over. A `pending` future rather than a long sleep, so "the picker did

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -74,8 +74,8 @@ const CODEX_HOME_ENV: &str = "CODEX_HOME";
 /// agent's config directory (`~/.claude/wf-skills` or `~/.codex/wf-skills`).
 ///
 /// A sibling of `skills/` rather than a directory inside it, because the agents
-/// read *every* directory under `skills/` — a copy in there would register five
-/// more skills under a second set of names.
+/// read *every* directory under `skills/` — a copy in there would register the
+/// whole bundle again under a second set of names.
 pub const MIRROR: &str = "wf-skills";
 
 /// Where the copy came from, recorded inside it: the bundle directory the last
@@ -510,7 +510,7 @@ pub enum Outcome {
 /// When a directory cannot be created, a copy cannot be written, or a link
 /// cannot be replaced. A skill that is merely *blocked* or absent from the
 /// bundle is not an error — it is an [`Outcome`], so one bad skill never costs
-/// the other four their install.
+/// the rest their install.
 pub fn install(bundle: &Bundle, target: &Target) -> Result<Vec<(String, Outcome)>> {
     for dir in [&target.links, &target.mirror] {
         std::fs::create_dir_all(dir).with_context(|| format!("cannot create {}", dir.display()))?;
@@ -649,7 +649,7 @@ pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
             // that resolves on the host and dangles in the container — and it
             // can never match a link somebody else left, however dead it looks.
             // A target that could not be read is `Stale(None)`, and falls to
-            // the arm below: with nothing to prove ownership of, the sweep has
+            // the arm below: with nothing to prove ownership of, `refresh` has
             // no permission to touch it.
             Link::Stale(Some(points_at)) if is_ours(&points_at, &bundle) => Some(Some(points_at)),
             Link::Stale(_) | Link::Unmanaged => continue,

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -651,9 +651,7 @@ pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
             // A target that could not be read is `Stale(None)`, and falls to
             // the arm below: with nothing to prove ownership of, the sweep has
             // no permission to touch it.
-            Link::Stale(Some(points_at)) if is_ours(&points_at, &bundle) => {
-                Some(Some(points_at))
-            }
+            Link::Stale(Some(points_at)) if is_ours(&points_at, &bundle) => Some(Some(points_at)),
             Link::Stale(_) | Link::Unmanaged => continue,
         };
         // Always the copy before the link, so a link this function creates

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -277,8 +277,11 @@ enum Link {
     /// A symlink, but not that one — an older `wf`'s link into a package
     /// prefix, a checkout someone pointed at once, or an absolute path into the
     /// copy that would dangle in a container. Relinking is safe: nothing but a
-    /// link is lost.
-    Stale(PathBuf),
+    /// link is lost. `None` when the target itself could not be read — still a
+    /// link and still safely replaceable, but with nothing to report or to
+    /// prove ownership of, and carried as the absence it is rather than as an
+    /// empty path a report would print.
+    Stale(Option<PathBuf>),
     /// A real directory. Somebody else owns this — chezmoi, a hand-edit, a
     /// plugin — so `wf` reports it and does not touch it. Deleting a directory
     /// it did not create is not `wf`'s call to make.
@@ -316,8 +319,9 @@ pub enum State {
     /// `copied_from` is what [`install`] recorded, and `None` means a copy old
     /// enough to predate the record.
     Outdated { copied_from: Option<PathBuf> },
-    /// A symlink pointing somewhere else entirely.
-    Stale(PathBuf),
+    /// A symlink pointing somewhere else entirely — or, `None`, one whose
+    /// target could not be read at all.
+    Stale(Option<PathBuf>),
     /// A real directory another tool owns.
     Unmanaged,
     /// Nothing there.
@@ -389,8 +393,8 @@ fn link_state(name: &str, link: &Path) -> Link {
     }
     match std::fs::read_link(link) {
         Ok(target) if target == Target::link_target(name) => Link::Current,
-        Ok(target) => Link::Stale(target),
-        Err(_) => Link::Stale(PathBuf::new()),
+        Ok(target) => Link::Stale(Some(target)),
+        Err(_) => Link::Stale(None),
     }
 }
 
@@ -537,14 +541,18 @@ pub fn install(bundle: &Bundle, target: &Target) -> Result<Vec<(String, Outcome)
             Link::Current => Outcome::AlreadyCurrent,
             Link::Unmanaged => unreachable!("handled above"),
             state => {
+                // A stale link is removed whether or not its target could be
+                // read — either way it is only a link, and only a link is
+                // lost. `was` keeps the target where there is one to name.
                 let was = match state {
-                    Link::Stale(target) => Some(target),
+                    Link::Stale(target) => {
+                        std::fs::remove_file(&link).with_context(|| {
+                            format!("cannot replace the link {}", link.display())
+                        })?;
+                        target
+                    }
                     _ => None,
                 };
-                if was.is_some() {
-                    std::fs::remove_file(&link)
-                        .with_context(|| format!("cannot replace the link {}", link.display()))?;
-                }
                 std::os::unix::fs::symlink(Target::link_target(name), &link).with_context(
                     || format!("cannot link {} → {}", link.display(), copy.display()),
                 )?;
@@ -640,7 +648,12 @@ pub fn refresh(target: &Target) -> Result<Vec<(String, Healed)>> {
             // into the package prefix every `wf` before #110 wrote — the one
             // that resolves on the host and dangles in the container — and it
             // can never match a link somebody else left, however dead it looks.
-            Link::Stale(points_at) if is_ours(&points_at, &bundle) => Some(Some(points_at)),
+            // A target that could not be read is `Stale(None)`, and falls to
+            // the arm below: with nothing to prove ownership of, the sweep has
+            // no permission to touch it.
+            Link::Stale(Some(points_at)) if is_ours(&points_at, &bundle) => {
+                Some(Some(points_at))
+            }
             Link::Stale(_) | Link::Unmanaged => continue,
         };
         // Always the copy before the link, so a link this function creates
@@ -791,22 +804,7 @@ pub fn report(bundle: &Bundle, target: &Target) -> String {
     // disagreed would be the worst possible output for this command.
     let statuses = status(bundle, target);
     for Status { name, state } in &statuses {
-        let line = match state {
-            State::Current => "ok".to_string(),
-            // Where from, when that is known and is not where this build's
-            // bundle is: "outdated" alone leaves you guessing between a package
-            // update you have not launched since and a checkout you installed
-            // from months ago, and the fix is different.
-            State::Outdated { copied_from } => match copied_from {
-                Some(source) if *source != bundle.path => {
-                    format!("outdated — the copy came from {}", source.display())
-                }
-                _ => "outdated — the copy is not this build's".to_string(),
-            },
-            State::Stale(points_at) => format!("stale — links to {}", points_at.display()),
-            State::Unmanaged => "not a link — another tool owns this one".to_string(),
-            State::Missing => "missing".to_string(),
-        };
+        let line = state_line(state, &bundle.path);
         let _ = writeln!(out, "  {name:<15} {line}");
     }
     if statuses.iter().all(|s| s.state.is_current()) {
@@ -815,6 +813,27 @@ pub fn report(bundle: &Bundle, target: &Target) -> String {
         out.push_str("\nRun `wf skills install` to link them.\n");
     }
     out
+}
+
+/// One state as the line `wf skills status` prints for it.
+fn state_line(state: &State, bundle_path: &Path) -> String {
+    match state {
+        State::Current => "ok".to_string(),
+        // Where from, when that is known and is not where this build's
+        // bundle is: "outdated" alone leaves you guessing between a package
+        // update you have not launched since and a checkout you installed
+        // from months ago, and the fix is different.
+        State::Outdated { copied_from } => match copied_from {
+            Some(source) if source != bundle_path => {
+                format!("outdated — the copy came from {}", source.display())
+            }
+            _ => "outdated — the copy is not this build's".to_string(),
+        },
+        State::Stale(Some(points_at)) => format!("stale — links to {}", points_at.display()),
+        State::Stale(None) => "stale — the link's target could not be read".to_string(),
+        State::Unmanaged => "not a link — another tool owns this one".to_string(),
+        State::Missing => "missing".to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -953,6 +972,25 @@ mod tests {
     }
 
     #[test]
+    fn a_stale_link_whose_target_cannot_be_read_is_reported_without_a_path() {
+        // A failed `read_link` used to be carried as `Stale(PathBuf::new())`,
+        // and the status line printed "stale — links to " with nothing after
+        // it. There is no target to name, and the line says that instead.
+        assert_eq!(
+            state_line(&State::Stale(None), Path::new("/bundle")),
+            "stale — the link's target could not be read"
+        );
+        // The ordinary stale link still names where it points.
+        assert_eq!(
+            state_line(
+                &State::Stale(Some(PathBuf::from("/somewhere/else"))),
+                Path::new("/bundle")
+            ),
+            "stale — links to /somewhere/else"
+        );
+    }
+
+    #[test]
     fn a_link_into_the_package_bundle_is_stale_and_gets_repointed() {
         // What every `wf` up to this one wrote, and what is on every machine
         // that has run `wf skills install`: an absolute link into the prefix.
@@ -965,7 +1003,7 @@ mod tests {
 
         assert_eq!(
             link_state("wf", &target.links().join("wf")),
-            Link::Stale(old.clone())
+            Link::Stale(Some(old.clone()))
         );
         let done = install(&bundle, &target).expect("install");
         let wf_skill = done.iter().find(|(n, _)| n == "wf").expect("entry");


### PR DESCRIPTION
Closes #192. Five independent fixes from the 0.19.2 review's robustness sweep, one test-first slice each:

1. **Blocking probe off the runtime worker.** `devlaunch_on_path()` waits ~90ms for a Python interpreter with std's `Command::output()`, and `reap::workspaces` reached it from a tokio worker inside the picker's background survey. The answer is now awaited through an off-thread seam (`spawn_blocking`), tested by the observable: a current-thread runtime's timers keep firing while a blocking call made through the seam runs.

2. **PATH resolution matches execvp.** `resolve_on_path` took the first `is_file()` hit, so a stray non-executable `claude` early on PATH failed a launch the OS would have made. Resolution now requires an execute bit (the same approximation `which(1)` makes), with the rules split from the one line that reads the environment so tests never mutate PATH under a parallel suite.

3. **Discovery backs off.** `spawn_discovery` respawned a `gh` process every 4s for the whole session even when the failure was structural. The wait now doubles per consecutive miss and settles at sixteen times the old cadence — a blip still recovers on the first quick retry, a mid-session `gh auth login` is noticed within the minute, and a broken `gh` costs one process a minute instead of fifteen. Pure schedule function with literal expected values, worded clear of refresh.rs's source-text denylist.

4. **Prose drift.** The reap guard's red message said "five" over a nine-entry list (and its sibling comment made the same stale count); model.rs said "four types" where `wf` knows five; picker.rs claimed the session record is written before the terminal is restored when it is written just after. Counts are now count-free so a list edit cannot re-stale them.

5. **No empty path in the skills report.** A failed `read_link` was carried as `Stale(PathBuf::new())` and printed "stale — links to " with nothing after it. `Stale` now carries `Option<PathBuf>`; the report says the target could not be read, the sweep declines to touch a link it cannot prove it wrote, and install still replaces it.

Full local chain green (fmt, clippy, lib/bins/examples, skill_docs, devcontainer_prebuild, toolchain_pin, offline_green, live_fetch common, doc) under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve launch, discovery, and skills robustness while keeping runtime responsiveness, retry behavior, and status reporting reliable.

New Features:
- Add asynchronous offloading for blocking interpreter probes so runtime workers remain responsive.
- Make PATH resolution skip non-executable files and improve stale-link reporting when symlink targets cannot be read.

Bug Fixes:
- Prevent discovery from repeatedly respawning failed processes at a high frequency by applying bounded retry backoff.
- Correct stale counts and ordering claims in user-facing and maintenance prose.

Enhancements:
- Preserve safe replacement of unreadable stale links while avoiding unsupported ownership claims during refresh.

Tests:
- Add coverage for non-executable PATH candidates, runtime responsiveness during blocking work, bounded discovery backoff, and unreadable stale-link status output.