### PR TITLE
Release 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wf"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 description = "Multi-project wayfinder ticket selector: a fuzzy-find picker over agentic planning maps that runs the agent on the ticket you pick"
 license = "MIT"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ schema_version: 1
 
 context:
   # Must equal Cargo.toml's version — CI fails the build if they drift.
-  version: "0.20.0"
+  version: "0.21.0"
 
 package:
   name: wf


### PR DESCRIPTION
Version bump only: `Cargo.toml`, `Cargo.lock` and `recipe/recipe.yaml` to 0.21.0 (CI fails the build if the three drift).

Minor, for #210 — a launch names the terminal after the ticket it launched and the agent cannot take the name back. The release commit carries the notes.

After merge: annotated `v0.21.0` on the merge commit, which is what `package.yml` reacts to.

## Summary by Sourcery

Build:
- Align the Cargo package, lockfile, and packaging recipe versions for the 0.21.0 release.