### PR TITLE
Name the terminal after the launched node, and keep the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,6 +1245,60 @@ a hand-over measured from a keystroke hours old. The same clearing covers every
 up`, and `wf reap`'s listing and removals — because `wf` run inside a workspace
 starts with the stamps of the launch that built it already in its environment.
 
+### The name on the terminal
+
+A launch is a session you switch away from: five tickets are five terminals, and
+from outside the only thing telling them apart is the window — or multiplexer
+tab — name. So a launch **names it after the node it launched**, `wayfinder#191`,
+the same key the picker's row and the launch notice show. One OSC 2 escape,
+written to stderr as the last thing before the process is replaced.
+
+**And it tells the agent to leave that name alone.** Claude Code rewrites the
+terminal title continuously while it runs, from its own read of what the session
+is doing, and a terminal takes the last writer's word for it — so the escape `wf`
+writes and the agent's are not two signals but one contest, and `wf` loses it
+within a second of handing over. A launch therefore sets
+`CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` for the agent it starts, which is Claude
+Code's own variable and the same one `aid` sets on the `claude` it starts
+(blooop/devlaunch#436).
+
+**Only on the host arm**, because that is the only arm where `wf` is the thing
+that could do it. A host launch execs the agent itself, so the variable goes on
+that process. An isolated launch becomes `dl` — whose environment no container
+shell inherits, since a container's is built on the far side of an ssh — and
+since devlaunch#436 (`dl` 0.14.0) `dl`'s title stage exports the same variable
+into the container's login profile, which every `dl <ws> -- <cmd>` payload reads,
+because those run under `bash -lc`. That is the fix for a `claude` *you* type at
+a workspace prompt, and it covers a `claude` `wf` starts there for the same
+reason. `wf` could carry it in the payload instead — `env
+CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1 claude …`, spelt with `env` because `exec
+VAR=1 claude` is bash hunting for a program called `VAR=1` — and deliberately
+does not: it is a second mechanism for a job the container arm already does, and
+the half that owns the container owns what its shells export.
+
+The name is `dl`'s there too: it writes the workspace spec,
+`blooop/wayfinder@wayfinder/wayfinder-191`, over `wf`'s a moment later, which is
+its call to make about a terminal it is taking over. `wf` writes its own name
+anyway rather than guessing — if `dl`'s titling is switched off, `wf`'s is the
+name that stands, and the window is never left wearing what some session hours
+ago called it.
+
+**`WF_NO_TITLE`** turns the whole thing off — the escape and the quieting
+together, since a name nobody wrote is a name nothing has to protect, and an
+agent silenced with nothing put in its place is the stale-title case above.
+Anything set is off, including a value this list never anticipated; `0`, `false`,
+`no` and the empty string are how you turn it back on without unsetting it. That
+is the opposite reading to `WF_PREWARM`'s allowlist, and deliberately: the cost
+of being wrong here is one escape sequence nobody wanted, where there it would be
+clones and containers nobody asked for. `dl`'s own `DEVLAUNCH_NO_TITLE` is not
+consulted — it governs `dl`'s escape, and somebody who turned that off has said
+nothing about whether `wf` may name the terminal it is handing over.
+
+**Codex is left to name the terminal however it likes.** Whether `codex` writes
+titles, and what it would read if it does, is not something this repo has a
+source for — and a guessed variable name is worse than the gap, because it looks
+like a fix. devlaunch#436 leaves `codex` and `gemini` open for the same reason.
+
 ### `wf reap` — clearing away finished tickets
 
 A workspace per ticket means workspaces accumulate as fast as tickets are

--- a/README.md
+++ b/README.md
@@ -1262,32 +1262,40 @@ within a second of handing over. A launch therefore sets
 Code's own variable and the same one `aid` sets on the `claude` it starts
 (blooop/devlaunch#436).
 
-**Only on the host arm**, because that is the only arm where `wf` is the thing
-that could do it. A host launch execs the agent itself, so the variable goes on
-that process. An isolated launch becomes `dl` — whose environment no container
-shell inherits, since a container's is built on the far side of an ssh — and
-since devlaunch#436 (`dl` 0.14.0) `dl`'s title stage exports the same variable
-into the container's login profile, which every `dl <ws> -- <cmd>` payload reads,
-because those run under `bash -lc`. That is the fix for a `claude` *you* type at
-a workspace prompt, and it covers a `claude` `wf` starts there for the same
-reason. `wf` could carry it in the payload instead — `env
-CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1 claude …`, spelt with `env` because `exec
-VAR=1 claude` is bash hunting for a program called `VAR=1` — and deliberately
-does not: it is a second mechanism for a job the container arm already does, and
-the half that owns the container owns what its shells export.
+**Both halves are the host arm's, and neither happens anywhere else.** That is
+one rule rather than two decisions: a name is written only where the same launch
+can keep it. On the host arm `wf` execs the agent itself, so it writes the escape
+and sets the variable on that process, and nothing else is involved — no
+container, no login profile, no setup stage.
 
-The name is `dl`'s there too: it writes the workspace spec,
-`blooop/wayfinder@wayfinder/wayfinder-191`, over `wf`'s a moment later, which is
-its call to make about a terminal it is taking over. `wf` writes its own name
-anyway rather than guessing — if `dl`'s titling is switched off, `wf`'s is the
-name that stands, and the window is never left wearing what some session hours
-ago called it.
+**An isolated launch writes nothing and sets nothing, because the terminal is
+`dl`'s from the moment `wf` hands it over.** `dl` names it after the workspace
+spec — `blooop/wayfinder@wayfinder/wayfinder-191` — and repaints that at every
+prompt, and since devlaunch#436 (`dl` 0.14.0) the same title stage exports the
+suppression into the container's login profile, which a `dl <ws> -- <cmd>`
+payload reads because those run under `bash -lc`. An escape from `wf` there would
+be replaced within the second; and a `wf` that quieted the agent would be a
+second mechanism for a job the half that owns the container already does. (`wf`
+could carry it in the payload as `env CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1 claude
+…` — spelt with `env` because `exec VAR=1 claude` is bash hunting for a program
+called `VAR=1` — and did until 0.14.0 shipped.)
+
+**Two container cases that leaves alone, both `dl`-side and stated rather than
+implied.** The profile line exists only in a workspace that has been through a
+`dl` ≥ 0.14.0 `up`: an attach to a container that is already running provisions
+nothing, so a workspace last set up by an older `dl` keeps titling as it did
+until it next cycles. And `DEVLAUNCH_NO_TITLE` governs all three of `dl`'s pieces
+together, the export included — so with it set, a container session is claude's
+to name, exactly as before any of this. `wf` does not read that variable and does
+not paper over either case: on that arm `wf` is not the writer, and a name it
+could not keep is a name it should not write.
 
 **`WF_NO_TITLE`** turns the whole thing off — the escape and the quieting
 together, since a name nobody wrote is a name nothing has to protect, and an
 agent silenced with nothing put in its place is the stale-title case above.
-Anything set is off, including a value this list never anticipated; `0`, `false`,
-`no` and the empty string are how you turn it back on without unsetting it. That
+Anything set is off, including a value this list never anticipated and one no
+encoding can read; `0`, `false`, `no` and the empty string are how you turn it
+back on without unsetting it. That
 is the opposite reading to `WF_PREWARM`'s allowlist, and deliberately: the cost
 of being wrong here is one escape sequence nobody wanted, where there it would be
 clones and containers nobody asked for. `dl`'s own `DEVLAUNCH_NO_TITLE` is not

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -26,6 +26,10 @@
 //! The checkout keeps two jobs: declaring the devcontainer, and hosting
 //! host-mode launches.
 //!
+//! The terminal a launch hands over is also **named** after the node it
+//! launched, and the agent is told to leave that name alone — [`crate::title`]
+//! for both halves and why either alone is worth nothing.
+//!
 //! The one thing that can go wrong is ordering: the terminal must be restored
 //! *before* the image is replaced, because after that there is no `wf` left to
 //! do it. So this module never restores anything and never `exec`s itself off
@@ -42,6 +46,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{MapId, PrLink, Stage, Ticket, TicketType};
 use crate::projects::{Checkout, Resume, Session};
+use crate::title::TerminalTitle;
+
+/// What Claude Code reads to leave the terminal's name alone — the name being
+/// the one a launch just wrote ([`crate::title`]).
+///
+/// Claude Code's own variable, not `wf`'s to spell differently: `wf` is a
+/// writer of it and a writer that invented its own name would be setting
+/// nothing. `aid` sets the same variable on the `claude` it starts
+/// (blooop/devlaunch#436), and the two agree because they are the same fix
+/// applied by whoever started the agent.
+const CLAUDE_QUIET_TITLE_VAR: &str = "CLAUDE_CODE_DISABLE_TERMINAL_TITLE";
 
 /// Which interactive coding agent `wf` becomes after a launch.
 ///
@@ -118,6 +133,29 @@ impl Agent {
         match self {
             Agent::Claude => "--dangerously-skip-permissions",
             Agent::Codex => "--dangerously-bypass-approvals-and-sandbox",
+        }
+    }
+
+    /// The variable that stops this CLI from renaming the terminal a launch
+    /// has just named, or `None` for one with no such variable.
+    ///
+    /// Claude Code writes the title continuously while it runs, so it and the
+    /// escape a launch writes are one contest rather than two signals, and the
+    /// agent wins every round after the first
+    /// ([`crate::title`], blooop/devlaunch#436). Setting this is what makes
+    /// naming the terminal worth doing at all.
+    ///
+    /// **Codex gets `None`, and that is a gap rather than a claim.** Whether
+    /// `codex` writes titles, and what it would read if it does, is not
+    /// something this repo has a source for — and a guessed variable name is
+    /// worse than an unfixed gap, because it looks like a fix. A Codex launch
+    /// therefore names the terminal and lets `codex` rename it, which is the
+    /// same thing that happens today. devlaunch#436 leaves `codex` and
+    /// `gemini` open for the same reason.
+    fn quiet_title_var(self) -> Option<&'static str> {
+        match self {
+            Agent::Claude => Some(CLAUDE_QUIET_TITLE_VAR),
+            Agent::Codex => None,
         }
     }
 
@@ -1992,6 +2030,43 @@ impl Launch {
         }
     }
 
