### PR TITLE
Release 0.19.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.19.3"
+  version: "0.19.4"
 
 package:
   name: wf


### PR DESCRIPTION
Patch: the medium-severity findings of the 0.19.2 review are fixed (#182). Four
independent reviewers read all of `src/`, `tests/` and the workflows; nine of
the eleven tickets that came out of it ship here, each built test-first and
reviewed in fresh context.

The one that could lose work: `wf reap` asked for a node's linked PRs five at a
time and never asked whether five was all of them. GitHub returns references
oldest-first, so on a node with six the *open* PR is exactly the one that falls
off the page — the node read as done-by-merge and its workspace was reaped with
work in flight (#183). A truncated rollup is now unreadable evidence rather
than an answer, which is the keeping arm reap already lands on for an unknown
PR state. The same silent-cap shape cost the screen a whole map: a map issue
with 21+ labels whose `wayfinder:map` fell outside the first 20 failed
re-verification and was rejected as "no longer a map" while discovery kept
finding it, permanently (#184).

Two more losses, both in the gap between reading state and acting on it.
`projects.json` was a bare truncate-then-write with three writers, so a torn
read parsed as corrupt, fell back to an empty default, and the next save
rewrote the registry from empty — every checkout, seed and session record gone
(#185). And interactive reap read "running" from the listing it opened with,
then blocked on the y/N prompt for as long as a human took: a session started
in that window was a live container the stale plan tore down (#186).

`wf skills install` no longer adopts. `create_dir_all` silently took ownership
of a `~/.claude/wf-skills` a user or another tool had made, and pruning then
deleted every entry not in the bundle — against the README's promise that a
skill of yours can never match however dead it looks. Pruning now requires the
`.source` record wf wrote, and a directory without one is reported and left
(#187). This is the one behaviour a user can hit: an install over a directory
wf cannot prove it made now refuses and exits 1 rather than sweeping it.

The rest: the count line counts tickets rather than drawn rows, so a DAG
diamond no longer reads `5/4`, and a cursor on a duplicated ticket stops
teleporting to the first drawing (#188). PATH resolution checks the execute bit
execvp checks, discovery backs off instead of respawning `gh` every four
seconds forever, the devlaunch probe is off the tokio worker, and several
load-bearing comments that miscounted their own lists are count-free (#192).

Two things guard the tests themselves. A `tests/*.rs` that no workflow command
runs now fails the build — "an assertion nothing runs is not an assertion" was
this repo's rule everywhere except one meta-level up, where it had reopened
(#189). And the README states the tracker-content injection posture beside
#73's trade: issue titles are attacker-writable on any repo that accepts
issues and reach the prompt of an agent running with permissions bypassed. The
escaping is airtight and semantic steering is not defended, so the paragraph
says so, bound to what the launch actually embeds (#193).

Two tickets are deliberately not here. Both are green with an open PR and both
failed a second review on test *strength* rather than behaviour: the red-run
alert's `if:` guard is asserted as loose substrings (#190), and unicode column
budgeting overruns on a variation selector (#191). Each carries a handoff.

`live.yml` has been red on `main` since before this release and stays red:
`live_discovery` asserts the lowest-numbered open map on this repo has seven
tickets and finds two. It is the non-blocking tier asserting the tracker's
present contents, unrelated to anything here, and #182 carries it as fog.

---
Bumps `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` — the same three files 0.19.3 touched. No code or skill changed in this commit; the binary is what the nine merged PRs made.

Merging this and tagging `v0.19.4` is what reaches the `release` job in `package.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the package and recipe versions to 0.19.4.