### PR TITLE
Draw the issues no map claims, and adopt them into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,11 @@ maps as clusters beneath.
   ▌ wayfinder · the general dev-process tree  ○2  ◐1
     ○ #134 The manager hands pointers, never readings [build]
     ○ #133 The ctx handoff's guards don't yet guard   [build]
+
+  ▌ wayfinder · yours or unclaimed  ○1  ◍2
+    ○ #207 Widen the count line
+    ◍ #190 A red live or scheduled run files an issue [build]  ⇄ PR#202 open ✓
+    ◍ #191 Widths survive non-ASCII titles            [build]  ⇄ PR#203 open ✓
 ```
 
 **Outside one** it opens on the **project list** — every registered repo, most
@@ -316,8 +321,9 @@ pattern) is **one** project: they are two places it can run, and they share its
 maps, so the project's stamp is the newest of theirs.
 
 Every registered repo is a row on the project list, mapped or not. A repo with
-no open `wayfinder:map` simply has no clusters on its screen — its own row is
-still there, and is where its first map gets charted (see
+no open `wayfinder:map` has no *map* clusters on its screen — it may still have
+an [inbox](#the-inbox-issues-no-map-claims) — and its own
+row is still there, which is where its first map gets charted (see
 [Launching](#launching)).
 
 **Every open map renders as its own cluster** — a `▌ repo · map title` header
@@ -332,6 +338,69 @@ touched most recently sits at the top, and a map whose every ticket is done
 sinks to the bottom however fresh it is — it is history, not work. Maps with
 equal (or unreadable) timestamps fall back to `repo`, then map number, so the
 order never shuffles between frames.
+
+### The inbox: issues no map claims
+
+A repo's screen ends with one more cluster, `▌ repo · yours or unclaimed`,
+holding **every open issue in that repo that is yours or nobody's and is not on
+a map**. It is read once at startup alongside the map search, neither waiting
+on the other.
+
+**Yours or nobody's, not every open issue**, and that is the shape of the
+feature rather than a filter on it. A repo's whole open issue list is not
+curated — dependabot, other people's work in flight, stale requests — and
+pouring it in would not make a bigger `wf`, it would bury the charted maps
+under a worse `gh issue list`. Dropping *somebody else's* issues leaves the set
+you could actually pick up.
+
+The header is in the vocabulary the rows already use: an assigned issue is
+**claimed** (`◐`) and an unassigned one is on the **frontier** (`○`), so
+"unclaimed" is what this screen already means by an open issue nobody has
+taken. The heading says what is in the cluster, not how it was found.
+
+**It costs two searches and one round trip.** GitHub issue search has no `OR` —
+qualifiers `AND` together, so `assignee:@me no:assignee` is a contradiction
+matching nothing. So `assignee:@me` and `no:assignee` are two searches, aliased
+into a single GraphQL query sharing one fragment for the selection. They are
+disjoint by construction (an issue cannot be both), so nothing needs
+deduplicating between them, and a row's status comes from its own `assignees`
+field rather than from which half found it.
+
+**Map issues are dropped from it.** A map is an open issue with nobody
+assigned, so `no:assignee` finds every map in every repo asked about — and a
+map is a cluster *header* on this screen. Without that drop, every header would
+also appear as a row of the inbox below it.
+
+**It sorts after every map, however fresh it is** — below finished maps too.
+That is the one ordering key that is not about recency: a map is work somebody
+charted, the inbox is work that merely exists, and an issue touched this
+morning must not push the charted half of the screen down. Everything else
+about it is an ordinary cluster: the same stage glyphs, the same PR badges, the
+same fuzzy-find, the same `←`/`→` depth navigation.
+
+**A map claims its own rows out of it.** An issue you have claimed on a map
+matches `assignee:@me` too, so it is in both answers — and it belongs on the
+map, where its blockers and its leverage are. The inbox is therefore *derived*:
+the raw reading is kept and the maps are subtracted from it on every arrival,
+so a map landing late takes its rows with it, and a map whose fetch **failed**
+leaves its rows visible in the inbox rather than nowhere at all. An inbox left
+with no rows is dropped entirely — a heading over nothing says nothing.
+
+**A failed read says so.** Three things look identical on screen — nothing is
+assigned to you, everything assigned is already claimed by a map, and the query
+never answered — because an empty inbox draws no heading at all. So a failure
+puts `· inbox unread` on the count line. Nothing retries it: that is the final
+word for the run, and running `wf` again is the way to ask.
+
+**The header is a place to stand, not a node.** A map's header launches because
+there is an issue behind it; the inbox's is a heading over rows that each have
+their own issue, so `enter` on it says so instead of inventing a target.
+
+**The project list leaves the inbox out of its counts** — `· 2 maps` counts
+maps, and the stage rollup beside it is the maps' — because that list is drawn
+before you enter anything and its glyphs are there to say how much *charted*
+work is moving. An inbox of thirty assigned issues would render `◐30` over
+every repo and drown the two or three glyphs that were the point.
 
 **The default screen is the leverage view**: each cluster shows its takeable
 tickets (frontier and claimed), sorted by how many open tickets each one
@@ -721,6 +790,45 @@ there are no launch rows, and `enter` with an empty `task` field refuses on the
 count line rather than filing something blank. Which is why the creating default
 is safe: `enter enter` on a fresh screen does nothing at all.
 
+### Adopting: an inbox row gets a map of its own
+
+`enter` on a row of the [inbox](#the-inbox-issues-no-map-claims)
+offers exactly one thing:
+
+```
+┌ launch Claude · blooop/wayfinder · #191 Widths survive non-ASCII titles ┐
+│                                                                         │
+│  ▶ adopt         /wf-one   put it under a map of its own, then build it │
+│                                                                         │
+│    steer  █                                                             │
+│                                                                         │
+│  enter launch · ←/→ agent · ↑/↓ pick · type to fill · esc cancel        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`wf-one` files a **map** and parents the existing issue under it, then runs the
+ordinary `wf-tdd` → gate → `wf-review` lifecycle on it. Nothing is created that
+you have to name — the issue already has a title, which is the whole difference
+between adopting and filing, and why this row takes no `task` field.
+
+**Why a map at all**, rather than launching the issue where it stands: the
+lifecycle needs somewhere to keep its breadcrumbs and its handoff, and every
+`/wf` route takes a map as its first argument. That requirement is not an
+accident to route around — it is what makes a run resumable across sessions. So
+adoption gives the issue the one thing it is missing and hands it to the path
+that already works, which is why `wf`'s launch contract needed no widening for
+any of this.
+
+**There is no mode axis on this row.** `wf-one` owns the whole of a
+single-ticket map's lifecycle and decides the small things alone, so "who
+decides" is already answered by the route rather than being a row to pick.
+
+The adoption runs in the issue's own per-node workspace —
+`wayfinder/<short-repo>-<n>`, exactly as any launch of that number would — so it
+prewarms like any node, resumes like any node, and
+[`wf reap`](#wf-reap--clearing-away-finished-tickets) clears it away like any
+node. Nothing downstream has to know a map was created along the way.
+
 ### `mid`: which questions are worth asking
 
 The mode rows are one axis — who decides — and its two ends were the only
@@ -851,6 +959,7 @@ on what was found — which is what makes the create path work on the first fram
 | anything | any unfinished stage | mid | `<sigil>wf-mid <map> [<n>]` |
 | anything | any unfinished stage | auto | `<sigil>wf-auto <map> [<n>]` |
 | anything | any unfinished stage | plain | the selected agent, with no skill; anything typed is the whole prompt |
+| an inbox row | any unfinished stage | adopt | `<sigil>wf-one adopt <n>` |
 | a project row | — | new task | `<sigil>wf-one <task>` |
 | a project row | — | new map | `<sigil>wf [<seed>]` |
 | a project row | — | new map, mid | `<sigil>wf-mid [<seed>]` |

--- a/README.md
+++ b/README.md
@@ -378,6 +378,15 @@ morning must not push the charted half of the screen down. Everything else
 about it is an ordinary cluster: the same stage glyphs, the same PR badges, the
 same fuzzy-find, the same `←`/`→` depth navigation.
 
+**Its rows are in date order, newest first** — where a map's rows are ordered
+by what taking them unlocks and then by number. A map's numbers are the order
+its author charted it in, so they mean something; an inbox is a pile with no
+author, and ascending number order would put the oldest issue in the repo at
+the top. A row whose timestamp did not parse sorts last rather than being
+guessed into place. `sort:updated-desc` is on both searches for the same
+reason: one page of 100 spans every repo, so the rows worth keeping are the
+ones something just happened to.
+
 **A map claims its own rows out of it.** An issue you have claimed on a map
 matches `assignee:@me` too, so it is in both answers — and it belongs on the
 map, where its blockers and its leverage are. The inbox is therefore *derived*:
@@ -395,6 +404,16 @@ word for the run, and running `wf` again is the way to ask.
 **The header is a place to stand, not a node.** A map's header launches because
 there is an issue behind it; the inbox's is a heading over rows that each have
 their own issue, so `enter` on it says so instead of inventing a target.
+
+**Adoption waits while the map picture is incomplete.** The inbox is only as
+trustworthy as the maps are complete, and a row a *missing* map would have
+claimed is still drawn — so while any map of that repo is still out, or any
+failed, `enter` on a loose row refuses and says which. Adopting a ticket that
+already has a map would file a second one and reparent the issue under it, and
+GitHub allows an issue exactly one parent, so the map it was charted on would
+silently lose it. `wf-one adopt` asks the tracker for the issue's parent before
+filing anything, because this reading can be stale for reasons no local state
+shows.
 
 **The project list leaves the inbox out of its counts** — `· 2 maps` counts
 maps, and the stage rollup beside it is the maps' — because that list is drawn

--- a/examples/preview_screen.rs
+++ b/examples/preview_screen.rs
@@ -5,6 +5,10 @@
 //! Run: `cargo run --example preview_screen -- blooop/wayfinder 47 [more...]`
 //! Keys to replay come from $KEYS, e.g. KEYS="down right right" — one of
 //! down/up/left/right/tab/<char>.
+//!
+//! The inbox (`yours or unclaimed`) is read for the same repos and subtracted
+//! against the maps given, so the frame here is the frame `wf` draws once both
+//! reads have landed.
 
 use std::collections::BTreeMap;
 
@@ -34,6 +38,40 @@ fn press(app: &mut App, name: &str) {
     app.handle_key(KeyEvent::new(code, mods));
 }
 
+/// The inbox, subtracted against the maps that were fetched — the same
+/// derivation `picker`'s fold makes, so the frame this dumps is the frame `wf`
+/// draws once both reads have landed.
+async fn add_inbox(
+    clusters: &mut BTreeMap<wf::model::ClusterId, wf::model::Cluster>,
+    ids: &[MapId],
+    mapped: &BTreeMap<String, Vec<u64>>,
+) {
+    let repos: Vec<String> = ids.iter().map(|id| id.repo.clone()).collect();
+    let inbox = match wf::fetch::fetch_inbox(&repos).await {
+        Ok(inbox) => inbox,
+        Err(e) => {
+            eprintln!("inbox failed: {e}");
+            return;
+        }
+    };
+    for (repo, cluster) in inbox {
+        let claimed = mapped.get(&repo).cloned().unwrap_or_default();
+        let tickets: Vec<_> = cluster
+            .tickets
+            .iter()
+            .filter(|t| !claimed.contains(&t.number))
+            .cloned()
+            .collect();
+        if tickets.is_empty() {
+            continue;
+        }
+        clusters.insert(
+            wf::model::ClusterId::Inbox(repo),
+            wf::model::Cluster::inbox(cluster.last_activity, tickets, cluster.truncated),
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -46,14 +84,21 @@ async fn main() {
         .collect();
 
     let mut clusters = BTreeMap::new();
+    let mut mapped: BTreeMap<String, Vec<u64>> = BTreeMap::new();
     for id in &ids {
         match wf::fetch::fetch_map(id).await {
             Ok(map) => {
-                clusters.insert(id.clone(), map);
+                mapped
+                    .entry(id.repo.clone())
+                    .or_default()
+                    .extend(map.tickets.iter().map(|t| t.number));
+                clusters.insert(wf::model::ClusterId::Map(id.clone()), map);
             }
             Err(e) => eprintln!("{}#{} failed: {e}", id.repo, id.number),
         }
     }
+
+    add_inbox(&mut clusters, &ids, &mapped).await;
 
     let keys: Vec<String> = std::env::var("KEYS")
         .unwrap_or_default()
@@ -79,7 +124,7 @@ async fn main() {
     let stops = app.stops();
     let pos = app.cursor_pos();
     let label = |at: &wf::view::StopAt| match &at.stop {
-        wf::view::Stop::Map(id) => format!("map #{}", id.number),
+        wf::view::Stop::Cluster(id) => format!("cluster {}", id.label()),
         wf::view::Stop::Ticket(row) => format!("#{}", app.ticket(row).number),
         wf::view::Stop::Group(g) => format!("{:?}", g.kind),
         wf::view::Stop::Project(repo) => format!("project {repo}"),

--- a/skills/wf-one/SKILL.md
+++ b/skills/wf-one/SKILL.md
@@ -13,9 +13,19 @@ For work whose shape is already known. There is nothing to decide and nothing to
 
 Two issues, not one: wf's cluster header is a map and headers are not cursor stops, so the ticket is the row you land on and launch from. The map is the container that makes it visible.
 
+## Two ways in
+
+**`<sigil>wf-one <task>`** — the work does not exist yet. File both issues below.
+
+**`<sigil>wf-one adopt <n>`** — issue `<n>` already exists and no map claims it. `wf` draws it in the *yours or unclaimed* cluster and `enter` sends it here. **Do not create a second issue for it.** File the map, parent the existing issue under it, and pick up at **Run it** — everything after setup is identical, which is the whole reason adoption routes here rather than to a skill of its own.
+
+Read the issue first (`gh issue view <n> --repo "$REPO"`) — its title and body are the ticket, already written by whoever filed it. Do not retitle or rewrite it to look like something you filed; you are giving it a map, not taking it over. Type labels are the one thing to add if it has none: `wayfinder:build` for code, `wayfinder:task` for other doing, so the row's stage starts deriving from its PRs.
+
+If the issue turns out to be too big for one ticket, that is the same signal the **Don't let it fan out** section below describes, and it has the same answer: say so, leave a `### handoff`, and hand it to `wf`. Do not chart around it.
+
 ## Set it up
 
-A `wf-one` launch is a **creation**: it names work that does not exist on the tracker yet, so its line is `<sigil>wf-one <task>` and never carries a `ctx: <json>` block. Nor may you synthesize one when handing the ticket to `wf-tdd` or `wf-review` below — the block is `wf`'s record of what it fetched, and a hand-written one would be a claim about tracker state nobody read. Those subagents discover from the ticket, exactly as a hand-typed invocation does. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
+A `wf-one` launch is a **creation** either way: even adopting, the map it needs does not exist on the tracker yet, so its line is `<sigil>wf-one <task>` or `<sigil>wf-one adopt <n>` and never carries a `ctx: <json>` block. Nor may you synthesize one when handing the ticket to `wf-tdd` or `wf-review` below — the block is `wf`'s record of what it fetched, and a hand-written one would be a claim about tracker state nobody read. Those subagents discover from the ticket, exactly as a hand-typed invocation does. See **The launch context** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md).
 
 Tracker mechanics — pinning the repo, creating and parenting issues, labels, claiming — are in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md) in the sibling `wf` skill. Pin the repo from the working repo's own remote and pass it explicitly on every `gh` call; push branches by name.
 
@@ -32,6 +42,8 @@ Tracker mechanics — pinning the repo, creating and parenting issues, labels, c
    ```
 
 2. **The ticket**, as the map's only child, claimed to yourself before any work. `wayfinder:build` for code — wf then derives the row's stage from its PRs, so the row shows real progress — or `wayfinder:task` for other doing. Body is one `## Work` section: what to do, and how you will know it's done.
+
+   **Adopting**: the ticket is issue `<n>`, which exists. Parent it under the map you just made and claim it — that is the whole of this step. See **Create a ticket (create, then parent)** in [GITHUB_TRACKER.md](../wf/GITHUB_TRACKER.md); the parenting call takes the issue's database id and does not care that the issue is old.
 
 File both **before** starting. That is what makes the run resumable rather than a session you hope survives.
 
@@ -55,4 +67,4 @@ Decisions small enough to take alone are yours, in this order when they collide:
 
 ## Close it out
 
-A resolution comment on the ticket saying what happened, then close the ticket — and **close the map with it**. A one-ticket map is done when its ticket is, and leaving it open leaves an empty cluster in `wf` forever.
+A resolution comment on the ticket saying what happened, then close the ticket — and **close the map with it**. A one-ticket map is done when its ticket is, and leaving it open leaves an empty cluster in `wf` forever. An adopted ticket closes the same way: it was somebody's issue before it was a ticket, so the resolution comment is what they will read.

--- a/skills/wf-one/SKILL.md
+++ b/skills/wf-one/SKILL.md
@@ -19,7 +19,15 @@ Two issues, not one: wf's cluster header is a map and headers are not cursor sto
 
 **`<sigil>wf-one adopt <n>`** — issue `<n>` already exists and no map claims it. `wf` draws it in the *yours or unclaimed* cluster and `enter` sends it here. **Do not create a second issue for it.** File the map, parent the existing issue under it, and pick up at **Run it** — everything after setup is identical, which is the whole reason adoption routes here rather than to a skill of its own.
 
-Read the issue first (`gh issue view <n> --repo "$REPO"`) — its title and body are the ticket, already written by whoever filed it. Do not retitle or rewrite it to look like something you filed; you are giving it a map, not taking it over. Type labels are the one thing to add if it has none: `wayfinder:build` for code, `wayfinder:task` for other doing, so the row's stage starts deriving from its PRs.
+**Check it has no parent first, and stop if it has.** `wf` offers adoption from a reading that can be stale — a map whose fetch failed, a search page cut short, a map opened a second ago — and an issue may have only **one** parent, so parenting an already-mapped ticket takes it off the map it was charted on. That is somebody's map quietly losing a ticket, and nothing would report it.
+
+```bash
+gh api "repos/$REPO/issues/<n>/parent" --jq .number 2>/dev/null
+```
+
+An answer means it is already on a map: **do not adopt it**. Say which map it is on and stop — the human wanted that ticket, so hand them `wf` on it rather than a second map. Only silence here is a loose issue.
+
+Read the issue next (`gh issue view <n> --repo "$REPO"`) — its title and body are the ticket, already written by whoever filed it. Do not retitle or rewrite it to look like something you filed; you are giving it a map, not taking it over. Type labels are the one thing to add if it has none: `wayfinder:build` for code, `wayfinder:task` for other doing, so the row's stage starts deriving from its PRs.
 
 If the issue turns out to be too big for one ticket, that is the same signal the **Don't let it fan out** section below describes, and it has the same answer: say so, leave a `### handoff`, and hand it to `wf`. Do not chart around it.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,9 +13,13 @@ use std::time::SystemTime;
 
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::launch::{self, Agent, Candidate, Launch, LaunchMode, MapRef, Route, Staged, Targets};
+use crate::launch::{
+    self, Agent, Candidate, Launch, LaunchMode, MapRef, Mode, Route, Staged, Targets,
+};
 use crate::liveness::Liveness;
-use crate::model::{stage, Activity, Map, MapId, MapSet, Status, Ticket};
+use crate::model::{
+    stage, Activity, Cluster, ClusterId, MapId, MapSet, Status, Ticket, INBOX_HEADER,
+};
 use crate::projects::{self, Checkout, Resume, Session};
 use crate::reclaim::Reclaimable;
 use crate::refresh::Startup;
@@ -148,7 +152,7 @@ fn next_agent(agent: Agent) -> Agent {
 /// sifted view looks a row's query score up by.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Row {
-    pub map: MapId,
+    pub cluster: ClusterId,
     /// Index into that cluster's `tickets`.
     pub index: usize,
 }
@@ -158,7 +162,7 @@ pub struct Row {
 /// [`Row`] this survives a refetch, which is the whole reason both exist.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RowKey {
-    pub map: MapId,
+    pub cluster: ClusterId,
     pub ticket: u64,
 }
 
@@ -167,7 +171,7 @@ pub struct RowKey {
 /// [`GroupId`] already names a map and a kind rather than any index.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StopKey {
-    Map(MapId),
+    Cluster(ClusterId),
     /// A ticket row, plus **which drawing of it** — the leverage lens
     /// deliberately draws one ticket under every root that unblocks it, so on
     /// a DAG diamond the [`RowKey`] alone names two stops. Without the
@@ -276,7 +280,7 @@ pub struct App {
     /// The clusters on screen: every open map that has arrived, keyed by id.
     /// Render order is *not* this map's key order — it is decided by
     /// [`App::scoped_clusters`], which leads on activity.
-    pub clusters: BTreeMap<MapId, Map>,
+    pub clusters: BTreeMap<ClusterId, Cluster>,
     /// The maps believed open — the cached seed until the search answers, the
     /// search's answer afterwards. This is the set the loaders are reconciled
     /// against, and with one load per run the search's answer is the last word
@@ -294,6 +298,15 @@ pub struct App {
     /// The other half of that handoff (#35): the conversations previous
     /// launches left here, at most one per node.
     pub sessions: Vec<Session>,
+    /// The inbox read failed — **state, not a message**, for the same reason
+    /// `failed` below is.
+    ///
+    /// Its own flag rather than a member of `failed`, which is keyed by map:
+    /// there is no map here to name, and the reader needs to be told a
+    /// different thing. A failed map leaves a hole where a cluster was; a
+    /// failed inbox leaves a screen that looks finished, because an empty
+    /// inbox draws nothing at all.
+    pub inbox_failed: bool,
     /// Maps whose last fetch failed — **state, not a message.**
     ///
     /// A failure has to be drawn on every frame, and the one-shot `notice` is
@@ -372,7 +385,7 @@ enum Prewarmed {
 
 impl App {
     /// An app over clusters already in hand — so nothing is being waited on.
-    pub fn new(clusters: BTreeMap<MapId, Map>) -> Self {
+    pub fn new(clusters: BTreeMap<ClusterId, Cluster>) -> Self {
         Self {
             clusters,
             open_maps: MapSet::new(),
@@ -382,6 +395,7 @@ impl App {
             checkouts: Vec::new(),
             sessions: Vec::new(),
             failed: BTreeSet::new(),
+            inbox_failed: false,
             startup: Startup::loaded(),
             reclaimable: None,
             liveness: Liveness::default(),
@@ -484,37 +498,47 @@ impl App {
         self.point_at(&key);
     }
 
-    fn in_scope(&self, id: &MapId) -> bool {
-        self.current_repo() == Some(id.repo.as_str())
+    fn in_scope(&self, id: &ClusterId) -> bool {
+        self.current_repo() == Some(id.repo())
     }
 
-    /// The clusters currently in scope, in render order: **work before
-    /// history, most recently active first.**
+    /// The clusters currently in scope, in render order: **maps before the
+    /// inbox, work before history, most recently active first.**
     ///
-    /// Three keys, in this order:
+    /// Four keys, in this order:
     ///
-    /// 1. Whether the map still has open work ([`Map::has_open_work`]). A
-    ///    finished map is history, and history belongs at the bottom however
-    ///    recently it was finished — otherwise a map completed this morning
-    ///    outranks every live one, which is the exact inversion this order
-    ///    exists to fix.
-    /// 2. Last activity, newest first. `None` (a timestamp that did not parse)
+    /// 1. Whether it is the loose "yours or unclaimed" cluster. Maps lead
+    ///    unconditionally, whatever either side's activity says: a map is work
+    ///    somebody charted, the inbox is work that merely exists, and an issue
+    ///    touched this morning outranking a charted map would bury the curated
+    ///    half of the screen under the uncurated one. This is the one key that
+    ///    is not about recency, and it is first for that reason.
+    /// 2. Whether the cluster still has open work
+    ///    ([`Cluster::has_open_work`]). A finished map is history, and history
+    ///    belongs at the bottom however recently it was finished — otherwise a
+    ///    map completed this morning outranks every live one, which is the
+    ///    exact inversion this order exists to fix.
+    /// 3. Last activity, newest first. `None` (a timestamp that did not parse)
     ///    sorts after every known one rather than being guessed into place.
-    /// 3. The [`MapId`] — (repo, number), the stable tie-break, so equal
-    ///    activity never renders in an arbitrary order that shifts between
-    ///    frames.
-    pub fn scoped_clusters(&self) -> Vec<(&MapId, &Map)> {
+    /// 4. The [`ClusterId`] — the stable tie-break, so equal activity never
+    ///    renders in an arbitrary order that shifts between frames.
+    pub fn scoped_clusters(&self) -> Vec<(&ClusterId, &Cluster)> {
         // `!has_open_work` so `false` (live) sorts before `true` (finished), and
         // `Reverse` so the newest activity leads — with `None` last, since
         // `None < Some` reversed puts the unknown stamps at the end. Declared
         // before the first statement: an item after one is `clippy::pedantic`'s
         // `items_after_statements`, which CI escalates to an error.
         fn key<'a>(
-            (id, map): &(&'a MapId, &'a Map),
-        ) -> (bool, Reverse<Option<Activity>>, &'a MapId) {
-            (!map.has_open_work(), Reverse(map.last_activity), *id)
+            (id, cluster): &(&'a ClusterId, &'a Cluster),
+        ) -> (bool, bool, Reverse<Option<Activity>>, &'a ClusterId) {
+            (
+                matches!(id, ClusterId::Inbox(_)),
+                !cluster.has_open_work(),
+                Reverse(cluster.last_activity),
+                *id,
+            )
         }
-        let mut clusters: Vec<(&MapId, &Map)> = self
+        let mut clusters: Vec<(&ClusterId, &Cluster)> = self
             .clusters
             .iter()
             .filter(|(id, _)| self.in_scope(id))
@@ -529,7 +553,7 @@ impl App {
             .into_iter()
             .flat_map(|(id, map)| {
                 (0..map.tickets.len()).map(|index| Row {
-                    map: id.clone(),
+                    cluster: id.clone(),
                     index,
                 })
             })
@@ -620,25 +644,40 @@ impl App {
                 projects::mru_repos(&self.checkouts).len(),
             ),
             Level::Project { .. } => {
-                let shown: BTreeSet<(MapId, usize)> = self
+                let shown: BTreeSet<(ClusterId, usize)> = self
                     .visible()
                     .into_iter()
-                    .map(|row| (row.map, row.index))
+                    .map(|row| (row.cluster, row.index))
                     .collect();
                 (shown.len(), self.scoped().len())
             }
         }
     }
 
+    /// The map this cluster *is*, when it is one: the (id, title) pair a
+    /// launch needs, read as a single fact.
+    ///
+    /// `None` for the loose cluster, which has no map issue — and the reason
+    /// this is one lookup rather than two is the redundancy [`Source`]
+    /// documents: taking the number from the key and the title from the value
+    /// separately is what would let a launch aim at a map that is not the
+    /// cluster it was picked in.
+    fn map_ref(&self, id: &ClusterId) -> Option<MapRef> {
+        match (id, self.clusters.get(id)?.map_title()) {
+            (ClusterId::Map(map_id), Some(title)) => Some(MapRef::new(map_id, title)),
+            (ClusterId::Map(_), None) | (ClusterId::Inbox(_), _) => None,
+        }
+    }
+
     /// The ticket a row names.
     pub fn ticket(&self, row: &Row) -> &Ticket {
-        &self.clusters[&row.map].tickets[row.index]
+        &self.clusters[&row.cluster].tickets[row.index]
     }
 
     /// A row's durable identity — the anchor a refetch preserves.
     pub fn row_key(&self, row: &Row) -> RowKey {
         RowKey {
-            map: row.map.clone(),
+            cluster: row.cluster.clone(),
             ticket: self.ticket(row).number,
         }
     }
@@ -655,7 +694,7 @@ impl App {
         let mut keys: Vec<StopKey> = Vec::new();
         for at in self.stops() {
             let key = match &at.stop {
-                Stop::Map(id) => StopKey::Map(id.clone()),
+                Stop::Cluster(id) => StopKey::Cluster(id.clone()),
                 Stop::Ticket(row) => {
                     let row_key = self.row_key(row);
                     let occurrence = keys
@@ -689,7 +728,7 @@ impl App {
             Cursor::Untouched => self
                 .stops()
                 .iter()
-                .position(|at| !matches!(at.stop, Stop::Map(_)))
+                .position(|at| !matches!(at.stop, Stop::Cluster(_)))
                 .unwrap_or(0),
             Cursor::Chosen(pos) => pos.min(self.stops().len().saturating_sub(1)),
         }
@@ -707,15 +746,15 @@ impl App {
     pub fn cursor_row(&self) -> Option<Row> {
         match self.cursor_stop() {
             Some(Stop::Ticket(row)) => Some(row),
-            Some(Stop::Map(_) | Stop::Group(_) | Stop::Project(_)) | None => None,
+            Some(Stop::Cluster(_) | Stop::Group(_) | Stop::Project(_)) | None => None,
         }
     }
 
     /// The ticket under the cursor, if the cursor is on one.
     pub fn cursor_ticket(&self) -> Option<&Ticket> {
         self.cursor_row().map(|row| {
-            let map: &Map = &self.clusters[&row.map];
-            &map.tickets[row.index]
+            let cluster: &Cluster = &self.clusters[&row.cluster];
+            &cluster.tickets[row.index]
         })
     }
 
@@ -899,7 +938,7 @@ impl App {
     /// time and the order leads on activity, so anchoring the start position too
     /// would let the first map to land drag the cursor downwards the moment a
     /// busier map sorted above it.
-    pub fn replace_clusters(&mut self, clusters: BTreeMap<MapId, Map>) {
+    pub fn replace_clusters(&mut self, clusters: BTreeMap<ClusterId, Cluster>) {
         let pinned = match self.cursor {
             Cursor::Untouched => None,
             Cursor::Chosen(_) => Some(match self.cursor_key() {
@@ -941,15 +980,7 @@ impl App {
                 }
                 Outcome::Continue
             }
-            Some(Stop::Map(id)) => {
-                let staged = Staged::map(&MapRef::new(&id, &self.clusters[&id].title));
-                // A map is a node (#96), so a charting session is as
-                // resumable as a build one — and rather more worth resuming.
-                let staged = self.resumable(staged, id.number);
-                self.prewarm(&staged);
-                self.open_launch_picker(staged);
-                Outcome::Continue
-            }
+            Some(Stop::Cluster(id)) => self.request_cluster_launch(&id),
             // One stop, two screens, and the screen decides — which is the
             // only place in the key handler that is true, and is what makes
             // the level a level rather than a filter.
@@ -976,6 +1007,30 @@ impl App {
         }
     }
 
+    /// The header half of [`App::request_launch`]: a map header launches the
+    /// map, and the loose cluster's header launches nothing.
+    ///
+    /// The loose refusal is not a missing feature. A map header is a node —
+    /// there is an issue behind it that an agent can be told to chart or drive
+    /// — and the inbox header is the absence of one: it is a heading over rows
+    /// that each have their own issue. Aiming an agent at it would have to
+    /// invent a target.
+    fn request_cluster_launch(&mut self, id: &ClusterId) -> Outcome {
+        let Some(map) = self.map_ref(id) else {
+            self.notice = Some(format!(
+                "{INBOX_HEADER} is a heading, not a node — pick an issue under it"
+            ));
+            return Outcome::Continue;
+        };
+        let staged = Staged::map(&map);
+        // A map is a node (#96), so a charting session is as
+        // resumable as a build one — and rather more worth resuming.
+        let staged = self.resumable(staged, map.id.number);
+        self.prewarm(&staged);
+        self.open_launch_picker(staged);
+        Outcome::Continue
+    }
+
     /// The ticket half of [`App::request_launch`], split out so the two
     /// refusals sit together and the stop match above stays readable.
     fn request_ticket_launch(&mut self, row: &Row) -> Outcome {
@@ -989,17 +1044,29 @@ impl App {
             ));
             return Outcome::Continue;
         }
-        // The map the row was picked in, carried whole: a ticket can sit on a
-        // map in another repo, and a bare number would name the wrong issue
-        // there (#124).
-        let map = MapRef::new(&row.map, &self.clusters[&row.map].title);
-        match Staged::ticket(ticket, &map, stage(&ticket.prs, &ticket.status)) {
+        // Two stagings, one refusal. A mapped row carries the map whole — a
+        // ticket can sit on a map in another repo, and a bare number would
+        // name the wrong issue there (#124) — and its launchable stage is what
+        // decides whether there is anything to do.
+        //
+        // A row in the loose cluster has no map, and that is what adoption is
+        // for: the issue exists, so there is nothing to file — only a map to
+        // put it under. Adoption has no stages to be past, so the one thing
+        // that would make it pointless is asked here instead: an issue already
+        // closed does not want a map. Everything downstream of adoption is the
+        // ordinary mapped path, which is why the launch contract is left alone.
+        let staged = match self.map_ref(&row.cluster) {
+            Some(map) => Staged::ticket(ticket, &map, stage(&ticket.prs, &ticket.status)),
+            None => (!matches!(ticket.status, Status::Done)).then(|| Staged::loose(ticket)),
+        };
+        let number = ticket.number;
+        match staged {
             None => {
-                self.notice = Some(format!("#{} is done — nothing to launch", ticket.number));
+                self.notice = Some(format!("#{number} is done — nothing to launch"));
                 Outcome::Continue
             }
             Some(staged) => {
-                let staged = self.resumable(staged, ticket.number);
+                let staged = self.resumable(staged, number);
                 self.prewarm(&staged);
                 self.open_launch_picker(staged);
                 Outcome::Continue
@@ -1133,6 +1200,13 @@ impl App {
         self.act_on(targets, repo, "+new")
     }
 
+    /// Resolve an adoption: the issue exists, so there is nothing to type and
+    /// nothing to refuse — only where the agent runs.
+    fn resolve_adoption(&mut self, repo: &str, number: u64, mode: &LaunchMode) -> Outcome {
+        let targets = launch::plan_adopt(&self.checkouts, repo, number, mode);
+        self.act_on(targets, repo, &format!("#{number}"))
+    }
+
     /// What a resolved [`Targets`] does to the screen: launch, prompt for the
     /// tree, or say there is none. Shared by both resolutions so a creation
     /// cannot drift into reporting its checkouts differently from a node.
@@ -1206,6 +1280,21 @@ impl App {
                     // Unreachable: the row is built from the record, so a
                     // resume row without one cannot be drawn to be picked.
                     self.notice = Some("nothing to resume here".to_string());
+                }
+                // No text to complete and no refusal: adoption names an issue
+                // that already exists, so the only thing the second enter
+                // still decides is which checkout it runs in.
+                Candidate::Adopt => {
+                    if let Some(number) = staged.adoptable() {
+                        return self.resolve_adoption(
+                            &staged.repo,
+                            number,
+                            &LaunchMode::picked(agent, Mode::Interactive, &steer),
+                        );
+                    }
+                    // Unreachable: the row is only offered on a loose stop,
+                    // which is the one stop built from an issue number.
+                    self.notice = Some("nothing to adopt here".to_string());
                 }
                 Candidate::Create(kind) => match kind.with_text(&steer) {
                     Some(creation) => return self.resolve_creation(&staged.repo, &creation, agent),
@@ -1415,7 +1504,7 @@ impl App {
 mod tests {
     use super::*;
     use crate::launch::{CreationKind, Isolation, Mode, Route};
-    use crate::model::{classify, Checks, PrLink, PrStatus, Review, TicketType};
+    use crate::model::{classify, Checks, PrLink, PrStatus, Review, Source, TicketType};
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
@@ -1453,7 +1542,7 @@ mod tests {
     /// about. `App::new` opens on the project *list*, which is what `wf` run
     /// outside a checkout shows and which draws no cluster at all, so a test
     /// about clusters has to say which project's it means.
-    fn app_on(repo: &str, clusters: BTreeMap<MapId, Map>) -> App {
+    fn app_on(repo: &str, clusters: BTreeMap<ClusterId, Cluster>) -> App {
         let mut app = App::new(clusters);
         app.enter(repo);
         app
@@ -1465,9 +1554,11 @@ mod tests {
     fn fixture_app() -> App {
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/wayfinder", 1),
-            Map {
-                title: "Map: wf".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: wf".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![
@@ -1507,9 +1598,11 @@ mod tests {
             },
         );
         clusters.insert(
-            MapId::new("blooop/dotfiles", 4),
-            Map {
-                title: "Map: dotfiles".to_string(),
+            ClusterId::Map(MapId::new("blooop/dotfiles", 4)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: dotfiles".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket(
@@ -1526,11 +1619,13 @@ mod tests {
     }
 
     /// A one-ticket cluster with a given last-activity stamp, open or finished.
-    fn cluster(repo: &str, number: u64, stamp: Option<&str>, open: bool) -> (MapId, Map) {
+    fn cluster(repo: &str, number: u64, stamp: Option<&str>, open: bool) -> (ClusterId, Cluster) {
         (
-            MapId::new(repo, number),
-            Map {
-                title: format!("Map: {repo}"),
+            ClusterId::Map(MapId::new(repo, number)),
+            Cluster {
+                source: Source::Map {
+                    title: format!("Map: {repo}"),
+                },
                 last_activity: stamp.map(|s| Activity::parse(s).expect("fixture stamp parses")),
                 truncated: false,
                 tickets: vec![ticket(repo, 1, "only ticket", open, false, vec![])],
@@ -1538,11 +1633,170 @@ mod tests {
         )
     }
 
-    fn cluster_order(app: &App) -> Vec<MapId> {
+    fn cluster_order(app: &App) -> Vec<ClusterId> {
         app.scoped_clusters()
             .into_iter()
             .map(|(id, _)| id.clone())
             .collect()
+    }
+
+    /// The inbox cluster for `repo`, holding `numbers` — every row assigned,
+    /// which is what puts a row in the inbox at all.
+    fn inbox(repo: &str, numbers: &[u64], stamp: Option<&str>) -> (ClusterId, Cluster) {
+        (
+            ClusterId::Inbox(repo.to_string()),
+            Cluster::inbox(
+                stamp.map(|s| Activity::parse(s).expect("fixture stamp parses")),
+                numbers
+                    .iter()
+                    .map(|n| ticket(repo, *n, "yours or unclaimed", true, true, vec![]))
+                    .collect(),
+                false,
+            ),
+        )
+    }
+
+    #[test]
+    fn the_inbox_sorts_after_every_map_however_fresh_it_is() {
+        // The one ordering key that is not about recency. A map is work
+        // somebody charted; the inbox is work that merely exists, and an issue
+        // touched this morning must not bury the charted half of the screen.
+        let clusters: BTreeMap<_, _> = [
+            inbox(PROJECT, &[91], Some("2026-08-24T12:00:00Z")),
+            cluster(PROJECT, 1, Some("2026-08-01T00:00:00Z"), true),
+            cluster(PROJECT, 2, Some("2026-08-02T00:00:00Z"), true),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            cluster_order(&app_on(PROJECT, clusters)),
+            vec![
+                ClusterId::Map(MapId::new(PROJECT, 2)),
+                ClusterId::Map(MapId::new(PROJECT, 1)),
+                ClusterId::Inbox(PROJECT.to_string()),
+            ],
+            "the freshest map leads and the fresher inbox still trails"
+        );
+    }
+
+    #[test]
+    fn the_inbox_sorts_after_a_finished_map_too() {
+        // Finished maps are history and already sort last among maps. The
+        // inbox is below history: the key that separates them is first.
+        let clusters: BTreeMap<_, _> = [
+            inbox(PROJECT, &[91], Some("2026-08-24T12:00:00Z")),
+            cluster(PROJECT, 1, Some("2026-01-01T00:00:00Z"), false),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            cluster_order(&app_on(PROJECT, clusters)),
+            vec![
+                ClusterId::Map(MapId::new(PROJECT, 1)),
+                ClusterId::Inbox(PROJECT.to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn the_inbox_header_is_a_place_to_stand_and_not_a_node() {
+        // A map header launches because there is an issue behind it. The inbox
+        // header is a heading over rows that each have their own issue, so
+        // aiming an agent at it would have to invent a target.
+        let clusters: BTreeMap<_, _> = [inbox(PROJECT, &[91], None)].into_iter().collect();
+        let mut app = app_on(PROJECT, clusters);
+        go_to(&mut app, "inbox blooop/wayfinder");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(
+            !matches!(app.overlay, Overlay::PickLaunch { .. }),
+            "no picker"
+        );
+        assert!(
+            app.notice
+                .as_deref()
+                .is_some_and(|n| n.contains("not a node")),
+            "{:?}",
+            app.notice
+        );
+    }
+
+    #[test]
+    fn an_inbox_row_stages_adoption_rather_than_a_mapped_launch() {
+        let clusters: BTreeMap<_, _> = [inbox(PROJECT, &[91], None)].into_iter().collect();
+        let mut app = app_on(PROJECT, clusters);
+        go_to(&mut app, "#91");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        let Overlay::PickLaunch { staged, .. } = &app.overlay else {
+            panic!("the launch picker is up: {:?}", app.overlay);
+        };
+        assert_eq!(staged.adoptable(), Some(91));
+        assert_eq!(
+            staged.candidates(),
+            vec![Candidate::Adopt],
+            "one way forward, and no mode axis: `/wf-one` owns the lifecycle"
+        );
+    }
+
+    #[test]
+    fn a_closed_inbox_row_is_refused_the_way_a_done_ticket_is() {
+        // Adoption has no stages to be past, so the one thing that would make
+        // it pointless is asked where the mapped refusal already lives.
+        //
+        // Reached through the forest lens, which is the only place a done row
+        // is a stop — and the honest statement of how reachable this is at all:
+        // the inbox read asks for `is:open`, so a closed row can only be one
+        // the tracker closed after answering. The guard is totality, not a
+        // path a human walks.
+        let clusters: BTreeMap<_, _> = [(
+            ClusterId::Inbox(PROJECT.to_string()),
+            Cluster::inbox(
+                None,
+                vec![ticket(PROJECT, 91, "already closed", false, true, vec![])],
+                false,
+            ),
+        )]
+        .into_iter()
+        .collect();
+        let mut app = app_on(PROJECT, clusters);
+        app.handle_key(key(KeyCode::Tab));
+        go_to(&mut app, "#91");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(!matches!(app.overlay, Overlay::PickLaunch { .. }));
+        assert!(
+            app.notice.as_deref().is_some_and(|n| n.contains("is done")),
+            "{:?}",
+            app.notice
+        );
+    }
+
+    #[test]
+    fn a_mapped_row_still_stages_a_mapped_launch_beside_an_inbox() {
+        // The other half of the fork: an inbox on screen changes nothing about
+        // what a map's own row does.
+        let clusters: BTreeMap<_, _> = [
+            inbox(PROJECT, &[91], None),
+            cluster(PROJECT, 1, Some("2026-08-01T00:00:00Z"), true),
+        ]
+        .into_iter()
+        .collect();
+        let mut app = app_on(PROJECT, clusters);
+        go_to(&mut app, "#1");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        let Overlay::PickLaunch { staged, .. } = &app.overlay else {
+            panic!("the launch picker is up: {:?}", app.overlay);
+        };
+        assert_eq!(staged.adoptable(), None, "a mapped row is not adopted");
+        assert!(
+            staged.candidates().iter().any(|c| matches!(
+                c,
+                Candidate::Launch {
+                    mode: Mode::Interactive,
+                    ..
+                }
+            )),
+            "the mode rows are untouched: {:?}",
+            staged.candidates()
+        );
     }
 
     #[test]
@@ -1550,7 +1804,7 @@ mod tests {
         // The bug this fixes: `blooop/finished` is both the lowest id *and* the
         // most recently touched, and it still belongs at the bottom — a map with
         // nothing left to do is history, however fresh.
-        let clusters: BTreeMap<MapId, Map> = [
+        let clusters: BTreeMap<ClusterId, Cluster> = [
             cluster(PROJECT, 1, Some("2026-08-06T12:00:00Z"), false),
             cluster(PROJECT, 2, Some("2026-08-01T09:00:00Z"), true),
             cluster(PROJECT, 3, Some("2026-08-05T09:00:00Z"), true),
@@ -1561,13 +1815,13 @@ mod tests {
         assert_eq!(
             cluster_order(&app_on(PROJECT, clusters)),
             vec![
-                MapId::new(PROJECT, 3),
-                MapId::new(PROJECT, 2),
+                ClusterId::Map(MapId::new(PROJECT, 3)),
+                ClusterId::Map(MapId::new(PROJECT, 2)),
                 // An unparsed stamp is not guessed into the middle of the live
                 // maps: it sorts after every dated one…
-                MapId::new(PROJECT, 4),
+                ClusterId::Map(MapId::new(PROJECT, 4)),
                 // …and the finished map is still below it.
-                MapId::new(PROJECT, 1),
+                ClusterId::Map(MapId::new(PROJECT, 1)),
             ]
         );
     }
@@ -1579,7 +1833,7 @@ mod tests {
         // tie-break is the whole `MapId`; on one project's screen — the only
         // kind there is — that is the map number.
         let stamp = Some("2026-08-06T12:00:00Z");
-        let clusters: BTreeMap<MapId, Map> = [
+        let clusters: BTreeMap<ClusterId, Cluster> = [
             cluster(PROJECT, 47, stamp, true),
             cluster(PROJECT, 4, stamp, true),
             cluster(PROJECT, 1, stamp, true),
@@ -1589,9 +1843,9 @@ mod tests {
         assert_eq!(
             cluster_order(&app_on(PROJECT, clusters)),
             vec![
-                MapId::new(PROJECT, 1),
-                MapId::new(PROJECT, 4),
-                MapId::new(PROJECT, 47),
+                ClusterId::Map(MapId::new(PROJECT, 1)),
+                ClusterId::Map(MapId::new(PROJECT, 4)),
+                ClusterId::Map(MapId::new(PROJECT, 47)),
             ]
         );
     }
@@ -1623,7 +1877,7 @@ mod tests {
     /// Two live maps of one project, the second of them older, so a map fresher
     /// than both sorts above the pair and pushes every existing stop down by
     /// two — its header and its row (#96).
-    fn streaming_pair() -> BTreeMap<MapId, Map> {
+    fn streaming_pair() -> BTreeMap<ClusterId, Cluster> {
         [
             cluster(PROJECT, 1, Some("2026-08-01T00:00:00Z"), true),
             cluster(PROJECT, 3, Some("2026-07-01T00:00:00Z"), true),
@@ -1634,7 +1888,7 @@ mod tests {
 
     /// The pair with a fresher map added — it renders first, so every original
     /// stop moves down two.
-    fn streaming_trio() -> BTreeMap<MapId, Map> {
+    fn streaming_trio() -> BTreeMap<ClusterId, Cluster> {
         let mut all = streaming_pair();
         all.extend([cluster(PROJECT, 2, Some("2026-08-07T00:00:00Z"), true)]);
         all
@@ -1652,16 +1906,16 @@ mod tests {
         }
         assert_eq!(app.cursor_pos(), 4);
         assert_eq!(
-            app.cursor_row().map(|row| row.map),
-            Some(MapId::new(PROJECT, 3))
+            app.cursor_row().map(|row| row.cluster),
+            Some(ClusterId::Map(MapId::new(PROJECT, 3)))
         );
 
         app.replace_clusters(streaming_trio());
 
         assert_eq!(app.cursor_pos(), 6, "the fresher map pushed the row down");
         assert_eq!(
-            app.cursor_row().map(|row| row.map),
-            Some(MapId::new(PROJECT, 3)),
+            app.cursor_row().map(|row| row.cluster),
+            Some(ClusterId::Map(MapId::new(PROJECT, 3))),
             "still the row they chose"
         );
     }
@@ -1678,15 +1932,15 @@ mod tests {
         }
         assert_eq!(app.cursor_pos(), 2);
         assert_eq!(
-            app.cursor_row().map(|row| row.map),
-            Some(MapId::new(PROJECT, 1))
+            app.cursor_row().map(|row| row.cluster),
+            Some(ClusterId::Map(MapId::new(PROJECT, 1)))
         );
 
         app.replace_clusters(streaming_trio());
 
         assert_eq!(
-            app.cursor_row().map(|row| row.map),
-            Some(MapId::new(PROJECT, 1)),
+            app.cursor_row().map(|row| row.cluster),
+            Some(ClusterId::Map(MapId::new(PROJECT, 1))),
             "their stop, not whatever is on top now"
         );
         assert_eq!(app.cursor_pos(), 4);
@@ -1710,11 +1964,13 @@ mod tests {
     /// One map with finished work in it, so the leverage lens gives it a `Done`
     /// group line — a stop the forest lens, which has no group lines at all, does
     /// not have.
-    fn map_with_a_done_group() -> BTreeMap<MapId, Map> {
+    fn map_with_a_done_group() -> BTreeMap<ClusterId, Cluster> {
         BTreeMap::from([(
-            MapId::new(PROJECT, 1),
-            Map {
-                title: "Map: the slow one".to_string(),
+            ClusterId::Map(MapId::new(PROJECT, 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the slow one".to_string(),
+                },
                 last_activity: Some(
                     Activity::parse("2026-08-01T00:00:00Z").expect("fixture stamp parses"),
                 ),
@@ -1780,9 +2036,11 @@ mod tests {
 
         let mut fresher = app.clusters.clone();
         fresher.insert(
-            MapId::new(PROJECT, 99),
-            Map {
-                title: "Map: late arrival".to_string(),
+            ClusterId::Map(MapId::new(PROJECT, 99)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: late arrival".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket(PROJECT, 200, "zzz sleeper", true, false, vec![])],
@@ -1814,9 +2072,11 @@ mod tests {
 
         let mut fresher = app.clusters.clone();
         fresher.insert(
-            MapId::new(PROJECT, 99),
-            Map {
-                title: "Map: fresher".to_string(),
+            ClusterId::Map(MapId::new(PROJECT, 99)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: fresher".to_string(),
+                },
                 last_activity: Some(
                     Activity::parse("2026-08-07T00:00:00Z").expect("fixture stamp parses"),
                 ),
@@ -1849,7 +2109,8 @@ mod tests {
     /// `map #n`, a group by kind. Reads like the screen does.
     fn at(app: &App) -> String {
         match app.cursor_stop() {
-            Some(Stop::Map(id)) => format!("map #{}", id.number),
+            Some(Stop::Cluster(ClusterId::Map(id))) => format!("map #{}", id.number),
+            Some(Stop::Cluster(ClusterId::Inbox(repo))) => format!("inbox {repo}"),
             Some(Stop::Ticket(row)) => format!("#{}", app.ticket(&row).number),
             Some(Stop::Group(g)) => format!("{:?}", g.kind),
             Some(Stop::Project(repo)) => format!("project {repo}"),
@@ -1933,9 +2194,11 @@ mod tests {
         // them and stops at the last rather than leaking back out to depth 0.
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/wayfinder", 1),
-            Map {
-                title: "Map: wf".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: wf".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![
@@ -1966,9 +2229,11 @@ mod tests {
     fn knotty_app() -> App {
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/bencher", 1064),
-            Map {
-                title: "Map: endgame".to_string(),
+            ClusterId::Map(MapId::new("blooop/bencher", 1064)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: endgame".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![
@@ -2104,9 +2369,11 @@ mod tests {
         // there — every stop must stay reachable by them alone.
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/bencher", 1064),
-            Map {
-                title: "Map: endgame".to_string(),
+            ClusterId::Map(MapId::new("blooop/bencher", 1064)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: endgame".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![
@@ -2510,9 +2777,11 @@ mod tests {
         let mut clusters = BTreeMap::new();
         for map_number in [1u64, 47] {
             clusters.insert(
-                MapId::new("blooop/wayfinder", map_number),
-                Map {
-                    title: format!("Map: {map_number}"),
+                ClusterId::Map(MapId::new("blooop/wayfinder", map_number)),
+                Cluster {
+                    source: Source::Map {
+                        title: format!("Map: {map_number}"),
+                    },
                     last_activity: None,
                     truncated: false,
                     tickets: vec![ticket(
@@ -2779,7 +3048,7 @@ mod tests {
             app.handle_key(key(KeyCode::Down)); // …to the auto row
             app
         };
-        let wf = MapId::new("blooop/wayfinder", 1);
+        let wf = ClusterId::Map(MapId::new("blooop/wayfinder", 1));
 
         // Reordered: #6's old index now names #9.
         let mut app = staged();
@@ -2819,9 +3088,9 @@ mod tests {
         let mut app = staged();
         let mut shrunk = BTreeMap::new();
         shrunk.insert(
-            MapId::new("blooop/dotfiles", 4),
+            ClusterId::Map(MapId::new("blooop/dotfiles", 4)),
             app.clusters
-                .get(&MapId::new("blooop/dotfiles", 4))
+                .get(&ClusterId::Map(MapId::new("blooop/dotfiles", 4)))
                 .expect("the dotfiles map")
                 .clone(),
         );
@@ -3086,7 +3355,7 @@ mod tests {
             Some(&Stop::Project("blooop/wayfinder".to_string()))
         );
         assert!(
-            stops.iter().any(|s| matches!(s, Stop::Map(_))),
+            stops.iter().any(|s| matches!(s, Stop::Cluster(_))),
             "the clusters still follow it: {stops:?}"
         );
     }
@@ -3323,9 +3592,11 @@ mod tests {
             t.prs = prs;
             let mut clusters = BTreeMap::new();
             clusters.insert(
-                MapId::new("blooop/wayfinder", 59),
-                Map {
-                    title: "Map: the spine".to_string(),
+                ClusterId::Map(MapId::new("blooop/wayfinder", 59)),
+                Cluster {
+                    source: Source::Map {
+                        title: "Map: the spine".to_string(),
+                    },
                     last_activity: None,
                     truncated: false,
                     tickets: vec![t],
@@ -3427,27 +3698,33 @@ mod tests {
         // shows both — and the other repo's map is on another screen entirely.
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/wayfinder", 1),
-            Map {
-                title: "Map: wf".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: wf".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket("blooop/wayfinder", 6, "t6", true, false, vec![])],
             },
         );
         clusters.insert(
-            MapId::new("blooop/wayfinder", 47),
-            Map {
-                title: "Map: selection view".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 47)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: selection view".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket("blooop/wayfinder", 50, "t50", true, false, vec![])],
             },
         );
         clusters.insert(
-            MapId::new("blooop/dotfiles", 4),
-            Map {
-                title: "Map: dotfiles".to_string(),
+            ClusterId::Map(MapId::new("blooop/dotfiles", 4)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: dotfiles".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket("blooop/dotfiles", 103, "t103", true, false, vec![])],
@@ -3456,7 +3733,9 @@ mod tests {
         let app = app_on("blooop/wayfinder", clusters);
         let visible = app.visible();
         assert_eq!(visible.len(), 2, "both wayfinder maps are on this screen");
-        assert!(visible.iter().all(|row| row.map.repo == "blooop/wayfinder"));
+        assert!(visible
+            .iter()
+            .all(|row| row.cluster.repo() == "blooop/wayfinder"));
     }
 
     #[test]
@@ -3466,9 +3745,11 @@ mod tests {
         let mut clusters = BTreeMap::new();
         for owner in ["blooop", "upstream"] {
             clusters.insert(
-                MapId::new(format!("{owner}/dotfiles"), 1),
-                Map {
-                    title: "Map: dotfiles".to_string(),
+                ClusterId::Map(MapId::new(format!("{owner}/dotfiles"), 1)),
+                Cluster {
+                    source: Source::Map {
+                        title: "Map: dotfiles".to_string(),
+                    },
                     last_activity: None,
                     truncated: false,
                     tickets: vec![ticket(
@@ -3488,7 +3769,7 @@ mod tests {
             1,
             "the fork's identically-numbered row must not show"
         );
-        assert_eq!(app.visible()[0].map.repo, "upstream/dotfiles");
+        assert_eq!(app.visible()[0].cluster.repo(), "upstream/dotfiles");
     }
 
     #[test]
@@ -3541,9 +3822,11 @@ mod tests {
     fn diamond_app() -> App {
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new(PROJECT, 1),
-            Map {
-                title: "Map: diamond".to_string(),
+            ClusterId::Map(MapId::new(PROJECT, 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: diamond".to_string(),
+                },
                 last_activity: None,
                 tickets: vec![
                     ticket(PROJECT, 2, "Choose the stack", false, true, vec![]),
@@ -3620,7 +3903,7 @@ mod tests {
         app.cursor = Cursor::Chosen(drawings[1]);
         let mut swapped = app.clusters.clone();
         let map = swapped
-            .get_mut(&MapId::new(PROJECT, 1))
+            .get_mut(&ClusterId::Map(MapId::new(PROJECT, 1)))
             .expect("the diamond map");
         map.tickets[2] = ticket(PROJECT, 9, "Main screen design", false, true, vec![]);
         app.replace_clusters(swapped);
@@ -3743,7 +4026,7 @@ mod tests {
         go_to(&mut app, "#6"); // position 2: the project row and the header
         let mut smaller = app.clusters.clone();
         smaller
-            .get_mut(&MapId::new("blooop/wayfinder", 1))
+            .get_mut(&ClusterId::Map(MapId::new("blooop/wayfinder", 1)))
             .unwrap()
             .tickets
             .retain(|t| t.number != 6);

--- a/src/app.rs
+++ b/src/app.rs
@@ -277,7 +277,8 @@ impl Pinned {
 
 #[derive(Debug)]
 pub struct App {
-    /// The clusters on screen: every open map that has arrived, keyed by id.
+    /// The clusters on screen, keyed by id: every open map that has arrived,
+    /// and each repo's inbox once its own read has landed.
     /// Render order is *not* this map's key order — it is decided by
     /// [`App::scoped_clusters`], which leads on activity.
     pub clusters: BTreeMap<ClusterId, Cluster>,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1007,6 +1007,39 @@ impl App {
         }
     }
 
+    /// Why adoption must not be offered for a row in `repo` right now, if it
+    /// must not.
+    ///
+    /// The inbox is what is left of the read once the maps in hand have claimed
+    /// their own rows, so it is only as trustworthy as the maps are complete.
+    /// A row a *missing* map would have claimed is still drawn — deliberately,
+    /// because a row that is nowhere is worse than a row in the wrong
+    /// place — but drawing it and acting on it are different things. Adoption
+    /// files a map and parents the issue under it, and an issue may have only
+    /// one parent, so adopting a ticket that already has a map takes it off the
+    /// map it was charted on. That is tracker data loss, and it is invisible
+    /// from here.
+    ///
+    /// So the refusal is keyed on what `wf` does not know rather than on what
+    /// it has seen: any map of this repo still out, or any that failed, and
+    /// adoption waits. `wf` cannot tell "loose" from "early" until then. The
+    /// launched skill checks the same thing again against the live tracker,
+    /// because this reading can be stale for reasons no local state shows —
+    /// a search page cut short, a map opened a second ago.
+    fn adoption_refusal(&self, repo: &str) -> Option<String> {
+        if !self.startup.is_loaded() {
+            return Some(format!(
+                "still loading {repo}'s maps — adoption waits until they have all reported"
+            ));
+        }
+        let failed: Vec<&MapId> = self.failed.iter().filter(|id| id.repo == repo).collect();
+        let first = failed.first()?;
+        Some(format!(
+            "{}#{} did not load, so a row here may already be on it — adoption waits",
+            first.repo, first.number
+        ))
+    }
+
     /// The header half of [`App::request_launch`]: a map header launches the
     /// map, and the loose cluster's header launches nothing.
     ///
@@ -1057,7 +1090,13 @@ impl App {
         // ordinary mapped path, which is why the launch contract is left alone.
         let staged = match self.map_ref(&row.cluster) {
             Some(map) => Staged::ticket(ticket, &map, stage(&ticket.prs, &ticket.status)),
-            None => (!matches!(ticket.status, Status::Done)).then(|| Staged::loose(ticket)),
+            None => match self.adoption_refusal(&ticket.repo) {
+                Some(why) => {
+                    self.notice = Some(why);
+                    return Outcome::Continue;
+                }
+                None => (!matches!(ticket.status, Status::Done)).then(|| Staged::loose(ticket)),
+            },
         };
         let number = ticket.number;
         match staged {
@@ -1734,6 +1773,70 @@ mod tests {
             staged.candidates(),
             vec![Candidate::Adopt],
             "one way forward, and no mode axis: `/wf-one` owns the lifecycle"
+        );
+    }
+
+    #[test]
+    fn adoption_is_refused_while_this_repos_map_picture_is_incomplete() {
+        // The inbox keeps showing rows a map that failed to load would have
+        // claimed — deliberately, because a row that is nowhere is worse. But
+        // *visible* and *actionable* are different things: adopting a ticket
+        // that already has a map files a second map and reparents the issue
+        // off its real one, and GitHub allows an issue only one parent, so the
+        // map it was charted on silently loses it.
+        let clusters: BTreeMap<_, _> = [inbox(PROJECT, &[91], None)].into_iter().collect();
+        let mut app = app_on(PROJECT, clusters);
+        app.failed.insert(MapId::new(PROJECT, 1));
+        go_to(&mut app, "#91");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(
+            !matches!(app.overlay, Overlay::PickLaunch { .. }),
+            "no picker: {:?}",
+            app.overlay
+        );
+        assert!(
+            app.notice
+                .as_deref()
+                .is_some_and(|n| n.contains("did not load")),
+            "{:?}",
+            app.notice
+        );
+    }
+
+    #[test]
+    fn adoption_is_refused_while_the_maps_are_still_arriving() {
+        // The same hole for the whole startup window rather than only after a
+        // failure: the inbox is one query and the maps stream, so until every
+        // map for this repo has reported there is no way to know whether a row
+        // is loose or merely early.
+        let clusters: BTreeMap<_, _> = [inbox(PROJECT, &[91], None)].into_iter().collect();
+        let mut app = app_on(PROJECT, clusters);
+        app.startup = Startup::seeded(&[MapId::new(PROJECT, 1)].into_iter().collect());
+        go_to(&mut app, "#91");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(!matches!(app.overlay, Overlay::PickLaunch { .. }));
+        assert!(
+            app.notice
+                .as_deref()
+                .is_some_and(|n| n.contains("still loading")),
+            "{:?}",
+            app.notice
+        );
+    }
+
+    #[test]
+    fn a_failed_map_in_another_repo_does_not_refuse_this_repos_adoption() {
+        // The refusal is per repo: a map that failed in `dotfiles` says nothing
+        // about whether a wayfinder issue is loose.
+        let clusters: BTreeMap<_, _> = [inbox(PROJECT, &[91], None)].into_iter().collect();
+        let mut app = app_on(PROJECT, clusters);
+        app.failed.insert(MapId::new("blooop/dotfiles", 4));
+        go_to(&mut app, "#91");
+        assert_eq!(app.handle_key(key(KeyCode::Enter)), Outcome::Continue);
+        assert!(
+            matches!(app.overlay, Overlay::PickLaunch { .. }),
+            "adoption is still offered: {:?}",
+            app.notice
         );
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -550,6 +550,19 @@ pub async fn fetch_inbox(repos: &[String]) -> Result<Vec<(String, Cluster)>> {
     parse_inbox(&output.stdout)
 }
 
+/// One repo's inbox mid-build.
+///
+/// Each row is kept beside its **own** stamp, because the inbox is ordered by
+/// when something happened and a [`Ticket`] carries no time of its own — a
+/// map's rows are numbered in the order its author charted them, so a ticket
+/// has never needed one. `activity` is the cluster's stamp (the newest of the
+/// rows'), which is a different question from any one row's.
+struct Building {
+    rows: Vec<(Option<Activity>, Ticket)>,
+    activity: Option<Activity>,
+    truncated: bool,
+}
+
 /// Turn one inbox response into one cluster per repo — the whole parse
 /// boundary, kept apart from the process call so it is testable without the
 /// network.
@@ -571,14 +584,8 @@ fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
     let page_cut_short =
         data.mine.page_info.has_next_page || data.unassigned.page_info.has_next_page;
 
-    // Each row is kept beside its own stamp, because the inbox is ordered by
-    // *when something happened* and a [`Ticket`] carries no time of its own —
-    // a map's rows are numbered in the order its author charted them, so a
-    // ticket has never needed one.
-    let mut by_repo: std::collections::BTreeMap<
-        String,
-        (Vec<(Option<Activity>, Ticket)>, Option<Activity>, bool),
-    > = std::collections::BTreeMap::new();
+    let mut by_repo: std::collections::BTreeMap<String, Building> =
+        std::collections::BTreeMap::new();
     // Concatenated rather than merged: the two searches are disjoint by
     // construction — an issue is assigned to you or it is assigned to nobody,
     // never both — so there is nothing here to deduplicate. What each row
@@ -605,33 +612,44 @@ fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
         let activity = node.updated_at.as_deref().and_then(Activity::parse);
         let blockers_cut_short = node.issue.blocked_by.page_info.has_next_page;
         let ticket = parse_ticket(node.issue, &repo);
-        let entry = by_repo
-            .entry(repo)
-            .or_insert((Vec::new(), None, page_cut_short));
-        entry.0.push((activity, ticket));
+        let entry = by_repo.entry(repo).or_insert_with(|| Building {
+            rows: Vec::new(),
+            activity: None,
+            truncated: page_cut_short,
+        });
+        entry.rows.push((activity, ticket));
         // The cluster's stamp is the newest of its rows': a pile of issues has
         // no single thing that was updated, and the order the screen wants is
         // "where has something happened".
-        entry.1 = entry.1.max(activity);
-        entry.2 |= blockers_cut_short;
+        entry.activity = entry.activity.max(activity);
+        entry.truncated |= blockers_cut_short;
     }
 
     Ok(by_repo
         .into_iter()
-        .map(|(repo, (mut rows, activity, truncated))| {
-            // Newest first, and **not** by number: ascending number order puts
-            // the oldest issue in the repo at the top, which is the inversion
-            // of what an inbox is for. A stamp that did not parse sorts last
-            // rather than being guessed into place — `None < Some` reversed —
-            // the same answer the cluster order gives an unreadable map stamp.
-            //
-            // The number breaks ties newest-first too, so two issues touched in
-            // the same second do not render in an order that shifts between
-            // frames.
-            rows.sort_by_key(|(stamp, ticket)| (Reverse(*stamp), Reverse(ticket.number)));
-            let tickets = rows.into_iter().map(|(_, ticket)| ticket).collect();
-            (repo, Cluster::inbox(activity, tickets, truncated))
-        })
+        .map(
+            |(
+                repo,
+                Building {
+                    mut rows,
+                    activity,
+                    truncated,
+                },
+            )| {
+                // Newest first, and **not** by number: ascending number order puts
+                // the oldest issue in the repo at the top, which is the inversion
+                // of what an inbox is for. A stamp that did not parse sorts last
+                // rather than being guessed into place — `None < Some` reversed —
+                // the same answer the cluster order gives an unreadable map stamp.
+                //
+                // The number breaks ties newest-first too, so two issues touched in
+                // the same second do not render in an order that shifts between
+                // frames.
+                rows.sort_by_key(|(stamp, ticket)| (Reverse(*stamp), Reverse(ticket.number)));
+                let tickets = rows.into_iter().map(|(_, ticket)| ticket).collect();
+                (repo, Cluster::inbox(activity, tickets, truncated))
+            },
+        )
         .collect())
 }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -24,6 +24,7 @@
 //! zombie it will never reap: aborting the task drops the `Child`, and only
 //! `kill_on_drop` turns that into a signal.
 
+use std::cmp::Reverse;
 use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
@@ -506,7 +507,17 @@ pub async fn fetch_inbox(repos: &[String]) -> Result<Vec<(String, Cluster)>> {
     // The two halves differ in exactly one qualifier, so they are built from
     // one string: a scope that drifted between them would silently make the
     // inbox mean two different things in its two halves.
-    let scoped = |who: &str| format!("{who} is:issue is:open {}", scope.join(" "));
+    // `sort:updated-desc` is what makes the page cap survivable: one page of
+    // 100 spans every repo asked about, so without an order *which* rows fall
+    // off it is arbitrary — and the rows worth having are the ones something
+    // just happened to. It also means the order the screen wants is the order
+    // the tracker already ranked, rather than something recovered afterwards.
+    let scoped = |who: &str| {
+        format!(
+            "{who} is:issue is:open sort:updated-desc {}",
+            scope.join(" ")
+        )
+    };
     let output = Command::new("gh")
         .args([
             "api",
@@ -553,8 +564,14 @@ fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
     let page_cut_short =
         data.mine.page_info.has_next_page || data.unassigned.page_info.has_next_page;
 
-    let mut by_repo: std::collections::BTreeMap<String, (Vec<Ticket>, Option<Activity>, bool)> =
-        std::collections::BTreeMap::new();
+    // Each row is kept beside its own stamp, because the inbox is ordered by
+    // *when something happened* and a [`Ticket`] carries no time of its own —
+    // a map's rows are numbered in the order its author charted them, so a
+    // ticket has never needed one.
+    let mut by_repo: std::collections::BTreeMap<
+        String,
+        (Vec<(Option<Activity>, Ticket)>, Option<Activity>, bool),
+    > = std::collections::BTreeMap::new();
     // Concatenated rather than merged: the two searches are disjoint by
     // construction — an issue is assigned to you or it is assigned to nobody,
     // never both — so there is nothing here to deduplicate. What each row
@@ -573,7 +590,7 @@ fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
         let entry = by_repo
             .entry(repo)
             .or_insert((Vec::new(), None, page_cut_short));
-        entry.0.push(ticket);
+        entry.0.push((activity, ticket));
         // The cluster's stamp is the newest of its rows': a pile of issues has
         // no single thing that was updated, and the order the screen wants is
         // "where has something happened".
@@ -583,8 +600,18 @@ fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
 
     Ok(by_repo
         .into_iter()
-        .map(|(repo, (mut tickets, activity, truncated))| {
-            tickets.sort_by_key(|t| t.number);
+        .map(|(repo, (mut rows, activity, truncated))| {
+            // Newest first, and **not** by number: ascending number order puts
+            // the oldest issue in the repo at the top, which is the inversion
+            // of what an inbox is for. A stamp that did not parse sorts last
+            // rather than being guessed into place — `None < Some` reversed —
+            // the same answer the cluster order gives an unreadable map stamp.
+            //
+            // The number breaks ties newest-first too, so two issues touched in
+            // the same second do not render in an order that shifts between
+            // frames.
+            rows.sort_by_key(|(stamp, ticket)| (Reverse(*stamp), Reverse(ticket.number)));
+            let tickets = rows.into_iter().map(|(_, ticket)| ticket).collect();
             (repo, Cluster::inbox(activity, tickets, truncated))
         })
         .collect())
@@ -784,9 +811,50 @@ mod tests {
         let numbers: Vec<u64> = wayfinder.tickets.iter().map(|t| t.number).collect();
         assert_eq!(
             numbers,
-            vec![190, 191, 207],
-            "both halves land in one cluster, sorted by number like a map's"
+            vec![207, 190, 191],
+            "both halves land in one cluster, newest first"
         );
+    }
+
+    #[test]
+    fn inbox_rows_come_back_newest_first() {
+        // The inbox is ordered by *when something happened*, not by issue
+        // number. A map's rows are numbered in the order its author charted
+        // them, so number order is meaningful there; an inbox is a pile with no
+        // author, and ascending number order puts the oldest thing in the repo
+        // at the top — the exact inversion of what an inbox is for.
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let wayfinder = &inbox
+            .iter()
+            .find(|(repo, _)| repo == "blooop/wayfinder")
+            .expect("wayfinder has rows")
+            .1;
+        let numbers: Vec<u64> = wayfinder.tickets.iter().map(|t| t.number).collect();
+        // #207 10:00 > #190 09:00 > #191 (two days earlier).
+        assert_eq!(numbers, vec![207, 190, 191]);
+    }
+
+    #[test]
+    fn an_inbox_row_whose_stamp_did_not_parse_sorts_last_rather_than_first() {
+        // Unknown activity is not guessed into place — the same answer the
+        // cluster order gives a map whose stamp did not parse. Sorting it first
+        // would put whatever the tracker garbled at the top of the inbox.
+        let body = INBOX_RESPONSE.replace(
+            r#""updatedAt": "2026-08-24T10:00:00Z""#,
+            r#""updatedAt": "not a timestamp""#,
+        );
+        assert_ne!(body, INBOX_RESPONSE, "the fixture's #207 stamp moved");
+        let inbox = parse_inbox(body.as_bytes()).expect("parse");
+        let numbers: Vec<u64> = inbox
+            .iter()
+            .find(|(repo, _)| repo == "blooop/wayfinder")
+            .expect("wayfinder has rows")
+            .1
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .collect();
+        assert_eq!(numbers, vec![190, 191, 207], "#207's stamp is unreadable");
     }
 
     #[test]
@@ -852,7 +920,7 @@ mod tests {
     #[test]
     fn the_inbox_reads_an_issue_exactly_as_a_map_reads_its_sub_issue() {
         let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
-        let ticket = &inbox[1].1.tickets[1];
+        let ticket = &inbox[1].1.tickets[2];
         assert_eq!(ticket.number, 191);
         assert_eq!(ticket.repo, "blooop/wayfinder", "its own repo, not a map's");
         assert_eq!(ticket.ticket_type, TicketType::Build, "labels still parse");

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -31,7 +31,8 @@ use serde::Deserialize;
 use tokio::process::Command;
 
 use crate::model::{
-    classify, Activity, Checks, Map, MapId, MapSet, PrLink, PrStatus, Review, Ticket, TicketType,
+    classify, Activity, Checks, Cluster, MapId, MapSet, PrLink, PrStatus, Review, Ticket,
+    TicketType,
 };
 
 /// The label that makes an issue a map. Both the search that *finds* maps and
@@ -77,6 +78,61 @@ query($owner: String!, $name: String!, $number: Int!) {
         pageInfo { hasNextPage }
       }
     }
+  }
+}";
+
+/// The inbox read: every open issue in the cached repos that is **yours or
+/// nobody's**, in one round trip.
+///
+/// Two searches, not every open issue, and that is the shape of the feature
+/// rather than a filter on it. A repo's whole open issue list is not curated —
+/// dependabot, other people's work in flight, stale requests — and pouring it
+/// in would not make a bigger wayfinder, it would bury the charted maps under
+/// a worse `gh issue list`. What is left after dropping *somebody else's*
+/// issues is the set you could actually pick up.
+///
+/// **Two searches because GitHub issue search has no `OR`.** Qualifiers `AND`
+/// together, so `assignee:@me no:assignee` is a contradiction that matches
+/// nothing. The two sets are disjoint by construction — an issue cannot be
+/// both assigned to you and unassigned — so they need no dedup against each
+/// other, only the same subtraction against the maps that every inbox row
+/// gets. Aliased into one query rather than sent as two, so the cost stays one
+/// round trip and one rate-limit point.
+///
+/// The selection is deliberately the *same* one [`MAP_QUERY`] makes of a map's
+/// sub-issues, plus the two things a row outside a map has to carry itself:
+/// which repo it is in, and when it was touched. Same selection means
+/// [`parse_ticket`] reads both, so an issue cannot render one way in a map and
+/// another in the inbox. It is a GraphQL fragment for that reason — one
+/// selection written once, spread into both searches, so the two halves of the
+/// inbox cannot drift from each other either.
+///
+/// `is:issue` is in both query strings because GitHub's `type: ISSUE` search
+/// covers pull requests too, and a PR is not a ticket.
+const INBOX_QUERY: &str = "\
+fragment Row on Issue {
+  number title state updatedAt
+  repository { nameWithOwner }
+  labels(first: 10) { nodes { name } }
+  assignees(first: 5) { nodes { login } }
+  blockedBy(first: 50) { nodes { number state } pageInfo { hasNextPage } }
+  closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
+    nodes {
+      number state isDraft reviewDecision
+      statusCheckRollup { state }
+      repository { nameWithOwner }
+    }
+    pageInfo { hasNextPage }
+  }
+}
+query($mine: String!, $unassigned: String!) {
+  mine: search(query: $mine, type: ISSUE, first: 100) {
+    nodes { ...Row }
+    pageInfo { hasNextPage }
+  }
+  unassigned: search(query: $unassigned, type: ISSUE, first: 100) {
+    nodes { ...Row }
+    pageInfo { hasNextPage }
   }
 }";
 
@@ -305,7 +361,7 @@ pub(crate) fn is_open(state: &str) -> bool {
 /// thing to the caller — the cluster for this map does not arrive — and
 /// [`refresh`](crate::refresh) turns it into the failure note on screen rather
 /// than an exit.
-pub async fn fetch_map(id: &MapId) -> Result<Map> {
+pub async fn fetch_map(id: &MapId) -> Result<Cluster> {
     let (owner, name) = id
         .repo
         .split_once('/')
@@ -339,11 +395,11 @@ pub async fn fetch_map(id: &MapId) -> Result<Map> {
     parse_map(&output.stdout, id)
 }
 
-/// Turn one `gh api graphql` response body into a [`Map`] — the whole parse
+/// Turn one `gh api graphql` response body into a [`Cluster`] — the whole parse
 /// boundary, kept apart from the process call so it is testable without the
 /// network. Every raw tracker string a ticket is derived from (state,
 /// assignees, blocker states, labels) is interpreted exactly here.
-fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
+fn parse_map(body: &[u8], id: &MapId) -> Result<Cluster> {
     let resp: GraphQlResponse<ResponseData> =
         serde_json::from_slice(body).context("unparseable GraphQL response from gh")?;
     if let Some(err) = resp.errors.first() {
@@ -388,48 +444,191 @@ fn parse_map(body: &[u8], id: &MapId) -> Result<Map> {
         .into_iter()
         .map(|sub| {
             truncated |= sub.blocked_by.page_info.has_next_page;
-            // One pass over the same edges yields both facts: the open subset
-            // is status, the whole set is structure (#50).
-            let open_blockers: Vec<u64> = sub
-                .blocked_by
-                .nodes
-                .iter()
-                .filter(|b| is_open(&b.state))
-                .map(|b| b.number)
-                .collect();
-            let blocked_by: Vec<u64> = sub.blocked_by.nodes.iter().map(|b| b.number).collect();
-            let prs: Vec<PrLink> = sub
-                .closed_by_prs
-                .nodes
-                .iter()
-                .filter_map(parse_pr)
-                .collect();
-            Ticket {
-                repo: id.repo.clone(),
-                number: sub.number,
-                title: sub.title,
-                status: classify(
-                    is_open(&sub.state),
-                    !sub.assignees.nodes.is_empty(),
-                    open_blockers,
-                ),
-                ticket_type: TicketType::from_labels(
-                    sub.labels.nodes.iter().map(|l| l.name.as_str()),
-                ),
-                blocked_by,
-                prs,
-            }
+            parse_ticket(sub, &id.repo)
         })
         .collect();
     tickets.sort_by_key(|t| t.number);
 
-    Ok(Map {
-        title: issue.title,
+    Ok(Cluster::map(
+        issue.title,
         // Interpreted here and nowhere inward, like every other tracker string.
-        last_activity: issue.updated_at.as_deref().and_then(Activity::parse),
+        issue.updated_at.as_deref().and_then(Activity::parse),
         tickets,
         truncated,
-    })
+    ))
+}
+
+/// The two aliased searches, as the response carries them.
+#[derive(Deserialize)]
+struct InboxData {
+    mine: Paged<InboxIssue>,
+    unassigned: Paged<InboxIssue>,
+}
+
+/// One inbox row as the search answers: an ordinary issue selection plus the
+/// two facts a row outside a map cannot borrow from one.
+#[derive(Deserialize)]
+struct InboxIssue {
+    #[serde(flatten)]
+    issue: SubIssue,
+    /// Defaulted for the same reason every other optional selection here is:
+    /// a response without it reads as "activity unknown" rather than failing
+    /// the whole inbox.
+    #[serde(rename = "updatedAt", default)]
+    updated_at: Option<String>,
+    repository: RepoRef,
+}
+
+/// Fetch the inbox live: every open issue across `repos` that is assigned to
+/// the viewer or to nobody, grouped into one [`Cluster`] per repo — one
+/// `gh api graphql` round trip.
+///
+/// Repos with nothing to show are simply absent, so a machine with a clean
+/// inbox renders no inbox clusters at all rather than a row of empty headings.
+///
+/// Map issues themselves are dropped here: a `wayfinder:map` issue is a cluster
+/// header on this screen, and listing it as a row of the inbox would draw the
+/// same issue twice in two different meanings. Its *tickets* are dropped
+/// elsewhere and deliberately so — see the fold in `picker`, which subtracts
+/// them as the maps land, because this query cannot know which issues a map
+/// has claimed.
+///
+/// # Errors
+///
+/// A `gh` that is missing or unauthenticated, a network failure, or a response
+/// that does not parse. An empty `repos` is not an error — it is an empty
+/// inbox, which is what a machine with nothing discovered yet has.
+pub async fn fetch_inbox(repos: &[String]) -> Result<Vec<(String, Cluster)>> {
+    if repos.is_empty() {
+        return Ok(Vec::new());
+    }
+    let scope: Vec<String> = repos.iter().map(|r| format!("repo:{r}")).collect();
+    // The two halves differ in exactly one qualifier, so they are built from
+    // one string: a scope that drifted between them would silently make the
+    // inbox mean two different things in its two halves.
+    let scoped = |who: &str| format!("{who} is:issue is:open {}", scope.join(" "));
+    let output = Command::new("gh")
+        .args([
+            "api",
+            "graphql",
+            "-f",
+            &format!("mine={}", scoped("assignee:@me")),
+            "-f",
+            &format!("unassigned={}", scoped("no:assignee")),
+            "-f",
+            &format!("query={INBOX_QUERY}"),
+        ])
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await
+        .context("failed to run `gh` for the inbox")?;
+    if !output.status.success() {
+        bail!(
+            "`gh api graphql` failed for the inbox: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    parse_inbox(&output.stdout)
+}
+
+/// Turn one inbox response into one cluster per repo — the whole parse
+/// boundary, kept apart from the process call so it is testable without the
+/// network.
+///
+/// Truncation is per repo and folds the same way a map's does: the search page
+/// being cut short means *every* repo's rows may be partial, because one page
+/// spans them all and there is no way to tell which repo lost rows. Saying so
+/// on all of them is the honest answer; picking one would be a guess.
+fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
+    let resp: GraphQlResponse<InboxData> =
+        serde_json::from_slice(body).context("unparseable GraphQL response from gh")?;
+    if let Some(err) = resp.errors.first() {
+        bail!("GraphQL error: {}", err.message);
+    }
+    let data = resp.data.context("no data in the inbox response")?;
+    // Either half being cut short means rows are missing, and neither says
+    // which repo lost them — so both halves fold into one claim, the same way
+    // one search's page already does across the repos it spans.
+    let page_cut_short =
+        data.mine.page_info.has_next_page || data.unassigned.page_info.has_next_page;
+
+    let mut by_repo: std::collections::BTreeMap<String, (Vec<Ticket>, Option<Activity>, bool)> =
+        std::collections::BTreeMap::new();
+    // Concatenated rather than merged: the two searches are disjoint by
+    // construction — an issue is assigned to you or it is assigned to nobody,
+    // never both — so there is nothing here to deduplicate. What each row
+    // *is* still comes from its own `assignees` selection through
+    // `parse_ticket`, not from which half it arrived in, so a row does not
+    // depend on the query that found it.
+    for node in data.mine.nodes.into_iter().chain(data.unassigned.nodes) {
+        // A map is a heading here, not a row.
+        if node.issue.labels.nodes.iter().any(|l| l.name == MAP_LABEL) {
+            continue;
+        }
+        let repo = node.repository.name_with_owner.clone();
+        let activity = node.updated_at.as_deref().and_then(Activity::parse);
+        let blockers_cut_short = node.issue.blocked_by.page_info.has_next_page;
+        let ticket = parse_ticket(node.issue, &repo);
+        let entry = by_repo
+            .entry(repo)
+            .or_insert((Vec::new(), None, page_cut_short));
+        entry.0.push(ticket);
+        // The cluster's stamp is the newest of its rows': a pile of issues has
+        // no single thing that was updated, and the order the screen wants is
+        // "where has something happened".
+        entry.1 = entry.1.max(activity);
+        entry.2 |= blockers_cut_short;
+    }
+
+    Ok(by_repo
+        .into_iter()
+        .map(|(repo, (mut tickets, activity, truncated))| {
+            tickets.sort_by_key(|t| t.number);
+            (repo, Cluster::inbox(activity, tickets, truncated))
+        })
+        .collect())
+}
+
+/// Turn one issue selection into a [`Ticket`] — the only place the tracker's
+/// raw strings for an issue become a ticket, whether that issue arrived as a
+/// map's sub-issue or as a row of the inbox.
+///
+/// One function rather than one per caller: the two reads select the same
+/// fields, and a second copy of this is how the inbox and a map would come to
+/// disagree about the same issue's status. `repo` is passed in because the two
+/// callers know it differently — a sub-issue takes its map's repo, an inbox
+/// row carries its own.
+fn parse_ticket(sub: SubIssue, repo: &str) -> Ticket {
+    // One pass over the same edges yields both facts: the open subset
+    // is status, the whole set is structure (#50).
+    let open_blockers: Vec<u64> = sub
+        .blocked_by
+        .nodes
+        .iter()
+        .filter(|b| is_open(&b.state))
+        .map(|b| b.number)
+        .collect();
+    let blocked_by: Vec<u64> = sub.blocked_by.nodes.iter().map(|b| b.number).collect();
+    let prs: Vec<PrLink> = sub
+        .closed_by_prs
+        .nodes
+        .iter()
+        .filter_map(parse_pr)
+        .collect();
+    Ticket {
+        repo: repo.to_string(),
+        number: sub.number,
+        title: sub.title,
+        status: classify(
+            is_open(&sub.state),
+            !sub.assignees.nodes.is_empty(),
+            open_blockers,
+        ),
+        ticket_type: TicketType::from_labels(sub.labels.nodes.iter().map(|l| l.name.as_str())),
+        blocked_by,
+        prs,
+    }
 }
 
 /// One item of a `search/issues` response — just what map detection needs.
@@ -509,6 +708,240 @@ fn parse_map_search(body: &[u8]) -> Result<MapSet> {
 mod tests {
     use super::*;
     use crate::model::Status;
+
+    /// One inbox response, shaped exactly like the live one: both aliased
+    /// searches, two repos, a `wayfinder:map` issue that must not become a row,
+    /// and a blocker page the tracker cut short.
+    ///
+    /// The `unassigned` half deliberately carries a map issue, because that is
+    /// what the live one carries: a map is an open issue nobody is assigned to,
+    /// so `no:assignee` finds every map in every repo asked about.
+    const INBOX_RESPONSE: &str = r#"{"data": {
+      "mine": {
+        "nodes": [
+          {"number": 191, "title": "Non-ASCII titles", "state": "OPEN",
+           "updatedAt": "2026-08-22T16:06:12Z",
+           "repository": {"nameWithOwner": "blooop/wayfinder"},
+           "labels": {"nodes": [{"name": "wayfinder:build"}]},
+           "assignees": {"nodes": [{"login": "blooop"}]},
+           "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": false}},
+           "closedByPullRequestsReferences": {
+             "nodes": [{"number": 203, "state": "OPEN", "isDraft": false,
+                        "reviewDecision": null,
+                        "statusCheckRollup": {"state": "SUCCESS"},
+                        "repository": {"nameWithOwner": "blooop/wayfinder"}}],
+             "pageInfo": {"hasNextPage": false}}},
+          {"number": 190, "title": "A red run files an issue", "state": "OPEN",
+           "updatedAt": "2026-08-24T09:00:00Z",
+           "repository": {"nameWithOwner": "blooop/wayfinder"},
+           "labels": {"nodes": []},
+           "assignees": {"nodes": [{"login": "blooop"}]},
+           "blockedBy": {"nodes": [{"number": 12, "state": "OPEN"}],
+                         "pageInfo": {"hasNextPage": true}},
+           "closedByPullRequestsReferences": {"nodes": [], "pageInfo": {"hasNextPage": false}}},
+          {"number": 4, "title": "Pin the toolchain", "state": "OPEN",
+           "updatedAt": "2026-08-20T00:00:00Z",
+           "repository": {"nameWithOwner": "blooop/dotfiles"},
+           "labels": {"nodes": []},
+           "assignees": {"nodes": [{"login": "blooop"}]},
+           "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": false}},
+           "closedByPullRequestsReferences": {"nodes": [], "pageInfo": {"hasNextPage": false}}}
+        ],
+        "pageInfo": {"hasNextPage": false}
+      },
+      "unassigned": {
+        "nodes": [
+          {"number": 207, "title": "test ticket", "state": "OPEN",
+           "updatedAt": "2026-08-24T10:00:00Z",
+           "repository": {"nameWithOwner": "blooop/wayfinder"},
+           "labels": {"nodes": []},
+           "assignees": {"nodes": []},
+           "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": false}},
+           "closedByPullRequestsReferences": {"nodes": [], "pageInfo": {"hasNextPage": false}}},
+          {"number": 7, "title": "Map: the other project", "state": "OPEN",
+           "updatedAt": "2026-08-23T00:00:00Z",
+           "repository": {"nameWithOwner": "blooop/dotfiles"},
+           "labels": {"nodes": [{"name": "wayfinder:map"}]},
+           "assignees": {"nodes": []},
+           "blockedBy": {"nodes": [], "pageInfo": {"hasNextPage": false}},
+           "closedByPullRequestsReferences": {"nodes": [], "pageInfo": {"hasNextPage": false}}}
+        ],
+        "pageInfo": {"hasNextPage": false}
+      }
+    }}"#;
+
+    #[test]
+    fn the_inbox_holds_what_is_yours_and_what_is_nobodys_in_one_cluster() {
+        // The two searches exist only because GitHub issue search has no `OR`;
+        // downstream there is one inbox per repo, and which half a row arrived
+        // in is not a fact anything keeps.
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let wayfinder = &inbox
+            .iter()
+            .find(|(repo, _)| repo == "blooop/wayfinder")
+            .expect("wayfinder has rows")
+            .1;
+        let numbers: Vec<u64> = wayfinder.tickets.iter().map(|t| t.number).collect();
+        assert_eq!(
+            numbers,
+            vec![190, 191, 207],
+            "both halves land in one cluster, sorted by number like a map's"
+        );
+    }
+
+    #[test]
+    fn an_inbox_rows_status_comes_from_its_assignees_not_from_which_search_found_it() {
+        // The reason both halves go through `parse_ticket`: an unassigned issue
+        // is a *frontier* row and an assigned one is *claimed*, and that is the
+        // difference the glyph column draws. Deriving it from the alias would
+        // work today and be wrong the moment either query changes.
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let by_number = |n: u64| {
+            inbox
+                .iter()
+                .flat_map(|(_, cluster)| &cluster.tickets)
+                .find(|t| t.number == n)
+                .unwrap_or_else(|| panic!("#{n} is in the inbox"))
+                .clone()
+        };
+        assert_eq!(by_number(191).status, Status::Claimed, "assigned to me");
+        assert_eq!(
+            by_number(207).status,
+            Status::Frontier,
+            "assigned to nobody"
+        );
+    }
+
+    #[test]
+    fn the_inbox_groups_by_repo_and_orders_each_cluster_by_its_newest_row() {
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let repos: Vec<&str> = inbox.iter().map(|(repo, _)| repo.as_str()).collect();
+        assert_eq!(repos, vec!["blooop/dotfiles", "blooop/wayfinder"]);
+
+        let wayfinder = &inbox[1].1;
+        // The cluster's stamp is the newest of its rows, whichever half that
+        // row came from: #207 (unassigned, 10:00) was touched after #190
+        // (mine, 09:00), and the cluster is ordered by where something
+        // happened.
+        assert_eq!(
+            wayfinder.last_activity,
+            Activity::parse("2026-08-24T10:00:00Z"),
+        );
+    }
+
+    #[test]
+    fn a_map_issue_is_a_heading_and_never_a_row_of_the_inbox() {
+        // Sharper now than when the query was `assignee:@me`: a map is an open
+        // issue with nobody assigned, so `no:assignee` finds *every* map in
+        // every repo asked about, and without this every cluster header would
+        // also be a row of the inbox below it.
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let dotfiles = &inbox
+            .iter()
+            .find(|(repo, _)| repo == "blooop/dotfiles")
+            .expect("dotfiles has an assigned issue")
+            .1;
+        let numbers: Vec<u64> = dotfiles.tickets.iter().map(|t| t.number).collect();
+        assert_eq!(
+            numbers,
+            vec![4],
+            "map issue #7 is drawn as a cluster, not listed under one"
+        );
+    }
+
+    #[test]
+    fn the_inbox_reads_an_issue_exactly_as_a_map_reads_its_sub_issue() {
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let ticket = &inbox[1].1.tickets[1];
+        assert_eq!(ticket.number, 191);
+        assert_eq!(ticket.repo, "blooop/wayfinder", "its own repo, not a map's");
+        assert_eq!(ticket.ticket_type, TicketType::Build, "labels still parse");
+        assert_eq!(ticket.status, Status::Claimed, "this one is assigned");
+        assert_eq!(ticket.prs.len(), 1, "the linked PR rides along");
+        assert_eq!(ticket.prs[0].number, 203);
+    }
+
+    #[test]
+    fn a_blocker_page_cut_short_makes_its_repos_inbox_partial() {
+        let inbox = parse_inbox(INBOX_RESPONSE.as_bytes()).expect("parse");
+        let wayfinder = &inbox[1].1;
+        assert!(
+            wayfinder.truncated,
+            "#190's blocker page said there was more"
+        );
+        let dotfiles = &inbox[0].1;
+        assert!(
+            !dotfiles.truncated,
+            "and the other repo's rows are not made partial by it"
+        );
+    }
+
+    /// The same fixture with one search's *own* page flag flipped — not a
+    /// blocker page's, and not the other half's.
+    ///
+    /// Anchored inside the named alias rather than by a global replace, which
+    /// is the mistake this helper exists to make impossible: `replacen(.., 1)`
+    /// always finds `mine`'s flag first, so a loop over both halves using it
+    /// tests `mine` twice and passes while proving half of what it claims.
+    fn with_page_cut_short(half: &str) -> String {
+        const FLAG: &str = "],\n        \"pageInfo\": {\"hasNextPage\": false}";
+        let alias = format!("\"{half}\": {{\n        \"nodes\"");
+        let at = INBOX_RESPONSE
+            .find(&alias)
+            .unwrap_or_else(|| panic!("the fixture's `{half}` alias moved"));
+        let rel = INBOX_RESPONSE[at..]
+            .find(FLAG)
+            .unwrap_or_else(|| panic!("the fixture's `{half}` page flag moved"));
+        let cut = at + rel;
+        format!(
+            "{}{}{}",
+            &INBOX_RESPONSE[..cut],
+            FLAG.replace("false", "true"),
+            &INBOX_RESPONSE[cut + FLAG.len()..]
+        )
+    }
+
+    #[test]
+    fn either_search_page_cut_short_makes_every_repos_inbox_partial() {
+        // One page spans every repo, so a cut-short page cannot say which of
+        // them lost rows — and with two searches it cannot say which *half*
+        // either. Saying so on every cluster is the honest answer; picking one
+        // would be a guess.
+        //
+        // Both halves are checked, because the rule reached by only one of
+        // them is the rule half-implemented.
+        for half in ["mine", "unassigned"] {
+            let cut = with_page_cut_short(half);
+            assert_ne!(cut, INBOX_RESPONSE, "the `{half}` flag did not move");
+            let inbox = parse_inbox(cut.as_bytes()).expect("parse");
+            assert!(
+                inbox.iter().all(|(_, cluster)| cluster.truncated),
+                "a cut-short `{half}` page makes every repo say its rows may be partial"
+            );
+        }
+        // And the two really are different bytes — the guard on the helper
+        // above, since both edits produce a response that parses.
+        assert_ne!(
+            with_page_cut_short("mine"),
+            with_page_cut_short("unassigned"),
+            "each half's own flag is what moved"
+        );
+    }
+
+    #[test]
+    fn an_empty_inbox_is_an_answer_and_not_an_error() {
+        let body = r#"{"data": {
+            "mine": {"nodes": [], "pageInfo": {"hasNextPage": false}},
+            "unassigned": {"nodes": [], "pageInfo": {"hasNextPage": false}}
+        }}"#;
+        assert!(parse_inbox(body.as_bytes()).expect("parse").is_empty());
+    }
+
+    #[test]
+    fn a_graphql_error_fails_the_inbox_rather_than_reading_as_empty() {
+        let body = r#"{"errors": [{"message": "Bad credentials"}]}"#;
+        assert!(parse_inbox(body.as_bytes()).is_err());
+    }
 
     #[test]
     fn map_search_keeps_every_open_map_including_several_on_one_repo() {
@@ -631,7 +1064,7 @@ mod tests {
     #[test]
     fn the_map_parse_carries_each_sub_issues_type_through_from_its_labels() {
         let map = parse_map(MAP_RESPONSE.as_bytes(), &wf_map_id()).expect("parse");
-        assert_eq!(map.title, "Map: wf");
+        assert_eq!(map.map_title(), Some("Map: wf"));
         let types: Vec<(u64, TicketType)> = map
             .tickets
             .iter()
@@ -725,7 +1158,11 @@ mod tests {
         );
         let map = parse_map(body.as_bytes(), &wf_map_id())
             .expect("a label page the tracker cut short cannot prove the label is gone");
-        assert_eq!(map.title, "Map: wf", "the map renders as itself");
+        assert_eq!(
+            map.map_title(),
+            Some("Map: wf"),
+            "the map renders as itself"
+        );
 
         // And the label page being cut short is not the *tree* being cut
         // short: nothing ticket-bearing was truncated here.

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -114,7 +114,7 @@ const INBOX_QUERY: &str = "\
 fragment Row on Issue {
   number title state updatedAt
   repository { nameWithOwner }
-  labels(first: 10) { nodes { name } }
+  labels(first: 100) { nodes { name } pageInfo { hasNextPage } }
   assignees(first: 5) { nodes { login } }
   blockedBy(first: 50) { nodes { number state } pageInfo { hasNextPage } }
   closedByPullRequestsReferences(first: 5, includeClosedPrs: true) {
@@ -214,7 +214,14 @@ struct SubIssue {
     number: u64,
     title: String,
     state: String,
-    labels: Nodes<Label>,
+    /// Paged rather than bare nodes because the *inbox* reads the page flag:
+    /// there, the map label's **absence** is what keeps a map issue out of its
+    /// own inbox, and a page cut short cannot prove an absence (#184). A map's
+    /// own sub-issues are read from the same struct and do not consult it — a
+    /// label page cut short there costs a `[type]` suffix, not a row drawn
+    /// twice — which is why [`MAP_QUERY`] does not ask for the flag and
+    /// `Paged`'s default reads it as "no claim of more".
+    labels: Paged<Label>,
     assignees: Nodes<Assignee>,
     #[serde(rename = "blockedBy")]
     blocked_by: Paged<Blocker>,
@@ -579,8 +586,19 @@ fn parse_inbox(body: &[u8]) -> Result<Vec<(String, Cluster)>> {
     // `parse_ticket`, not from which half it arrived in, so a row does not
     // depend on the query that found it.
     for node in data.mine.nodes.into_iter().chain(data.unassigned.nodes) {
-        // A map is a heading here, not a row.
-        if node.issue.labels.nodes.iter().any(|l| l.name == MAP_LABEL) {
+        // A map is a heading on this screen, not a row — and a map is an open
+        // issue nobody is assigned to, so `no:assignee` finds every one of
+        // them. This is the only thing keeping them out.
+        //
+        // So the *absence* of the label has to be proven, not assumed (#184):
+        // a page the tracker cut short cannot prove a label is gone, and a map
+        // drawn as a row is a row offering to adopt a map. Unproven means
+        // dropped, which costs at worst one heavily-labelled issue that has to
+        // be reached from its own map — where a wrongly-drawn map row would
+        // cost a reparenting.
+        let not_a_map = !node.issue.labels.nodes.iter().any(|l| l.name == MAP_LABEL)
+            && !node.issue.labels.page_info.has_next_page;
+        if !not_a_map {
             continue;
         }
         let repo = node.repository.name_with_owner.clone();
@@ -796,6 +814,52 @@ mod tests {
         "pageInfo": {"hasNextPage": false}
       }
     }}"#;
+
+    #[test]
+    fn a_map_wearing_more_labels_than_one_page_holds_is_still_not_a_row() {
+        // The #184 shape, on the inbox side. A map is an open issue nobody is
+        // assigned to, so `no:assignee` finds every one of them, and the only
+        // thing keeping a map out of its own inbox is the label check. A label
+        // page cut short cannot prove the label is gone — so it does not get to
+        // — and the row is dropped rather than drawn as an issue offering to
+        // adopt a map.
+        let body = INBOX_RESPONSE.replace(
+            r#""labels": {"nodes": [{"name": "wayfinder:map"}]}"#,
+            r#""labels": {"nodes": [{"name": "bug"}], "pageInfo": {"hasNextPage": true}}"#,
+        );
+        assert_ne!(body, INBOX_RESPONSE, "the fixture's map label moved");
+        let inbox = parse_inbox(body.as_bytes()).expect("parse");
+        let dotfiles = inbox.iter().find(|(repo, _)| repo == "blooop/dotfiles");
+        let numbers: Vec<u64> = dotfiles
+            .map(|(_, cluster)| cluster.tickets.iter().map(|t| t.number).collect())
+            .unwrap_or_default();
+        assert!(
+            !numbers.contains(&7),
+            "#7's label page was cut short, so it cannot be proven not to be a map: {numbers:?}"
+        );
+    }
+
+    #[test]
+    fn a_complete_label_page_without_the_map_label_is_an_ordinary_row() {
+        // The other half, so the rule above is not just "drop anything with
+        // more labels than we asked for": a page the tracker says is all of it,
+        // with no map label on it, is proof.
+        let body = INBOX_RESPONSE.replace(
+            r#""labels": {"nodes": [{"name": "wayfinder:map"}]}"#,
+            r#""labels": {"nodes": [{"name": "bug"}], "pageInfo": {"hasNextPage": false}}"#,
+        );
+        let inbox = parse_inbox(body.as_bytes()).expect("parse");
+        let numbers: Vec<u64> = inbox
+            .iter()
+            .find(|(repo, _)| repo == "blooop/dotfiles")
+            .expect("dotfiles has rows")
+            .1
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .collect();
+        assert!(numbers.contains(&7), "{numbers:?}");
+    }
 
     #[test]
     fn the_inbox_holds_what_is_yours_and_what_is_nobodys_in_one_cluster() {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -24,7 +24,7 @@ use std::fmt;
 use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher, Utf32Str};
 
-use crate::model::{Map, Ticket};
+use crate::model::{Cluster, Ticket};
 
 /// The part of the haystack the row itself draws: `#n title`. Public because
 /// the screen underlines characters *by index* into it — the string drawn and
@@ -190,12 +190,13 @@ impl Query {
     }
 
     /// Where the query landed in a cluster's repo name, taken from whichever of
-    /// its tickets matched best. Every ticket in a map shares one repo name but
+    /// its tickets matched best. Every ticket in a cluster shares one repo name but
     /// not one match — `wf6` can reach the repo through one row and not
     /// another — and the header is drawn once, so it answers for the row the
     /// query liked most, which is the row it put at the top.
-    pub fn in_repo(&mut self, map: &Map) -> Vec<usize> {
-        map.tickets
+    pub fn in_repo(&mut self, cluster: &Cluster) -> Vec<usize> {
+        cluster
+            .tickets
             .iter()
             .filter_map(|ticket| self.hit(ticket))
             .max_by_key(|hit| hit.score)

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -170,6 +170,13 @@ pub enum Route {
     Plain,
 }
 
+/// The word that tells `/wf-one` its ticket already exists.
+///
+/// A subcommand-shaped argument rather than a bare number, because `/wf-one`'s
+/// other argument is free text: `wf-one 42` is a task called "42", and this
+/// keeps the two readings apart at the skill's own front door.
+pub const ADOPT_ARG: &str = "adopt";
+
 impl Route {
     /// The bundled skill this route invokes, without the selected agent's
     /// sigil. [`Route::Plain`] invokes no skill.
@@ -476,6 +483,14 @@ pub enum Candidate {
     Launch { mode: Mode, route: Route },
     /// Start something new in the staged node's repo.
     Create(CreationKind),
+    /// Put a loose issue under a map of its own and work it — `/wf-one`'s
+    /// route, reached from the inbox rather than from a project row.
+    ///
+    /// Its own variant rather than a [`CreationKind`], because nothing is
+    /// being created that the human has to name: the issue already exists and
+    /// already has a title, so this row takes no text field. That is the whole
+    /// difference between adopting and filing.
+    Adopt,
     /// Rejoin the conversation a previous launch of this node left on this
     /// machine (#35) — no skill, no context block, no fresh session.
     ///
@@ -493,6 +508,7 @@ impl Candidate {
         match self {
             Candidate::Launch { mode, .. } => mode.label(),
             Candidate::Create(kind) => kind.label(),
+            Candidate::Adopt => "adopt",
             Candidate::Resume { .. } => "resume",
         }
     }
@@ -502,6 +518,7 @@ impl Candidate {
         match self {
             Candidate::Launch { mode, .. } => mode.blurb(),
             Candidate::Create(kind) => kind.blurb(),
+            Candidate::Adopt => "put it under a map of its own, then build it",
             // Says what it does, not how long ago: the age is a fact about
             // *this* record and is drawn from it, beside the row.
             Candidate::Resume { .. } => "pick the conversation back up where you left it",
@@ -517,7 +534,7 @@ impl Candidate {
     /// that runs Claude.
     pub fn agent(self, picked: Agent) -> Agent {
         match self {
-            Candidate::Launch { .. } | Candidate::Create(_) => picked,
+            Candidate::Launch { .. } | Candidate::Create(_) | Candidate::Adopt => picked,
             Candidate::Resume { agent } => agent,
         }
     }
@@ -534,6 +551,7 @@ impl Candidate {
         match self {
             Candidate::Launch { route, .. } => route.invocation(agent),
             Candidate::Create(kind) => kind.route().invocation(agent),
+            Candidate::Adopt => Route::One.invocation(agent),
             Candidate::Resume { .. } => {
                 format!("{} {}", agent.program(), agent.resume_argv().join(" "))
             }
@@ -546,7 +564,7 @@ impl Candidate {
     /// their resume flag.
     pub fn field(self) -> &'static str {
         match self {
-            Candidate::Launch { .. } | Candidate::Resume { .. } => "steer",
+            Candidate::Launch { .. } | Candidate::Resume { .. } | Candidate::Adopt => "steer",
             Candidate::Create(kind) => kind.field(),
         }
     }
@@ -878,6 +896,33 @@ pub enum StagedAt {
         /// launched cannot be offered one.
         resume: Option<Resume>,
     },
+    /// An issue the tracker knows about that **no map claims** — a row of the
+    /// loose "yours or unclaimed" cluster.
+    ///
+    /// A third arm rather than a [`StagedAt::Node`] whose `map` is optional,
+    /// for the reason the whole cluster split exists: a mapped node and a
+    /// loose one differ in what can be *done* with them, not in whether a
+    /// field was filled in. A node launches into its map's lifecycle; a loose
+    /// issue has to be adopted into a map before that lifecycle has anywhere
+    /// to keep its breadcrumbs. Making `map` an `Option` would push that
+    /// difference into every route arm and every reader of the launch context.
+    ///
+    /// Deliberately carries no `Aim` and no stage. Adoption is one act with
+    /// one route whatever the issue's type or PR state — the map does not
+    /// exist yet, so there is no lifecycle to be at a stage of — and the
+    /// skill it hands off to reads the issue itself.
+    Loose {
+        /// The issue's own number: what adoption parents under a new map, and
+        /// what the per-node workspace is named after, exactly as a mapped
+        /// node's is.
+        number: u64,
+        /// The issue title, as the picker showed it.
+        title: String,
+        /// The conversation a previous adoption of this issue left on this
+        /// machine, if there is one. An adopted issue keeps its number, so its
+        /// workspace and its session record are the ones any node would have.
+        resume: Option<Resume>,
+    },
     /// A whole project: the repo-level stop every project screen opens on,
     /// and the only stop creation hangs off.
     Project,
@@ -930,17 +975,51 @@ impl Staged {
     /// dropped.
     #[must_use]
     pub fn with_resume(mut self, resume: Resume) -> Staged {
-        if let StagedAt::Node { resume: slot, .. } = &mut self.at {
-            *slot = Some(resume);
+        match &mut self.at {
+            StagedAt::Node { resume: slot, .. } | StagedAt::Loose { resume: slot, .. } => {
+                *slot = Some(resume);
+            }
+            StagedAt::Project => {}
         }
         self
+    }
+
+    /// The issue adoption would adopt — `None` on every stop that is not a
+    /// loose one, which is every stop the picker never drew an adopt row on.
+    ///
+    /// Shaped like [`Staged::resume`] and for the same reason: the picker's row
+    /// and the act the second enter performs read the same field, so a row
+    /// that could be drawn without something to act on cannot exist.
+    pub fn adoptable(&self) -> Option<u64> {
+        match &self.at {
+            StagedAt::Loose { number, .. } => Some(*number),
+            StagedAt::Node { .. } | StagedAt::Project => None,
+        }
     }
 
     /// The conversation this stop can be resumed into, if any.
     pub fn resume(&self) -> Option<&Resume> {
         match &self.at {
-            StagedAt::Node { resume, .. } => resume.as_ref(),
+            StagedAt::Node { resume, .. } | StagedAt::Loose { resume, .. } => resume.as_ref(),
             StagedAt::Project => None,
+        }
+    }
+
+    /// Stage the adoption of a loose issue — a row of the inbox cluster.
+    ///
+    /// Total where [`Staged::ticket`] refuses: a finished issue has no
+    /// launchable *stage*, but adoption has no stages to be past. Nothing is
+    /// gained by refusing to put a closed issue under a map, and the caller
+    /// keeps its own refusal (a done row is not offered) without this needing
+    /// to restate it.
+    pub fn loose(ticket: &Ticket) -> Staged {
+        Staged {
+            repo: ticket.repo.clone(),
+            at: StagedAt::Loose {
+                number: ticket.number,
+                title: ticket.title.clone(),
+                resume: None,
+            },
         }
     }
 
@@ -964,7 +1043,8 @@ impl Staged {
             StagedAt::Node {
                 aim: Aim::Ticket { title, .. },
                 ..
-            } => title,
+            }
+            | StagedAt::Loose { title, .. } => title,
             StagedAt::Node {
                 aim: Aim::Map, map, ..
             } => &map.title,
@@ -981,7 +1061,10 @@ impl Staged {
     pub fn route(&self, mode: Mode) -> Option<Route> {
         match &self.at {
             StagedAt::Node { aim, .. } => Some(route(aim, mode)),
-            StagedAt::Project => None,
+            // Adoption's route is fixed (`/wf-one`) and does not read the mode
+            // axis, so answering here would be answering a question this stop
+            // does not have — see [`StagedAt::Loose`].
+            StagedAt::Loose { .. } | StagedAt::Project => None,
         }
     }
 
@@ -1032,6 +1115,16 @@ impl Staged {
                     route: route(aim, mode),
                 }))
                 .collect(),
+            // An issue no map claims offers exactly one way forward, plus the
+            // conversation a previous adoption left. There is no mode axis:
+            // `wf-one` owns the whole of a single-ticket map's lifecycle and
+            // decides the small things alone, so "who decides" is already
+            // answered by the route rather than being a row to pick.
+            StagedAt::Loose { resume, .. } => resume
+                .iter()
+                .map(|r| Candidate::Resume { agent: r.agent })
+                .chain([Candidate::Adopt])
+                .collect(),
             // A project names nothing that exists yet, so there is nothing to
             // launch — only the ways to start something.
             StagedAt::Project => CreationKind::all()
@@ -1052,7 +1145,8 @@ impl Staged {
             StagedAt::Node {
                 aim: Aim::Ticket { number, .. },
                 ..
-            } => format!("#{number}"),
+            }
+            | StagedAt::Loose { number, .. } => format!("#{number}"),
             StagedAt::Project => "+new".to_string(),
         }
     }
@@ -1079,6 +1173,11 @@ impl Staged {
     ///   as backing out.
     pub fn node_workspace(&self) -> Option<String> {
         match &self.at {
+            // An adoption runs in the issue's own per-node workspace, the same
+            // one any launch of that number would use, so it prewarms like any
+            // node — the map it is about to be given does not change where the
+            // work happens.
+            StagedAt::Loose { number, .. } => Some(node_workspace_name(&self.repo, *number)),
             StagedAt::Node { aim, map, .. } => Some(node_workspace_name(
                 &self.repo,
                 match aim {
@@ -1613,6 +1712,21 @@ enum Job {
     },
     /// Start something new in the repo — the skill files the issues.
     Create { creation: Creation, agent: Agent },
+    /// Adopt an existing issue: the skill files the *map* and parents the
+    /// issue under it, then works it as that map's only ticket.
+    ///
+    /// Half a creation and half a node, which is why it is neither. Like a
+    /// creation it hands the agent no [`LaunchContext`] — there is no map yet
+    /// for `wf` to have read, and a synthesized block would be a claim about
+    /// tracker state nobody looked at. Like a node it has a number, so it runs
+    /// in the per-node workspace and reaps like anything else.
+    Adopt {
+        /// The issue being adopted.
+        number: u64,
+        /// What the launch picker settled on. Only the agent and the steering
+        /// text are read: adoption's route is fixed.
+        mode: LaunchMode,
+    },
     /// Rejoin the conversation a previous launch of this node left (#35).
     ///
     /// Carries the node's number so [`Launch::workspace`] resolves to the same
@@ -1644,7 +1758,7 @@ impl Job {
                 Aim::Ticket { number, .. } => *number,
             }),
             Job::Create { .. } => None,
-            Job::Resume { number, .. } => Some(*number),
+            Job::Adopt { number, .. } | Job::Resume { number, .. } => Some(*number),
         }
     }
 
@@ -1652,7 +1766,7 @@ impl Job {
     /// creation nor resume has a launch mode of its own.
     fn agent(&self) -> Agent {
         match self {
-            Job::Node { mode, .. } => mode.agent(),
+            Job::Node { mode, .. } | Job::Adopt { mode, .. } => mode.agent(),
             Job::Create { agent, .. } | Job::Resume { agent, .. } => *agent,
         }
     }
@@ -1728,6 +1842,10 @@ impl Launch {
             Job::Node { .. } => self.key(),
             // A creation has no `#n` to name yet, so the notice names the act.
             Job::Create { creation, .. } => creation.kind().label().to_string(),
+            // An adoption has a number *and* is starting something, so it
+            // names both: what is being adopted, and that adoption is what is
+            // happening to it rather than an ordinary launch.
+            Job::Adopt { .. } => format!("adopt {}", self.key()),
             // A resume has a number, so it names the node *and* says that it
             // is going back rather than starting: the two are one keystroke
             // apart in the picker and the notice is the last chance to see
@@ -1758,6 +1876,14 @@ impl Launch {
         let prompt = match &self.job {
             Job::Node { mode, .. } => mode.opening_prompt(self.skill_invocation()),
             Job::Create { creation, .. } => Some(creation.invocation(agent)),
+            // Steered like a node — an adoption is a session someone may want
+            // to point at something — but invoked like a creation: the number
+            // is the skill's argument, not a `ctx:` block, because there is no
+            // map for `wf` to have read yet.
+            Job::Adopt { number, mode } => mode.opening_prompt(Some(format!(
+                "{} {ADOPT_ARG} {number}",
+                Route::One.invocation(agent)
+            ))),
             Job::Resume { prompt, .. } => {
                 let mut argv = vec![agent.program().to_string()];
                 argv.extend(agent.resume_argv().iter().map(|a| (*a).to_string()));
@@ -2243,6 +2369,25 @@ pub fn plan(checkouts: &[Checkout], staged: &Staged, route: Route, mode: &Launch
     )
 }
 
+/// Resolve an adoption against the projects cache — the same rules as
+/// [`plan`], and for the same reason: the question is only *where* the agent
+/// runs, and zero or one candidate checkout never prompts.
+///
+/// Separate from [`plan`] because an adoption is not a node launch: there is
+/// no aim, no map and no route to pass in. Separate from [`plan_create`]
+/// because it has a number, and the number is what puts it in the per-node
+/// workspace rather than the repo's bare one.
+pub fn plan_adopt(checkouts: &[Checkout], repo: &str, number: u64, mode: &LaunchMode) -> Targets {
+    resolve(
+        checkouts,
+        repo,
+        &Job::Adopt {
+            number,
+            mode: mode.clone(),
+        },
+    )
+}
+
 /// Resolve a creation against the projects cache — the same rules as [`plan`]:
 /// zero or one candidate checkout never prompts. The creation arrives already
 /// complete ([`CreationKind::with_text`] refused the empty task), so this
@@ -2285,10 +2430,14 @@ pub fn resume_launch(staged: &Staged, steer: &str) -> Option<Launch> {
         StagedAt::Node {
             aim: Aim::Map, map, ..
         } => map.id.number,
+        // An adopted issue's conversation is keyed by the issue's own number,
+        // which is what its workspace was named after — the map it was given
+        // is not part of the way back in, and is why these two are one arm.
         StagedAt::Node {
             aim: Aim::Ticket { number, .. },
             ..
-        } => *number,
+        }
+        | StagedAt::Loose { number, .. } => *number,
         // Unreachable: `Staged::resume` already answered `None` here.
         StagedAt::Project => return None,
     };
@@ -3642,6 +3791,116 @@ mod tests {
             isolation: Isolation::Host,
         };
         assert_eq!(one.agent_argv().last().map(String::as_str), Some("/wf-one"));
+    }
+
+    /// A loose issue in the wayfinder checkout — an inbox row.
+    fn loose(number: u64) -> Ticket {
+        Ticket {
+            repo: "blooop/wayfinder".to_string(),
+            number,
+            title: "Widths survive non-ASCII titles".to_string(),
+            status: classify(true, true, vec![]),
+            ticket_type: TicketType::Untyped,
+            blocked_by: vec![],
+            prs: vec![],
+        }
+    }
+
+    fn adopt_launch(mode: &LaunchMode) -> Launch {
+        match plan_adopt(&cache(), "blooop/wayfinder", 191, mode) {
+            Targets::One(l) => l,
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn adoption_invokes_wf_one_on_the_issue_and_carries_no_context_block() {
+        // The number is the skill's *argument*, not a `ctx:` block: there is no
+        // map for `wf` to have read yet, and a synthesized block would be a
+        // claim about tracker state nobody looked at. `wf-one`'s own doc says
+        // its line never carries one.
+        let prompt = adopt_launch(&interactive(""))
+            .agent_argv()
+            .last()
+            .expect("a prompt")
+            .clone();
+        assert_eq!(prompt, "/wf-one adopt 191");
+        assert!(!prompt.contains("ctx:"), "{prompt}");
+    }
+
+    #[test]
+    fn adoption_still_takes_steering_text() {
+        // Steered like a node — it is a session someone may want to point at
+        // something — even though it is invoked like a creation.
+        let prompt = adopt_launch(&interactive("keep the existing title"))
+            .agent_argv()
+            .last()
+            .expect("a prompt")
+            .clone();
+        assert_eq!(prompt, "/wf-one adopt 191 steer: keep the existing title");
+    }
+
+    #[test]
+    fn an_adoption_runs_in_the_issues_own_per_node_workspace() {
+        // Which is what makes it reap like anything else: the branch `wf` mints
+        // is named after the number, and the number is the issue's, so nothing
+        // downstream has to know a map was created along the way.
+        let launch = adopt_launch(&interactive(""));
+        let workspace = "blooop/wayfinder@wayfinder/wayfinder-191";
+        assert_eq!(launch.workspace(), workspace);
+        assert_eq!(launch.key(), "wayfinder#191");
+        // And the prewarm warms that same workspace, known at stage time —
+        // which is what lets `enter enter` on an inbox row start the container
+        // while the picker is still up.
+        assert_eq!(
+            Staged::loose(&loose(191)).node_workspace(),
+            Some(workspace.to_string())
+        );
+    }
+
+    #[test]
+    fn the_notice_says_adoption_rather_than_an_ordinary_launch() {
+        // One keystroke apart in the picker from a mapped launch, so the notice
+        // is the last chance to see which one was taken.
+        let described = adopt_launch(&interactive("")).describe();
+        assert!(described.contains("adopt wayfinder#191"), "{described}");
+    }
+
+    #[test]
+    fn an_inbox_row_offers_adoption_and_a_resume_and_no_mode_rows() {
+        let staged = Staged::loose(&loose(191));
+        assert_eq!(staged.candidates(), vec![Candidate::Adopt]);
+        assert_eq!(staged.key(), "#191");
+        assert_eq!(staged.title(), "Widths survive non-ASCII titles");
+        // The mode axis has nothing to say here: `/wf-one` owns the whole of a
+        // single-ticket map's lifecycle, so who decides is already answered.
+        assert_eq!(staged.route(Mode::Interactive), None);
+        assert_eq!(staged.route(Mode::Auto), None);
+
+        // A previous adoption's conversation leads, exactly as it does on a
+        // mapped node — an adopted issue keeps its number, so its session
+        // record is the one any node would have.
+        let with_resume = staged.with_resume(resume(Agent::Codex));
+        assert_eq!(
+            with_resume.candidates(),
+            vec![
+                Candidate::Resume {
+                    agent: Agent::Codex
+                },
+                Candidate::Adopt
+            ]
+        );
+        assert_eq!(with_resume.adoptable(), Some(191));
+    }
+
+    #[test]
+    fn the_adopt_row_names_the_skill_it_execs() {
+        assert_eq!(Candidate::Adopt.label(), "adopt");
+        assert_eq!(Candidate::Adopt.invocation(Agent::Claude), "/wf-one");
+        assert_eq!(Candidate::Adopt.invocation(Agent::Codex), "$wf-one");
+        // It takes steering text, not a task: the issue already has a title,
+        // which is the whole difference between adopting and filing.
+        assert_eq!(Candidate::Adopt.field(), "steer");
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -480,7 +480,7 @@ pub struct Ticket {
     /// [`Status::Blocked::needs`] is *status*: `needs` is the open subset at
     /// fetch time, and both are parsed once from the same `gh` response rather
     /// than one being re-derived from the other. Reverse (unblocks) edges are
-    /// derived locally by inversion ([`Map::unblocks`]); the numbers may name
+    /// derived locally by inversion ([`Cluster::unblocks`]); the numbers may name
     /// issues outside the map, which inversion simply never visits.
     pub blocked_by: Vec<u64>,
     /// The PRs linked to this ticket (#52), in the tracker's order.

--- a/src/model.rs
+++ b/src/model.rs
@@ -531,29 +531,187 @@ impl Activity {
     }
 }
 
-/// One map's cluster: the map issue plus its sub-issue tickets.
+/// Which cluster on screen — the identity every row, stop, group and load
+/// event is keyed by.
 ///
-/// Deliberately *without* its own [`MapId`]: a map is always held under its id
-/// (in the clusters the screen renders, in a load event), so carrying a second
-/// copy would let the two disagree.
+/// A sum rather than a [`MapId`] with an optional number, because the two
+/// kinds of cluster differ in what they *are* and not in whether a field was
+/// filled in: a map has an issue of its own (so its header launches, and its
+/// tickets are that issue's sub-issues), and a loose cluster does not (so its
+/// header is a place to stand and nothing more). Every site that decides
+/// something from the kind matches both arms with no wildcard, which is what
+/// makes a third kind of cluster a compile error rather than a silent
+/// misreading.
+///
+/// `Ord` puts every map before every loose cluster — the variant order does
+/// it, and [`crate::app::App::scoped_clusters`] leads on the same distinction
+/// rather than re-deriving it — so the curated work is always above the
+/// inbox, whatever either one's activity says.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ClusterId {
+    /// One open `wayfinder:map` issue and the sub-issues under it.
+    Map(MapId),
+    /// One repo's issues assigned to the viewer that no map claims. Keyed by
+    /// the full repo slug and nothing else: there is exactly one such cluster
+    /// per repo, because "mine, here" is not a thing there can be two of.
+    Inbox(String),
+}
+
+/// What the loose cluster's header calls itself. One constant rather than a
+/// literal at each site, because the screen text and the tests that assert on
+/// it must be the same string.
+///
+/// "Yours or unclaimed" rather than a description of the query, and in the
+/// vocabulary the rows below it already use: an assigned issue classifies as
+/// [`Status::Claimed`] and an unassigned one as [`Status::Frontier`], so
+/// "unclaimed" is the word this screen already means by an unassigned open
+/// issue. It says what is in the cluster, which is the question a heading
+/// answers — not `assignee:@me OR no:assignee`, which says how it was found.
+pub const INBOX_HEADER: &str = "yours or unclaimed";
+
+impl ClusterId {
+    /// The repo this cluster belongs to — what the project scope filters on,
+    /// and the only question both arms answer the same way.
+    pub fn repo(&self) -> &str {
+        match self {
+            ClusterId::Map(id) => &id.repo,
+            ClusterId::Inbox(repo) => repo,
+        }
+    }
+
+    /// The short repo name shown in the header (display only, never a key).
+    pub fn short_repo(&self) -> &str {
+        let repo = self.repo();
+        repo.split('/').next_back().unwrap_or(repo)
+    }
+
+    /// How a note on the count line names this cluster — the one place a
+    /// cluster is written out in prose, so the two kinds read differently
+    /// there rather than a loose cluster borrowing an issue number it has not
+    /// got.
+    pub fn label(&self) -> String {
+        match self {
+            ClusterId::Map(id) => format!("{}#{}", id.repo, id.number),
+            ClusterId::Inbox(repo) => format!("{repo} ({INBOX_HEADER})"),
+        }
+    }
+}
+
+/// What a cluster's rows were read from, and the one fact only one kind of
+/// cluster has: a map's title.
+///
+/// The title lives *in the variant* rather than beside a kind flag, so a
+/// loose cluster carrying a map title — or a map missing one — cannot be
+/// written down. The cluster's [`ClusterId`] says the same thing a second
+/// time, which is the one redundancy here: the two are paired at construction
+/// ([`Cluster::map`] and [`Cluster::inbox`] are the only ways in) and the
+/// pairing is asserted by [`Cluster::agrees_with`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Source {
+    /// A map issue: these tickets are its sub-issues, and the header is the
+    /// map itself — launchable, because charting or driving a whole map is
+    /// something an agent can be aimed at.
+    Map {
+        /// Title of the map issue itself.
+        title: String,
+    },
+    /// The viewer's own assigned issues, claimed by no map. There is no issue
+    /// to be titled by and nothing to launch at the header: the rows are the
+    /// only things here an agent can be aimed at.
+    Inbox,
+}
+
+/// One cluster: where its rows came from, and the rows.
+///
+/// Deliberately *without* its own [`ClusterId`]: a cluster is always held
+/// under its id (in the clusters the screen renders, in a load event), so
+/// carrying a second copy would let the two disagree.
 #[derive(Debug, Clone)]
-pub struct Map {
-    /// Title of the map issue itself.
-    pub title: String,
-    /// When the map issue was last touched, if the tracker's timestamp parsed
-    /// ([`Activity`]) — the cluster sort key.
+pub struct Cluster {
+    /// What this cluster is, and a map's title if it is one.
+    pub source: Source,
+    /// When the cluster was last touched, if the tracker's timestamp parsed
+    /// ([`Activity`]) — the cluster sort key. For a map that is the map
+    /// issue's own `updatedAt`; for a loose cluster it is the newest of its
+    /// issues', because a pile of issues has no single thing that was updated.
     pub last_activity: Option<Activity>,
     pub tickets: Vec<Ticket>,
     /// The tracker said a ticket-bearing page was not all of it (#184): a
     /// 101st sub-issue or a 51st blocking edge did not fit the fetch, so
     /// `tickets` — and the classification drawn from the edges — is partial.
-    /// Carried on the map rather than swallowed, because the only honest
+    /// Carried on the cluster rather than swallowed, because the only honest
     /// render of a partial tree is one that says so; the count line is where
     /// it is said.
     pub truncated: bool,
 }
 
-impl Map {
+impl Cluster {
+    /// A map's cluster. One of the two constructors, so a cluster's
+    /// [`Source`] is always decided in the same breath as its rows.
+    pub fn map(
+        title: impl Into<String>,
+        last_activity: Option<Activity>,
+        tickets: Vec<Ticket>,
+        truncated: bool,
+    ) -> Cluster {
+        Cluster {
+            source: Source::Map {
+                title: title.into(),
+            },
+            last_activity,
+            tickets,
+            truncated,
+        }
+    }
+
+    /// A loose cluster of the viewer's own issues.
+    pub fn inbox(
+        last_activity: Option<Activity>,
+        tickets: Vec<Ticket>,
+        truncated: bool,
+    ) -> Cluster {
+        Cluster {
+            source: Source::Inbox,
+            last_activity,
+            tickets,
+            truncated,
+        }
+    }
+
+    /// Whether this cluster's [`Source`] is the kind `id` says it is — the
+    /// guard on the one redundancy [`Source`] documents.
+    ///
+    /// Read by the single place clusters are inserted, so a mispaired cluster
+    /// cannot reach the screen. A method rather than a `debug_assert` at that
+    /// call site, because a test can name it.
+    pub fn agrees_with(&self, id: &ClusterId) -> bool {
+        matches!(
+            (id, &self.source),
+            (ClusterId::Map(_), Source::Map { .. }) | (ClusterId::Inbox(_), Source::Inbox)
+        )
+    }
+
+    /// The map issue's title, for the header and the launch. `None` for a
+    /// loose cluster, which has no issue of its own — the caller is asking
+    /// "what is this map called", and there is no map.
+    pub fn map_title(&self) -> Option<&str> {
+        match &self.source {
+            Source::Map { title } => Some(title),
+            Source::Inbox => None,
+        }
+    }
+
+    /// What the header draws after the repo name. A map is named by its issue;
+    /// the loose cluster names what it *is*, because there is no issue to name
+    /// it after and "the rest" would say nothing about why these rows are
+    /// here.
+    pub fn header_name(&self) -> &str {
+        match &self.source {
+            Source::Map { title } => title,
+            Source::Inbox => INBOX_HEADER,
+        }
+    }
+
     /// Where `number`'s ticket sits in `tickets` — the row-index half of a
     /// [`crate::app::Row`]. `None` for a number that is not on this map (a
     /// blocking edge may name any issue).
@@ -573,17 +731,17 @@ impl Map {
             .collect()
     }
 
-    /// Whether any ticket on this map is still open — whether the map is work
-    /// or history. A map whose every ticket is done is *finished*, and so is a
-    /// map with no tickets at all: both have nothing left to do, which is the
-    /// one question the cluster order asks (finished maps sort last).
+    /// Whether any ticket here is still open — whether the cluster is work or
+    /// history. A cluster whose every ticket is done is *finished*, and so is
+    /// one with no tickets at all: both have nothing left to do, which is the
+    /// one question the cluster order asks (finished clusters sort last).
     pub fn has_open_work(&self) -> bool {
         self.tickets
             .iter()
             .any(|t| !matches!(t.status, Status::Done))
     }
 
-    /// The whole map tallied by glyph — the cluster header's counts (#78).
+    /// The whole cluster tallied by glyph — the header's counts (#78).
     /// Stages, through the same [`RowGlyph`] the rows are drawn from, so a
     /// ticket drawn `!` is counted under `!`.
     pub fn tally(&self) -> Vec<(RowGlyph, usize)> {
@@ -1070,15 +1228,19 @@ mod tests {
 
     #[test]
     fn a_map_has_open_work_until_every_ticket_is_done() {
-        let live = Map {
-            title: "Map: wf".to_string(),
+        let live = Cluster {
+            source: Source::Map {
+                title: "Map: wf".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![ticket(2, false, vec![]), ticket(6, true, vec![])],
         };
         assert!(live.has_open_work());
-        let finished = Map {
-            title: "Map: wf".to_string(),
+        let finished = Cluster {
+            source: Source::Map {
+                title: "Map: wf".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![ticket(2, false, vec![]), ticket(6, false, vec![])],
@@ -1086,8 +1248,10 @@ mod tests {
         assert!(!finished.has_open_work(), "every ticket done is finished");
         // A map with no tickets has nothing left to do either — the same answer
         // to the same question, not a third case.
-        let empty = Map {
-            title: "Map: wf".to_string(),
+        let empty = Cluster {
+            source: Source::Map {
+                title: "Map: wf".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![],
@@ -1129,8 +1293,10 @@ mod tests {
     fn unblocks_is_the_local_inversion_of_the_full_edge_set() {
         // #50 → #51 and #50 → #52, with #48 closed but its edge kept: the DAG
         // survives the blocker closing, which is exactly why closed edges stay.
-        let map = Map {
-            title: "Map: selection view".to_string(),
+        let map = Cluster {
+            source: Source::Map {
+                title: "Map: selection view".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![
@@ -1160,8 +1326,10 @@ mod tests {
         claimed.status = Status::Claimed;
         let mut blocked = ticket(7, true, vec![6]);
         blocked.status = Status::Blocked { needs: vec![6] };
-        let map = Map {
-            title: "Map: wf".to_string(),
+        let map = Cluster {
+            source: Source::Map {
+                title: "Map: wf".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![ticket(6, true, vec![]), claimed, blocked, done],

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -89,7 +89,7 @@
 //! terminal, *then* exec, because after the exec there is no `wf` left to
 //! restore anything.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -102,7 +102,7 @@ use tokio::task::JoinHandle;
 
 use wf::app::{App, Outcome};
 use wf::launch::{Agent, Handoff, Launch};
-use wf::model::{Map, MapId};
+use wf::model::{Cluster, ClusterId, MapId, Ticket};
 use wf::projects::{self, ProjectsCache};
 use wf::refresh::{LoadEvent, Loaders, MapFetch, Startup, Survey};
 use wf::skills;
@@ -192,7 +192,22 @@ enum Ending {
 /// drive the *assembly* instead of handing a value straight to [`fold`].
 struct Picker {
     app: App,
-    clusters: BTreeMap<MapId, Map>,
+    /// The maps in hand, keyed by map — **not** by [`ClusterId`], because this
+    /// container holds maps and nothing else. The inbox is not a map and lives
+    /// beside it; what the screen draws is the two combined by [`rendered`].
+    clusters: BTreeMap<MapId, Cluster>,
+    /// The inbox **as it was read**, before any map claimed a row of it.
+    ///
+    /// Kept raw and re-derived rather than folded straight into `clusters`,
+    /// because the two reads race by design: the inbox is one query, the maps
+    /// are one per map, and each lands when it lands. An issue you have
+    /// claimed on a map is in both answers — that is what `assignee:@me`
+    /// means — so which cluster it belongs in is not knowable until that map
+    /// has arrived. Subtracting at render time makes the inbox *derived*: a
+    /// map landing moves its rows out of the inbox with nothing to undo, and a
+    /// map whose fetch failed leaves its rows visible in the inbox rather than
+    /// nowhere at all.
+    inbox: Vec<(String, Cluster)>,
     loaders: Loaders,
     /// The sending end, kept because a fold can start further loads.
     tx: UnboundedSender<LoadEvent>,
@@ -216,6 +231,7 @@ impl Picker {
         Self {
             app,
             clusters: BTreeMap::new(),
+            inbox: Vec::new(),
             loaders,
             tx,
             updates,
@@ -239,6 +255,7 @@ impl Picker {
                 event,
                 &mut self.app,
                 &mut self.clusters,
+                &mut self.inbox,
                 &mut self.loaders,
                 &self.tx,
             );
@@ -246,6 +263,56 @@ impl Picker {
         terminal.draw(|frame| wf::ui::draw(frame, &self.app))?;
         Ok(())
     }
+}
+
+/// What the screen draws: every map in hand, plus what is left of the inbox
+/// once the maps have claimed their own rows.
+///
+/// The subtraction is the whole function. An issue assigned to you that sits
+/// on a map is in both reads, and it belongs on the map — that is where its
+/// blockers, its leverage and its lifecycle are. Left in both it would draw
+/// twice, once as a node in its tree and once as a loose row, and the second
+/// drawing would offer to adopt an issue that already has a map.
+///
+/// Derived on every arrival rather than applied once, because the maps stream:
+/// a map landing later must take its rows out of the inbox, and there is no
+/// point in the sequence where the answer is final. The cost is that a row can
+/// move out of the inbox mid-session, and a cursor sitting on it is carried by
+/// position rather than identity when it does — a map arriving is already the
+/// event [`App::replace_clusters`] is built to absorb, and this is one more
+/// row it moves.
+///
+/// An inbox cluster left with no rows is dropped entirely: a heading over
+/// nothing says nothing.
+fn rendered(
+    clusters: &BTreeMap<MapId, Cluster>,
+    inbox: &[(String, Cluster)],
+) -> BTreeMap<ClusterId, Cluster> {
+    let mut rendered: BTreeMap<ClusterId, Cluster> = clusters
+        .iter()
+        .map(|(id, cluster)| (ClusterId::Map(id.clone()), cluster.clone()))
+        .collect();
+    for (repo, cluster) in inbox {
+        let mapped: BTreeSet<u64> = clusters
+            .iter()
+            .filter(|(id, _)| &id.repo == repo)
+            .flat_map(|(_, cluster)| cluster.tickets.iter().map(|t| t.number))
+            .collect();
+        let tickets: Vec<Ticket> = cluster
+            .tickets
+            .iter()
+            .filter(|t| !mapped.contains(&t.number))
+            .cloned()
+            .collect();
+        if tickets.is_empty() {
+            continue;
+        }
+        rendered.insert(
+            ClusterId::Inbox(repo.clone()),
+            Cluster::inbox(cluster.last_activity, tickets, cluster.truncated),
+        );
+    }
+    rendered
 }
 
 /// Fold one arrival into what the screen draws.
@@ -270,7 +337,8 @@ impl Picker {
 fn fold(
     event: LoadEvent,
     app: &mut App,
-    clusters: &mut BTreeMap<MapId, Map>,
+    clusters: &mut BTreeMap<MapId, Cluster>,
+    inbox: &mut Vec<(String, Cluster)>,
     loaders: &mut Loaders,
     tx: &UnboundedSender<LoadEvent>,
 ) {
@@ -294,7 +362,7 @@ fn fold(
             clusters.retain(|id, _| found.contains(id));
             app.failed.retain(|id| found.contains(id));
             app.open_maps = found;
-            app.replace_clusters(clusters.clone());
+            app.replace_clusters(rendered(clusters, inbox));
         }
         // Discovery retries, so this is a status report and not an end
         // state: `wf` stays on screen and recovers when the search does.
@@ -307,7 +375,7 @@ fn fold(
                 MapFetch::Loaded(new_map) => {
                     app.failed.remove(&id);
                     clusters.insert(id, new_map);
-                    app.replace_clusters(clusters.clone());
+                    app.replace_clusters(rendered(clusters, inbox));
                 }
                 // Nothing polls any more, so a failed load is not a blip
                 // the next cycle papers over — it is the final word on
@@ -318,6 +386,20 @@ fn fold(
                     app.failed.insert(id);
                 }
             }
+        }
+        // The inbox landed. It does not replace anything the maps put on
+        // screen: it is subtracted against them, and re-subtracted every time
+        // a map arrives, which is why the raw reading is what gets stored.
+        LoadEvent::Inbox(found) => {
+            app.inbox_failed = false;
+            *inbox = found;
+            app.replace_clusters(rendered(clusters, inbox));
+        }
+        // Nothing retries it, so this is the final word for the run — recorded
+        // as state rather than announced as a notice, exactly like a failed
+        // map, because a notice is gone on the next keypress and this is not.
+        LoadEvent::InboxFailed => {
+            app.inbox_failed = true;
         }
         // The background reading landed (#137). A plain state write on
         // a screen that has been up and answering keys the whole time.
@@ -362,9 +444,13 @@ fn spawn_reading(tx: &UnboundedSender<LoadEvent>) -> Survey {
 /// make on both at once. Nothing after this point can be drawn, and the process
 /// is about to be replaced — an in-flight `gh` or `dl` that outlives the `exec`
 /// is inherited by the agent as a child holding the terminal it just took over.
-async fn stop_background(discovery: JoinHandle<()>, survey: Survey) {
+async fn stop_background(discovery: JoinHandle<()>, inbox: JoinHandle<()>, survey: Survey) {
     discovery.abort();
     let _ = discovery.await;
+    // The inbox read holds a `gh` of its own, for exactly the same reason and
+    // with exactly the same cost if it outlives the exec.
+    inbox.abort();
+    let _ = inbox.await;
     // The reading holds a `dl` and a `gh` of its own, and the same reasoning
     // applies — [`Survey::stop`] is where the waiting is spelt out.
     survey.stop().await;
@@ -394,6 +480,7 @@ async fn run<B: Backend, K: Keys>(
     keys: &mut K,
     mut picker: Picker,
     discovery: JoinHandle<()>,
+    inbox: JoinHandle<()>,
     survey: Survey,
 ) -> Result<Ending> {
     loop {
@@ -419,7 +506,7 @@ async fn run<B: Backend, K: Keys>(
                 // fold in the human, who was still choosing a mode.
                 let handoff = Handoff::now(picker.app.prewarm_fired(&launch));
                 picker.loaders.shutdown().await;
-                stop_background(discovery, survey).await;
+                stop_background(discovery, inbox, survey).await;
                 return Ok(Ending::Handover(launch, handoff));
             }
             Outcome::Continue => {}
@@ -444,10 +531,14 @@ async fn session<B: Backend, K: Keys>(
     cache_path: PathBuf,
 ) -> Result<Ending> {
     let (tx, updates) = mpsc::unbounded_channel();
+    // Both reads go out at once and neither waits on the other: the maps are
+    // the screen and the inbox is beside it, so a slow inbox never holds up a
+    // map and a slow map never holds up the inbox.
+    let inbox = wf::refresh::spawn_inbox(repos.clone(), tx.clone());
     let discovery = wf::refresh::spawn_discovery(repos, cache_path, tx.clone());
     let survey = spawn_reading(&tx);
     let picker = Picker::new(app, tx, updates);
-    run(terminal, keys, picker, discovery, survey).await
+    run(terminal, keys, picker, discovery, inbox, survey).await
 }
 
 /// Everything `wf` with no arguments does: register the checkout, put the
@@ -629,6 +720,241 @@ mod tests {
     use super::*;
     use crate::probe;
     use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+    /// One inbox row, claimed the way `assignee:@me` guarantees.
+    fn assigned(repo: &str, number: u64) -> Ticket {
+        Ticket {
+            repo: repo.to_string(),
+            number,
+            title: format!("issue {number}"),
+            status: wf::model::classify(true, true, vec![]),
+            ticket_type: wf::model::TicketType::Untyped,
+            blocked_by: vec![],
+            prs: vec![],
+        }
+    }
+
+    /// A map holding exactly `numbers`.
+    fn map_of(repo: &str, numbers: &[u64]) -> Cluster {
+        Cluster::map(
+            "Map: fixture",
+            None,
+            numbers.iter().map(|n| assigned(repo, *n)).collect(),
+            false,
+        )
+    }
+
+    #[test]
+    fn a_map_claims_its_rows_out_of_the_inbox() {
+        // #190 is on the map and also assigned, which is exactly what claiming
+        // a ticket does. It must draw once, on the map.
+        let maps = BTreeMap::from([(
+            MapId::new("blooop/wayfinder", 1),
+            map_of("blooop/wayfinder", &[190]),
+        )]);
+        let inbox = vec![(
+            "blooop/wayfinder".to_string(),
+            Cluster::inbox(
+                None,
+                vec![
+                    assigned("blooop/wayfinder", 190),
+                    assigned("blooop/wayfinder", 42),
+                ],
+                false,
+            ),
+        )];
+        let rendered = rendered(&maps, &inbox);
+        let left: Vec<u64> = rendered[&ClusterId::Inbox("blooop/wayfinder".to_string())]
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .collect();
+        assert_eq!(left, vec![42], "#190 belongs to its map, not the inbox");
+    }
+
+    #[test]
+    fn a_map_that_has_not_landed_leaves_its_rows_in_the_inbox() {
+        // The honest answer while a map is still in flight — or has failed.
+        // The alternative is a row that is nowhere, which is worse than a row
+        // that is in the inbox until its map says otherwise.
+        let inbox = vec![(
+            "blooop/wayfinder".to_string(),
+            Cluster::inbox(None, vec![assigned("blooop/wayfinder", 190)], false),
+        )];
+        let rendered = rendered(&BTreeMap::new(), &inbox);
+        assert_eq!(
+            rendered[&ClusterId::Inbox("blooop/wayfinder".to_string())]
+                .tickets
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn an_inbox_a_map_emptied_leaves_the_screen_rather_than_heading_nothing() {
+        let maps = BTreeMap::from([(
+            MapId::new("blooop/wayfinder", 1),
+            map_of("blooop/wayfinder", &[190]),
+        )]);
+        let inbox = vec![(
+            "blooop/wayfinder".to_string(),
+            Cluster::inbox(None, vec![assigned("blooop/wayfinder", 190)], false),
+        )];
+        let rendered = rendered(&maps, &inbox);
+        assert!(
+            !rendered.contains_key(&ClusterId::Inbox("blooop/wayfinder".to_string())),
+            "a heading over no rows says nothing"
+        );
+        assert_eq!(rendered.len(), 1, "the map is still there");
+    }
+
+    #[test]
+    fn one_repos_map_never_claims_another_repos_inbox_row() {
+        // The subtraction is per repo: issue numbers are only unique inside
+        // one, so matching on number alone would have dotfiles#4 vanish
+        // because wayfinder#4 is on a map.
+        let maps = BTreeMap::from([(
+            MapId::new("blooop/wayfinder", 1),
+            map_of("blooop/wayfinder", &[4]),
+        )]);
+        let inbox = vec![(
+            "blooop/dotfiles".to_string(),
+            Cluster::inbox(None, vec![assigned("blooop/dotfiles", 4)], false),
+        )];
+        let rendered = rendered(&maps, &inbox);
+        assert_eq!(
+            rendered[&ClusterId::Inbox("blooop/dotfiles".to_string())]
+                .tickets
+                .len(),
+            1,
+            "dotfiles#4 is not wayfinder#4"
+        );
+    }
+
+    #[test]
+    fn the_inbox_arrival_is_folded_against_the_maps_already_in_hand() {
+        // The fold, not just the helper: an inbox landing after a map must be
+        // subtracted on the way in rather than replacing what is on screen.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut app = App::empty();
+        app.enter("blooop/wayfinder");
+        let mut clusters = BTreeMap::new();
+        let mut inbox = Vec::new();
+        let mut loaders = Loaders::new();
+        fold(
+            LoadEvent::Fetched {
+                id: MapId::new("blooop/wayfinder", 1),
+                outcome: MapFetch::Loaded(map_of("blooop/wayfinder", &[190])),
+            },
+            &mut app,
+            &mut clusters,
+            &mut inbox,
+            &mut loaders,
+            &tx,
+        );
+        fold(
+            LoadEvent::Inbox(vec![(
+                "blooop/wayfinder".to_string(),
+                Cluster::inbox(
+                    None,
+                    vec![
+                        assigned("blooop/wayfinder", 190),
+                        assigned("blooop/wayfinder", 42),
+                    ],
+                    false,
+                ),
+            )]),
+            &mut app,
+            &mut clusters,
+            &mut inbox,
+            &mut loaders,
+            &tx,
+        );
+        let inbox_rows: Vec<u64> = app.clusters[&ClusterId::Inbox("blooop/wayfinder".to_string())]
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .collect();
+        assert_eq!(inbox_rows, vec![42]);
+        assert!(
+            app.clusters
+                .contains_key(&ClusterId::Map(MapId::new("blooop/wayfinder", 1))),
+            "the map is still on screen"
+        );
+    }
+
+    #[test]
+    fn a_map_landing_after_the_inbox_takes_its_rows_out_of_it() {
+        // The other order, which is the one that races: the inbox is one query
+        // and lands early, each map lands when it lands.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut app = App::empty();
+        app.enter("blooop/wayfinder");
+        let mut clusters = BTreeMap::new();
+        let mut inbox = Vec::new();
+        let mut loaders = Loaders::new();
+        fold(
+            LoadEvent::Inbox(vec![(
+                "blooop/wayfinder".to_string(),
+                Cluster::inbox(
+                    None,
+                    vec![
+                        assigned("blooop/wayfinder", 190),
+                        assigned("blooop/wayfinder", 42),
+                    ],
+                    false,
+                ),
+            )]),
+            &mut app,
+            &mut clusters,
+            &mut inbox,
+            &mut loaders,
+            &tx,
+        );
+        assert_eq!(
+            app.clusters[&ClusterId::Inbox("blooop/wayfinder".to_string())]
+                .tickets
+                .len(),
+            2,
+            "both rows are the inbox's until a map claims one"
+        );
+        fold(
+            LoadEvent::Fetched {
+                id: MapId::new("blooop/wayfinder", 1),
+                outcome: MapFetch::Loaded(map_of("blooop/wayfinder", &[190])),
+            },
+            &mut app,
+            &mut clusters,
+            &mut inbox,
+            &mut loaders,
+            &tx,
+        );
+        let inbox_rows: Vec<u64> = app.clusters[&ClusterId::Inbox("blooop/wayfinder".to_string())]
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .collect();
+        assert_eq!(inbox_rows, vec![42], "the map took #190 with it");
+    }
+
+    #[test]
+    fn a_failed_inbox_read_is_recorded_as_state_and_a_later_answer_clears_it() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut app = App::empty();
+        let mut clusters = BTreeMap::new();
+        let mut inbox = Vec::new();
+        let mut loaders = Loaders::new();
+        let mut feed = |event, app: &mut App| {
+            fold(event, app, &mut clusters, &mut inbox, &mut loaders, &tx);
+        };
+        feed(LoadEvent::InboxFailed, &mut app);
+        assert!(app.inbox_failed, "the count line has something to say");
+        // Nothing retries it in a real run, so this is the final word — but
+        // the clearing arm exists so the flag cannot outlive an answer that
+        // did arrive.
+        feed(LoadEvent::Inbox(Vec::new()), &mut app);
+        assert!(!app.inbox_failed);
+    }
 
     /// How long the probe waits after each thing it does — after the reading
     /// reaches the screen, after each key it types, and after the session ends.
@@ -1325,7 +1651,15 @@ mod tests {
             },
             tx,
         );
-        stop_background(discovery, survey).await;
+        // A pending task stands in for the inbox read: what is being proved is
+        // that `stop_background` waits for everything it was handed, and an
+        // inbox that never answers is the shape that would outlive the exec.
+        let for_inbox = witness.clone();
+        let inbox = tokio::spawn(async move {
+            std::future::pending::<()>().await;
+            drop(for_inbox);
+        });
+        stop_background(discovery, inbox, survey).await;
         assert_eq!(
             std::sync::Arc::strong_count(&witness),
             1,

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -293,10 +293,17 @@ fn rendered(
         .map(|(id, cluster)| (ClusterId::Map(id.clone()), cluster.clone()))
         .collect();
     for (repo, cluster) in inbox {
+        // A map's tickets, and the map issue's own number. The label check in
+        // `parse_inbox` already keeps maps out, but it reads a label page and
+        // this reads the identity of a map `wf` actually fetched — authoritative
+        // where a page can be cut short. Belt and braces on the one confusion
+        // that costs a reparenting: a map drawn as a row offering to adopt it.
         let mapped: BTreeSet<u64> = clusters
             .iter()
             .filter(|(id, _)| &id.repo == repo)
-            .flat_map(|(_, cluster)| cluster.tickets.iter().map(|t| t.number))
+            .flat_map(|(id, cluster)| {
+                std::iter::once(id.number).chain(cluster.tickets.iter().map(|t| t.number))
+            })
             .collect();
         let tickets: Vec<Ticket> = cluster
             .tickets
@@ -770,6 +777,37 @@ mod tests {
             .map(|t| t.number)
             .collect();
         assert_eq!(left, vec![42], "#190 belongs to its map, not the inbox");
+    }
+
+    #[test]
+    fn a_map_issue_itself_never_survives_into_the_inbox() {
+        // The label check in `parse_inbox` is the first guard and reads a page
+        // that can be cut short. This one reads the identity of a map `wf`
+        // fetched, so it cannot be blinded the same way — and the row it stops
+        // is the one that costs a reparenting, since adopting a map would
+        // parent a map under a map.
+        let maps = BTreeMap::from([(
+            MapId::new("blooop/wayfinder", 182),
+            map_of("blooop/wayfinder", &[190]),
+        )]);
+        let inbox = vec![(
+            "blooop/wayfinder".to_string(),
+            Cluster::inbox(
+                None,
+                vec![
+                    assigned("blooop/wayfinder", 182),
+                    assigned("blooop/wayfinder", 42),
+                ],
+                false,
+            ),
+        )];
+        let rendered = rendered(&maps, &inbox);
+        let left: Vec<u64> = rendered[&ClusterId::Inbox("blooop/wayfinder".to_string())]
+            .tickets
+            .iter()
+            .map(|t| t.number)
+            .collect();
+        assert_eq!(left, vec![42], "#182 is a heading, not a row");
     }
 
     #[test]

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -39,7 +39,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::fetch;
-use crate::model::{Map, MapId, MapSet};
+use crate::model::{Cluster, MapId, MapSet};
 use crate::projects::ProjectsCache;
 use crate::reclaim::Reading;
 
@@ -54,7 +54,7 @@ pub const RETRY_INTERVAL: Duration = Duration::from_secs(4);
 #[derive(Debug)]
 pub enum MapFetch {
     /// The map came back.
-    Loaded(Map),
+    Loaded(Cluster),
     /// The fetch failed (network, auth, parse); nothing to show for this map.
     Failed,
 }
@@ -73,6 +73,24 @@ pub enum LoadEvent {
     SearchFailed,
     /// One map's load reported.
     Fetched { id: MapId, outcome: MapFetch },
+    /// The inbox read returned: one cluster per repo holding whatever there is
+    /// no map for and nobody else on, keyed by repo slug. Empty is a real
+    /// answer — a tracker with nothing loose in it.
+    ///
+    /// Sent once. Unlike the map search this does not retry: the maps are the
+    /// screen and an empty one is a broken `wf`, whereas a missed inbox costs
+    /// one heading. But it is *not* silent — see [`LoadEvent::InboxFailed`].
+    Inbox(Vec<(String, Cluster)>),
+    /// The inbox read failed. Reported rather than swallowed, because the
+    /// three ways to have no inbox are indistinguishable on screen and only
+    /// one of them is a problem: nothing is assigned to you, everything
+    /// assigned is already claimed by a map, or the query never answered. An
+    /// empty inbox draws no heading at all, so without this the failure looks
+    /// exactly like a tidy tracker and there is nothing to act on.
+    ///
+    /// State, not a notice, for [`crate::app::App::failed`]'s reason: it has
+    /// to survive the next keypress, because it stays true for the whole run.
+    InboxFailed,
     /// The background reading landed (#137) — what a `wf reap` would claim,
     /// and what is running or has stopped.
     ///
@@ -346,6 +364,24 @@ pub fn spawn_discovery(
     })
 }
 
+/// Read the inbox once, off the path to the first frame: every open issue
+/// across the cached repos that is the viewer's or nobody's.
+///
+/// One shot and no retry, for the reason [`LoadEvent::Inbox`] gives — but a
+/// failure is reported ([`LoadEvent::InboxFailed`]) rather than swallowed.
+/// Its handle is returned like discovery's so the launch path can stop it and
+/// wait — it holds a `gh` child of its own, and the same reasoning as
+/// [`Loaders::shutdown`] applies.
+pub fn spawn_inbox(repos: Vec<String>, tx: mpsc::UnboundedSender<LoadEvent>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let event = match fetch::fetch_inbox(&repos).await {
+            Ok(found) => LoadEvent::Inbox(found),
+            Err(_) => LoadEvent::InboxFailed,
+        };
+        let _ = tx.send(event);
+    })
+}
+
 /// How long the map search waits after its `failures`-th consecutive miss.
 ///
 /// Doubles from [`RETRY_INTERVAL`] and stops growing at sixteen times it,
@@ -470,6 +506,7 @@ pub fn preserve_cursor<K: PartialEq>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::ClusterId;
 
     #[test]
     fn discovery_retries_back_off_by_doubling() {
@@ -659,7 +696,7 @@ mod tests {
         // was in rather than jumping to the other map's copy of the ticket.
         // Against the real `RowKey`, since that is the K this is generic for.
         let on = |map: u64| crate::app::RowKey {
-            map: MapId::new("blooop/wayfinder", map),
+            cluster: ClusterId::Map(MapId::new("blooop/wayfinder", map)),
             ticket: 6,
         };
         let order = [on(1), on(47)];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,7 +17,9 @@ use crate::app::{App, Overlay};
 use crate::filter;
 use crate::launch::{Agent, Candidate, Launch, Staged};
 use crate::liveness::Life;
-use crate::model::{Checks, Map, MapId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket};
+use crate::model::{
+    Checks, Cluster, ClusterId, PrLink, PrStatus, Review, RowGlyph, Stage, Status, Ticket,
+};
 use crate::reclaim::Reclaimable;
 use crate::view::{Branch, Fold, GroupKind, Item, Plan, ProjectRow};
 
@@ -36,8 +38,8 @@ fn glyph_style(glyph: RowGlyph) -> Style {
     }
 }
 
-/// The cluster header: `▌ <repo> · <map title>  ○n ◐n ◍n !n ●n ⊘n`. The counts
-/// are the whole map's, not the query's — they describe the cluster's shape,
+/// The cluster header: `▌ <repo> · <cluster title>  ○n ◐n ◍n !n ●n ⊘n`. The counts
+/// are the whole cluster's, not the query's — they describe the cluster's shape,
 /// and the group headers already carry `matched/total` while a query is live.
 ///
 /// They are **stage** counts (#78), tallied through the same [`RowGlyph`] the
@@ -45,7 +47,7 @@ fn glyph_style(glyph: RowGlyph) -> Style {
 /// header used to keep its own four-status tally with its own glyph array and
 /// its own colour table, which meant the same characters said different things
 /// a line apart: a node the row drew `!` was counted under `○`, and `◍`/`!`
-/// could not appear here at all. Glyphs the map has nobody in drop out rather
+/// could not appear here at all. Glyphs the cluster has nobody in drop out rather
 /// than showing a zero.
 ///
 /// The repo name carries the query's match on it (`lit`), because the repo is
@@ -53,8 +55,8 @@ fn glyph_style(glyph: RowGlyph) -> Style {
 /// typing a project name would otherwise sift the whole screen down to one
 /// cluster while underlining nothing anywhere.
 fn cluster_header(
-    id: &MapId,
-    map: &Map,
+    id: &ClusterId,
+    cluster: &Cluster,
     lit: &[usize],
     under_cursor: bool,
     marks: Marks,
@@ -65,12 +67,12 @@ fn cluster_header(
     // read as belonging to the first row rather than to the header (#96).
     let mut spans = vec![cursor_span(under_cursor), Span::styled("▌ ", cyan)];
     spans.extend(lit_spans(id.short_repo(), lit, cyan));
-    spans.push(Span::styled(format!(" · {}", map.title), cyan));
-    // A map is a node, so a charting session is as resumable as a build one,
-    // and a map's own workspace is as launchable — the header is the only place
+    spans.push(Span::styled(format!(" · {}", cluster.header_name()), cyan));
+    // A cluster is a node, so a charting session is as resumable as a build one,
+    // and a cluster's own workspace is as launchable — the header is the only place
     // the list can say either (#35).
     spans.extend(marks.spans());
-    for (glyph, count) in map.tally() {
+    for (glyph, count) in cluster.tally() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
             format!("{}{count}", glyph.char()),
@@ -91,7 +93,7 @@ fn cluster_header(
 /// identical.
 ///
 /// The tail says what is inside, and has three honest answers: the stage
-/// rollup once maps are on hand, `no map — enter to start one` once the search
+/// rollup once maps are on hand, `no cluster — enter to start one` once the search
 /// has answered and found none, and `loading…` in between. That third one is
 /// the whole reason [`ProjectRow::loaded`] exists — a repo whose maps are still
 /// in flight and a repo that has none are the same zero, and calling the first
@@ -338,7 +340,7 @@ fn ticket_line(
 }
 
 /// A context row on a sifted screen: the same row, dimmed whole. It is drawn to
-/// say where the matches under it live — which map, and which takeable ticket
+/// say where the matches under it live — which cluster, and which takeable ticket
 /// unlocks them — and nothing about it is actionable, so it carries no cursor
 /// marker, no `also needs`, and no rollup. Nothing lit, either, and not merely
 /// by omission: a row the query landed on is a match, and a match is drawn as
@@ -451,14 +453,23 @@ fn body_with_cursor(app: &App, plan: &Plan) -> (Vec<Line<'static>>, Option<usize
         let under_cursor = item.stop_at().is_some() && mark(&lines, &mut cursor_line);
         match item {
             Item::Header(id) => {
-                let map = &app.clusters[id];
-                let lit = query.as_mut().map(|q| q.in_repo(map)).unwrap_or_default();
+                let cluster = &app.clusters[id];
+                let lit = query
+                    .as_mut()
+                    .map(|q| q.in_repo(cluster))
+                    .unwrap_or_default();
                 lines.push(cluster_header(
                     id,
-                    map,
+                    cluster,
                     &lit,
                     under_cursor,
-                    Marks::of(app, &id.repo, id.number),
+                    // A map issue is a node, so it can carry a resume or a
+                    // running container; a loose cluster is not one, so there
+                    // is nothing about it to mark.
+                    match id {
+                        ClusterId::Map(map_id) => Marks::of(app, &map_id.repo, map_id.number),
+                        ClusterId::Inbox(_) => Marks::default(),
+                    },
                 ));
             }
             Item::Ticket {
@@ -522,7 +533,7 @@ fn key_hints(app: &App) -> &'static str {
 /// cache and needs no network, so the ambiguity the old heading had to
 /// disentangle is gone with the screen that had it: an empty list now means one
 /// thing (nothing registered) instead of three (still loading, every fetch
-/// failed, or genuinely none). A failed *map* fetch no longer empties this
+/// failed, or genuinely none). A failed *cluster* fetch no longer empties this
 /// screen at all — the projects are still listed — so it is named here only
 /// while it is the most interesting thing true, and on the count line
 /// ([`failure_note`]) in every case.
@@ -539,7 +550,7 @@ pub fn heading(app: &App) -> String {
     if projects.is_empty() {
         return "no projects — run wf inside a checkout to register it".to_string();
     }
-    // Naming the map is the whole value when there is one: "GitHub is
+    // Naming the cluster is the whole value when there is one: "GitHub is
     // unreachable" and "that project has nothing open" are different problems
     // with different fixes, and a bare count reads the same either way.
     //
@@ -547,7 +558,7 @@ pub fn heading(app: &App) -> String {
     // Naming a key that no longer exists is worse than saying nothing, and
     // saying nothing leaves the reader on a screen with a failure and no move
     // to make — so it names the move that is left. Restarting really is the
-    // retry now: each map is fetched once per run, and a warm start is ~0.6 s.
+    // retry now: each cluster is fetched once per run, and a warm start is ~0.6 s.
     if app.clusters.is_empty() && app.startup.is_loaded() {
         match app.failed.len() {
             0 => {}
@@ -586,21 +597,37 @@ pub fn failure_note(app: &App) -> String {
     }
 }
 
-/// The `· … truncated` segment on the count line (#184): a map the tracker
+/// The `· inbox unread` segment on the count line: the inbox query failed, so
+/// this screen is not the whole answer.
+///
+/// It exists because an empty inbox draws **nothing** — no heading, no rows —
+/// which makes a failed read indistinguishable from a tidy tracker. A failed
+/// map at least leaves a visible hole where its cluster was; this leaves a
+/// screen that looks finished. Worded as what the reader lost rather than as
+/// an error, because the maps beside it are perfectly good.
+pub fn inbox_note(app: &App) -> String {
+    if app.inbox_failed {
+        "· inbox unread".to_string()
+    } else {
+        String::new()
+    }
+}
+
+/// The `· … truncated` segment on the count line (#184): a cluster the tracker
 /// could not send all of — more sub-issues or blocking edges than one page
 /// holds, per [`Map`]'s `truncated` — named where the reader is, because the
 /// body draws a normal-looking tree either way and this line is the only
 /// place left to say the tree is partial.
 ///
 /// Shaped exactly like [`failure_note`], its nearest kin: both are persistent
-/// facts about a whole map that the rows cannot carry, one map is named, more
+/// facts about a whole cluster that the rows cannot carry, one cluster is named, more
 /// collapse to a count.
 pub fn truncated_note(app: &App) -> String {
-    let mut truncated = app.clusters.iter().filter(|(_, map)| map.truncated);
+    let mut truncated = app.clusters.iter().filter(|(_, cluster)| cluster.truncated);
     match (truncated.next(), truncated.count()) {
         (None, _) => String::new(),
-        (Some((id, _)), 0) => format!("· {}#{} truncated", id.repo, id.number),
-        (Some(_), more) => format!("· {} maps truncated", more + 1),
+        (Some((id, _)), 0) => format!("· {} truncated", id.label()),
+        (Some(_), more) => format!("· {} clusters truncated", more + 1),
     }
 }
 
@@ -629,8 +656,8 @@ pub fn reclaim_note(app: &App, width: usize) -> String {
 }
 
 /// The `· N idle maps hidden` segment on the count line (#51): the leverage
-/// view drops a map with nothing takeable from the body, and the count is the
-/// only trace of it — silence would read as the map not existing at all. The
+/// view drops a cluster with nothing takeable from the body, and the count is the
+/// only trace of it — silence would read as the cluster not existing at all. The
 /// forest (`tab`) shows the dropped maps in full.
 pub fn idle_note(plan: &Plan) -> String {
     match plan.idle_hidden {
@@ -997,6 +1024,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
     let mut parts: Vec<String> = [
         app.startup.hint(),
         failure_note(app),
+        inbox_note(app),
         truncated_note(app),
         idle_note(&plan),
     ]
@@ -1074,7 +1102,7 @@ pub fn draw(frame: &mut Frame<'_>, app: &App) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, Activity, Map, MapId, MapSet, Ticket, TicketType};
+    use crate::model::{classify, Activity, MapId, MapSet, Source, Ticket, TicketType};
     use crate::refresh::Startup;
     use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -1100,12 +1128,14 @@ mod tests {
         }
     }
 
-    fn wf_map() -> Map {
+    fn wf_map() -> Cluster {
         let t = |number, title: &str, open, assigned, needs: Vec<u64>| {
             ticket("blooop/wayfinder", number, title, open, assigned, needs)
         };
-        Map {
-            title: "Map: wf".to_string(),
+        Cluster {
+            source: Source::Map {
+                title: "Map: wf".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![
@@ -1121,15 +1151,160 @@ mod tests {
     /// An app standing on `repo`'s screen. `App::new` opens on the project
     /// *list*, which draws no cluster at all, so a test about what a cluster
     /// looks like has to say which project's screen it is on.
-    fn app_on(repo: &str, clusters: BTreeMap<MapId, Map>) -> App {
+    fn app_on(repo: &str, clusters: BTreeMap<ClusterId, Cluster>) -> App {
         let mut app = App::new(clusters);
         app.enter(repo);
         app
     }
 
+    /// An app standing on wayfinder with one map and an inbox beside it.
+    fn with_inbox() -> App {
+        let mut clusters = BTreeMap::new();
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
+        clusters.insert(
+            ClusterId::Inbox("blooop/wayfinder".to_string()),
+            Cluster::inbox(
+                None,
+                vec![
+                    ticket(
+                        "blooop/wayfinder",
+                        91,
+                        "Widen the count line",
+                        true,
+                        true,
+                        vec![],
+                    ),
+                    ticket(
+                        "blooop/wayfinder",
+                        104,
+                        "Drop the dead flag",
+                        true,
+                        true,
+                        vec![],
+                    ),
+                ],
+                false,
+            ),
+        );
+        app_on("blooop/wayfinder", clusters)
+    }
+
+    #[test]
+    fn a_failed_inbox_read_says_so_because_an_empty_inbox_draws_nothing() {
+        // The case this segment exists for. A failed *map* leaves a visible
+        // hole where its cluster was; a failed inbox leaves a screen that
+        // looks finished, because "nothing assigned", "all of it claimed by a
+        // map" and "the query never answered" are the same blank screen.
+        let mut app = fixture_app();
+        let quiet = render(&app);
+        assert!(!quiet.contains("inbox"), "{quiet}");
+
+        app.inbox_failed = true;
+        let screen = render(&app);
+        assert!(screen.contains("· inbox unread"), "{screen}");
+        // The maps beside it are perfectly good, so the note says what was
+        // lost rather than announcing a broken screen.
+        assert!(screen.contains("▌ wayfinder · Map: wf"), "{screen}");
+    }
+
+    #[test]
+    fn an_inbox_that_answered_empty_is_silent() {
+        // Only a *failure* is worth a segment. A tidy tracker draws nothing
+        // and says nothing, which is the whole reason the failure needs to.
+        let mut app = with_inbox();
+        app.inbox_failed = false;
+        assert!(!render(&app).contains("inbox unread"));
+    }
+
+    #[test]
+    fn the_inbox_header_names_what_it_is_rather_than_a_map_it_has_not_got() {
+        let screen = render(&with_inbox());
+        assert!(
+            screen.contains("▌ wayfinder · yours or unclaimed"),
+            "{screen}"
+        );
+        // And it still carries stage counts in the same glyph vocabulary the
+        // rows below it use — both rows are assigned, so both are claimed.
+        assert!(
+            screen.contains("▌ wayfinder · yours or unclaimed  ◐2"),
+            "{screen}"
+        );
+    }
+
+    #[test]
+    fn the_inbox_draws_below_every_map() {
+        let screen = render(&with_inbox());
+        let lines: Vec<&str> = screen.lines().collect();
+        let map = lines
+            .iter()
+            .position(|l| l.contains("· Map: wf"))
+            .expect("the map header");
+        let inbox = lines
+            .iter()
+            .position(|l| l.contains("· yours or unclaimed"))
+            .expect("the inbox header");
+        assert!(map < inbox, "curated work leads: {screen}");
+    }
+
+    #[test]
+    fn the_project_row_counts_maps_and_leaves_the_inbox_out_of_its_rollup() {
+        // The project list is drawn before you enter anything and its glyphs
+        // say how much charted work is moving. An inbox of assigned issues
+        // would render `◐N` over every repo and drown that.
+        let screen = render(&with_inbox());
+        assert!(screen.contains("▌ blooop/wayfinder · 1 map"), "{screen}");
+        assert!(
+            !screen.contains("· 2 maps"),
+            "the inbox is not a second map: {screen}"
+        );
+    }
+
+    #[test]
+    fn an_inbox_row_is_findable_by_the_same_query_a_mapped_row_is() {
+        let mut app = with_inbox();
+        for c in "widen".chars() {
+            app.handle_key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        let screen = render(&app);
+        assert!(screen.contains("#91"), "the inbox row sifted in: {screen}");
+        assert!(
+            screen.contains("▌ wayfinder · yours or unclaimed"),
+            "and kept its header, like any sifted cluster: {screen}"
+        );
+        assert!(
+            !screen.contains("Re-entry breadcrumbs"),
+            "the map's non-matching rows left: {screen}"
+        );
+    }
+
+    #[test]
+    fn a_truncated_inbox_is_named_as_the_inbox_and_not_as_an_issue_number() {
+        let mut clusters = BTreeMap::new();
+        clusters.insert(
+            ClusterId::Inbox("blooop/wayfinder".to_string()),
+            Cluster::inbox(
+                None,
+                vec![ticket(
+                    "blooop/wayfinder",
+                    91,
+                    "one row",
+                    true,
+                    true,
+                    vec![],
+                )],
+                true,
+            ),
+        );
+        let screen = render(&app_on("blooop/wayfinder", clusters));
+        assert!(
+            screen.contains("· blooop/wayfinder (yours or unclaimed) truncated"),
+            "a loose cluster has no issue number to borrow: {screen}"
+        );
+    }
+
     fn fixture_app() -> App {
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
         app_on("blooop/wayfinder", clusters)
     }
 
@@ -1183,7 +1358,7 @@ mod tests {
     fn a_row_you_left_a_conversation_on_says_so_before_anything_is_fetched() {
         // The badge is drawn from the local cache, so it is on the *first*
         // frame — the same frame-zero rule the project list follows. Nothing
-        // asks `dl`, and nothing waits for the map search.
+        // asks `dl`, and nothing waits for the cluster search.
         let screen = render(&app_resuming(7));
         let row = screen
             .lines()
@@ -1200,7 +1375,7 @@ mod tests {
 
     #[test]
     fn a_map_you_have_charted_before_carries_the_badge_too() {
-        // A map is a node (#96) and its picker offers the resume row, so the
+        // A cluster is a node (#96) and its picker offers the resume row, so the
         // list has to say so — otherwise the only way to discover a charting
         // session is waiting is to press enter on every header.
         let screen = render(&app_resuming(1));
@@ -1278,8 +1453,9 @@ mod tests {
         // the header has to agree, because they are one vocabulary. Counting
         // statuses instead sweeps it back under `○`, and `◍`/`!` could never
         // appear in a header at all.
-        let mut map = wf_map();
-        map.tickets
+        let mut cluster = wf_map();
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 6)
             .expect("#6 in the fixture")
@@ -1293,7 +1469,8 @@ mod tests {
         }];
         // #9 is claimed with a passing, approved PR: in review — the other
         // stage the four-status header had no glyph for.
-        map.tickets
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 9)
             .expect("#9 in the fixture")
@@ -1306,9 +1483,9 @@ mod tests {
             },
         }];
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let screen = render(&app_on("blooop/wayfinder", clusters));
-        // ○0 is not drawn: the counts name the stages the map is actually in.
+        // ○0 is not drawn: the counts name the stages the cluster is actually in.
         assert!(
             screen.contains("▌ wayfinder · Map: wf  ◍1  !1  ●1  ⊘2"),
             "{screen}"
@@ -1393,8 +1570,8 @@ mod tests {
 
     #[test]
     fn pr_badges_ride_their_ticket_row() {
-        let mut map = wf_map();
-        let t6 = map
+        let mut cluster = wf_map();
+        let t6 = cluster
             .tickets
             .iter_mut()
             .find(|t| t.number == 6)
@@ -1416,7 +1593,8 @@ mod tests {
             },
         ];
         // Nothing outstanding on #9's PR: checks pass, no review required.
-        map.tickets
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 9)
             .expect("#9 in the fixture")
@@ -1429,7 +1607,7 @@ mod tests {
             },
         }];
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         // Same-repo badge: `⇄ PR#n <state>` after the [type] suffix.
@@ -1449,8 +1627,9 @@ mod tests {
         // The status column *is* the stage column now (#61/#62): an approved
         // open PR reads ◍ in review, failing checks read ! needs attention —
         // whatever the ticket's own state says.
-        let mut map = wf_map();
-        map.tickets
+        let mut cluster = wf_map();
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 6)
             .expect("#6")
@@ -1462,7 +1641,8 @@ mod tests {
                 review: Review::Approved,
             },
         }];
-        map.tickets
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 9)
             .expect("#9")
@@ -1475,7 +1655,7 @@ mod tests {
             },
         }];
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let screen = render(&app_on("blooop/wayfinder", clusters));
         assert!(screen.contains("◍ #6 Re-entry breadcrumbs"), "{screen}");
         assert!(screen.contains("! #9 Main screen design"), "{screen}");
@@ -1488,8 +1668,9 @@ mod tests {
         // Done ticket #2's PR is still open with pending checks: the shut
         // group says so as a glyph+count pair, so a closed-but-unlanded branch
         // is watched at a glance without opening it.
-        let mut map = wf_map();
-        map.tickets
+        let mut cluster = wf_map();
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 2)
             .expect("#2")
@@ -1502,7 +1683,7 @@ mod tests {
             },
         }];
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let mut app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         assert!(screen.contains("● 1 done (hidden) ◐1"), "{screen}");
@@ -1522,8 +1703,9 @@ mod tests {
 
     #[test]
     fn an_in_flight_open_pr_gets_no_verdict_glyph() {
-        let mut map = wf_map();
-        map.tickets
+        let mut cluster = wf_map();
+        cluster
+            .tickets
             .iter_mut()
             .find(|t| t.number == 6)
             .expect("#6")
@@ -1536,7 +1718,7 @@ mod tests {
             },
         }];
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let screen = render(&app_on("blooop/wayfinder", clusters));
         assert!(screen.contains("⇄ PR#14 open"), "{screen}");
         assert!(!screen.contains('✓'), "{screen}");
@@ -1615,7 +1797,7 @@ mod tests {
 
     /// A stall reaches the count line as well as the row, because the row is
     /// not always on screen: the project list has no ticket rows at all, and a
-    /// stalled node can be inside a fold or another map.
+    /// stalled node can be inside a fold or another cluster.
     #[test]
     fn the_count_line_names_what_stopped_moving() {
         let mut app = fixture_app();
@@ -1791,16 +1973,16 @@ mod tests {
         }
     }
 
-    /// A map the tracker could not send all of is named on the count line
+    /// A cluster the tracker could not send all of is named on the count line
     /// (#184): the body draws a perfectly normal tree either way, so this
     /// segment is the only trace that tickets — or the blocking edges their
     /// classification is drawn from — are missing from it.
     #[test]
     fn the_count_line_says_when_a_map_arrived_truncated() {
         let mut clusters = BTreeMap::new();
-        let mut map = wf_map();
-        map.truncated = true;
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        let mut cluster = wf_map();
+        cluster.truncated = true;
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         let line = screen
@@ -1809,12 +1991,12 @@ mod tests {
             .unwrap_or_else(|| panic!("no truncation segment: {screen}"));
         assert!(
             line.contains("blooop/wayfinder#1 truncated"),
-            "one truncated map is named, like one failed map is: {line}"
+            "one truncated cluster is named, like one failed cluster is: {line}"
         );
 
-        // A complete map says nothing — silence is the ordinary case.
+        // A complete cluster says nothing — silence is the ordinary case.
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
         let app = app_on("blooop/wayfinder", clusters);
         assert!(!render(&app).contains("truncated"));
     }
@@ -1824,11 +2006,13 @@ mod tests {
         let mut clusters = BTreeMap::new();
         let mut first = wf_map();
         first.truncated = true;
-        clusters.insert(MapId::new("blooop/wayfinder", 1), first);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), first);
         clusters.insert(
-            MapId::new("blooop/wayfinder", 47),
-            Map {
-                title: "Map: the selection view".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 47)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the selection view".to_string(),
+                },
                 last_activity: None,
                 truncated: true,
                 tickets: vec![ticket(
@@ -1844,7 +2028,7 @@ mod tests {
         let app = app_on("blooop/wayfinder", clusters);
         let screen = render(&app);
         assert!(
-            screen.contains("· 2 maps truncated"),
+            screen.contains("· 2 clusters truncated"),
             "several collapse to a count, like failures do: {screen}"
         );
     }
@@ -1852,13 +2036,15 @@ mod tests {
     #[test]
     fn idle_maps_drop_to_the_count_line_and_tab_brings_them_back() {
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
-        // A second map of the *same* project: a screen is one repo's, so an
-        // idle map has to be one of this repo's to be dropped from it.
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
+        // A second cluster of the *same* project: a screen is one repo's, so an
+        // idle cluster has to be one of this repo's to be dropped from it.
         clusters.insert(
-            MapId::new("blooop/wayfinder", 4),
-            Map {
-                title: "Map: the archive".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 4)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the archive".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket(
@@ -1893,11 +2079,13 @@ mod tests {
         // The #50 acceptance case: two open maps on one repo are two clusters,
         // where the old lowest-number rule showed only one.
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
         clusters.insert(
-            MapId::new("blooop/wayfinder", 47),
-            Map {
-                title: "Map: the selection view".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 47)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the selection view".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket(
@@ -1914,10 +2102,10 @@ mod tests {
         let screen = render(&app);
         let first = screen
             .find("▌ wayfinder · Map: wf")
-            .expect("map #1's cluster");
+            .expect("cluster #1's cluster");
         let second = screen
             .find("▌ wayfinder · Map: the selection view")
-            .expect("map #47's cluster");
+            .expect("cluster #47's cluster");
         assert!(
             first < second,
             "equal activity falls back to (repo, number)"
@@ -1929,14 +2117,16 @@ mod tests {
 
     #[test]
     fn a_finished_map_renders_below_the_live_ones_however_recent_it_is() {
-        // The reported symptom: the finished map held the lowest issue number
+        // The reported symptom: the finished cluster held the lowest issue number
         // *and* the freshest activity, and so sat at the top of the tree. Both
         // of the keys that would have put it there are deliberately set here.
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/wayfinder", 1),
-            Map {
-                title: "Map: the archive".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the archive".to_string(),
+                },
                 last_activity: Activity::parse("2026-08-06T12:00:00Z"),
                 truncated: false,
                 tickets: vec![ticket(
@@ -1950,9 +2140,11 @@ mod tests {
             },
         );
         clusters.insert(
-            MapId::new("blooop/wayfinder", 47),
-            Map {
-                title: "Map: the selection view".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 47)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the selection view".to_string(),
+                },
                 last_activity: Activity::parse("2026-08-01T12:00:00Z"),
                 truncated: false,
                 tickets: vec![ticket(
@@ -1966,7 +2158,7 @@ mod tests {
             },
         );
         let mut app = app_on("blooop/wayfinder", clusters);
-        // The forest, because that is the screen a finished map appears on at
+        // The forest, because that is the screen a finished cluster appears on at
         // all — leverage drops it as idle.
         app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         let screen = render(&app);
@@ -2143,8 +2335,8 @@ mod tests {
         // Two done tickets, one of them matching: typing has to reach inside
         // the group that holds it, and the group has to stay honest about the
         // one it is still holding back.
-        let mut map = wf_map();
-        map.tickets.push(ticket(
+        let mut cluster = wf_map();
+        cluster.tickets.push(ticket(
             "blooop/wayfinder",
             3,
             "Stack the PRs",
@@ -2153,7 +2345,7 @@ mod tests {
             vec![],
         ));
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), map);
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), cluster);
         let mut app = app_on("blooop/wayfinder", clusters);
         type_str(&mut app, "choose");
         let screen = render(&app);
@@ -2205,7 +2397,7 @@ mod tests {
         assert_eq!(screen.matches('▶').count(), 1, "{screen}");
     }
 
-    /// The fixture map plus Build 4 launch inputs: two checkouts of the repo,
+    /// The fixture cluster plus Build 4 launch inputs: two checkouts of the repo,
     /// so `enter` opens the which-checkout picker.
     fn launchable_app() -> App {
         let checkout = |path: &str| {
@@ -2434,7 +2626,7 @@ mod tests {
         // list as no projects at all. Saying "no projects — run wf inside a
         // checkout" there sends the user to fix the one thing that is not
         // broken, so the failure has to win the heading — and it names the
-        // *map*, because with several on one repo the repo alone is ambiguous.
+        // *cluster*, because with several on one repo the repo alone is ambiguous.
         let mut app = App::empty().with_checkouts(vec![
             crate::projects::Checkout::new(
                 std::path::PathBuf::from("/data/proj/wayfinder"),
@@ -2464,7 +2656,7 @@ mod tests {
     #[test]
     fn a_partial_failure_is_visible_and_survives_the_next_keypress() {
         // The case that hides best: the clusters that did load look completely
-        // normal, so the count line is the only place left to say a map is
+        // normal, so the count line is the only place left to say a cluster is
         // missing — and `notice` cannot be that place, because `handle_key`
         // clears it on every keypress and nothing polls to re-announce it.
         let mut app = fixture_app();
@@ -2499,7 +2691,7 @@ mod tests {
 
     #[test]
     fn a_partial_load_shows_progress_beside_the_clusters_already_in() {
-        // One map of three has landed: the rows are real and fresh, and the
+        // One cluster of three has landed: the rows are real and fresh, and the
         // count line still says more is coming.
         let mut app = fixture_app();
         let found: MapSet = [
@@ -2528,9 +2720,11 @@ mod tests {
         // what `enter` would pick is broken.
         let mut clusters = BTreeMap::new();
         clusters.insert(
-            MapId::new("blooop/wayfinder", 1),
-            Map {
-                title: "Map: wf".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 1)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: wf".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: (1..=30)
@@ -2548,9 +2742,11 @@ mod tests {
             },
         );
         clusters.insert(
-            MapId::new("blooop/wayfinder", 47),
-            Map {
-                title: "Map: the selection view".to_string(),
+            ClusterId::Map(MapId::new("blooop/wayfinder", 47)),
+            Cluster {
+                source: Source::Map {
+                    title: "Map: the selection view".to_string(),
+                },
                 last_activity: None,
                 truncated: false,
                 tickets: vec![ticket(
@@ -2587,7 +2783,7 @@ mod tests {
         // first, each saying how much is inside it in the same glyph vocabulary
         // the rows below use.
         let mut clusters = BTreeMap::new();
-        clusters.insert(MapId::new("blooop/wayfinder", 1), wf_map());
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
         let stamped = |path: &str, repo: &str, at: u64| crate::projects::Checkout {
             path: std::path::PathBuf::from(path),
             repo: repo.to_string(),
@@ -2615,7 +2811,7 @@ mod tests {
             .position(|l| l.contains("▌ blooop/newthing · no map — enter to start one"))
             .expect("the map-less project — a row here like any other");
         assert!(wayfinder < newthing, "most recently used first: {screen}");
-        // The counts are the map's, in the glyphs the rows use.
+        // The counts are the cluster's, in the glyphs the rows use.
         assert!(lines[wayfinder].contains("○1"), "{screen}");
         // And no ticket got onto this screen.
         assert!(!screen.contains("#6 Re-entry breadcrumbs"), "{screen}");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -93,7 +93,7 @@ fn cluster_header(
 /// identical.
 ///
 /// The tail says what is inside, and has three honest answers: the stage
-/// rollup once maps are on hand, `no cluster — enter to start one` once the search
+/// rollup once maps are on hand, `no map — enter to start one` once the search
 /// has answered and found none, and `loading…` in between. That third one is
 /// the whole reason [`ProjectRow::loaded`] exists — a repo whose maps are still
 /// in flight and a repo that has none are the same zero, and calling the first
@@ -623,7 +623,7 @@ pub fn inbox_note(app: &App) -> String {
 
 /// The `· … truncated` segment on the count line (#184): a cluster the tracker
 /// could not send all of — more sub-issues or blocking edges than one page
-/// holds, per [`Map`]'s `truncated` — named where the reader is, because the
+/// holds, per [`Cluster`]'s `truncated` — named where the reader is, because the
 /// body draws a normal-looking tree either way and this line is the only
 /// place left to say the tree is partial.
 ///

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -559,7 +559,15 @@ pub fn heading(app: &App) -> String {
     // saying nothing leaves the reader on a screen with a failure and no move
     // to make — so it names the move that is left. Restarting really is the
     // retry now: each cluster is fetched once per run, and a warm start is ~0.6 s.
-    if app.clusters.is_empty() && app.startup.is_loaded() {
+    // No *map* arrived, rather than no cluster: the inbox is a cluster too and
+    // comes from a different query, so one loose row would otherwise make
+    // "every map failed" read as an ordinary screen. The failure this heading
+    // exists for is a failure to fetch maps, and only maps can answer for it.
+    let no_maps = !app
+        .clusters
+        .keys()
+        .any(|id| matches!(id, ClusterId::Map(_)));
+    if no_maps && app.startup.is_loaded() {
         match app.failed.len() {
             0 => {}
             1 => {
@@ -1187,6 +1195,43 @@ mod tests {
             ),
         );
         app_on("blooop/wayfinder", clusters)
+    }
+
+    #[test]
+    fn an_inbox_does_not_hide_the_every_map_failed_heading() {
+        // The heading says "GitHub is unreachable" rather than "nothing open",
+        // and it only speaks when no cluster arrived. The inbox is a cluster
+        // now, and it arrives from a *different* query — so one loose row was
+        // enough to make every map failing read as an ordinary project list.
+        //
+        // On the list rather than a project screen, because that is the screen
+        // this heading is drawn on.
+        let mut app = App::empty().with_checkouts(vec![crate::projects::Checkout::new(
+            std::path::PathBuf::from("/data/proj/wayfinder"),
+            "blooop/wayfinder".to_string(),
+        )]);
+        app.startup = Startup::loaded();
+        app.failed.insert(MapId::new("blooop/wayfinder", 1));
+        app.replace_clusters(BTreeMap::from([(
+            ClusterId::Inbox("blooop/wayfinder".to_string()),
+            Cluster::inbox(
+                None,
+                vec![ticket(
+                    "blooop/wayfinder",
+                    91,
+                    "one row",
+                    true,
+                    true,
+                    vec![],
+                )],
+                false,
+            ),
+        )]));
+        let screen = render(&app);
+        assert!(
+            screen.contains("blooop/wayfinder#1 — fetch failed, run wf again"),
+            "{screen}"
+        );
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1232,6 +1232,57 @@ mod tests {
     }
 
     #[test]
+    fn inbox_rows_draw_newest_first_and_map_rows_still_draw_by_number() {
+        // The parse orders the inbox by activity; this is the half that proves
+        // the *screen* keeps that order, because both lenses re-sort their
+        // roots and the tie-break used to be the issue number.
+        let mut clusters = BTreeMap::new();
+        clusters.insert(ClusterId::Map(MapId::new("blooop/wayfinder", 1)), wf_map());
+        clusters.insert(
+            ClusterId::Inbox("blooop/wayfinder".to_string()),
+            Cluster::inbox(
+                None,
+                // Already in the order the parse produced: newest first, which
+                // is deliberately *not* ascending number order.
+                vec![
+                    ticket("blooop/wayfinder", 207, "newest", true, false, vec![]),
+                    ticket("blooop/wayfinder", 104, "middle", true, false, vec![]),
+                    ticket("blooop/wayfinder", 190, "oldest", true, false, vec![]),
+                ],
+                false,
+            ),
+        );
+        let app = app_on("blooop/wayfinder", clusters);
+        let drawn: Vec<&str> = body_lines(&app)
+            .iter()
+            .filter_map(|line| {
+                let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                ["#207", "#104", "#190", "#6", "#7"]
+                    .into_iter()
+                    .find(|n| text.contains(*n))
+            })
+            .collect();
+        let inbox_rows: Vec<&str> = drawn
+            .iter()
+            .copied()
+            .filter(|n| ["#207", "#104", "#190"].contains(n))
+            .collect();
+        assert_eq!(
+            inbox_rows,
+            vec!["#207", "#104", "#190"],
+            "the cluster's own order survives the lens: {drawn:?}"
+        );
+        // And the map beside it is untouched — its rows are number-ordered
+        // because that is what its parse produced.
+        let map_rows: Vec<&str> = drawn
+            .iter()
+            .copied()
+            .filter(|n| ["#6", "#7"].contains(n))
+            .collect();
+        assert_eq!(map_rows, vec!["#6", "#7"], "{drawn:?}");
+    }
+
+    #[test]
     fn the_inbox_draws_below_every_map() {
         let screen = render(&with_inbox());
         let lines: Vec<&str> = screen.lines().collect();

--- a/src/view.rs
+++ b/src/view.rs
@@ -8,10 +8,10 @@
 //! - **Leverage** (the default): per cluster, the takeable tickets (frontier +
 //!   claimed) sorted most-open-dependents-first, each with the subtree of open
 //!   tickets it unblocks. Done collapses to a [`Item::Group`] line, as do
-//!   blocked tickets no subtree reaches; a map with nothing takeable leaves the
+//!   blocked tickets no subtree reaches; a cluster with nothing takeable leaves the
 //!   body entirely and is only counted ([`Plan::idle_hidden`]).
 //! - **Forest** (`tab`): the whole DAG, done dimmed in place. Tree parent =
-//!   lowest-numbered in-map blocker; the other in-map blockers annotate the row
+//!   lowest-numbered in-cluster blocker; the other in-cluster blockers annotate the row
 //!   (`⤷ also needs #n`).
 //! - **Sifted** (a live query): whichever of those two trees is toggled, pruned
 //!   to the rows that matched. Clearing the query restores it whole.
@@ -39,7 +39,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::app::Row;
 use crate::filter;
-use crate::model::{Map, MapId, RowGlyph, Status, Ticket};
+use crate::model::{Cluster, ClusterId, RowGlyph, Status, Ticket};
 
 /// The structural screen `tab` toggles between — the half of the view state
 /// that is *stored*. The other half (whether a query is sifting the body) is
@@ -102,7 +102,7 @@ pub enum GroupKind {
 /// key and half of the cursor's anchor.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GroupId {
-    pub map: MapId,
+    pub cluster: ClusterId,
     pub kind: GroupKind,
 }
 
@@ -113,18 +113,21 @@ pub type Expanded = BTreeSet<GroupId>;
 /// What the cursor is on. Since #57 that is no longer always a ticket: a
 /// collapsed group is a stop too, because opening one is an action the cursor
 /// has to be able to name — and since #96 so is a cluster header, because a
-/// map is a thing you can launch an agent at.
+/// cluster is a thing you can launch an agent at.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Stop {
-    /// A cluster header: the whole map, launched as one.
-    Map(MapId),
+    /// A cluster header. A cluster's header launches — charting or driving a whole
+    /// cluster is something an agent can be aimed at — and a loose cluster's is a
+    /// place to stand and nothing more, which is a difference the
+    /// [`ClusterId`] carries rather than a second field here.
+    Cluster(ClusterId),
     Ticket(Row),
     Group(GroupId),
     /// A whole project, by full slug — a row of the project list, and the row
     /// the project screen opens on.
     ///
-    /// The one stop that names a repo rather than something in a map, which is
-    /// why creation lives here: starting a map or a task is an act on a repo,
+    /// The one stop that names a repo rather than something in a cluster, which is
+    /// why creation lives here: starting a cluster or a task is an act on a repo,
     /// and this is the only stop that *is* one. What `enter` does to it
     /// depends on which screen drew it — enter the project, or create in it —
     /// and that is the whole of the two-level navigation.
@@ -144,12 +147,20 @@ pub enum Stop {
 pub struct ProjectRow {
     /// Full slug, `owner/name`.
     pub repo: String,
-    /// How many of this repo's open maps are on hand.
+    /// How many of this repo's open **maps** are on hand — the inbox is not
+    /// one of them.
+    ///
+    /// Counting clusters here instead was the tempting shortcut and is a lie
+    /// the row cannot recover from: a repo with two maps and an inbox would
+    /// read "3 maps", and a repo with *only* an inbox would stop reading "no
+    /// map — enter to start one" exactly when that sentence is the one thing
+    /// the row has to say. The inbox is not work somebody charted, and this
+    /// number is how much charted work there is.
     pub maps: usize,
     /// Stage counts across them, in display order — empty when none are.
     pub rollup: Vec<(RowGlyph, usize)>,
-    /// Whether the map search has answered, so `maps: 0` can be read as "no
-    /// map" rather than "not yet".
+    /// Whether the cluster search has answered, so `maps: 0` can be read as "no
+    /// cluster" rather than "not yet".
     pub loaded: bool,
     /// Where a live query landed in the slug, in char indices — what the row
     /// underlines. Empty on the structured screen, which has no query.
@@ -157,18 +168,31 @@ pub struct ProjectRow {
 }
 
 impl ProjectRow {
-    /// The row for `repo`, tallied from whichever of its maps have arrived.
+    /// The row for `repo`, tallied from whichever of its **maps** have
+    /// arrived.
     ///
     /// Takes every cluster rather than the repo's, so the caller cannot hand it
     /// a filtered set and get a rollup that quietly means something narrower
     /// than the row says.
+    ///
+    /// The inbox is excluded from both halves, and from the rollup for a
+    /// sharper reason than the count: the project list is drawn before you
+    /// enter anything, and its glyphs are there to say how much charted work
+    /// is moving. An inbox of thirty assigned issues would render `◐30` over
+    /// every repo — assigned issues classify as claimed — and drown the two or
+    /// three glyphs that were the point. The inbox is a thing you go and look
+    /// at, not a thing the summary is about.
     #[must_use]
-    pub fn new(repo: &str, clusters: &BTreeMap<MapId, Map>, loaded: bool) -> ProjectRow {
-        let mine = || clusters.iter().filter(|(id, _)| id.repo == repo);
+    pub fn new(repo: &str, clusters: &BTreeMap<ClusterId, Cluster>, loaded: bool) -> ProjectRow {
+        let maps = || {
+            clusters
+                .iter()
+                .filter(|(id, _)| id.repo() == repo && matches!(id, ClusterId::Map(_)))
+        };
         ProjectRow {
             repo: repo.to_string(),
-            maps: mine().count(),
-            rollup: RowGlyph::tally(mine().flat_map(|(_, map)| &map.tickets)),
+            maps: maps().count(),
+            rollup: RowGlyph::tally(maps().flat_map(|(_, cluster)| &cluster.tickets)),
             loaded,
             lit: Vec::new(),
         }
@@ -187,8 +211,8 @@ pub struct StopAt {
 /// the rule.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Item {
-    /// A cluster header — the map this and the following lines belong to.
-    Header(MapId),
+    /// A cluster header — the cluster this and the following lines belong to.
+    Header(ClusterId),
     /// A project row: the body of the project list, and the first line of a
     /// project's own screen.
     Project(ProjectRow),
@@ -200,7 +224,7 @@ pub enum Item {
         /// branch. On a sifted screen it places a match that navigation still
         /// treats as depth 0, and a `⋯` in it marks an elided ancestor.
         prefix: String,
-        /// Forest only: in-map blockers beyond the primary parent.
+        /// Forest only: in-cluster blockers beyond the primary parent.
         also_needs: Vec<u64>,
         /// Whether this row heads a branch, and what is in it.
         branch: Branch,
@@ -239,7 +263,7 @@ impl Item {
             // walk and a header is not something you descend *into* — `←` from
             // a top-level row already steps back to it as the previous stop.
             Item::Header(id) => Some(StopAt {
-                stop: Stop::Map(id.clone()),
+                stop: Stop::Cluster(id.clone()),
                 depth: 0,
             }),
             Item::Project(project) => Some(StopAt {
@@ -358,7 +382,7 @@ impl Plan {
 /// Matching what is on screen is the rule both screens are keeping.
 pub fn projects(
     repos: &[String],
-    clusters: &BTreeMap<MapId, Map>,
+    clusters: &BTreeMap<ClusterId, Cluster>,
     loaded: bool,
     query: &str,
 ) -> Plan {
@@ -403,7 +427,7 @@ pub fn projects(
 /// screen starts something in this repo, and reaching a ticket is one `↓` down
 /// into the maps below.
 pub fn plan(
-    clusters: &[(&MapId, &Map)],
+    clusters: &[(&ClusterId, &Cluster)],
     screen: Screen<'_>,
     expanded: &Expanded,
     project: Option<ProjectRow>,
@@ -456,17 +480,20 @@ enum Sieve {
 }
 
 impl Sieve {
-    fn new(clusters: &[(&MapId, &Map)], screen: Screen<'_>) -> Sieve {
+    fn new(clusters: &[(&ClusterId, &Cluster)], screen: Screen<'_>) -> Sieve {
         let Screen::Sifted { query, .. } = screen else {
             return Sieve::Everything;
         };
         let mut kept = BTreeMap::new();
-        for (id, map) in clusters {
-            for (index, score) in filter::scores(&map.tickets, query).into_iter().enumerate() {
+        for (id, cluster) in clusters {
+            for (index, score) in filter::scores(&cluster.tickets, query)
+                .into_iter()
+                .enumerate()
+            {
                 if let Some(score) = score {
                     kept.insert(
                         Row {
-                            map: (*id).clone(),
+                            cluster: (*id).clone(),
                             index,
                         },
                         score,
@@ -495,14 +522,14 @@ impl Sieve {
 /// clusters that match equally well (or not at all — they are about to leave
 /// the body) keep the order they came in.
 fn best_first<'a>(
-    clusters: &[(&'a MapId, &'a Map)],
+    clusters: &[(&'a ClusterId, &'a Cluster)],
     kept: &BTreeMap<Row, u32>,
-) -> Vec<(&'a MapId, &'a Map)> {
+) -> Vec<(&'a ClusterId, &'a Cluster)> {
     let mut ordered = clusters.to_vec();
     ordered.sort_by_key(|(id, _)| {
         Reverse(
             kept.iter()
-                .filter(|(row, _)| &row.map == *id)
+                .filter(|(row, _)| &row.cluster == *id)
                 .map(|(_, score)| *score)
                 .max(),
         )
@@ -671,8 +698,8 @@ fn prune_tree(tree: &[Item], kept: &BTreeMap<Row, u32>) -> Vec<Item> {
 /// once however many times the walk drew it. A header, a spacer, or a group
 /// line closes the open branch: the rows a group holds hang from the group,
 /// not from the last ticket above it.
-fn attach_rollups(items: &mut [Item], clusters: &[(&MapId, &Map)]) {
-    let maps: BTreeMap<&MapId, &Map> = clusters.iter().copied().collect();
+fn attach_rollups(items: &mut [Item], clusters: &[(&ClusterId, &Cluster)]) {
+    let by_id: BTreeMap<&ClusterId, &Cluster> = clusters.iter().copied().collect();
     let mut branches: Vec<(usize, Vec<Row>)> = Vec::new();
     let mut open: Option<(usize, Vec<Row>)> = None;
     for (i, item) in items.iter().enumerate() {
@@ -704,7 +731,11 @@ fn attach_rollups(items: &mut [Item], clusters: &[(&MapId, &Map)]) {
         if beneath.is_empty() {
             continue;
         }
-        let rollup = RowGlyph::tally(beneath.iter().map(|row| &maps[&row.map].tickets[row.index]));
+        let rollup = RowGlyph::tally(
+            beneath
+                .iter()
+                .map(|row| &by_id[&row.cluster].tickets[row.index]),
+        );
         if let Item::Ticket { branch, .. } = &mut items[i] {
             *branch = Branch::Root { rollup };
         }
@@ -722,15 +753,20 @@ fn is_open(t: &Ticket) -> bool {
 /// Open direct dependents of `number`, ascending — the subtree children in the
 /// leverage view, and the leverage sort key at the roots (done dependents are
 /// not leverage: they are already unlocked).
-fn open_unblocks(map: &Map, number: u64) -> Vec<u64> {
-    map.unblocks(number)
+fn open_unblocks(cluster: &Cluster, number: u64) -> Vec<u64> {
+    cluster
+        .unblocks(number)
         .into_iter()
-        .filter(|&n| map.index_of(n).is_some_and(|i| is_open(&map.tickets[i])))
+        .filter(|&n| {
+            cluster
+                .index_of(n)
+                .is_some_and(|i| is_open(&cluster.tickets[i]))
+        })
         .collect()
 }
 
 fn ticket_item(
-    id: &MapId,
+    id: &ClusterId,
     index: usize,
     depth: usize,
     prefix: String,
@@ -738,7 +774,7 @@ fn ticket_item(
 ) -> Item {
     Item::Ticket {
         row: Row {
-            map: id.clone(),
+            cluster: id.clone(),
             index,
         },
         depth,
@@ -762,8 +798,8 @@ fn ticket_item(
 /// matching does not render at all.
 fn push_group(
     items: &mut Vec<Item>,
-    id: &MapId,
-    map: &Map,
+    id: &ClusterId,
+    cluster: &Cluster,
     kind: GroupKind,
     held: &[usize],
     expanded: &Expanded,
@@ -773,7 +809,7 @@ fn push_group(
         return;
     }
     let group = GroupId {
-        map: (*id).clone(),
+        cluster: (*id).clone(),
         kind,
     };
     let (fold, shown, depth) = match sieve {
@@ -782,7 +818,7 @@ fn push_group(
                 .iter()
                 .filter_map(|&index| {
                     let row = Row {
-                        map: (*id).clone(),
+                        cluster: (*id).clone(),
                         index,
                     };
                     kept.get(&row).map(|&score| (index, score))
@@ -791,7 +827,7 @@ fn push_group(
             if matched.is_empty() {
                 return;
             }
-            // Stable, so held rows that score alike keep the map's own order.
+            // Stable, so held rows that score alike keep the cluster's own order.
             matched.sort_by_key(|&(_, score)| Reverse(score));
             (
                 Fold::Sifted {
@@ -804,7 +840,7 @@ fn push_group(
         Sieve::Everything if expanded.contains(&group) => (Fold::Open, held.to_vec(), 1),
         Sieve::Everything => (
             Fold::Shut {
-                rollup: RowGlyph::tally(held.iter().map(|&index| &map.tickets[index])),
+                rollup: RowGlyph::tally(held.iter().map(|&index| &cluster.tickets[index])),
             },
             vec![],
             1,
@@ -821,11 +857,11 @@ fn push_group(
     }
 }
 
-fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded, sieve: &Sieve) -> Plan {
+fn leverage(clusters: &[(&ClusterId, &Cluster)], expanded: &Expanded, sieve: &Sieve) -> Plan {
     let mut plan = Plan::default();
-    for (id, map) in clusters {
-        let mut roots: Vec<&Ticket> = map.tickets.iter().filter(|t| takeable(t)).collect();
-        // A map with nothing takeable leaves the leverage body and is only
+    for (id, cluster) in clusters {
+        let mut roots: Vec<&Ticket> = cluster.tickets.iter().filter(|t| takeable(t)).collect();
+        // A cluster with nothing takeable leaves the leverage body and is only
         // counted. Not while a query is live, though: its done and blocked work
         // is exactly as findable by typing as anyone else's, so the cluster is
         // built anyway and the sieve decides whether any of it survives.
@@ -833,18 +869,18 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded, sieve: &Sieve) -> 
             plan.idle_hidden += 1;
             continue;
         }
-        roots.sort_by_key(|t| (Reverse(open_unblocks(map, t.number).len()), t.number));
+        roots.sort_by_key(|t| (Reverse(open_unblocks(cluster, t.number).len()), t.number));
 
         let mut tree = Vec::new();
         let mut reached = BTreeSet::new();
         for root in roots {
-            let index = map
+            let index = cluster
                 .index_of(root.number)
-                .expect("root is one of map.tickets");
+                .expect("root is one of cluster.tickets");
             tree.push(ticket_item(id, index, 0, String::new(), vec![]));
             let mut path = vec![root.number];
             walk_unblocks(
-                map,
+                cluster,
                 id,
                 root.number,
                 1,
@@ -861,7 +897,7 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded, sieve: &Sieve) -> 
         // what it is not showing, and a way to look. Reached-ness is read off
         // the whole walk, before the sieve, so a query cannot push a ticket
         // into this group by pruning the branch that reached it.
-        let deeper: Vec<usize> = map
+        let deeper: Vec<usize> = cluster
             .tickets
             .iter()
             .enumerate()
@@ -873,23 +909,31 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded, sieve: &Sieve) -> 
         push_group(
             &mut body,
             id,
-            map,
+            cluster,
             GroupKind::BlockedDeeper,
             &deeper,
             expanded,
             sieve,
         );
 
-        let done: Vec<usize> = map
+        let done: Vec<usize> = cluster
             .tickets
             .iter()
             .enumerate()
             .filter(|(_, t)| !is_open(t))
             .map(|(i, _)| i)
             .collect();
-        push_group(&mut body, id, map, GroupKind::Done, &done, expanded, sieve);
+        push_group(
+            &mut body,
+            id,
+            cluster,
+            GroupKind::Done,
+            &done,
+            expanded,
+            sieve,
+        );
 
-        // Only a sift can empty a cluster — a map with a takeable root always
+        // Only a sift can empty a cluster — a cluster with a takeable root always
         // has a row — and a cluster a query emptied leaves the body header and
         // all, the way filtering is expected to work.
         if body.is_empty() {
@@ -909,8 +953,8 @@ fn leverage(clusters: &[(&MapId, &Map)], expanded: &Expanded, sieve: &Sieve) -> 
 /// cycle and is skipped rather than recursed into.
 #[allow(clippy::too_many_arguments)]
 fn walk_unblocks(
-    map: &Map,
-    id: &MapId,
+    cluster: &Cluster,
+    id: &ClusterId,
     number: u64,
     depth: usize,
     stem: &str,
@@ -918,14 +962,14 @@ fn walk_unblocks(
     reached: &mut BTreeSet<u64>,
     items: &mut Vec<Item>,
 ) {
-    let children: Vec<u64> = open_unblocks(map, number)
+    let children: Vec<u64> = open_unblocks(cluster, number)
         .into_iter()
         .filter(|n| !path.contains(n))
         .collect();
     for (i, &child) in children.iter().enumerate() {
-        let index = map
+        let index = cluster
             .index_of(child)
-            .expect("dependent is one of map.tickets");
+            .expect("dependent is one of cluster.tickets");
         let (branch, continuation) = link(i + 1 == children.len(), false);
         items.push(ticket_item(
             id,
@@ -937,7 +981,7 @@ fn walk_unblocks(
         reached.insert(child);
         path.push(child);
         walk_unblocks(
-            map,
+            cluster,
             id,
             child,
             depth + 1,
@@ -950,26 +994,26 @@ fn walk_unblocks(
     }
 }
 
-fn forest(clusters: &[(&MapId, &Map)], sieve: &Sieve) -> Plan {
+fn forest(clusters: &[(&ClusterId, &Cluster)], sieve: &Sieve) -> Plan {
     let mut plan = Plan::default();
-    for (id, map) in clusters {
+    for (id, cluster) in clusters {
         let mut tree = Vec::new();
 
-        // Primary parent = lowest-numbered in-map blocker; everything else on
+        // Primary parent = lowest-numbered in-cluster blocker; everything else on
         // the edge list annotates the row.
         let in_map_blockers = |t: &Ticket| -> Vec<u64> {
             let mut blockers: Vec<u64> = t
                 .blocked_by
                 .iter()
                 .copied()
-                .filter(|&b| map.index_of(b).is_some())
+                .filter(|&b| cluster.index_of(b).is_some())
                 .collect();
             blockers.sort_unstable();
             blockers
         };
         let mut children: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
         let mut roots: Vec<u64> = vec![];
-        for t in &map.tickets {
+        for t in &cluster.tickets {
             match in_map_blockers(t).first() {
                 Some(&parent) => children.entry(parent).or_default().push(t.number),
                 None => roots.push(t.number),
@@ -980,7 +1024,7 @@ fn forest(clusters: &[(&MapId, &Map)], sieve: &Sieve) -> Plan {
         let mut visited = BTreeSet::new();
         for &root in &roots {
             walk_forest(
-                map,
+                cluster,
                 id,
                 root,
                 0,
@@ -994,15 +1038,15 @@ fn forest(clusters: &[(&MapId, &Map)], sieve: &Sieve) -> Plan {
         }
         // A blocking cycle leaves its members parented to each other and
         // reachable from no root; sweep them in as roots so the forest stays
-        // total — every ticket of the map is a row.
-        while let Some(orphan) = map
+        // total — every ticket of the cluster is a row.
+        while let Some(orphan) = cluster
             .tickets
             .iter()
             .map(|t| t.number)
             .find(|n| !visited.contains(n))
         {
             walk_forest(
-                map,
+                cluster,
                 id,
                 orphan,
                 0,
@@ -1016,7 +1060,7 @@ fn forest(clusters: &[(&MapId, &Map)], sieve: &Sieve) -> Plan {
         }
         let mut body = sieve.sift(tree);
         // The forest is total, so an empty cluster here is always a query's
-        // doing: nothing in this map matched, and the cluster goes with it.
+        // doing: nothing in this cluster matched, and the cluster goes with it.
         if body.is_empty() {
             continue;
         }
@@ -1037,8 +1081,8 @@ fn forest(clusters: &[(&MapId, &Map)], sieve: &Sieve) -> Plan {
 /// belong to different depths.
 #[allow(clippy::too_many_arguments)]
 fn walk_forest(
-    map: &Map,
-    id: &MapId,
+    cluster: &Cluster,
+    id: &ClusterId,
     number: u64,
     depth: usize,
     prefix: &str,
@@ -1051,10 +1095,10 @@ fn walk_forest(
     if !visited.insert(number) {
         return;
     }
-    let index = map
+    let index = cluster
         .index_of(number)
-        .expect("forest node is one of map.tickets");
-    let also_needs: Vec<u64> = in_map_blockers(&map.tickets[index])
+        .expect("forest node is one of cluster.tickets");
+    let also_needs: Vec<u64> = in_map_blockers(&cluster.tickets[index])
         .into_iter()
         .skip(1)
         .collect();
@@ -1072,7 +1116,7 @@ fn walk_forest(
         // space; every earlier child keeps the vertical bar running past it.
         let (branch, continuation) = link(i + 1 == kids.len(), false);
         walk_forest(
-            map,
+            cluster,
             id,
             kid,
             depth + 1,
@@ -1089,12 +1133,14 @@ fn walk_forest(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{classify, Checks, PrLink, PrStatus, Review, Stage, TicketType};
+    use crate::model::{
+        classify, Checks, MapId, PrLink, PrStatus, Review, Source, Stage, TicketType,
+    };
 
     /// The body without a project row — the case every test below but the
     /// project row's own is about. Shadows [`super::plan`] so those tests read as
     /// what they are testing rather than trailing a `None` each.
-    fn plan(clusters: &[(&MapId, &Map)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
+    fn plan(clusters: &[(&ClusterId, &Cluster)], screen: Screen<'_>, expanded: &Expanded) -> Plan {
         super::plan(clusters, screen, expanded, None)
     }
 
@@ -1112,9 +1158,9 @@ mod tests {
     }
 
     /// Blocked status honestly derived: a blocker is "open" iff it is an open
-    /// ticket of this map (fixtures never blocked on out-of-map issues unless
+    /// ticket of this map (fixtures never blocked on out-of-cluster issues unless
     /// the test says so).
-    fn map(tickets: Vec<Ticket>) -> Map {
+    fn map(tickets: Vec<Ticket>) -> Cluster {
         let open: BTreeSet<u64> = tickets
             .iter()
             .filter(|t| is_open(t))
@@ -1135,16 +1181,18 @@ mod tests {
                 t
             })
             .collect();
-        Map {
-            title: "Map: fixture".to_string(),
+        Cluster {
+            source: Source::Map {
+                title: "Map: fixture".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets,
         }
     }
 
-    /// Ticket numbers of the plan's ticket rows, resolved against `map`.
-    fn stops(plan: &Plan, m: &Map) -> Vec<u64> {
+    /// Ticket numbers of the plan's ticket rows, resolved against `cluster`.
+    fn stops(plan: &Plan, m: &Cluster) -> Vec<u64> {
         plan.rows()
             .iter()
             .map(|r| m.tickets[r.index].number)
@@ -1152,20 +1200,21 @@ mod tests {
     }
 
     /// Every cursor stop as (what it is, depth) — tickets by number, maps by
-    /// `map #n`, groups by kind. This is the navigation surface, so it is what
+    /// `cluster #n`, groups by kind. This is the navigation surface, so it is what
     /// the tests assert on.
     /// The cluster header's stop, which every plan below opens with since #96.
     /// Named once so the assertions stay about the rows under it.
     fn header() -> (String, usize) {
-        ("map #47".to_string(), 0)
+        ("cluster #47".to_string(), 0)
     }
 
-    fn nav(plan: &Plan, m: &Map) -> Vec<(String, usize)> {
+    fn nav(plan: &Plan, m: &Cluster) -> Vec<(String, usize)> {
         plan.stops()
             .into_iter()
             .map(|at| {
                 let label = match at.stop {
-                    Stop::Map(id) => format!("map #{}", id.number),
+                    Stop::Cluster(ClusterId::Map(id)) => format!("cluster #{}", id.number),
+                    Stop::Cluster(ClusterId::Inbox(repo)) => format!("inbox {repo}"),
                     Stop::Ticket(row) => format!("#{}", m.tickets[row.index].number),
                     Stop::Group(g) => format!("{:?}", g.kind),
                     Stop::Project(repo) => format!("project {repo}"),
@@ -1177,7 +1226,7 @@ mod tests {
 
     /// Every top-level ticket row as (number, what it heads) — the branch
     /// roots and what each says about the subtree drawn beneath it.
-    fn roots(plan: &Plan, m: &Map) -> Vec<(u64, Branch)> {
+    fn roots(plan: &Plan, m: &Cluster) -> Vec<(u64, Branch)> {
         plan.items
             .iter()
             .filter_map(|item| match item {
@@ -1192,8 +1241,8 @@ mod tests {
             .collect()
     }
 
-    fn id() -> MapId {
-        MapId::new("blooop/wayfinder", 47)
+    fn id() -> ClusterId {
+        ClusterId::Map(MapId::new("blooop/wayfinder", 47))
     }
 
     fn nothing() -> Expanded {
@@ -1253,7 +1302,7 @@ mod tests {
             .filter(|(_, depth)| *depth == 0)
             .map(|(label, _)| label)
             .collect();
-        assert_eq!(top, vec!["map #47", "#6", "#9", "Done"]);
+        assert_eq!(top, vec!["cluster #47", "#6", "#9", "Done"]);
     }
 
     #[test]
@@ -1265,7 +1314,7 @@ mod tests {
         ]);
         let binding = id();
         let open: Expanded = [GroupId {
-            map: binding.clone(),
+            cluster: binding.clone(),
             kind: GroupKind::Done,
         }]
         .into_iter()
@@ -1314,22 +1363,22 @@ mod tests {
 
     #[test]
     fn every_cluster_opens_with_its_header_as_a_stop() {
-        // #96: a map is a thing you can launch an agent at, so the cursor has
+        // #96: a cluster is a thing you can launch an agent at, so the cursor has
         // to be able to name it. One stop per cluster, at the front of it and
         // at depth 0 — context rows and spacers stay unreachable.
         let m = map(vec![ticket(6, true, false, vec![])]);
-        let other = MapId::new("blooop/dotfiles", 4);
+        let other = ClusterId::Map(MapId::new("blooop/dotfiles", 4));
         let binding = id();
         let plan = plan(
             &[(&binding, &m), (&other, &m)],
             Screen::Structured(Lens::Leverage),
             &nothing(),
         );
-        let headers: Vec<MapId> = plan
+        let headers: Vec<ClusterId> = plan
             .stops()
             .into_iter()
             .filter_map(|at| match at.stop {
-                Stop::Map(id) => Some(id),
+                Stop::Cluster(id) => Some(id),
                 Stop::Ticket(_) | Stop::Group(_) | Stop::Project(_) => None,
             })
             .collect();
@@ -1396,7 +1445,7 @@ mod tests {
         // Open, the rows are right there — the rollup only exists while shut,
         // so a rollup on an expanded row is unrepresentable, not just unshown.
         let open: Expanded = [GroupId {
-            map: binding.clone(),
+            cluster: binding.clone(),
             kind: GroupKind::Done,
         }]
         .into_iter()
@@ -1470,8 +1519,10 @@ mod tests {
     fn the_blocked_deeper_rollup_reads_blocked_not_stage() {
         // A held-back blocked ticket rolls up as ⊘ — its stage is unactionable
         // and the override carries into the counts (#62).
-        let m = Map {
-            title: "Map: fixture".to_string(),
+        let m = Cluster {
+            source: Source::Map {
+                title: "Map: fixture".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![
@@ -1578,15 +1629,15 @@ mod tests {
     #[test]
     fn expansion_is_per_cluster_not_global() {
         // Two clusters both holding done work: opening one must not open the
-        // other, which is why the key carries the map.
+        // other, which is why the key carries the cluster.
         let m = map(vec![
             ticket(2, false, false, vec![]),
             ticket(6, true, false, vec![]),
         ]);
-        let a = MapId::new("blooop/wayfinder", 47);
-        let b = MapId::new("blooop/dotfiles", 4);
+        let a = ClusterId::Map(MapId::new("blooop/wayfinder", 47));
+        let b = ClusterId::Map(MapId::new("blooop/dotfiles", 4));
         let open: Expanded = [GroupId {
-            map: b.clone(),
+            cluster: b.clone(),
             kind: GroupKind::Done,
         }]
         .into_iter()
@@ -1609,12 +1660,14 @@ mod tests {
 
     #[test]
     fn leverage_holds_back_what_no_subtree_reaches() {
-        // #7 blocked only by an out-of-map issue: no root's subtree reaches it,
+        // #7 blocked only by an out-of-cluster issue: no root's subtree reaches it,
         // so it is held behind the blocked group rather than silently dropped.
-        // Built without the `map` helper — that helper derives blocked status
-        // from in-map blockers, and this blocker is deliberately not one.
-        let m = Map {
-            title: "Map: fixture".to_string(),
+        // Built without the `cluster` helper — that helper derives blocked status
+        // from in-cluster blockers, and this blocker is deliberately not one.
+        let m = Cluster {
+            source: Source::Map {
+                title: "Map: fixture".to_string(),
+            },
             last_activity: None,
             truncated: false,
             tickets: vec![
@@ -1642,7 +1695,7 @@ mod tests {
     fn leverage_drops_idle_maps_and_counts_them() {
         let idle = map(vec![ticket(2, false, false, vec![])]);
         let live = map(vec![ticket(6, true, false, vec![])]);
-        let idle_id = MapId::new("blooop/dotfiles", 4);
+        let idle_id = ClusterId::Map(MapId::new("blooop/dotfiles", 4));
         let live_id = id();
         let plan = plan(
             &[(&idle_id, &idle), (&live_id, &live)],
@@ -1756,7 +1809,7 @@ mod tests {
 
     #[test]
     fn forest_furniture_stays_aligned_three_levels_deep() {
-        // The shape the live wf map exposed: a root with two children, the
+        // The shape the live wf cluster exposed: a root with two children, the
         // *first* of which has a child of its own. The grandchild must hang
         // from its parent's running bar (`│ └─`) — a node's own line and its
         // children's lines are different depths, and deriving one from the
@@ -1824,7 +1877,7 @@ mod tests {
 
     /// The body as one string per line, furniture included: this is a test
     /// about the *shape* a query leaves behind, so the shape is what it reads.
-    fn shape(plan: &Plan, m: &Map) -> Vec<String> {
+    fn shape(plan: &Plan, m: &Cluster) -> Vec<String> {
         let number = |row: &Row| m.tickets[row.index].number;
         plan.items
             .iter()
@@ -1927,7 +1980,7 @@ mod tests {
         // order the multi-project screen is otherwise built on.
         let loose = map(vec![titled(103, "a-l-p-h-a spelled out", true, vec![])]);
         let exact = map(vec![titled(6, "alpha", true, vec![])]);
-        let loose_id = MapId::new("blooop/dotfiles", 4);
+        let loose_id = ClusterId::Map(MapId::new("blooop/dotfiles", 4));
         let exact_id = id();
         let plan = plan(
             &[(&loose_id, &loose), (&exact_id, &exact)],
@@ -1947,7 +2000,7 @@ mod tests {
         let hit = map(vec![titled(6, "alpha", true, vec![])]);
         let miss = map(vec![titled(103, "nothing like it", true, vec![])]);
         let hit_id = id();
-        let miss_id = MapId::new("blooop/dotfiles", 4);
+        let miss_id = ClusterId::Map(MapId::new("blooop/dotfiles", 4));
         let plan = plan(
             &[(&miss_id, &miss), (&hit_id, &hit)],
             sifted("alpha"),
@@ -1959,7 +2012,7 @@ mod tests {
                 Item::Header(hit_id.clone()),
                 Item::Ticket {
                     row: Row {
-                        map: hit_id,
+                        cluster: hit_id,
                         index: 0
                     },
                     depth: 0,
@@ -1991,9 +2044,9 @@ mod tests {
 
     #[test]
     fn a_query_reaches_into_a_map_the_leverage_screen_drops() {
-        // A map with nothing takeable is not on the leverage screen at all —
+        // A cluster with nothing takeable is not on the leverage screen at all —
         // but its finished work is exactly as findable by typing as anyone
-        // else's, so the sieve gets to look before the map is dropped.
+        // else's, so the sieve gets to look before the cluster is dropped.
         let m = map(vec![titled(2, "alpha", false, vec![])]);
         let binding = id();
         let idle = plan(
@@ -2008,7 +2061,7 @@ mod tests {
         assert_eq!(shape(&found, &m), vec!["▌ wayfinder", "Done 1/1", "└─#2"]);
         assert_eq!(
             found.idle_hidden, 0,
-            "the map is on screen, so there is nothing to say it is hidden"
+            "the cluster is on screen, so there is nothing to say it is hidden"
         );
     }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -159,8 +159,9 @@ pub struct ProjectRow {
     pub maps: usize,
     /// Stage counts across them, in display order — empty when none are.
     pub rollup: Vec<(RowGlyph, usize)>,
-    /// Whether the cluster search has answered, so `maps: 0` can be read as "no
-    /// cluster" rather than "not yet".
+    /// Whether the **map** search has answered, so `maps: 0` can be read as
+    /// "no map" rather than "not yet". The inbox has its own read and does not
+    /// speak for this — `maps` deliberately excludes it.
     pub loaded: bool,
     /// Where a live query landed in the slug, in char indices — what the row
     /// underlines. Empty on the structured screen, which has no query.

--- a/src/view.rs
+++ b/src/view.rs
@@ -869,7 +869,18 @@ fn leverage(clusters: &[(&ClusterId, &Cluster)], expanded: &Expanded, sieve: &Si
             plan.idle_hidden += 1;
             continue;
         }
-        roots.sort_by_key(|t| (Reverse(open_unblocks(cluster, t.number).len()), t.number));
+        // The tie-break is the row's **place in its cluster**, not its number.
+        // A map's tickets are number-sorted at the parse boundary, so for a map
+        // the two are the same order; an inbox's are activity-sorted, and
+        // keying on the number there would re-impose oldest-first on rows that
+        // were deliberately ordered by when something happened. One rule, and
+        // each cluster's parse decides what its own order means.
+        roots.sort_by_key(|t| {
+            (
+                Reverse(open_unblocks(cluster, t.number).len()),
+                cluster.index_of(t.number),
+            )
+        });
 
         let mut tree = Vec::new();
         let mut reached = BTreeSet::new();
@@ -1019,7 +1030,9 @@ fn forest(clusters: &[(&ClusterId, &Cluster)], sieve: &Sieve) -> Plan {
                 None => roots.push(t.number),
             }
         }
-        roots.sort_unstable();
+        // In cluster order, for [`leverage`]'s reason: the same order a map
+        // gets from its numbers and an inbox from its activity.
+        roots.sort_by_key(|n| cluster.index_of(*n));
 
         let mut visited = BTreeSet::new();
         for &root in &roots {

--- a/tests/live_fetch.rs
+++ b/tests/live_fetch.rs
@@ -24,7 +24,7 @@ async fn fetches_the_live_wayfinder_map() {
     // has. That an issue is a map at all is checked where it can be: `fetch_map`
     // refuses anything that is not an open `wayfinder:map` (#28).
     assert!(
-        !map.title.is_empty(),
+        map.map_title().is_some_and(|t| !t.is_empty()),
         "the map issue's title must come back"
     );
     assert!(
@@ -91,4 +91,73 @@ async fn fetches_the_live_wayfinder_map() {
     // (`open_unassigned_with_open_blockers_is_blocked`,
     // `closed_is_done_even_if_assigned_or_blocked`) and at the parse boundary
     // in `fetch::tests`. What only the live API can prove is above.
+}
+
+/// The inbox read against the real tracker: the one thing a fixture cannot
+/// prove is that the `search`-based GraphQL query is *valid* — a mistyped
+/// selection, a field GitHub renamed, or `blockedBy` not existing on a bare
+/// `Issue` all come back as a GraphQL error rather than a parse failure, and
+/// the whole feature would be an empty heading nobody could debug from a unit
+/// test.
+///
+/// Deliberately makes **no claim about what is in it**. Whose inbox this runs
+/// as depends on the token — a maintainer locally, `GH_TOKEN` in CI — and the
+/// unassigned half depends on whatever is untriaged today, so an empty answer
+/// is a correct answer and the assertions are about shape, not contents. The
+/// one thing asserted unconditionally is that both searches *ran*.
+#[tokio::test]
+#[ignore = "live: needs network + an authenticated gh"]
+async fn reads_the_live_inbox() {
+    let inbox = wf::fetch::fetch_inbox(&[common::THIS_REPO.to_string()])
+        .await
+        .unwrap_or_else(|e| panic!("live inbox read: {e:#}"));
+
+    for (repo, cluster) in &inbox {
+        assert_eq!(
+            repo,
+            common::THIS_REPO,
+            "only the repos asked for come back"
+        );
+        assert!(
+            cluster.map_title().is_none(),
+            "an inbox cluster has no map issue to be titled by"
+        );
+        assert!(
+            !cluster.tickets.is_empty(),
+            "a repo with nothing assigned is absent, never an empty heading"
+        );
+        for ticket in &cluster.tickets {
+            assert_eq!(ticket.repo, *repo, "each row carries its own repo");
+            // Both halves of the query ask `is:open`, so nothing here is done.
+            // Which of the other three a row is depends on which half found it
+            // — assigned is claimed, unassigned is frontier, or blocked when
+            // something open blocks it — and asserting one of them would only
+            // hold while the tracker happened to be in that state. What is
+            // asserted is the invariant the *query* guarantees.
+            assert_ne!(
+                ticket.status,
+                Status::Done,
+                "#{} came back done from an is:open search",
+                ticket.number
+            );
+        }
+        // A map is an open issue with nobody assigned, so `no:assignee` finds
+        // every map in every repo asked about. Live proof that the label drop
+        // works, since this repo always has an open map: without it every
+        // cluster header would also be a row of the inbox below it.
+        let maps = wf::fetch::find_maps(&[common::THIS_REPO.to_string()])
+            .await
+            .expect("the map search answers");
+        for id in &maps {
+            assert!(
+                !cluster.tickets.iter().any(|t| t.number == id.number),
+                "map #{} is a heading, not a row of the inbox",
+                id.number
+            );
+        }
+        assert!(
+            cluster.last_activity.is_some(),
+            "the live updatedAt selection must parse, or every inbox sorts as unknown"
+        );
+    }
 }

--- a/tests/live_streaming_startup.rs
+++ b/tests/live_streaming_startup.rs
@@ -57,7 +57,10 @@ async fn discovery_then_every_map_arrives_through_one_channel() {
             // error here and a decision someone makes — this file runs only
             // after a merge (`live.yml`), which would make a wildcard in it
             // the slowest-observed thing in the tree.
-            other @ (LoadEvent::Fetched { .. } | LoadEvent::Surveyed { .. }) => {
+            other @ (LoadEvent::Fetched { .. }
+            | LoadEvent::Inbox(_)
+            | LoadEvent::InboxFailed
+            | LoadEvent::Surveyed { .. }) => {
                 panic!("expected discovery first, got {other:?}")
             }
         }

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -681,6 +681,28 @@ fn the_context_section_states_the_fallback_and_the_live_read() {
     }
 }
 
+/// The word the binary puts in front of an adopted issue's number is the word
+/// `wf-one` documents reading.
+///
+/// The skills are part of this repo precisely so this cannot drift, and this is
+/// the pair that would drift silently: `wf` execs `wf-one adopt <n>` from the
+/// inbox, and a skill that never learned the subcommand would read `adopt 191`
+/// as a task description and file a *second* issue called "adopt 191" beside
+/// the one the human picked. Nothing anywhere would notice.
+#[test]
+fn the_adopt_argument_is_the_one_wf_one_documents() {
+    let doc = skill_doc("wf-one");
+    let arg = wf::launch::ADOPT_ARG;
+    assert!(
+        doc.contains(&format!("<sigil>wf-one {arg} <n>")),
+        "wf-one must show the `{arg}` form in its invocation grammar"
+    );
+    assert!(
+        doc.contains("Do not create a second issue for it"),
+        "wf-one must say that an adopted issue is the ticket, not a description of one"
+    );
+}
+
 /// Every shipped skill says where it stands on the block — a consumer that
 /// never learns of it would keep paying the discovery cost the block exists to
 /// remove.

--- a/tests/skill_docs.rs
+++ b/tests/skill_docs.rs
@@ -701,6 +701,21 @@ fn the_adopt_argument_is_the_one_wf_one_documents() {
         doc.contains("Do not create a second issue for it"),
         "wf-one must say that an adopted issue is the ticket, not a description of one"
     );
+    // The guard `wf` cannot enforce from here. Its own refusal keys on what it
+    // does not know (a map still out, a map that failed), and that is not the
+    // whole of what can be stale: a label page cut short, a map opened a
+    // second ago. An issue may have one parent, so adopting an already-mapped
+    // ticket takes it off the map it was charted on — silently, on somebody
+    // else's map. The skill is the only reader with a live tracker in front of
+    // it, so the check has to be written down where it runs.
+    assert!(
+        doc.contains("/parent"),
+        "wf-one must check the issue has no parent before adopting it"
+    );
+    assert!(
+        doc.contains("do not adopt it"),
+        "wf-one must refuse an issue that already has a map, not reparent it"
+    );
 }
 
 /// Every shipped skill says where it stands on the block — a consumer that


### PR DESCRIPTION
`wf` only ever showed wayfinder tickets: an issue reached the screen by being a
sub-issue of an open `wayfinder:map`, so everything else in a repo was
invisible. This adds a second kind of cluster for the rest.

## The shape

The cluster key stops being `MapId`. `ClusterId = Map(MapId) | Inbox(repo)` is a
sum rather than a `MapId` with an optional number, because the two kinds differ
in what they *are*: a map has an issue of its own, so its header launches and
its tickets are that issue's sub-issues; the inbox has none, so its header is a
place to stand. Every site that decides something from the kind matches both
arms, which is what makes a third kind a compile error rather than a silent
misreading.

The inbox is **what is yours or nobody's**, not every open issue. A repo's whole
issue list is not curated, and pouring it in would bury the charted maps under a
worse `gh issue list`. GitHub issue search has no `OR`, so `assignee:@me` and
`no:assignee` are two aliased searches sharing one fragment — one round trip,
one rate-limit point, and a selection that cannot drift from the one `MAP_QUERY`
makes of a sub-issue.

It is **derived**, not stored: the raw reading is kept and the maps subtracted
from it on every arrival. The two reads race by design — one inbox query, one
fetch per map — and an issue you have claimed on a map is in both answers. So a
map landing late takes its rows with it, and a map whose fetch failed leaves its
rows visible rather than nowhere.

`enter` on an inbox row **adopts**: `/wf-one adopt <n>` files a map and parents
the existing issue under it, then runs the ordinary lifecycle. That leaves the
launch contract alone — every `/wf` route still takes a map, which is what makes
a run resumable — so `CONTEXT_VERSION` stays 1 and prewarm, resume and reap need
no changes.

## What the self-review found

Five defects, each its own commit with a failing test first:

- **The inbox drew oldest-first**, not in date order. `last_activity` went on the
  cluster, where the project scope leaves nothing to compare; both lenses then
  re-sorted roots by issue number. Every row's `updatedAt` was already fetched
  and thrown away.
- **Adopting a row whose map failed to load took it off that map.** An issue may
  have one parent, so parenting an already-mapped ticket silently removes it from
  the map it was charted on. Two guards: `wf` refuses while its picture is
  incomplete, and `wf-one adopt` asks the tracker for the parent before filing.
- **A map wearing more than ten labels drew as an adoptable inbox row** — the
  #184 shape on the other side of the codebase, and adopting a map parents a map
  under a map.
- **One loose row hid the every-map-failed heading**, demoting "GitHub is
  unreachable" to a dim count-line segment.
- **Two broken intra-doc links** the rename left behind, which CI's
  `RUSTDOCFLAGS: -D warnings` would have failed on, plus four comments the
  rename or the diff itself falsified.

## Verification

12 test binaries green (525 tests), `clippy -D warnings`, `cargo doc`, `cargo
fmt`. The 17-test `live_devlaunch` contract green under `pixi run -e floor`. A
live inbox read against this tracker. And the real screen driven by hand through
`preview_screen`, including the case that motivated the widened scope.

**Unexercised:** no agent has yet run `/wf-one adopt <n>`. The binary side is
tested; the skill's tracker writes are new prose that has never executed. The
refusal guard it depends on is verified read-only — `issues/191/parent` answers
`182`, `issues/207/parent` 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)