+    /// The variable this launch sets on the process it becomes so the terminal
+    /// keeps the name it just wrote, or `None` where there is nothing to set.
+    ///
+    /// Three ways to get `None`, and the third is the interesting one:
+    ///
+    /// - nothing is being named ([`TerminalTitle::Off`]), so there is no name
+    ///   to protect. Both halves of the feature ask this one question, which is
+    ///   what keeps either from happening without the other: an escape
+    ///   overwritten a second later is a feature that does not work, and an
+    ///   agent silenced with nothing put in its place leaves the window wearing
+    ///   what some session hours ago called it.
+    /// - the agent has no such variable ([`Agent::quiet_title_var`]).
+    /// - **the launch is isolated, where this is `dl`'s job and not `wf`'s.**
+    ///   Nothing `wf` sets here would reach the agent anyway — the process this
+    ///   becomes is `dl`, and a container's environment is built on the far
+    ///   side of an ssh — and since blooop/devlaunch#436 (`dl` 0.14.0) the
+    ///   title stage exports the same variable into the container's login
+    ///   profile, which every `dl <ws> -- <cmd>` payload reads, because those
+    ///   run under `bash -lc`. `wf` could carry it in the payload instead
+    ///   (`env VAR=1 claude …`, since `exec VAR=1 claude` is bash hunting for a
+    ///   program called `VAR=1`), and did until this was measured: it is a
+    ///   second mechanism for a job the container arm already does, and the arm
+    ///   that owns the container is the honest owner of what its shells export.
+    ///
+    /// So the host arm is what is left, and it is the arm with nothing else in
+    /// it: no container, no profile, no stage — `wf` execs the agent itself, so
+    /// `wf` is the only thing that can name that terminal or keep the name.
+    fn quiet_title_var(&self, title: &TerminalTitle) -> Option<&'static str> {
+        if !title.is_named() {
+            return None;
+        }
+        match self.isolation {
+            Isolation::Host => self.agent().quiet_title_var(),
+            Isolation::Devlaunch => None,
+        }
+    }
+
     /// What this launch tells the process it is about to become about the
     /// keystroke it came from ([`Handoff`]) — one entry per seam variable, in
     /// the published order, and `None` for one this launch has nothing to say
