### PR TITLE
Release 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.19.4"
+version = "0.20.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.19.4"
+  version: "0.20.0"
 
 package:
   name: wf


### PR DESCRIPTION
Minor: `wf` shows the issues no map claims, and adopts one into a map of its own.

Until now an issue reached the screen only by being a sub-issue of an open
`wayfinder:map`. Everything else in a repo — the thing somebody filed an hour
ago, the bug nobody has picked up — was invisible, and the only way to work it
was to chart a map by hand first. A repo's screen now ends with one more
cluster, `▌ repo · yours or unclaimed`, holding every open issue there that is
yours or nobody's and is on no map.

It is deliberately not every open issue. A repo's whole issue list is not
curated, and pouring it in would not make a bigger `wf` — it would bury the
charted maps under a worse `gh issue list`. Dropping somebody else's issues
leaves the set you could actually pick up, ordered newest-first, below every map
however fresh it is: a map is work somebody charted and the inbox is work that
merely exists.

`enter` on one of those rows adopts it. `/wf-one adopt <n>` files a map, parents
the existing issue under it, and runs the ordinary `wf-tdd` → gate → `wf-review`
lifecycle — so the launch contract is untouched, `CONTEXT_VERSION` stays 1, and
prewarm, resume and reap work on an adopted node exactly as on any other. The
map is not ceremony: every `/wf` route takes one, and it is where a run's
breadcrumbs and handoff live, which is what makes the run survive a session
ending.

The cluster key is a sum now — `ClusterId = Map | Inbox` — rather than a map id
with an optional number, because the two kinds differ in what they are and not
in whether a field was filled in. A map has an issue of its own, so its header
launches; the inbox has none, so its header is a place to stand. That rippled
through every row, stop, group and load event, and the compiler carried it.

Two things worth knowing before you use it. The inbox is *derived* — the raw
read is kept and the maps subtracted on every arrival — so a map that lands
late takes its rows with it, and a map whose fetch failed leaves its rows
visible rather than nowhere at all. Because those rows might already belong to
the map that failed, adoption refuses while any map of that repo is still out
or has failed, and `wf-one adopt` asks the tracker for the issue's parent
before it files anything: an issue may have exactly one parent, so adopting an
already-mapped ticket would take it off the map it was charted on.

A failed inbox read says `· inbox unread` on the count line, because an empty
inbox draws no heading — nothing loose, all of it claimed, and a query that
never answered were otherwise the same blank screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the package and recipe versions to 0.20.0.