@@ -2044,6 +2119,11 @@ impl Launch {
     /// literally and always starts it with the program name, so the split below
     /// cannot come up empty. The `expect` is there to say so.
     pub fn exec(&self, handoff: &Handoff) -> anyhow::Error {
+        // What this terminal is about to be called, decided once and read
+        // twice: the escape written below, and the quieting that keeps it
+        // ([`Launch::quiet_title_var`]). One value behind both, so a launch
+        // cannot write a name it then lets the agent overwrite.
+        let title = TerminalTitle::wanted(&self.key());
         let argv = self.agent_argv();
         let (program, rest) = argv.split_first().expect("agent argv is never empty");
 
@@ -2082,6 +2162,22 @@ impl Launch {
                 None => command.env_remove(var),
             };
         }
+        // What keeps the name written below from being renamed a second later,
+        // on the one arm where `wf` is the only thing that could set it — see
+        // [`Launch::quiet_title_var`] for why an isolated launch sets nothing.
+        // Set, never removed: a `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` somebody
+        // exported themselves is their setting, and turning `wf`'s titling off
+        // is not a licence to undo it.
+        if let Some(var) = self.quiet_title_var(&title) {
+            command.env(var, "1");
+        }
+        // Last, and after every check that could still turn this into an error
+        // rather than a launch: a `wf` that failed to resolve the agent has not
+        // handed the terminal to anything, so it has no business renaming it.
+        // On the container arm `dl` writes its own name over this one a moment
+        // later — see [`crate::title`] for why writing it anyway is the point
+        // rather than waste.
+        title.write();
         // `CommandExt::exec` only ever returns on failure.
         let err = command.exec();
         // Quoted, so the prompt reads as the single argument it is — the whole
@@ -4599,6 +4695,105 @@ mod tests {
         assert_eq!(
             changed, expected,
             "a `dl` that is not the launch clears both stamps and sets neither"
+        );
+    }
+
+    /// A terminal that is being named — what [`TerminalTitle::wanted`] returns
+    /// on a tty with `WF_NO_TITLE` unset, spelled here as a literal so these
+    /// tests decide nothing from the environment they run in.
+    fn named() -> TerminalTitle {
+        let title = TerminalTitle::named("wayfinder#80", None, true);
+        assert!(title.is_named(), "the fixture is a named terminal");
+        title
+    }
+
+    #[test]
+    fn an_isolated_launch_leaves_the_quieting_to_dl() {
+        // The container arm sets nothing and prefixes nothing. Two reasons, and
+        // either alone would be enough: the process this launch becomes is
+        // `dl`, whose environment no container shell inherits, and `dl` 0.14.0
+        // exports the same variable from the container's login profile — which
+        // every `dl <ws> -- <cmd>` reads, since those run under `bash -lc`
+        // (blooop/devlaunch#436).
+        let launch = isolated(Route::Tdd, interactive(""));
+        assert_eq!(launch.quiet_title_var(&named()), None);
+        let argv = launch.agent_argv();
+        assert_eq!(argv.first().map(String::as_str), Some(DEVLAUNCH));
+        assert!(
+            argv.last()
+                .expect("a payload")
+                .starts_with("'claude' '--dangerously-skip-permissions'"),
+            "the payload is the agent's own command and nothing in front of it: \
+             {argv:?}"
+        );
+    }
+
+    #[test]
+    fn a_host_launch_is_the_one_that_has_to_quiet_the_agent_itself() {
+        // The arm with nothing else in it: no container, no profile, no stage.
+        // `wf` execs the agent, so `wf` is the only thing that can name that
+        // terminal — and the only thing that can stop the agent renaming it.
+        // The variable goes on the child, never into the argv: there is no
+        // shell there to read an assignment, and an `env` in front of the
+        // program would make the process `wf` becomes an `env`.
+        let launch = on_the_host(Route::Tdd, interactive(""));
+        assert_eq!(
+            launch.quiet_title_var(&named()),
+            Some("CLAUDE_CODE_DISABLE_TERMINAL_TITLE"),
+        );
+        assert_eq!(
+            launch.agent_argv().first().map(String::as_str),
+            Some("claude"),
+            "the process `wf` becomes is the agent itself"
+        );
+    }
+
+    #[test]
+    fn a_terminal_nobody_is_naming_quiets_nothing() {
+        // One value over both halves ([`crate::title`]): with the titling off
+        // there is no name to protect, and an agent silenced with nothing put
+        // in its place leaves the window wearing what a session hours ago
+        // called it.
+        assert_eq!(
+            on_the_host(Route::Tdd, interactive("")).quiet_title_var(&TerminalTitle::Off),
+            None
+        );
+        assert_eq!(
+            isolated(Route::Tdd, interactive("")).quiet_title_var(&TerminalTitle::Off),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_is_left_to_name_the_terminal_however_it_likes() {
+        // A gap stated rather than papered over: nothing here has a source for
+        // what `codex` would read, and a guessed variable name is worse than
+        // an unfixed gap because it looks like a fix (devlaunch#436 leaves
+        // `codex` and `gemini` open for the same reason). So a Codex launch
+        // names the terminal and takes its chances.
+        //
+        // On the host, which is where a Codex launch actually goes
+        // (`codex_stays_on_the_host_even_when_the_checkout_declares_a_devcontainer`)
+        // and so the one arm where a variable would have been set.
+        let codex = LaunchMode::picked(Agent::Codex, Mode::Interactive, "");
+        assert_eq!(
+            on_the_host(Route::Tdd, codex).quiet_title_var(&named()),
+            None
+        );
+        assert_eq!(Agent::Codex.quiet_title_var(), None);
+    }
+
+    #[test]
+    fn the_terminal_is_named_after_the_node_that_was_launched() {
+        // The name is the key the picker draws and the notice says
+        // (`Launch::key`) rather than a third spelling of the same node: a tab
+        // called something no screen ever showed is a tab nobody can match up
+        // to what they launched.
+        let launch = isolated_ticket(191, Route::Tdd, interactive(""));
+        assert_eq!(launch.key(), "wayfinder#191");
+        assert_eq!(
+            TerminalTitle::named(&launch.key(), None, true).osc(),
+            Some("\x1b]2;wayfinder#191\x07")
         );
     }
 

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -2030,41 +2030,62 @@ impl Launch {
         }
     }
 
+    /// What this launch is about to call the terminal, if anything.
+    ///
+    /// **The host arm's, and only the host arm's.** An isolated launch writes
+    /// nothing, because there is nothing a name written here could survive:
+    /// `dl` writes its own escape — the workspace spec — over anything `wf` put
+    /// there a moment earlier, and where `dl`'s titling is switched off
+    /// (`DEVLAUNCH_NO_TITLE`) the title stage is what does not run, which is
+    /// also the stage that exports claude's suppression
+    /// ([`Launch::quiet_title_var`]). So on that arm the name is either
+    /// replaced within the second or left to an agent that renames it
+    /// continuously, and in both cases what `wf` wrote is gone. Writing it
+    /// anyway would break the one rule this feature holds: a name is written
+    /// only where the same launch can keep it.
+    ///
+    /// The host arm is the arm with nothing else in it — no container, no login
+    /// profile, no setup stage — so there `wf` is both the only writer and the
+    /// only thing that can keep what it wrote.
+    fn terminal_title(&self) -> TerminalTitle {
+        match self.isolation {
+            Isolation::Host => TerminalTitle::wanted(&self.key()),
+            Isolation::Devlaunch => TerminalTitle::Off,
+        }
+    }
+
     /// The variable this launch sets on the process it becomes so the terminal
     /// keeps the name it just wrote, or `None` where there is nothing to set.
     ///
-    /// Three ways to get `None`, and the third is the interesting one:
+    /// Two ways to get `None`. Nothing is being named — which on an isolated
+    /// launch is always ([`Self::terminal_title`]), and on a host launch is
+    /// `WF_NO_TITLE` or a stderr that is not a terminal. Or the agent has no
+    /// such variable ([`Agent::quiet_title_var`]).
     ///
-    /// - nothing is being named ([`TerminalTitle::Off`]), so there is no name
-    ///   to protect. Both halves of the feature ask this one question, which is
-    ///   what keeps either from happening without the other: an escape
-    ///   overwritten a second later is a feature that does not work, and an
-    ///   agent silenced with nothing put in its place leaves the window wearing
-    ///   what some session hours ago called it.
-    /// - the agent has no such variable ([`Agent::quiet_title_var`]).
-    /// - **the launch is isolated, where this is `dl`'s job and not `wf`'s.**
-    ///   Nothing `wf` sets here would reach the agent anyway — the process this
-    ///   becomes is `dl`, and a container's environment is built on the far
-    ///   side of an ssh — and since blooop/devlaunch#436 (`dl` 0.14.0) the
-    ///   title stage exports the same variable into the container's login
-    ///   profile, which every `dl <ws> -- <cmd>` payload reads, because those
-    ///   run under `bash -lc`. `wf` could carry it in the payload instead
-    ///   (`env VAR=1 claude …`, since `exec VAR=1 claude` is bash hunting for a
-    ///   program called `VAR=1`), and did until this was measured: it is a
-    ///   second mechanism for a job the container arm already does, and the arm
-    ///   that owns the container is the honest owner of what its shells export.
+    /// One question behind both halves of the feature, which is what keeps
+    /// either from happening without the other: an escape overwritten a second
+    /// later is a feature that does not work, and an agent silenced with
+    /// nothing put in its place leaves the window wearing what some session
+    /// hours ago called it.
     ///
-    /// So the host arm is what is left, and it is the arm with nothing else in
-    /// it: no container, no profile, no stage — `wf` execs the agent itself, so
-    /// `wf` is the only thing that can name that terminal or keep the name.
+    /// Inside a container this is `dl`'s job and not `wf`'s. Nothing `wf` sets
+    /// here would reach the agent anyway — the process this becomes is `dl`, and
+    /// a container's environment is built on the far side of an ssh — and since
+    /// blooop/devlaunch#436 (`dl` 0.14.0) the title stage exports the same
+    /// variable into the container's login profile, which every
+    /// `dl <ws> -- <cmd>` payload reads, because those run under `bash -lc`.
+    /// `wf` could carry it in the payload instead (`env VAR=1 claude …`, since
+    /// `exec VAR=1 claude` is bash hunting for a program called `VAR=1`), and
+    /// did until `dl` 0.14.0 shipped: it is a second mechanism for a job the
+    /// half that owns the container already does. What that leaves uncovered is
+    /// stated in the README rather than implied here — a workspace last
+    /// provisioned by an older `dl`, and a `DEVLAUNCH_NO_TITLE` that takes the
+    /// export with it.
     fn quiet_title_var(&self, title: &TerminalTitle) -> Option<&'static str> {
         if !title.is_named() {
             return None;
         }
-        match self.isolation {
-            Isolation::Host => self.agent().quiet_title_var(),
-            Isolation::Devlaunch => None,
-        }
+        self.agent().quiet_title_var()
     }
 
     /// What this launch tells the process it is about to become about the
@@ -2123,7 +2144,7 @@ impl Launch {
         // twice: the escape written below, and the quieting that keeps it
         // ([`Launch::quiet_title_var`]). One value behind both, so a launch
         // cannot write a name it then lets the agent overwrite.
-        let title = TerminalTitle::wanted(&self.key());
+        let title = self.terminal_title();
         let argv = self.agent_argv();
         let (program, rest) = argv.split_first().expect("agent argv is never empty");
 
@@ -2174,9 +2195,6 @@ impl Launch {
         // Last, and after every check that could still turn this into an error
         // rather than a launch: a `wf` that failed to resolve the agent has not
         // handed the terminal to anything, so it has no business renaming it.
-        // On the container arm `dl` writes its own name over this one a moment
-        // later — see [`crate::title`] for why writing it anyway is the point
-        // rather than waste.
         title.write();
         // `CommandExt::exec` only ever returns on failure.
         let err = command.exec();
@@ -4708,15 +4726,31 @@ mod tests {
     }
 
     #[test]
-    fn an_isolated_launch_leaves_the_quieting_to_dl() {
-        // The container arm sets nothing and prefixes nothing. Two reasons, and
-        // either alone would be enough: the process this launch becomes is
-        // `dl`, whose environment no container shell inherits, and `dl` 0.14.0
-        // exports the same variable from the container's login profile — which
-        // every `dl <ws> -- <cmd>` reads, since those run under `bash -lc`
-        // (blooop/devlaunch#436).
+    fn an_isolated_launch_names_nothing_because_nothing_it_wrote_would_last() {
+        // The rule the feature holds: a name is written only where the same
+        // launch can keep it. On this arm `dl` replaces `wf`'s escape with the
+        // workspace spec within the second, and where `dl`'s titling is off it
+        // is the title stage that does not run — the same stage that exports
+        // claude's suppression — so an escape from `wf` would be overwritten
+        // either by `dl` or by the agent. Both halves therefore say nothing
+        // here, and this is asserted on the arm rather than on the environment:
+        // `terminal_title` cannot ask about `WF_NO_TITLE` or a tty and reach
+        // any other answer.
         let launch = isolated(Route::Tdd, interactive(""));
-        assert_eq!(launch.quiet_title_var(&named()), None);
+        assert_eq!(launch.terminal_title(), TerminalTitle::Off);
+        assert_eq!(launch.quiet_title_var(&launch.terminal_title()), None);
+    }
+
+    #[test]
+    fn an_isolated_launch_leaves_the_quieting_to_dl() {
+        // Nothing is prefixed onto the payload either — the arm sets nothing
+        // *and* carries nothing. Two reasons, either alone enough: the process
+        // this launch becomes is `dl`, whose environment no container shell
+        // inherits, and `dl` 0.14.0 exports the same variable from the
+        // container's login profile, which every `dl <ws> -- <cmd>` reads since
+        // those run under `bash -lc` (blooop/devlaunch#436). The decision
+        // itself is pinned above, on the launch's own title.
+        let launch = isolated(Route::Tdd, interactive(""));
         let argv = launch.agent_argv();
         assert_eq!(argv.first().map(String::as_str), Some(DEVLAUNCH));
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,5 +53,6 @@ pub mod reap;
 pub mod reclaim;
 pub mod refresh;
 pub mod skills;
+pub mod title;
 pub mod ui;
 pub mod view;

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,0 +1,239 @@
+//! What the terminal is called while the agent a launch started is running.
+//!
+//! A `wf` launch is a session you switch away from: N tickets are N terminals,
+//! and the only thing that tells them apart from outside is the window — or
+//! multiplexer tab — name. So a launch names it, after the node it launched
+//! (`wayfinder#191`, [`crate::launch::Launch::key`]), with the OSC 2 escape
+//! every terminal this repo runs in understands, written once on the way out of
+//! the process.
+//!
+//! ## Why the agent has to be quieted for that to mean anything
+//!
+//! Claude Code writes the terminal title continuously while it runs, from its
+//! own read of what the session is doing. A terminal takes the last writer's
+//! word for it, so an escape `wf` writes and an escape the agent writes are not
+//! two signals but **one contest**, and the agent wins every round after the
+//! first: the name a launch wrote is gone inside a second. Naming the terminal
+//! and leaving the agent to name it too is therefore not half a feature, it is
+//! none of one — which is what blooop/devlaunch#436 measured on `dl`'s own
+//! title, and what the variable in [`crate::launch::Agent::quiet_title_var`]
+//! settles.
+//!
+//! That is why one value decides both halves here. A [`TerminalTitle::Off`]
+//! writes no escape *and* quiets nothing: a launch that is not naming the
+//! terminal has no name to protect, and an agent silenced with nothing put in
+//! its place leaves the window wearing whatever a session hours ago called it,
+//! which is worse than a name that moves.
+//!
+//! The quieting is the **host arm's** alone. An isolated launch becomes `dl`,
+//! and since blooop/devlaunch#436 (`dl` 0.14.0) `dl` exports the same variable
+//! into the container's login profile, which every `dl <ws> -- <cmd>` payload
+//! reads — so there the job is done by the half that owns the container. See
+//! [`crate::launch::Launch::quiet_title_var`].
+//!
+//! ## `WF_NO_TITLE`
+//!
+//! One variable, governing the whole feature — the escape and the quieting
+//! both, for the reason above. It is an opt-*out*, so an unrecognised value
+//! reads as "set": the cost of being wrong is one escape sequence nobody
+//! wanted, which is the cheap direction. This is deliberately the opposite rule
+//! to [`crate::launch::prewarm_enabled`]'s allowlist, and the asymmetry is the
+//! cost of being wrong there — `WF_PREWARM` opts *in* to clones and containers,
+//! so a value nobody anticipated must not start building any.
+//!
+//! `dl` has the same switch over its own three pieces (`DEVLAUNCH_NO_TITLE`:
+//! its escape, the `PS1` line, and the profile export above), and `wf`
+//! deliberately does not read it. It is `dl`'s variable for `dl`'s escape:
+//! on an isolated launch `dl` writes its own name over this one a moment later,
+//! and somebody who turned that off has said nothing about whether `wf` may
+//! name the terminal it is handing over.
+
+use std::io::{IsTerminal, Write};
+
+/// `WF_NO_TITLE`: do not name the terminal after the launch, and leave the
+/// agent's own titling alone. See the module docs for why it is one variable
+/// over both halves and why an unrecognised value turns it off.
+pub const DISABLE_VAR: &str = "WF_NO_TITLE";
+
+/// The spellings that leave the feature **on** despite the variable being set —
+/// what somebody who once turned it off writes to turn it back on without
+/// unsetting anything. Everything else, including a value this list never
+/// anticipated, turns it off.
+const FALSEY: [&str; 4] = ["", "0", "false", "no"];
+
+/// What this launch has to say about the terminal's name.
+///
+/// Two arms rather than an `Option<String>` so the type says what it is at
+/// every site that carries it, including the one that only asks whether
+/// anything is named at all ([`TerminalTitle::is_named`], which is how the
+/// quieting decision is taken from the same value as the escape).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TerminalTitle {
+    /// Write exactly this — a complete OSC 2 sequence, terminator and all.
+    Write(String),
+    /// Write nothing, and let the agent name the terminal however it likes.
+    Off,
+}
+
+impl TerminalTitle {
+    /// What this process wants written for `name`, read off the real
+    /// environment and the real stderr.
+    ///
+    /// The only impure entry point, and it does nothing but gather the two
+    /// inputs [`TerminalTitle::named`] decides from — so every rule is testable
+    /// without mutating an environment the rest of the suite shares.
+    pub fn wanted(name: &str) -> TerminalTitle {
+        TerminalTitle::named(
+            name,
+            std::env::var(DISABLE_VAR).ok().as_deref(),
+            std::io::stderr().is_terminal(),
+        )
+    }
+
+    /// The rule: name the terminal unless the variable says not to, there is no
+    /// terminal to name, or nothing survives [`sanitize`].
+    ///
+    /// `terminal` is stderr's, because stderr is the stream the escape is
+    /// written to — `wf > log` is still a session in a window, and `wf` piped
+    /// into something is not a launch at all, since the picker cannot be driven
+    /// without a tty.
+    pub fn named(name: &str, no_title: Option<&str>, terminal: bool) -> TerminalTitle {
+        if switched_off(no_title) || !terminal {
+            return TerminalTitle::Off;
+        }
+        match sanitize(name) {
+            Some(text) => TerminalTitle::Write(format!("\x1b]2;{text}\x07")),
+            None => TerminalTitle::Off,
+        }
+    }
+
+    /// The bytes to write, or nothing. Borrowed: the caller writes it and drops
+    /// it.
+    pub fn osc(&self) -> Option<&str> {
+        match self {
+            TerminalTitle::Write(osc) => Some(osc),
+            TerminalTitle::Off => None,
+        }
+    }
+
+    /// Is this launch naming the terminal? The same answer that decides whether
+    /// the agent's own titling is quieted — see the module docs.
+    pub fn is_named(&self) -> bool {
+        self.osc().is_some()
+    }
+
+    /// Write it, if there is anything to write.
+    ///
+    /// Errors are dropped on purpose, and flushing is not optional: this is the
+    /// last thing a launch does before `execvp` replaces the process, so an
+    /// escape left sitting in a `BufWriter` is an escape nobody ever writes —
+    /// and a terminal that would not take it is not a launch that failed.
+    pub fn write(&self) {
+        if let Some(osc) = self.osc() {
+            let mut stderr = std::io::stderr();
+            let _ = stderr.write_all(osc.as_bytes());
+            let _ = stderr.flush();
+        }
+    }
+}
+
+/// Whether a value of [`DISABLE_VAR`] turns the feature off. Set to anything
+/// but a [`FALSEY`] spelling, trimmed and case-folded.
+fn switched_off(value: Option<&str>) -> bool {
+    match value {
+        None => false,
+        Some(value) => !FALSEY.contains(&value.trim().to_ascii_lowercase().as_str()),
+    }
+}
+
+/// `name` with everything a terminal would read as an instruction taken out, or
+/// `None` if that leaves nothing worth writing.
+///
+/// Defence at the boundary the bytes are formed at, and not sold as more than
+/// that: the only name that reaches here is a [`crate::launch::Launch::key`],
+/// built from a repo slug and a ticket number, and a GitHub repo name cannot
+/// hold a control character. What the filter buys is that the guarantee is
+/// local — true of this function rather than borrowed from what the tracker
+/// happens to allow — so a name assembled from somewhere new later cannot make
+/// this the site of an escape-injected title. Dropped rather than escaped,
+/// which leaves the writer with nothing to decide.
+fn sanitize(name: &str) -> Option<String> {
+    let text: String = name.chars().filter(|ch| !ch.is_control()).collect();
+    let text = text.trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_named_launch_writes_one_osc_2_sequence() {
+        // The whole escape, pinned: `ESC ] 2 ; text BEL`. OSC 2 is the window
+        // title (OSC 0 is title *and* icon, which nothing here wants to
+        // touch), and BEL rather than ST because it is the terminator every
+        // emulator takes, including the ones that treat `ESC \` as two
+        // characters.
+        let title = TerminalTitle::named("wayfinder#191", None, true);
+        assert_eq!(title.osc(), Some("\x1b]2;wayfinder#191\x07"));
+        assert!(title.is_named());
+    }
+
+    #[test]
+    fn nothing_is_written_when_there_is_no_terminal_to_write_to() {
+        // A `wf` whose stderr is a file or a pipe is not in a window worth
+        // naming, and the escape would land in the file as bytes nobody
+        // decodes.
+        let title = TerminalTitle::named("wayfinder#191", None, false);
+        assert_eq!(title, TerminalTitle::Off);
+        assert!(!title.is_named());
+    }
+
+    #[test]
+    fn the_disable_variable_is_an_opt_out_and_unrecognised_means_off() {
+        // The direction that matters: anything set is "off", because the cost
+        // of reading a value nobody anticipated as off is one title, while
+        // reading it as on is the feature ignoring somebody who asked it to
+        // stop. `WF_NO_TITLE=please` is not a spelling this file knows, and it
+        // is not a request to keep titling.
+        for set in ["1", "true", "yes", "on", "please", "  1  "] {
+            assert_eq!(
+                TerminalTitle::named("wayfinder#191", Some(set), true),
+                TerminalTitle::Off,
+                "{set:?} must turn the title off"
+            );
+        }
+        // And the way back on without unsetting anything, which is what a
+        // `.bashrc` line that once said `WF_NO_TITLE=1` gets edited into.
+        // Empty is here because `WF_NO_TITLE=` is how a shell spells "unset"
+        // by accident, and exporting nothing must not disable a feature.
+        for unset in ["", "0", "false", "no", "FALSE", " no "] {
+            assert!(
+                TerminalTitle::named("wayfinder#191", Some(unset), true).is_named(),
+                "{unset:?} must leave the title on"
+            );
+        }
+    }
+
+    #[test]
+    fn a_name_cannot_carry_an_escape_of_its_own() {
+        // The boundary guard. A name holding its own OSC would otherwise close
+        // this sequence and open another, so what a terminal ended up wearing
+        // would be the *second* one — a title chosen by whatever composed the
+        // name rather than by this function.
+        assert_eq!(
+            TerminalTitle::named("ws\x1b]2;pwned\x07x\nrest", None, true).osc(),
+            Some("\x1b]2;ws]2;pwnedxrest\x07")
+        );
+        // Nothing left after the filter is nothing worth writing: an empty OSC
+        // 2 blanks the window's name, which is a change nobody asked for.
+        assert_eq!(
+            TerminalTitle::named("\x1b\x07 \n", None, true),
+            TerminalTitle::Off
+        );
+    }
+}

--- a/src/title.rs
+++ b/src/title.rs
@@ -16,7 +16,7 @@
 //! first: the name a launch wrote is gone inside a second. Naming the terminal
 //! and leaving the agent to name it too is therefore not half a feature, it is
 //! none of one — which is what blooop/devlaunch#436 measured on `dl`'s own
-//! title, and what the variable in [`crate::launch::Agent::quiet_title_var`]
+//! title, and what the variable in `Agent::quiet_title_var` (`crate::launch`)
 //! settles.
 //!
 //! That is why one value decides both halves here. A [`TerminalTitle::Off`]
@@ -30,7 +30,7 @@
 //! blooop/devlaunch#436 (`dl` 0.14.0) — exports the same suppression into the
 //! container's login profile, so an escape from `wf` there would be replaced
 //! within the second and a suppression from `wf` would be a second mechanism
-//! for one job. See [`crate::launch::Launch::terminal_title`], and the README
+//! for one job. See `Launch::terminal_title` in `crate::launch`, and the README
 //! for the two `dl`-side cases that leaves alone.
 //!
 //! ## `WF_NO_TITLE`
@@ -64,7 +64,7 @@ pub const DISABLE_VAR: &str = "WF_NO_TITLE";
 const FALSEY: [&str; 4] = ["", "0", "false", "no"];
 
 /// One complete OSC 2 sequence — `ESC ] 2 ; <name> BEL` — built from a name
-/// [`sanitize`] has already filtered.
+/// `sanitize` has already filtered.
 ///
 /// A newtype with a private field, so [`TerminalTitle::named`] is the only way
 /// to have one. The variant used to carry a bare `String` whose doc comment
@@ -119,7 +119,7 @@ impl TerminalTitle {
     }
 
     /// The rule: name the terminal unless the variable says not to, there is no
-    /// terminal to name, or nothing survives [`sanitize`].
+    /// terminal to name, or nothing survives `sanitize`.
     ///
     /// `terminal` is stderr's, because stderr is the stream the escape is
     /// written to — `wf > log` is still a session in a window, and `wf` piped

--- a/src/title.rs
+++ b/src/title.rs
@@ -25,11 +25,13 @@
 //! its place leaves the window wearing whatever a session hours ago called it,
 //! which is worse than a name that moves.
 //!
-//! The quieting is the **host arm's** alone. An isolated launch becomes `dl`,
-//! and since blooop/devlaunch#436 (`dl` 0.14.0) `dl` exports the same variable
-//! into the container's login profile, which every `dl <ws> -- <cmd>` payload
-//! reads — so there the job is done by the half that owns the container. See
-//! [`crate::launch::Launch::quiet_title_var`].
+//! Both halves are the **host arm's** alone. An isolated launch hands the
+//! terminal to `dl`, which names it after the workspace and — since
+//! blooop/devlaunch#436 (`dl` 0.14.0) — exports the same suppression into the
+//! container's login profile, so an escape from `wf` there would be replaced
+//! within the second and a suppression from `wf` would be a second mechanism
+//! for one job. See [`crate::launch::Launch::terminal_title`], and the README
+//! for the two `dl`-side cases that leaves alone.
 //!
 //! ## `WF_NO_TITLE`
 //!
@@ -43,10 +45,9 @@
 //!
 //! `dl` has the same switch over its own three pieces (`DEVLAUNCH_NO_TITLE`:
 //! its escape, the `PS1` line, and the profile export above), and `wf`
-//! deliberately does not read it. It is `dl`'s variable for `dl`'s escape:
-//! on an isolated launch `dl` writes its own name over this one a moment later,
-//! and somebody who turned that off has said nothing about whether `wf` may
-//! name the terminal it is handing over.
+//! deliberately does not read it — it governs a terminal `dl` has taken over,
+//! and this one governs the arm `wf` keeps. With it set, a container session is
+//! the agent's to name, which is what it was before any of this.
 
 use std::ffi::OsStr;
 use std::io::{IsTerminal, Write};

--- a/src/title.rs
+++ b/src/title.rs
@@ -62,16 +62,36 @@ pub const DISABLE_VAR: &str = "WF_NO_TITLE";
 /// anticipated, turns it off.
 const FALSEY: [&str; 4] = ["", "0", "false", "no"];
 
+/// One complete OSC 2 sequence — `ESC ] 2 ; <name> BEL` — built from a name
+/// [`sanitize`] has already filtered.
+///
+/// A newtype with a private field, so [`TerminalTitle::named`] is the only way
+/// to have one. The variant used to carry a bare `String` whose doc comment
+/// *said* "a complete OSC 2 sequence": a claim about a payload anything in the
+/// crate could fill with anything, which put the module's one guarantee — that
+/// no name reaches a terminal carrying escapes of its own — in a comment rather
+/// than in the types. The arms themselves stay public because callers construct
+/// [`TerminalTitle::Off`] to mean "not titling".
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Osc(String);
+
+impl Osc {
+    /// The bytes to write.
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// What this launch has to say about the terminal's name.
 ///
-/// Two arms rather than an `Option<String>` so the type says what it is at
+/// Two arms rather than an `Option<Osc>` so the type says what it is at
 /// every site that carries it, including the one that only asks whether
 /// anything is named at all ([`TerminalTitle::is_named`], which is how the
 /// quieting decision is taken from the same value as the escape).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TerminalTitle {
-    /// Write exactly this — a complete OSC 2 sequence, terminator and all.
-    Write(String),
+    /// Write exactly this, terminator and all — see [`Osc`].
+    Write(Osc),
     /// Write nothing, and let the agent name the terminal however it likes.
     Off,
 }
@@ -109,7 +129,7 @@ impl TerminalTitle {
             return TerminalTitle::Off;
         }
         match sanitize(name) {
-            Some(text) => TerminalTitle::Write(format!("\x1b]2;{text}\x07")),
+            Some(text) => TerminalTitle::Write(Osc(format!("\x1b]2;{text}\x07"))),
             None => TerminalTitle::Off,
         }
     }
@@ -118,7 +138,7 @@ impl TerminalTitle {
     /// it.
     pub fn osc(&self) -> Option<&str> {
         match self {
-            TerminalTitle::Write(osc) => Some(osc),
+            TerminalTitle::Write(osc) => Some(osc.as_str()),
             TerminalTitle::Off => None,
         }
     }
@@ -215,7 +235,7 @@ mod tests {
         // an undecodable value as "unset" would name their terminal anyway and
         // silence their agent against their wish.
         use std::os::unix::ffi::OsStrExt;
-        let raw = std::ffi::OsStr::from_bytes(b"\xff1");
+        let raw = OsStr::from_bytes(b"\xff1");
         assert_eq!(
             TerminalTitle::named("wayfinder#191", Some(raw), true),
             TerminalTitle::Off

--- a/src/title.rs
+++ b/src/title.rs
@@ -48,6 +48,7 @@
 //! and somebody who turned that off has said nothing about whether `wf` may
 //! name the terminal it is handing over.
 
+use std::ffi::OsStr;
 use std::io::{IsTerminal, Write};
 
 /// `WF_NO_TITLE`: do not name the terminal after the launch, and leave the
@@ -82,10 +83,16 @@ impl TerminalTitle {
     /// The only impure entry point, and it does nothing but gather the two
     /// inputs [`TerminalTitle::named`] decides from — so every rule is testable
     /// without mutating an environment the rest of the suite shares.
+    ///
+    /// `var_os` rather than `var`: an environment variable is bytes, and a
+    /// `var().ok()` reads one that is not UTF-8 as *unset*, which for an
+    /// opt-out means honouring `WF_NO_TITLE=$'\xff1'` by titling anyway. The
+    /// undecodable case belongs to whichever answer is safe, and here that is
+    /// "they asked for it off".
     pub fn wanted(name: &str) -> TerminalTitle {
         TerminalTitle::named(
             name,
-            std::env::var(DISABLE_VAR).ok().as_deref(),
+            std::env::var_os(DISABLE_VAR).as_deref(),
             std::io::stderr().is_terminal(),
         )
     }
@@ -97,7 +104,7 @@ impl TerminalTitle {
     /// written to — `wf > log` is still a session in a window, and `wf` piped
     /// into something is not a launch at all, since the picker cannot be driven
     /// without a tty.
-    pub fn named(name: &str, no_title: Option<&str>, terminal: bool) -> TerminalTitle {
+    pub fn named(name: &str, no_title: Option<&OsStr>, terminal: bool) -> TerminalTitle {
         if switched_off(no_title) || !terminal {
             return TerminalTitle::Off;
         }
@@ -139,10 +146,17 @@ impl TerminalTitle {
 
 /// Whether a value of [`DISABLE_VAR`] turns the feature off. Set to anything
 /// but a [`FALSEY`] spelling, trimmed and case-folded.
-fn switched_off(value: Option<&str>) -> bool {
+///
+/// Lossy rather than fallible, for the reason [`TerminalTitle::wanted`] reads
+/// bytes: a value that does not decode is a value somebody set, and every
+/// spelling that leaves the feature on is plain ASCII, so no lossy replacement
+/// can turn one of those into something else.
+fn switched_off(value: Option<&OsStr>) -> bool {
     match value {
         None => false,
-        Some(value) => !FALSEY.contains(&value.trim().to_ascii_lowercase().as_str()),
+        Some(value) => {
+            !FALSEY.contains(&value.to_string_lossy().trim().to_ascii_lowercase().as_str())
+        }
     }
 }
 
@@ -194,6 +208,21 @@ mod tests {
     }
 
     #[test]
+    fn a_value_no_encoding_could_read_still_turns_the_title_off() {
+        // The direction the rule is *for*, applied to the one value that is not
+        // a string: `WF_NO_TITLE=$'\xff1'`. An opt-out asked for by somebody
+        // whose shell put a stray byte in it is still an opt-out, and reading
+        // an undecodable value as "unset" would name their terminal anyway and
+        // silence their agent against their wish.
+        use std::os::unix::ffi::OsStrExt;
+        let raw = std::ffi::OsStr::from_bytes(b"\xff1");
+        assert_eq!(
+            TerminalTitle::named("wayfinder#191", Some(raw), true),
+            TerminalTitle::Off
+        );
+    }
+
+    #[test]
     fn the_disable_variable_is_an_opt_out_and_unrecognised_means_off() {
         // The direction that matters: anything set is "off", because the cost
         // of reading a value nobody anticipated as off is one title, while
@@ -202,7 +231,7 @@ mod tests {
         // is not a request to keep titling.
         for set in ["1", "true", "yes", "on", "please", "  1  "] {
             assert_eq!(
-                TerminalTitle::named("wayfinder#191", Some(set), true),
+                TerminalTitle::named("wayfinder#191", Some(OsStr::new(set)), true),
                 TerminalTitle::Off,
                 "{set:?} must turn the title off"
             );
@@ -213,7 +242,7 @@ mod tests {
         // by accident, and exporting nothing must not disable a feature.
         for unset in ["", "0", "false", "no", "FALSE", " no "] {
             assert!(
-                TerminalTitle::named("wayfinder#191", Some(unset), true).is_named(),
+                TerminalTitle::named("wayfinder#191", Some(OsStr::new(unset)), true).is_named(),
                 "{unset:?} must leave the title on"
             );
         }

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -182,6 +182,7 @@ impl Scratch {
         // the wrong child, or left an inherited one on a probe, is invisible in
         // an argv. Always written, empty when unset, so "the variable is not
         // here" is a value this file can read rather than a missing line.
+
         let record = |report: &Path| {
             format!(
                 "line=$({{ echo \"{INVOCATION}\"; echo \"pid=$$\"; echo \"cwd=$PWD\"; \
@@ -836,6 +837,27 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
         "wf never made the cursor visible again before handing over — \
          the agent inherits an invisible cursor"
     );
+
+    // Claim 3c: the terminal came back with a *name* on it — the node that was
+    // launched — written by `wf` and by nothing else here.
+    //
+    // Asserted on `handover`, the stream up to the agent's own first byte,
+    // which is what makes it `wf`'s escape rather than something the shim or
+    // the shell could have written. On a real launch `dl` writes its own name
+    // over this one a moment later; the shim writes none, so what is observable
+    // here is exactly `wf`'s half.
+    let named = format!("\x1b]2;wayfinder#{workspace_ticket}\x07");
+    assert!(
+        contains(handover, named.as_bytes()),
+        "wf must name the terminal after the node it launched, expected {named:?}"
+    );
+    // The other half of the feature is not `wf`'s on this arm and so is not
+    // observable here: inside a container the agent's own titling is quieted
+    // from the login profile `dl` writes, which every `bash -lc` payload reads
+    // (devlaunch#436). What `wf` does on the *host* arm — the same variable, set
+    // on the child it becomes — has no container and no `dl` in it, so it is
+    // pinned in the library instead
+    // (`a_host_launch_is_the_one_that_has_to_quiet_the_agent_itself`).
 
     // Claim 4: the agent can actually *run* the skill it was just handed. The
     // prompt is a slash command, so a link the agent cannot resolve is not an

--- a/tests/live_launch_exec.rs
+++ b/tests/live_launch_exec.rs
@@ -91,6 +91,13 @@ const COOKED: [&str; 4] = ["echo", "icanon", "isig", "opost"];
 /// the records are told apart.
 const INVOCATION: &str = "--- shim invocation ---";
 
+/// A `dl` that is installed and **below** [`wf::launch::DEVLAUNCH_FLOOR`], which
+/// is what sends a launch to the host arm (#80) without taking anybody's real
+/// `dl` off PATH. Far below rather than one patch below, for the same reason
+/// [`DL_SHIM_VERSION`] is far above: the floor's own rule is unit-tested, and
+/// this file should not need editing when it moves.
+const DL_STALE_VERSION: &str = "0.0.1";
+
 /// What the `dl` shim answers `--version` with. See `write_shims`.
 const DL_SHIM_VERSION: &str = "9999.0.0";
 
@@ -157,6 +164,19 @@ impl Scratch {
     /// the spawned `wf` to `claude`, and the shell that parses the quoted
     /// command is a genuine one rather than this test's idea of one.
     fn write_shims(&self) {
+        self.write_shims_reporting(DL_SHIM_VERSION);
+    }
+
+    /// The same pair, with `dl --version` answering whatever is asked for.
+    ///
+    /// One caller wants a `dl` above any floor and one wants a `dl` below it:
+    /// [`DL_STALE_VERSION`] is how the host-arm test reaches the host arm on a
+    /// machine that has a real `dl` installed. Shadowing rather than removing —
+    /// the scratch bin leads PATH, so the version this answers with is the
+    /// version `wf` sees, and no directory of the developer's toolchain has to
+    /// be taken away to arrange it (`scripts/without-dl.sh` says at length why
+    /// dropping PATH entries is the wrong tool).
+    fn write_shims_reporting(&self, version: &str) {
         // **Appended, one record per invocation**, rather than a file each
         // shim overwrites. A shim is called more than once per run — `wf` asks
         // `dl --version` before it will trust it with a launch — and the
@@ -182,12 +202,18 @@ impl Scratch {
         // the wrong child, or left an inherited one on a probe, is invisible in
         // an argv. Always written, empty when unset, so "the variable is not
         // here" is a value this file can read rather than a missing line.
-
+        //
+        // `notitle` is the variable that stops the agent renaming the terminal
+        // a launch just named, and it is read the same way and for the same
+        // reason: on the host arm `wf` sets it on the process it becomes, which
+        // is invisible in an argv, and the host test starts `wf` with it
+        // *removed* so a `1` here can only have come from `wf`.
         let record = |report: &Path| {
             format!(
                 "line=$({{ echo \"{INVOCATION}\"; echo \"pid=$$\"; echo \"cwd=$PWD\"; \
                  echo \"argv=$*\"; echo \"handoff=$DEVLAUNCH_HANDOFF_T0\"; \
-                 echo \"prewarm=$DEVLAUNCH_PREWARM_FIRED_AT\"; stty -a; }} 2>&1)\n\
+                 echo \"prewarm=$DEVLAUNCH_PREWARM_FIRED_AT\"; \
+                 echo \"notitle=$CLAUDE_CODE_DISABLE_TERMINAL_TITLE\"; stty -a; }} 2>&1)\n\
                  printf '%s\\n' \"$line\" >> {}\n",
                 report.display()
             )
@@ -209,7 +235,7 @@ impl Scratch {
         // for, and this test should not have to be edited every time it moves.
         let dl = format!(
             "#!/usr/bin/env bash\n{}\
-             if [ \"$1\" = \"--version\" ]; then printf 'dl {DL_SHIM_VERSION}\\n'; exit 0; fi\n\
+             if [ \"$1\" = \"--version\" ]; then printf 'dl {version}\\n'; exit 0; fi\n\
              exec bash -c \"exec $3\"\n",
             record(&self.dl_report())
         );
@@ -838,26 +864,21 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
          the agent inherits an invisible cursor"
     );
 
-    // Claim 3c: the terminal came back with a *name* on it — the node that was
-    // launched — written by `wf` and by nothing else here.
+    // Claim 3c: `wf` wrote no name on this arm, and that is the rule rather
+    // than an omission. `dl` names the terminal it is taking over — the
+    // workspace spec, and its own `PS1` line keeps it — and quiets the agent
+    // from the container's login profile (devlaunch#436), so an escape from
+    // `wf` here would be replaced within the second or left to an agent that
+    // renames it continuously. A name only goes where the same launch can keep
+    // it, which is the host arm, and
+    // `the_host_arm_names_the_terminal_and_keeps_the_name` drives that one.
     //
     // Asserted on `handover`, the stream up to the agent's own first byte,
-    // which is what makes it `wf`'s escape rather than something the shim or
-    // the shell could have written. On a real launch `dl` writes its own name
-    // over this one a moment later; the shim writes none, so what is observable
-    // here is exactly `wf`'s half.
-    let named = format!("\x1b]2;wayfinder#{workspace_ticket}\x07");
+    // because the shim writes no title of its own: any OSC 2 in there is `wf`'s.
     assert!(
-        contains(handover, named.as_bytes()),
-        "wf must name the terminal after the node it launched, expected {named:?}"
+        !contains(handover, b"\x1b]2;"),
+        "an isolated launch must leave the terminal's name to dl"
     );
-    // The other half of the feature is not `wf`'s on this arm and so is not
-    // observable here: inside a container the agent's own titling is quieted
-    // from the login profile `dl` writes, which every `bash -lc` payload reads
-    // (devlaunch#436). What `wf` does on the *host* arm — the same variable, set
-    // on the child it becomes — has no container and no `dl` in it, so it is
-    // pinned in the library instead
-    // (`a_host_launch_is_the_one_that_has_to_quiet_the_agent_itself`).
 
     // Claim 4: the agent can actually *run* the skill it was just handed. The
     // prompt is a slash command, so a link the agent cannot resolve is not an
@@ -926,6 +947,131 @@ fn enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind() {
             "only a launch is stamped, and this is not one:\n{aside}"
         );
     }
+}
+
+/// The host arm: `wf` names the terminal after the node it launched, and the
+/// agent it hands over to is told to leave that name alone.
+///
+/// The arm where both halves are `wf`'s, and the only arm where either is. An
+/// isolated launch hands the terminal to `dl`, which writes its own name over
+/// anything `wf` wrote and quiets the agent from the container's login profile
+/// (blooop/devlaunch#436) — so on that arm `wf` deliberately writes nothing, and
+/// the test above asserts exactly that. Here there is no container, no profile
+/// and no `dl` in the picture at all: what happens to the window is `wf`'s doing
+/// or nobody's.
+///
+/// Reached by a `dl` **below the version floor** rather than by an absent one.
+/// The scratch bin leads PATH, so the shim's `0.0.1` is the version `wf` sees
+/// whatever the developer has installed, and #80's rule sends the launch to the
+/// host. Dropping PATH entries would have been the other way, and the wrong one:
+/// `dl` is installed beside `gh` by the same `pixi global install`, so the
+/// obvious filter takes the tracker with it (`scripts/without-dl.sh`).
+///
+/// Both claims are only observable on a real launch. The escape is a byte fact
+/// about the stream before the agent's first output, and the variable is a fact
+/// about the environment `execvp` handed over — neither is in an argv, and the
+/// library can only assert the decision, not the handover.
+#[test]
+#[ignore = "live: needs network, gh, a blooop/wayfinder checkout, and a pty"]
+fn the_host_arm_names_the_terminal_and_keeps_the_name() {
+    let scratch = Scratch::new("host-title");
+    scratch.write_shims_reporting(DL_STALE_VERSION);
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let (master, slave) = openpty_sized(40, 120);
+    let path = format!(
+        "{}:{}",
+        scratch.bin().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut child = unsafe {
+        Command::new(env!("CARGO_BIN_EXE_wf"))
+            .current_dir(repo)
+            .env("PATH", &path)
+            .env("XDG_CACHE_HOME", scratch.cache())
+            .env("CLAUDE_CONFIG_DIR", scratch.claude())
+            .env("TERM", "xterm-256color")
+            // The claim about the variable is a claim about `wf` only if `wf`
+            // did not inherit it: an agent session run by `aid` or inside a
+            // provisioned workspace has it set already, and this suite is
+            // routinely run from one. Removed, so a `1` in the shim's record
+            // has exactly one possible author.
+            .env_remove("CLAUDE_CODE_DISABLE_TERMINAL_TITLE")
+            .stdin(Stdio::from(slave.try_clone().expect("dup slave")))
+            .stdout(Stdio::from(slave.try_clone().expect("dup slave")))
+            .stderr(Stdio::from(slave.try_clone().expect("dup slave")))
+            .pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            })
+            .spawn()
+            .expect("spawn wf under a pty")
+    };
+    let mut keys = std::fs::File::from(master.try_clone().expect("dup master"));
+    drop(slave);
+    let seen = spawn_reader(master);
+
+    launch_the_first_ticket(&mut keys, &seen, "▶ interactive");
+    let stream = wait_for(&seen, RAN, Duration::from_secs(30), "the agent to run");
+    let screen = String::from_utf8_lossy(&stream).into_owned();
+    let status = child.wait().expect("wait for the exec'd agent");
+    assert!(status.success(), "the agent exited {status}\n{screen}");
+
+    let claude_report =
+        std::fs::read_to_string(scratch.report()).expect("the claude shim's report");
+    let report = invocation(&claude_report, "claude", 0, 1);
+
+    // The arm, asserted rather than assumed: a `dl` this old is asked its
+    // version and then never used, so a launch record here would mean the floor
+    // let it through and this test is measuring the other arm.
+    let dl_report = std::fs::read_to_string(scratch.dl_report()).expect("the dl shim's report");
+    assert!(
+        dl_launches(&dl_report).is_empty(),
+        "a `dl` below the floor must not be handed the launch:\n{dl_report}"
+    );
+    assert_eq!(
+        Path::new(field(report, "cwd=")).canonicalize().ok(),
+        repo.canonicalize().ok(),
+        "a host launch runs the agent in the picked checkout"
+    );
+
+    // Which node this run happened to take is the live tracker's business, so
+    // the name is checked against the prompt rather than against a number this
+    // file chose: the last numeric argument of the skill invocation is the node
+    // (`/wf <map> <n>`, `/wf-tdd <n>`), and the terminal has to be wearing that
+    // one. Same source of truth as the workspace check in the test above, which
+    // is the point — the row, the prompt and the window name all say one node.
+    let argv = field(report, "argv=");
+    let (_, prompt) = argv.split_once(' ').expect("a switch and a prompt");
+    let invocation = prompt.split(" ctx: ").next().expect("a skill invocation");
+    let node = invocation
+        .split_whitespace()
+        .next_back()
+        .expect("an argument");
+    assert!(
+        node.chars().all(|c| c.is_ascii_digit()) && !node.is_empty(),
+        "the last argument of {invocation:?} is the node"
+    );
+    let handover = &stream[..stream
+        .windows(RAN.len())
+        .position(|w| w == RAN.as_bytes())
+        .expect("the marker is in the stream")];
+    let named = format!("\x1b]2;wayfinder#{node}\x07");
+    assert!(
+        contains(handover, named.as_bytes()),
+        "wf must name the terminal after the node it launched, expected {named:?}"
+    );
+    assert_eq!(
+        field(report, "notitle="),
+        "1",
+        "the agent must be told to leave that name alone, or it is gone within \
+         a second of the session starting"
+    );
 }
 
 /// Spawn `wf` under a fresh pty in `scratch`, returning the child, a handle to


### PR DESCRIPTION
## Summary

- **A launch names the terminal** after the node it launched — `wayfinder#191`, the same key the picker's row and the launch notice show — with one OSC 2 escape written to stderr as the last thing before the process image is replaced. Five tickets are five terminals, and from outside the window name is the only thing telling them apart.
- **And it tells the agent to leave that name alone.** Claude Code rewrites the title continuously from its own read of the session, and a terminal takes the last writer's word for it, so the two are one contest rather than two signals — `wf` loses it inside a second (blooop/devlaunch#436). A launch sets `CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1` on the agent it starts.
- **Both halves are the host arm's, and neither happens anywhere else.** One rule, not two decisions: a name is written only where the same launch can keep it. An isolated launch hands the terminal to `dl`, which names it after the workspace and — since devlaunch#436 shipped in `dl` 0.14.0 — exports the same suppression from the container's login profile, which every `dl <ws> -- <cmd>` payload reads because those run under `bash -lc`. An escape from `wf` there would be replaced within the second, so that arm writes nothing and sets nothing.
- **`WF_NO_TITLE` governs the pair.** An opt-out: anything set turns it off, including a value the list never anticipated and one no encoding can read. Deliberately the opposite reading to `WF_PREWARM`'s allowlist — being wrong here costs one escape sequence, not a clone and a container.
- **Codex is left able to rename the terminal.** No source exists for what variable `codex` reads, and a guessed name looks like a fix. devlaunch#436 leaves `codex` and `gemini` open for the same reason.

New module `src/title.rs` holds the decision (`TerminalTitle`), `Launch::terminal_title` is the single site that answers it per arm, and `Launch::quiet_title_var` takes the other half from the same value.

## Test plan

- `cargo test --locked` — 518 lib tests plus every offline binary, green. New: five unit tests in `title.rs` (the escape's exact bytes, no-tty, the opt-out rule including a non-UTF-8 value, escape injection through the name) and five in `launch.rs` (each arm's title and variable, the off case, codex, and the name being the launched node's key).
- `scripts/without-dl.sh cargo test --locked --lib --bins --examples` — the hermeticity run, green.
- `cargo clippy --locked --all-targets` clean, `cargo fmt` clean.
- **Live, run by name** (`tests/live_launch_exec.rs`, both `#[ignore]`d):
  - `the_host_arm_names_the_terminal_and_keeps_the_name` — new. Drives a real `wf` under a pty to the host arm (a `dl` shim below the version floor, since the scratch bin leads PATH and dropping PATH entries would take `gh` with it), then asserts the OSC 2 naming the launched node is in the stream *before* the agent's first byte, and that the agent's own environment carries the suppression — started with that variable removed, so the value has one possible author. Fails on both counts with `WF_NO_TITLE=1`, which is what keeps it honest.
  - `enter_execs_the_agent_into_a_per_ticket_workspace_and_leaves_no_wf_behind` — extended: the isolated run now asserts no OSC 2 reaches the stream at all, and its payload is the agent's own command with nothing in front of it.

## Review notes

Reviewed on two axes (Defects and Spec) before this PR existed; four findings, all fixed as their own commits — `bea397e` (the opt-out inverted on a non-UTF-8 value), `2eeb40c` (`Write` held a pre-formed escape anything could forge; now a private-field newtype), `94bb622` (the container arm wrote a name nothing would keep, plus the docs that overstated the guarantee).

Three things deliberately not done, each a decision rather than an oversight:

- **Two container cases stay uncovered, both `dl`-side.** The profile line exists only in a workspace that has been through a `dl` ≥ 0.14.0 `up` — an attach to an already-running container provisions nothing — and `DEVLAUNCH_NO_TITLE` takes all three of `dl`'s pieces with it, the export included. `wf` carrying the variable in the payload (`env VAR=1 claude …`) would cover both, and did until 0.14.0 shipped; it came out because it is a second mechanism for a job the half that owns the container already does. The README now states both cases rather than implying a guarantee the profile line does not carry.
- **This repo's own `.devcontainer/devcontainer.json` `containerEnv` is untouched.** It would close those two cases for wayfinder's own launches, at the cost of invalidating the prebuilt image tag (see the README's note) — a separate call, and not one this change needs.
- **`codex` gets nothing**, per the summary.

## Summary by Sourcery

Name host-mode terminals after their launched nodes and keep those names stable without interfering with devlaunch-managed sessions.

New Features:
- Name host-mode terminal sessions after the launched node using an OSC 2 title.
- Prevent Claude Code from overwriting host-mode launch titles while leaving Codex and Gemini behavior unchanged.

Bug Fixes:
- Avoid writing terminal titles or modifying agent title settings for isolated launches, where devlaunch owns terminal titling.

Enhancements:
- Centralize terminal-title decisions, opt-out handling, and safe title encoding in a dedicated module.
- Document host, isolated, opt-out, and devlaunch version-boundary behavior for terminal naming.

Documentation:
- Add user-facing documentation describing terminal naming, Claude Code suppression, opt-out behavior, and isolated-launch limitations.

Tests:
- Add unit coverage for title generation, terminal detection, opt-out values, non-UTF-8 environment values, sanitization, launch-arm behavior, and agent selection.
- Extend live PTY launch tests to verify host title emission and Claude suppression, and isolated-launch title omission.